### PR TITLE
apptainer-native build: forward proxy env + add pkg-config

### DIFF
--- a/builtin/builtin/compress_libs/build.sh
+++ b/builtin/builtin/compress_libs/build.sh
@@ -3,7 +3,7 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates git cmake build-essential \
+    ca-certificates git cmake build-essential pkg-config \
     zlib1g-dev libbz2-dev liblzo2-dev libzstd-dev liblz4-dev liblzma-dev \
     libbrotli-dev libsnappy-dev libblosc2-dev libzfp-dev \
  && rm -rf /var/lib/apt/lists/*

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -1710,6 +1710,14 @@ class Pipeline:
 
         def_content = f"Bootstrap: docker\nFrom: {base_image}\n\n"
         def_content += "%post\n"
+        # Forward outbound-proxy env from the build host so package
+        # build.sh's apt-get / git clone / curl reach external mirrors
+        # on HPC nodes that require an explicit proxy (e.g. Aurora).
+        for var in ('http_proxy', 'https_proxy', 'HTTP_PROXY',
+                    'HTTPS_PROXY', 'no_proxy', 'NO_PROXY'):
+            val = os.environ.get(var)
+            if val:
+                def_content += f"export {var}={val}\n"
         def_content += '\n'.join(build_scripts)
         def_content += "\n\n%environment\n"
         def_content += f"export PATH={env_path_str}\n"


### PR DESCRIPTION
## Summary
Two small fixes that together unblock \`_build_apptainer_native\` on clean ubuntu bases behind an outbound proxy.

1. **Proxy forwarding** in \`pipeline._build_apptainer_native\`: write \`http_proxy\` / \`https_proxy\` / \`no_proxy\` (lower- and upper-case) into the generated \`.def\`'s \`%post\`. \`apt-get\` / \`git clone\` / \`curl\` in package build scripts have no internet on a firewalled HPC node otherwise. No-op when no proxy is set.

2. **\`pkg-config\`** added to \`builtin.compress_libs\`'s apt deps. \`libpressio\`'s CMake calls \`find_package(PkgConfig)\` and aborts:
\`\`\`
CMake Error at FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
\`\`\`
Affects every container-mode use of compress_libs through the apptainer-native build path (likely first time exercised by the iowarp work).

## Aurora context
Surfaced while building the iowarp+apptainer SIF on Aurora. Aurora's compute nodes have outbound HTTPS only via \`proxy.alcf.anl.gov:3128\`; without the proxy forwarding, every \`apt-get update\` in the SIF \`%post\` hangs on connection. The pkg-config gap is independent of the site.

## Test plan
- [x] iowarp_apptainer_test.yaml SIF builds cleanly on Aurora compute node \`x4305c0s6b0n0\` after both fixes (~12 min: HDF5 → ADIOS2 → compress_libs → wrp_runtime). Resulting 509 MB SIF runs gray-scott through the IOWarp ADIOS2 engine.
- [ ] No-op verification on a non-HPC build host (no proxy env set → \`.def\` produced is byte-for-byte identical except for the pkg-config line in compress_libs).

## Relationship to other PRs
- #136 (apptainer instance:// wrap) — independent; both needed for the iowarp+apptainer flow but neither requires the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)