### PR TITLE
hostfile: treat the running machine's own name/IP as local

### DIFF
--- a/jarvis_cd/util/hostfile.py
+++ b/jarvis_cd/util/hostfile.py
@@ -150,31 +150,53 @@ class Hostfile:
         """Return a copy of this hostfile"""
         return self.subset(len(self))
         
+    @staticmethod
+    def _local_addresses() -> set:
+        """Names and IPs that resolve to this machine.
+
+        Includes 'localhost', loopback IP, the machine's hostname / FQDN,
+        and every IP bound to the local hostname. Used by is_local() so a
+        hostfile containing the host's own name (common on HPC compute
+        nodes) is treated as a single-node run instead of being promoted
+        to a no-op SSH.
+        """
+        addrs = {'localhost'}
+        try:
+            addrs.add(socket.gethostbyname('localhost'))
+        except socket.gaierror:
+            pass
+        try:
+            hostname = socket.gethostname()
+            addrs.add(hostname)
+            addrs.add(socket.getfqdn())
+            try:
+                _, _, ips = socket.gethostbyname_ex(hostname)
+                addrs.update(ips)
+            except socket.gaierror:
+                pass
+        except Exception:
+            pass
+        return addrs
+
     def is_local(self) -> bool:
         """
-        Whether this file contains only 'localhost'
+        Whether this hostfile points only to the local machine.
 
-        :return: True or false
+        Single-host entries that match localhost, the loopback IP, or
+        the running machine's own hostname / IP are treated as local so
+        single-node runs don't get promoted to SSH on port 22.
         """
         if len(self) == 0:
             return True
-            
-        if len(self.hosts) == 1:
-            if self.hosts[0] == 'localhost':
-                return True
-            try:
-                if self.hosts[0] == socket.gethostbyname('localhost'):
-                    return True
-            except socket.gaierror:
-                pass
-                
-        if len(self.hosts_ip) == 1:
-            try:
-                if self.hosts_ip[0] == socket.gethostbyname('localhost'):
-                    return True
-            except socket.gaierror:
-                pass
-                
+
+        if len(self.hosts) != 1:
+            return False
+
+        local = self._local_addresses()
+        if self.hosts[0] in local:
+            return True
+        if self.hosts_ip and self.hosts_ip[0] in local:
+            return True
         return False
         
     def save(self, path: str) -> 'Hostfile':


### PR DESCRIPTION
## Summary
- `Hostfile.is_local()` previously only matched `localhost` / `127.0.0.1`. On HPC compute nodes the hostfile typically contains the node's actual hostname (e.g. `x4305c1s3b0n0` on Aurora), so single-node runs were reported as **non-local**.
- That made `jarvis_cd/shell/exec_factory.py:_resolve_exec_info` and `jarvis_cd/shell/core_exec.py` (MpiVersion probe) promote the run to SSH on port 22. Nothing was listening on `:22` on the compute node / for the apptainer instance, so the orchestrator logged `Connection closed by <ip> port 22`, silently skipped the real workload, and still returned `Pipeline started successfully`.
- Fix: also recognize the running machine's own hostname, FQDN, and bound IPs as local. Factored into a small `_local_addresses()` helper so the same set is consulted for both the hostname and IP fallback.

## Why this is the right fix (vs. patching `port=22`)
For `apptainer + MPI`, `exec_factory.run()` already wraps the command into `apptainer exec sif mpirun …` and then dispatches via `_resolve_exec_info` with `exec_type=LOCAL`. On a true single-node run that should stay `LocalExec`. The SSH promotion is only correct when the hostfile points at a *different* machine; when it points at this machine, going through SSH is at best wasteful and (as observed) often broken.

## Test plan
- [x] Sanity-checked `is_local()` against: `localhost`, `127.0.0.1`, `socket.gethostname()`, an unrelated host, and a multi-host file → behaves as expected.
- [x] Re-ran `builtin/pipelines/portability/aurora/ior_single_node.yaml` on Aurora end-to-end. Before: 0-byte output, "Connection closed by … port 22" warnings, no log. After: IOR produces an 8 GiB output file and real numbers (~3.5–6.4 GiB/s write, ~4.5–5.7 GiB/s read, 3 reps, POSIX, 8 procs).
- [ ] Reviewer sanity check on multi-node (the non-local path is unchanged but worth a glance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)