### PR TITLE
apptainer: exec into the running instance, not the SIF

### DIFF
--- a/jarvis_cd/shell/exec_factory.py
+++ b/jarvis_cd/shell/exec_factory.py
@@ -45,12 +45,12 @@ class Exec(CoreExec):
         gpu = self.exec_info.gpu
         env = dict(self.exec_info.env) if self.exec_info.env else {}
 
-        # For apptainer, resolve the SIF path from shared_dir (accessible on all nodes)
-        if c == 'apptainer' and self.exec_info.shared_dir and self.exec_info.container_image:
-            from pathlib import Path
-            # The .sif lives in the pipeline shared dir (parent of the
-            # per-package shared dir).
-            img = str(Path(self.exec_info.shared_dir).parent / f'{self.exec_info.container_image}.sif')
+        # For apptainer, target the running instance started by
+        # _start_containerized_pipeline (instance name == pipeline name ==
+        # deploy_image_name), so daemons spawned by Service.start() (e.g.
+        # chimaera/iowarp runtime) persist across subsequent exec calls.
+        if c == 'apptainer' and self.exec_info.container_image:
+            img = f'instance://{self.exec_info.container_image}'
         else:
             img = self.exec_info.container_image or ''
 


### PR DESCRIPTION
## Summary
- jarvis-cd's apptainer container wrap previously did \`apptainer exec <sif> ...\`, giving every \`Exec(...)\` a fresh namespace. \`_start_containerized_pipeline\` already starts a persistent \`apptainer instance\` for the pipeline (mirroring \`docker compose up\`), but nothing else used it.
- Result: any Service-type package that starts a daemon (chimaera/iowarp runtime, hermes, redis, …) had the daemon die before the next \`Exec\` ran in a new namespace. Subsequent client calls timed out trying to reach the runtime.
- Fix: when an apptainer instance has been started, target it via \`instance://<container_image>\`. Mirrors the docker/podman branch (\`<engine> exec <container_name>\`). Instance name == \`deploy_image_name()\` == \`pipeline.name\`, same key \`_start_containerized_pipeline\` uses.

## Why this is the right fix
For \`apptainer + MPI\` Application pipelines (e.g. \`builtin/pipelines/portability/aurora/ior_single_node.yaml\`), the wrap goes through \`_prepare_container\` after \`exec_type=LOCAL\` is restored. Both \`apptainer exec <sif>\` and \`apptainer exec instance://<name>\` set up \$HOME bind-mounts the same way, so output paths under \`/home\` stay host-visible. No change in behavior for Application-only pipelines.

For Service-pkg pipelines (the new case), the running instance is the only place where a daemon's state can survive between \`Exec\`s.

## Aurora context
This bug surfaces specifically on apptainer-only HPC sites the moment you run a Service-type pipeline. Aurora is the first time we exercised iowarp's \`wrp_runtime\` (chimaera) as a Service in apptainer, hence the discovery; the fix itself is in the core apptainer path.

## Test plan
- [x] Existing apptainer Application pipeline (Aurora IOR single-node) still produces an 8 GiB output and real bandwidth numbers (~3.5–6.4 GiB/s write).
- [x] New \`iowarp_apptainer_test.yaml\` (clio-core, separate PR) end-to-end on Aurora: chimaera persists, CTE connects (\`Successfully connected to runtime (generation=…, server_pid=21)\`), \`gray-scott\` runs through ADIOS2 IowarpEngine, engine reports 32 ms wall / 26 ms I/O / 5.8 ms compute.
- [ ] Reviewer sanity check on multi-node + docker/podman paths (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)