### PR TITLE
MPI cpu_bind support + apptainer instance exec + Aurora portability fixes

### DIFF
--- a/builtin/builtin/nyx/sycl/Dockerfile.deploy
+++ b/builtin/builtin/nyx/sycl/Dockerfile.deploy
@@ -1,0 +1,37 @@
+FROM ##BUILD_IMAGE## AS builder
+FROM ##DEPLOY_BASE##
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        openmpi-bin libopenmpi3 \
+        openssh-server openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pre-built Nyx HydroTests binary
+COPY --from=builder /opt/Nyx/build/Exec/HydroTests/nyx_HydroTests \
+                    /opt/Nyx/build/Exec/HydroTests/nyx_HydroTests
+
+# Input files and sample decks needed by the test suite
+COPY --from=builder /opt/Nyx/Exec/HydroTests /opt/Nyx/Exec/HydroTests
+
+# Recreate symlink lost in multi-stage copy
+RUN ln -sf /opt/Nyx/build/Exec/HydroTests/nyx_HydroTests /usr/bin/nyx_HydroTests
+
+# Device-selector env vars (written by build.sh into /etc/environment;
+# Dockerfile layers don't source /etc/environment, so set them explicitly).
+ENV ONEAPI_DEVICE_SELECTOR=level_zero:gpu
+ENV SYCL_DEVICE_FILTER=level_zero:gpu
+
+# Generate SSH keys so all containers from this image share the same identity
+RUN mkdir -p /var/run/sshd /root/.ssh \
+    && ssh-keygen -A \
+    && ssh-keygen -t ed25519 -N "" -f /root/.ssh/id_ed25519 \
+    && cat /root/.ssh/id_ed25519.pub >> /root/.ssh/authorized_keys \
+    && chmod 700 /root/.ssh \
+    && chmod 600 /root/.ssh/authorized_keys \
+    && printf "StrictHostKeyChecking no\nUserKnownHostsFile /dev/null\n" >> /root/.ssh/config \
+    && chmod 600 /root/.ssh/config
+
+ENV PATH=/opt/Nyx/build/Exec/HydroTests:${PATH}
+
+EXPOSE 22
+CMD ["/bin/bash"]

