### PR TITLE
Make Aurora IOR single-node pipeline person-independent

### DIFF
--- a/builtin/pipelines/portability/aurora/ior_single_node.yaml
+++ b/builtin/pipelines/portability/aurora/ior_single_node.yaml
@@ -5,7 +5,7 @@ container_engine: apptainer
 container_base: ubuntu:24.04                                                                                                                                                                                                                                          
 container_ssh_port: 2233                                                                                                                                                                                                                                              
                                         
-hostfile: /home/isamuradli/hostfile_single.txt
+hostfile: $HOME/hostfile_single.txt
                                                                                                                                                                                                                                                                       
 pkgs:
   - pkg_type: builtin.ior                                                                                                                                                                                                                                             
@@ -15,7 +15,7 @@ pkgs:
     block: 1G                                                                                                                                                                                                                                                         
     xfer: 1M
     api: posix                                                                                                                                                                                                                                                        
-    out: /home/isamuradli/ior_aurora_single_file
+    out: /tmp/ior_aurora_single_file
     log: /tmp/ior_aurora_single_output.log  
     write: true                         
     read: true


### PR DESCRIPTION
## Summary
- Replace hardcoded `/home/isamuradli/` paths in `builtin/pipelines/portability/aurora/ior_single_node.yaml` so the pipeline works out-of-the-box for any user.
- `hostfile`: `/home/isamuradli/hostfile_single.txt` → `\$HOME/hostfile_single.txt`. The hostfile path is run through `os.path.expandvars` in `jarvis_cd/core/pipeline.py` (lines 871, 996), so `\$HOME` expands at load time.
- `out`: `/home/isamuradli/ior_aurora_single_file` → `/tmp/ior_aurora_single_file`. Matches the convention used everywhere in `builtin/pipelines/examples/` and `builtin/pipelines/portability/delta/`.

## Test plan
- [x] `jarvis ppl load yaml builtin/pipelines/portability/aurora/ior_single_node.yaml` succeeds on Aurora as a different user (`jcernuda`) after creating `\$HOME/hostfile_single.txt` with the local hostname. Apptainer SIF builds and pipeline configures cleanly.
- [ ] Reviewer confirms the upstream `out` path under `/tmp/` is acceptable for the portability suite (vs. a project filesystem path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)