--- a/builtin/builtin/nyx/sycl/build.sh
+++ b/builtin/builtin/nyx/sycl/build.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+# Build Nyx (AMReX HydroTests) with Intel SYCL backend (JIT mode).
+# Base image: intel/oneapi-hpckit (provides icpx, Level Zero loader, impi).
+set -e
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Base build tooling + OpenMPI + SSH server for multi-node MPI-over-SSH.
+#
+# Intel GPU runtime (intel-opencl-icd, libze-intel-gpu1, libze1) is
+# REQUIRED because intel/oneapi-hpckit ships the SYCL compiler (icpx) and
+# Level Zero *loader* (libze_loader.so) but NOT the Level Zero GPU
+# *backend* (libze_intel_gpu.so). Without the backend, zeDriverGet()
+# returns zero devices and SYCL reports "no GPU available" at runtime.
+#
+# The kernel i915 driver <-> user-mode runtime ABI is stable across
+# versions, so a container-shipped Level Zero 1.3.x runtime works fine
+# with Aurora's host i915 kernel driver (1.6.x). No host library binds
+# are needed at run time. See apptainer/apptainer#1592.
+apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates git cmake build-essential gfortran gnupg wget \
+    openmpi-bin libopenmpi-dev \
+    openssh-server openssh-client
+
+# Intel GPU user-mode runtime (Level Zero + OpenCL) from Intel's APT repo.
+# Ubuntu 24.04's universe repo does not ship these packages.
+#
+# CAREFUL: the intel/oneapi-hpckit base image ALREADY configures the Intel
+# GPU apt repo, but with a different keyring path
+# (/usr/share/keyrings/intel-graphics-archive-keyring.gpg). If we add our
+# own entry at a different path, `apt-get update` errors with:
+#   E: Conflicting values set for option Signed-By regarding source
+#      https://repositories.intel.com/gpu/ubuntu/ noble
+#   E: The list of sources could not be read.
+# ...and subsequent apt-get install for Intel-GPU packages is silently
+# skipped — apptainer's %post runs under /bin/sh, which does NOT honor
+# the `set -e` from the script's #!/bin/bash header, so this failure
+# was previously silent.
+#
+# Fix: explicitly purge any pre-existing Intel GPU repo entries (both
+# sources.list.d files and their keyrings) before adding our own single
+# entry. Then verify the GPU packages actually landed.
+set -e
+rm -f /etc/apt/sources.list.d/intel-gpu*.list \
+      /etc/apt/sources.list.d/intel-graphics*.list \
+      /usr/share/keyrings/intel-graphics-archive-keyring.gpg \
+      /usr/share/keyrings/intel-graphics.gpg
+wget -qO- https://repositories.intel.com/gpu/intel-graphics.key \
+    | gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg
+echo 'deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu noble unified' \
+    > /etc/apt/sources.list.d/intel-gpu-noble.list
+apt-get update
+# Intel renamed the Level Zero GPU backend packages in early 2024:
+#   OLD (pre-2024): intel-level-zero-gpu  (dep: libigc1,  libigdfcl1)
+#   NEW (current):  libze-intel-gpu1      (dep: libigc2,  libigdfcl2)
+# Intel's current noble/unified repo ships only the NEW packages; the
+# OLD `intel-level-zero-gpu` meta is still listed but its dependencies
+# were dropped, so installing it fails with "unmet dependencies".
+apt-get install -y --no-install-recommends \
+    intel-opencl-icd libze-intel-gpu1 libze1
+# Fail fast if the GPU runtime didn't actually land (catches silent apt
+# failures under apptainer's sh-based %post).
+for _pkg in libze-intel-gpu1 libze1 intel-opencl-icd; do
+  dpkg -s "$_pkg" >/dev/null 2>&1 || {
+    echo "ERROR: required Intel GPU runtime package '$_pkg' missing after apt install" >&2
+    exit 1
+  }
+done
+# Sanity: the Level Zero GPU backend .so must be on the image.
+ldconfig -p | grep -q 'libze_intel_gpu\.so\.1' || {
+  echo "ERROR: libze_intel_gpu.so.1 not in ldconfig cache after install" >&2
+  find /usr -name 'libze_intel_gpu*' 2>&1 >&2 || true
+  exit 1
+}
+rm -rf /var/lib/apt/lists/*
+
+# SSH setup (mirrors other builtin packages)
+mkdir -p /var/run/sshd /root/.ssh \
+    && ssh-keygen -A \
+    && ssh-keygen -t ed25519 -N "" -f /root/.ssh/id_ed25519 \
+    && cat /root/.ssh/id_ed25519.pub >> /root/.ssh/authorized_keys \
+    && chmod 700 /root/.ssh \
+    && chmod 600 /root/.ssh/authorized_keys \
+    && sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    && sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config \
+    && printf "StrictHostKeyChecking no\nUserKnownHostsFile /dev/null\n" >> /etc/ssh/ssh_config
+
+# Clone Nyx with AMReX submodule. AMReX 'development' branch carries the
+# most up-to-date SYCL support.
+git clone --recursive https://github.com/AMReX-Astro/Nyx.git /opt/Nyx \
+    && cd /opt/Nyx/subprojects/amrex && git checkout development
+
+# Patch Nyx's CMakeLists.txt: Nyx historically force-disables MPI when
+# Nyx_GPU_BACKEND=SYCL via cmake_dependent_option:
+#
+#   cmake_dependent_option( Nyx_MPI  "Enable MPI"  ON
+#      "NOT Nyx_GPU_BACKEND STREQUAL SYCL" OFF)
+#
+# This cascades into AMReX_MPI=OFF (see NyxSetupAMReX.cmake line 103,
+# `set(AMReX_MPI ${Nyx_MPI} ...)`), producing a non-MPI binary even when
+# -DNyx_MPI=YES is passed on the command line — cmake_dependent_option's
+# FORCE semantics override user -D flags.
+#
+# Modern AMReX SYCL + OpenMPI works fine on Intel PVC, so drop the
+# SYCL dependency and make Nyx_MPI a plain option defaulting to ON.
+cd /opt/Nyx
+python3 - <<'PY'
+import re, pathlib
+p = pathlib.Path('/opt/Nyx/CMakeLists.txt')
+src = p.read_text()
+new = re.sub(
+    r'cmake_dependent_option\(\s*Nyx_MPI\s+"Enable MPI"\s+ON\s*\n\s*"NOT Nyx_GPU_BACKEND STREQUAL SYCL"\s+OFF\)',
+    'option( Nyx_MPI  "Enable MPI"  ON )',
+    src,
+)
+if new == src:
+    raise SystemExit("ERROR: Nyx_MPI cmake_dependent_option pattern not found for patching")
+p.write_text(new)
+PY
+grep -n 'Nyx_MPI' /opt/Nyx/CMakeLists.txt | head -3
+
+# MPI selection (critical on Aurora inside apptainer):
+#   The intel/oneapi-hpckit image ships Intel MPI 2021.14 in PATH. CMake's
+#   FindMPI would pick Intel MPI's mpicxx by default, linking against
+#   /opt/intel/oneapi/mpi/2021.14/lib/libmpi.so.12. At runtime inside a
+#   rootless apptainer container, Intel MPI fails because:
+#     a) Its open_fabric() needs a libfabric OFI provider — Aurora's
+#        /opt/cray/libfabric is on the host only, not in the container.
+#     b) Its Hydra launcher auto-detects PBS and tries to read
+#        $PBS_NODEFILE which doesn't exist inside the container.
+#   Force CMake to use the apt-installed OpenMPI instead. OpenMPI bundles
+#   PMIx and uses BTL shared-memory on one node, so it works in a plain
+#   rootless apptainer container with zero host binds.
+unset I_MPI_ROOT I_MPI_OFI_LIBRARY_INTERNAL I_MPI_FABRICS I_MPI_PMI
+unset MPI_ROOT MPI_HOME MPICC_PROFILE
+# oneAPI's setvars.sh adds /opt/intel/oneapi/mpi/*/include to CPATH, which
+# beats CMake's explicit -I/usr/.../openmpi/include (CPATH is searched
+# before explicit -I by the preprocessor). With Intel MPI's mpi.h,
+# MPICH_NUMVERSION>=40000000 is defined, causing AMReX's
+# ParallelDescriptor to compile a call to MPIX_GPU_query_support —
+# a MPICH 4.0+ GPU-aware MPI extension absent from OpenMPI. At link
+# time we'd get: "undefined reference to MPIX_GPU_query_support".
+# Remove every Intel MPI entry from CPATH / LIBRARY_PATH / LD_LIBRARY_PATH
+# so the compiler sees only OpenMPI's mpi.h.
+_scrub() { echo "${1:-}" | tr ':' '\n' | grep -v '/opt/intel/oneapi/mpi/' | paste -sd: ; }
+export CPATH="$(_scrub "${CPATH:-}")"
+export LIBRARY_PATH="$(_scrub "${LIBRARY_PATH:-}")"
+export LD_LIBRARY_PATH="$(_scrub "${LD_LIBRARY_PATH:-}")"
+unset _scrub
+export MPI_HOME=/usr/lib/x86_64-linux-gnu/openmpi
+export CMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/openmpi:${CMAKE_PREFIX_PATH:-}
+# Verify /usr/bin/mpicxx is OpenMPI's, not Intel MPI's.
+mpicxx_show=$(/usr/bin/mpicxx -show 2>&1 || true)
+if echo "$mpicxx_show" | grep -q '/opt/intel/oneapi/mpi'; then
+  echo "ERROR: /usr/bin/mpicxx is NOT the apt-installed OpenMPI wrapper" >&2
+  echo "       (got: $mpicxx_show)" >&2
+  exit 1
+fi
+
+# Build Nyx HydroTests with AMReX SYCL backend (JIT, not AOT).
+#
+# JIT vs AOT for Intel GPU:
+#   - AOT (AMReX_SYCL_AOT=YES + AMReX_INTEL_ARCH=pvc) calls ocloc at
+#     build time to generate PVC-specific GPU code. The oneapi-hpckit
+#     image ships icpx but NOT ocloc/llvm-foreach, so AOT fails.
+#   - JIT (default) compiles to portable SPIR-V bitcode; the Level Zero
+#     runtime translates SPIR-V to native PVC code on first kernel
+#     launch and caches the result.
+#
+# OpenMP is suppressed at two layers:
+#   1. -DNyx_OMP=NO tells AMReX not to enable OpenMP, so AMReX's CMake
+#      does not call find_package(OpenMP) internally.
+#   2. -DCMAKE_DISABLE_FIND_PACKAGE_OpenMP=TRUE is a belt-and-suspenders
+#      guard: if any submodule calls find_package(OpenMP) anyway, it
+#      returns "not found" instead of injecting -fiopenmp. -fiopenmp
+#      combined with SYCL flags breaks AMReX's compiler flag check.
+cd /opt/Nyx
+cmake -S . -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DNyx_MPI=YES \
+    -DNyx_OMP=NO \
+    -DNyx_HYDRO=YES \
+    -DNyx_HEATCOOL=NO \
+    -DNyx_GPU_BACKEND=SYCL \
+    -DAMReX_GPU_BACKEND=SYCL \
+    -DAMReX_PRECISION=SINGLE \
+    -DAMReX_PARTICLES_PRECISION=SINGLE \
+    -DCMAKE_CXX_COMPILER=icpx \
+    -DMPI_C_COMPILER=/usr/bin/mpicc \
+    -DMPI_CXX_COMPILER=/usr/bin/mpicxx \
+    -DMPIEXEC_EXECUTABLE=/usr/bin/mpiexec \
+    -DMPI_HOME=/usr/lib/x86_64-linux-gnu/openmpi \
+    -DCMAKE_DISABLE_FIND_PACKAGE_OpenMP=TRUE
+cmake --build build --target nyx_HydroTests -j"${BUILD_JOBS:-4}"
+
+# Sanity check: linked binary must not reference Intel MPI.
+if ldd /opt/Nyx/build/Exec/HydroTests/nyx_HydroTests 2>/dev/null \
+     | grep -q '/opt/intel/oneapi/mpi/'; then
+  echo "ERROR: nyx_HydroTests built against Intel MPI despite MPI_*_COMPILER overrides" >&2
+  ldd /opt/Nyx/build/Exec/HydroTests/nyx_HydroTests | grep -i mpi >&2
+  exit 1
+fi
+
+ln -sf /opt/Nyx/build/Exec/HydroTests/nyx_HydroTests /usr/bin/nyx_HydroTests
+
+# Runtime env for EVERY `apptainer exec/shell/run` invocation. Apptainer
+# sources /.singularity.d/env/*.sh alphabetically at container entry; a
+# 99-* script runs last and can override the image's default ENV.
+#
+# Key constraints:
+#   1. /usr/bin MUST precede /opt/intel/oneapi/mpi/... on PATH so the
+#      apt-installed OpenMPI `mpiexec` is found (not Intel MPI's Hydra,
+#      which doesn't work in a rootless apptainer).
+#   2. LD_LIBRARY_PATH must include the icpx SYCL + Level Zero runtime
+#      dirs so libsycl.so.8, libur_loader.so.0, and libiomp5.so are
+#      resolvable at Nyx startup.
+#   3. ONEAPI_DEVICE_SELECTOR=level_zero:gpu pins the Level Zero GPU
+#      devices and hides the OpenCL CPU/GPU aliases so AMReX selects
+#      the Level Zero PVC device, not the OpenCL alias (which has
+#      known PVC JIT issues).
+#
+# SYCL_DEVICE_FILTER is intentionally NOT set: deprecated in DPC++ 2024+.
+mkdir -p /.singularity.d/env
+cat > /.singularity.d/env/99-sycl.sh <<'EOF'
+export PATH="/usr/bin:/opt/Nyx/build/Exec/HydroTests:/opt/intel/oneapi/compiler/2025.0/bin:/opt/intel/oneapi/mkl/2025.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/sbin:/bin"
+export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/2025.0/lib:/opt/intel/oneapi/mkl/2025.0/lib:/opt/intel/oneapi/tbb/2025.0/lib/intel64/gcc4.8:${LD_LIBRARY_PATH:-}"
+export LIBRARY_PATH="/opt/intel/oneapi/compiler/2025.0/lib:${LIBRARY_PATH:-}"
+export ONEAPI_DEVICE_SELECTOR=level_zero:gpu
+# Disable OpenMPI's CMA (process_vm_readv) single-copy intra-node
+# transfer. CMA requires PTRACE_MODE_ATTACH_REALCREDS which fails under
+# apptainer's unprivileged user namespace, printing `Read -1, expected
+# N, errno = 14` for every intra-node transfer. OpenMPI falls back to
+# plain shmem copy-in/copy-out so runs complete correctly but the log
+# is flooded. Using `none` forces the fallback up front.
+export OMPI_MCA_btl_vader_single_copy_mechanism=none
+EOF
+chmod +x /.singularity.d/env/99-sycl.sh
+
+# Propagate the same env via sshd SetEnv for SSH-based multi-node runs
+# (jarvis's Apptainer deploy mode opens an SSH session into the container
+# instance on each remote host; that session is launched by sshd with
+# UsePAM=no, which strips /etc/environment and ~/.profile).
+cat > /etc/ssh/sshd_config.d/99-sycl.conf <<'EOF'
+SetEnv PATH=/usr/bin:/opt/Nyx/build/Exec/HydroTests:/opt/intel/oneapi/compiler/2025.0/bin:/opt/intel/oneapi/mkl/2025.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/sbin:/bin
+SetEnv LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/2025.0/lib:/opt/intel/oneapi/mkl/2025.0/lib:/opt/intel/oneapi/tbb/2025.0/lib/intel64/gcc4.8
+SetEnv ONEAPI_DEVICE_SELECTOR=level_zero:gpu
+SetEnv OMPI_MCA_btl_vader_single_copy_mechanism=none
+EOF
+
+export PATH=/opt/Nyx/build/Exec/HydroTests:${PATH}

--- a/builtin/pipelines/portability/aurora/mca-params/README.md
+++ b/builtin/pipelines/portability/aurora/mca-params/README.md
@@ -1,0 +1,116 @@
+# Aurora multi-node MPI tuning files
+
+User-level MPI tuning required to run any jarvis Aurora pipeline at
+**>32 nodes** inside the apptainer container.
+
+## What's here
+
+| File | Goes to | Layer |
+|---|---|---|
+| `openmpi-mca-params.conf` | `~/.openmpi/mca-params.conf` | OpenMPI runtime |
+| `pmix-mca-params.conf`    | `~/.pmix/mca-params.conf`    | PMIx runtime (separate library) |
+
+Both files are read automatically by the relevant library at startup.
+Apptainer bind-mounts your `$HOME` into the container, so the files
+appear at the same paths inside the container without any code changes
+or SIF rebuild.
+
+## Install
+
+From any login node or compute node:
+
+```bash
+mkdir -p ~/.openmpi ~/.pmix
+cp builtin/pipelines/portability/aurora/mca-params/openmpi-mca-params.conf ~/.openmpi/mca-params.conf
+cp builtin/pipelines/portability/aurora/mca-params/pmix-mca-params.conf ~/.pmix/mca-params.conf
+```
+
+That's it. Future jarvis multi-node runs pick the files up automatically.
+
+## Remove
+
+```bash
+rm ~/.openmpi/mca-params.conf ~/.pmix/mca-params.conf
+```
+
+Reverts to OpenMPI/PMIx defaults. (Multi-node runs at <=32 nodes still
+work without these files; only larger scales need them.)
+
+## What problem they solve
+
+Two stacked failures during `MPI_Init` at 64+ nodes (384+ ranks):
+
+1. **TCP wireup explosion.** Aurora compute nodes expose 8 HSN
+   interfaces (`hsn0`–`hsn7`) plus a bonded management ethernet.
+   OpenMPI defaults to advertising every available IP on every
+   interface, producing ~1.3 M peer-to-peer TCP connection attempts
+   at 384 ranks. Wireup never finishes; MPI_Init hangs and the job
+   dies at walltime. Fix: `btl_tcp_if_include = hsn0` (and
+   `oob_tcp_if_include`) in the OpenMPI file restricts to one HSN.
+
+2. **PMIx GDS shmem fault.** The system libpmix.so.2 in the Ubuntu
+   24.04 container fails inside `gds_shmem.c` at 384 ranks with
+   `PMIX_ERR_NOMEM` (despite `/dev/shm` being 504 GB and empty),
+   then segfaults in the cleanup path. Fix: `gds = ^shmem` in the
+   PMIx file forces the hash backend (heap memory), bypassing the
+   broken code path.
+
+## Why two separate files
+
+OpenMPI and PMIx are two different libraries with two **separate**
+MCA frameworks. The `gds` parameter only takes effect via the
+PMIx-layer file (`~/.pmix/mca-params.conf`). Setting `gds = hash`
+in the OpenMPI file is silently ignored — OpenMPI's MCA parser
+doesn't know about that framework.
+
+We verified this experimentally during debugging: putting the GDS
+exclusion in the OpenMPI file changed nothing; moving it to the
+PMIx file is what actually disabled shmem.
+
+## Validation
+
+64-node Nyx run on Aurora with both files in place:
+
+| Metric | Value |
+|---|---|
+| MPI ranks | 384 |
+| SYCL devices initialized | 384 / 384 |
+| Wall time | 86 s |
+| Volume written | 2.16 TiB |
+| I/O fraction | 81 % |
+| All PVC tiles peak HBM | 97–101 GiB (uniform) |
+
+Same configuration without the files: hangs in `MPI_Init` for >480 s
+and is killed by PBS walltime. Zero kernels execute, zero bytes
+written.
+
+## What does NOT need patching
+
+- No source code in `jarvis-cd` needs modification.
+- No SIF rebuild required.
+- No environment variables to export.
+
+The repo's existing `jarvis_cd/shell/exec_factory.py` already injects
+the necessary launch-time `--mca` flags (`plm rsh`, `plm_rsh_no_tree_spawn`,
+`routed direct`, `plm_rsh_num_concurrent`) for multi-node bring-up.
+These tuning files complement those; both layers are needed at
+64+ nodes.
+
+## Per-parameter rationale
+
+Each line in both files has an inline comment explaining the
+specific problem it addresses, the cost when omitted, and the cost
+of the workaround. Read the files themselves for details.
+
+## When to re-tune
+
+These settings are conservative — they should work from 32 to ~512
+nodes without modification. If you scale to >512 nodes and still hit
+issues, candidate next levers:
+
+- Spread BTL across two HSN interfaces (`btl_tcp_if_include = hsn0,hsn1`)
+  for higher aggregate bandwidth at the cost of doubling wireup count.
+- Increase `plm_rsh_num_concurrent` (currently overridden to 32 by
+  `exec_factory.py`).
+- Investigate libfabric/OFI-based PMI on the host instead of containerized
+  TCP-only OpenMPI.

--- a/builtin/pipelines/portability/aurora/mca-params/openmpi-mca-params.conf
+++ b/builtin/pipelines/portability/aurora/mca-params/openmpi-mca-params.conf
@@ -1,0 +1,60 @@
+# OpenMPI MCA tuning for Aurora apptainer multi-node runs at >32 nodes.
+#
+# INSTALL:
+#   mkdir -p ~/.openmpi
+#   cp openmpi-mca-params.conf ~/.openmpi/mca-params.conf
+#
+# REMOVE:
+#   rm ~/.openmpi/mca-params.conf
+#
+# Effect: scoped to your user, applied automatically by every mpiexec
+# the moment it starts — no source code patches, no SIF rebuild.
+#
+# WHY: at 64+ nodes (384+ ranks) inside the apptainer container, the
+# OpenMPI default of advertising every available IP on every TCP-capable
+# interface causes the BTL/OOB wireup to attempt 384^2 * 9 ≈ 1.3M
+# TCP connections during MPI_Init. The connection storm hangs forever.
+# Pinning to a single HSN interface (and one TCP link per peer) drops
+# this to ~73K connections, which finishes in seconds.
+#
+# Validated: 64-node Nyx, 384 ranks, 1024^3 grid, 86 s wall, 81% I/O
+# fraction, all 384 PVC tiles utilized at ~98 GiB peak HBM.
+
+# --- Synchronous PMIx modex ----------------------------------------
+# Async modex requires a working PMIx GDS shmem store, which is broken
+# at scale on Ubuntu 24.04 system libpmix.so.2 (see pmix-mca-params.conf
+# for the GDS workaround). With sync modex + GDS hash backend the
+# combination is reliable.
+pmix_base_async_modex = 0
+async_mpi_init = 0
+
+# --- Skip BTLs unavailable inside rootless apptainer ---------------
+# self = intra-rank loopback. tcp = inter-rank.
+# vader is auto-disabled for single-copy by exec_factory.py because
+# CMA breaks under unprivileged user namespaces.
+btl = self,tcp
+
+# --- Restrict TCP to a SINGLE HSN interface ------------------------
+# Aurora compute nodes expose 8 HSN interfaces (hsn0-hsn7) plus
+# bond0/management. By default OpenMPI advertises and tries to
+# connect on all 9 interfaces from every rank, which multiplies
+# wireup connection count by 9 at scale. Pin to one HSN interface
+# for both BTL (data) and OOB (out-of-band coordination).
+btl_tcp_if_include = hsn0
+oob_tcp_if_include = hsn0
+
+# --- Single TCP link per peer (default 4) --------------------------
+# Cuts the per-pair connection count by another 4x.
+btl_tcp_links = 1
+
+# --- Skip IPv6 (the container has IPv6 link-locals we don't need) --
+btl_tcp_disable_family = IPv6
+oob_tcp_disable_family = IPv6
+
+# --- Explicit PML; skip auto-select probe loop ---------------------
+pml = ob1
+
+# --- More parallel SSH launches at startup -------------------------
+# (exec_factory.py sets 32 on the cmd line, which overrides this
+# file value. Kept here for documentation.)
+plm_rsh_num_concurrent = 64

--- a/builtin/pipelines/portability/aurora/mca-params/pmix-mca-params.conf
+++ b/builtin/pipelines/portability/aurora/mca-params/pmix-mca-params.conf
@@ -1,0 +1,29 @@
+# PMIx MCA tuning for Aurora apptainer multi-node runs at >32 nodes.
+#
+# INSTALL:
+#   mkdir -p ~/.pmix
+#   cp pmix-mca-params.conf ~/.pmix/mca-params.conf
+#
+# REMOVE:
+#   rm ~/.pmix/mca-params.conf
+#
+# This file is read by libpmix.so.2 directly (NOT by OpenMPI). It is a
+# separate config from ~/.openmpi/mca-params.conf — the gds= parameter
+# only takes effect via the PMIx-layer file.
+#
+# WHY: at 384 ranks the system libpmix.so.2 (Ubuntu 24.04, OpenMPI 4.1.6
+# bundle) returns PMIX_ERR_NOMEM from gds_shmem.c and segfaults in the
+# error-cleanup path during the rank-info exchange phase of MPI_Init.
+# The error message implies /dev/shm is full, but on Aurora the
+# container /dev/shm is 504 GB and effectively empty — this is a
+# buggy code path in PMIx that the shmem backend triggers at scale.
+# Excluding the shmem backend forces PMIx to use the hash backend
+# (in-process heap memory), which is unaffected.
+
+# --- Disable PMIx GDS shmem backend --------------------------------
+gds = ^shmem
+
+# --- Verbose level for component selection -------------------------
+# Set to 10 to see which gds module PMIx selects (logs ~400 MB per
+# 64-node run via stderr aggregation; only enable when debugging).
+gds_base_verbose = 0

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -4,6 +4,7 @@ Provides the consolidated Pipeline class that combines pipeline creation, loadin
 """
 
 import os
+import shlex
 import socket
 import yaml
 import copy
@@ -1998,7 +1999,25 @@ class Pipeline:
             ssh_port = self.container_ssh_port
 
             nv_flag = '--nv ' if getattr(self, 'container_gpu', False) else ''
+            # Pipeline yaml's `env:` block lands in self.env, but PSSH ssh's
+            # to each compute node strip the head-node env, so the apptainer
+            # instance launches with default env. Re-export the pipeline env
+            # vars on the compute node side as APPTAINERENV_<NAME> so they
+            # propagate inside the apptainer instance and reach every
+            # process spawned inside (including chimaera daemon and gray-
+            # scott ranks). Skip vars that would corrupt the container env
+            # (PATH, LD_*, HOME, USER, container-local mounts).
+            env_skip = {'PATH', 'LD_LIBRARY_PATH', 'LD_PRELOAD', 'HOME',
+                        'USER', 'PWD', 'OLDPWD', 'SHELL', 'TERM', 'TMPDIR',
+                        'APPTAINER_TMPDIR', 'PYTHONPATH'}
+            env_exports = ' '.join(
+                f'APPTAINERENV_{k}={shlex.quote(str(v))}'
+                for k, v in (self.env or {}).items()
+                if k not in env_skip and not k.startswith('_')
+                and not k.startswith('SLURM_') and not k.startswith('PBS_')
+            )
             start_cmd = (
+                f"{env_exports} "
                 f"apptainer instance start {nv_flag}--writable-tmpfs {sif_path} {instance_name}"
                 f" && apptainer exec {nv_flag}instance://{instance_name}"
                 f" /usr/sbin/sshd -p {ssh_port}"

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -69,11 +69,51 @@ class Pipeline:
         """True when every host in the hostfile is this machine (or hostfile
         is empty). Used to pick LocalExecInfo over PsshExecInfo for
         single-node/local runs without requiring sshd on :22. Real cluster
-        hostfiles contain remote hostnames and return False."""
+        hostfiles contain remote hostnames and return False.
+
+        On HPC like Aurora a hostfile can contain a domain alias the bare
+        gethostname doesn't match (e.g. x4305c5s0b0n0.hsn.cm.aurora.alcf...
+        while gethostname() returns x4305c5s0b0n0). Match by resolved IP
+        against every IP bound on this machine to handle multi-rail HSN.
+        """
         if not hf or len(hf) == 0:
             return True
         local_names = {'localhost', '127.0.0.1', socket.gethostname()}
-        return all(h in local_names for h in hf.hosts)
+        try:
+            local_names.add(socket.getfqdn())
+        except Exception:
+            pass
+        local_ips = set()
+        try:
+            local_ips.add(socket.gethostbyname('localhost'))
+        except socket.gaierror:
+            pass
+        try:
+            _, _, ips = socket.gethostbyname_ex(socket.gethostname())
+            local_ips.update(ips)
+        except socket.gaierror:
+            pass
+        # gethostbyname_ex on the bare hostname returns only the primary IP,
+        # not every NIC. On multi-rail HSN systems (Aurora's Slingshot has
+        # 8 hsn0..hsn7 interfaces) the hostfile entry can resolve to a
+        # secondary NIC IP we'd otherwise miss. Enumerate all bound IPs.
+        try:
+            import subprocess
+            out = subprocess.run(['hostname', '-I'], capture_output=True,
+                                 text=True, timeout=2)
+            local_ips.update(out.stdout.split())
+        except Exception:
+            pass
+        for h in hf.hosts:
+            if h in local_names:
+                continue
+            try:
+                if socket.gethostbyname(h) in local_ips:
+                    continue
+            except socket.gaierror:
+                pass
+            return False
+        return True
 
     def is_containerized(self) -> bool:
         """
@@ -1718,6 +1758,21 @@ class Pipeline:
             val = os.environ.get(var)
             if val:
                 def_content += f"export {var}={val}\n"
+        # Aurora's outbound HTTP proxy can reach most hosts but
+        # archive.ubuntu.com / security.ubuntu.com / *.ubuntu.com hang
+        # indefinitely (observed 2026-04-30). Swap apt sources to a
+        # public mirror that the proxy CAN reach so apt-get update
+        # doesn't block forever during SIF build. Override via
+        # JARVIS_APT_MIRROR=<host> if a different one is preferred.
+        apt_mirror = os.environ.get(
+            'JARVIS_APT_MIRROR', 'mirror.cs.uchicago.edu')
+        def_content += (
+            f"sed -ri 's|https?://(archive|security|[a-z]{{2}}\\.archive)\\.ubuntu\\.com|http://{apt_mirror}|g' "
+            "/etc/apt/sources.list "
+            "/etc/apt/sources.list.d/*.list "
+            "/etc/apt/sources.list.d/*.sources "
+            "2>/dev/null || true\n"
+        )
         def_content += '\n'.join(build_scripts)
         def_content += "\n\n%environment\n"
         def_content += f"export PATH={env_path_str}\n"

--- a/jarvis_cd/shell/exec_factory.py
+++ b/jarvis_cd/shell/exec_factory.py
@@ -45,12 +45,12 @@ class Exec(CoreExec):
         gpu = self.exec_info.gpu
         env = dict(self.exec_info.env) if self.exec_info.env else {}
 
-        # For apptainer, resolve the SIF path from shared_dir (accessible on all nodes)
-        if c == 'apptainer' and self.exec_info.shared_dir and self.exec_info.container_image:
-            from pathlib import Path
-            # The .sif lives in the pipeline shared dir (parent of the
-            # per-package shared dir).
-            img = str(Path(self.exec_info.shared_dir).parent / f'{self.exec_info.container_image}.sif')
+        # For apptainer, target the running instance started by
+        # _start_containerized_pipeline (instance name == pipeline name ==
+        # deploy_image_name), so daemons spawned by Service.start() (e.g.
+        # chimaera/iowarp runtime) persist across subsequent exec calls.
+        if c == 'apptainer' and self.exec_info.container_image:
+            img = f'instance://{self.exec_info.container_image}'
         else:
             img = self.exec_info.container_image or ''
 

--- a/jarvis_cd/shell/exec_info.py
+++ b/jarvis_cd/shell/exec_info.py
@@ -37,7 +37,7 @@ class ExecInfo:
                  strict_ssh=False, timeout=None,
                  container='none', gpu=False, container_image=None,
                  shared_dir=None, private_dir=None, bind_mounts=None,
-                 dry_run=False,
+                 dry_run=False, cpu_bind=None,
                  **kwargs):
         """
         Initialize execution information.
@@ -106,6 +106,11 @@ class ExecInfo:
         self.private_dir = private_dir
         self.bind_mounts = bind_mounts or []
         self.dry_run = dry_run
+        # Optional MPI cpu-binding spec (passed through to mpicmd as
+        # --cpu-bind=list:<cpu_bind>). Aurora's official 12-rank socket-
+        # balanced pattern is e.g. "1-8:9-16:...:93-100"; any string ZMQ
+        # mpiexec accepts works.
+        self.cpu_bind = cpu_bind
 
         # Basic environment for process execution (without LD_PRELOAD)
         # This is used for launching MPI itself, not the MPI processes
@@ -128,7 +133,7 @@ class ExecInfo:
                      'exec_async', 'stdin', 'strict_ssh', 'timeout',
                      'container', 'gpu', 'container_image',
                      'shared_dir', 'private_dir', 'bind_mounts',
-                     'dry_run']:
+                     'dry_run', 'cpu_bind']:
             current_attrs[attr] = getattr(self, attr)
 
         # Update with new values

--- a/jarvis_cd/shell/mpi_exec.py
+++ b/jarvis_cd/shell/mpi_exec.py
@@ -29,6 +29,7 @@ class LocalMpiExec(LocalExec):
         self.hostfile = exec_info.hostfile or Hostfile(hosts=['localhost'])
         self.mpi_env = exec_info.env
         self.ssh_port = exec_info.port if exec_info.port else None
+        self.cpu_bind = getattr(exec_info, 'cpu_bind', None)
 
         # Process command format
         if isinstance(cmd, str):
@@ -123,6 +124,10 @@ class OpenMpiExec(LocalMpiExec):
         if self.ppn is not None:
             params.append(f'-npernode {self.ppn}')
 
+        # CPU binding (Aurora canonical socket-balanced list, etc.)
+        if self.cpu_bind:
+            params.append(f'--cpu-bind=list:{self.cpu_bind}')
+
         if len(self.hostfile):
             if self.hostfile.path is None:
                 params.append(f'--host {",".join(self.hostfile.hosts)}')
@@ -173,6 +178,10 @@ class MpichExec(LocalMpiExec):
 
         if self.ppn is not None:
             params.append(f'-ppn {self.ppn}')
+
+        # CPU binding (Aurora canonical socket-balanced list, etc.)
+        if self.cpu_bind:
+            params.append(f'--cpu-bind=list:{self.cpu_bind}')
 
         if len(self.hostfile):
             if self.hostfile.path is None:
@@ -227,6 +236,10 @@ class CrayMpichExec(LocalMpiExec):
 
         if self.ppn is not None:
             params.append(f'--ppn {self.ppn}')
+
+        # CPU binding (Aurora canonical socket-balanced list, etc.)
+        if self.cpu_bind:
+            params.append(f'--cpu-bind=list:{self.cpu_bind}')
 
         if len(self.hostfile):
             if (self.hostfile.hosts[0] == 'localhost' and

--- a/jarvis_cd/shell/mpi_exec.py
+++ b/jarvis_cd/shell/mpi_exec.py
@@ -124,9 +124,29 @@ class OpenMpiExec(LocalMpiExec):
         if self.ppn is not None:
             params.append(f'-npernode {self.ppn}')
 
-        # CPU binding (Aurora canonical socket-balanced list, etc.)
+        # CPU binding. cpu_bind is provided in MPICH/Cray-PALS list syntax
+        # ("1-8:9-16:...:93-100"). OpenMPI does NOT accept that syntax;
+        # translate to its native --map-by ppr:R:socket:PE=W --bind-to core
+        # form. We assume a balanced layout: equal ranks per socket, equal
+        # PE (cores per rank). The cores reserved for system services
+        # (Aurora cores 0/52/104/156) end up unused as a side effect of
+        # PE=cores_per_rank not consuming the lower-end-of-socket spare
+        # cores.
         if self.cpu_bind:
-            params.append(f'--cpu-bind=list:{self.cpu_bind}')
+            slots = self.cpu_bind.split(':')
+            n = len(slots)
+            # Cores per rank from the first slot (e.g. "1-8" -> 8).
+            try:
+                a, b = slots[0].split('-')
+                pe = int(b) - int(a) + 1
+            except ValueError:
+                pe = 1
+            # Aurora has 2 sockets; balanced layout puts n/2 ranks/socket.
+            ppr_per_socket = max(1, n // 2)
+            params.append(
+                f'--map-by ppr:{ppr_per_socket}:socket:PE={pe} '
+                f'--bind-to core'
+            )
 
         if len(self.hostfile):
             if self.hostfile.path is None:


### PR DESCRIPTION
## Summary

Stack of jarvis-cd fixes that make the iowarp + gray-scott pipeline run end-to-end on Aurora apptainer at multi-node scale. Pairs with iowarp/clio-core PR #400.

## Key commits

- **\`f0800c5\` mpi_exec: translate cpu_bind list to OpenMPI --map-by syntax** — OpenMPI rejects \`--cpu-bind=list:<R0>:<R1>:...\` ("unknown option"). Aurora's canonical socket-balanced spec passed verbatim breaks every container run at mpiexec startup. Translate to \`--map-by ppr:N/2:socket:PE=W --bind-to core\` for OpenMPI; keep the original for MPICH/Cray/Intel-MPI.
- **\`3f6a9ec\` mpi_exec: thread MpiExecInfo.cpu_bind through to mpiexec --cpu-bind=list:** — adds the \`cpu_bind\` field on ExecInfo (preserved by .mod()) and emits it in OpenMPI / MPICH / Cray-MPICH mpicmd builders.
- **\`a39219d\` apptainer: exec into the running instance, not the SIF** — the per-package start path was \`apptainer exec <sif>\` which spins up a new container per command instead of using the long-running \`apptainer instance start\`. Switched to \`apptainer exec instance://<name>\`.
- **\`089f908\` apptainer-native build: forward proxy env + add pkg-config** — \`apptainer build --fakeroot\` runs without inheriting host env; HTTP/S proxy and pkg-config were missing inside %post.
- **Various Aurora pipeline + portability adds** (NYX SYCL builds, openmpi-mca-params, hostfile.is_local extension)

## Test plan

- [x] 2-node \`iowarp_apptainer_test\` on Aurora — gray-scott completes 10 steps with IowarpEngine writing through chimaera CTE
- [ ] Scaling sweep 2..1024 (in progress, gpu_hack queue)
- [ ] CI on non-Aurora clusters confirms cpu_bind and instance-exec are no-op when their inputs are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)