### PR TITLE
feat!: publish durable execution and package progress contracts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,20 +7,61 @@ on:
     branches: [ main, dev ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
+  progress-provider-compatibility:
+    name: Progress provider (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: false
+          version: "0.11.28"
+
+      - name: Exercise the package-owned provider
+        shell: bash
+        run: |
+          uv lock --check
+          uv run --frozen pytest -q test/unit/core/test_lammps_progress.py
+
   test:
     runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: false
+          version: "0.11.28"
 
       - name: Install system dependencies
         run: bash ci/install_deps.sh
@@ -32,14 +73,14 @@ jobs:
         run: bash ci/run_tests.sh
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: coverage-report
           path: htmlcov/
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         if: always()
         with:
           files: coverage.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,208 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build and attest release artifacts
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+
+    steps:
+      - name: Check out exact tag
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: false
+
+      - name: Run release-contract tests
+        shell: bash
+        run: |
+          uv run pytest -q \
+            test/unit/core/test_lammps_progress.py \
+            test/unit/core/test_scheduler_submission.py \
+            test/unit/core/test_pipeline_hostfile.py
+
+      - name: Build and inspect distributions
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          test "$GITHUB_REF_TYPE" = "tag"
+          test "$(git rev-list -n 1 "$TAG_NAME")" = "$GITHUB_SHA"
+          uv build
+          uvx --from 'twine==6.2.0' twine check dist/*
+          mapfile -t wheels < <(find dist -maxdepth 1 -type f -name '*.whl' -print | sort)
+          mapfile -t sdists < <(find dist -maxdepth 1 -type f -name '*.tar.gz' -print | sort)
+          test "${#wheels[@]}" -eq 1
+          test "${#sdists[@]}" -eq 1
+          python - "${wheels[0]}" "${TAG_NAME#v}" <<'PY'
+          import email
+          import sys
+          import zipfile
+
+          wheel, expected_version = sys.argv[1:]
+          with zipfile.ZipFile(wheel) as archive:
+              metadata_names = [
+                  name for name in archive.namelist() if name.endswith('.dist-info/METADATA')
+              ]
+              if len(metadata_names) != 1:
+                  raise SystemExit('wheel must contain exactly one METADATA file')
+              metadata = email.message_from_bytes(archive.read(metadata_names[0]))
+          if metadata['Name'] != 'jarvis_cd' or metadata['Version'] != expected_version:
+              raise SystemExit(
+                  f"tag/wheel mismatch: {metadata['Name']} {metadata['Version']}"
+              )
+          PY
+
+      - name: Smoke installed wheel and progress entry point
+        shell: bash
+        run: |
+          wheel="$(find dist -maxdepth 1 -type f -name '*.whl' -print -quit)"
+          uv venv --python 3.11 .release-smoke
+          uv pip install --python .release-smoke/bin/python "$wheel"
+          .release-smoke/bin/python - <<'PY'
+          from importlib.metadata import entry_points
+
+          from jarvis_cd.progress.lammps import adapter_from_package
+
+          selected = entry_points().select(
+              group='clio_relay.package_progress_adapters',
+              name='jarvis_lammps',
+          )
+          if len(selected) != 1:
+              raise SystemExit('jarvis_lammps entry point is missing or duplicated')
+          if selected[0].value != 'jarvis_cd.progress.lammps:adapter_from_package':
+              raise SystemExit(f'unexpected entry point target: {selected[0].value}')
+          adapter = adapter_from_package(
+              {'pkg_type': 'builtin.lammps', 'progress': {'total_steps': 10}}
+          )
+          if adapter is None or adapter.adapter_name != 'lammps':
+              raise SystemExit('installed LAMMPS progress provider is not functional')
+          PY
+
+      - name: Create release manifest
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          python - "$TAG_NAME" "$GITHUB_SHA" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          tag, commit = sys.argv[1:]
+          Path('dist/release-metadata.json').write_text(
+              json.dumps(
+                  {
+                      'schema_version': '1.0',
+                      'tag': tag,
+                      'version': tag.removeprefix('v'),
+                      'source_commit': commit,
+                      'progress_entry_point': {
+                          'group': 'clio_relay.package_progress_adapters',
+                          'name': 'jarvis_lammps',
+                          'value': 'jarvis_cd.progress.lammps:adapter_from_package',
+                      },
+                  },
+                  indent=2,
+                  sort_keys=True,
+              )
+              + '\n',
+              encoding='utf-8',
+          )
+          PY
+          (
+            cd dist
+            sha256sum --binary ./*.whl ./*.tar.gz release-metadata.json > SHA256SUMS
+            sha256sum --check --strict SHA256SUMS
+          )
+
+      - name: Attest release artifacts and metadata
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4
+        with:
+          subject-checksums: dist/SHA256SUMS
+
+      - name: Upload release bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: jarvis-cd-${{ github.ref_name }}
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
+            dist/release-metadata.json
+            dist/SHA256SUMS
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub release
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      attestations: read
+
+    steps:
+      - name: Download release bundle
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: jarvis-cd-${{ github.ref_name }}
+          path: dist
+
+      - name: Verify bundle and provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          TAG_NAME: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          (cd dist && sha256sum --check --strict SHA256SUMS)
+          for subject in dist/*.whl dist/*.tar.gz dist/release-metadata.json; do
+            gh attestation verify "$subject" \
+              --repo "$REPOSITORY" \
+              --signer-workflow "$REPOSITORY/.github/workflows/release.yml" \
+              --source-ref "refs/tags/$TAG_NAME" \
+              --source-digest "$GITHUB_SHA" \
+              --deny-self-hosted-runners
+          done
+
+      - name: Publish immutable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          TAG_NAME: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          if gh release view "$TAG_NAME" --repo "$REPOSITORY" >/dev/null 2>&1; then
+            echo "release already exists: $TAG_NAME" >&2
+            exit 1
+          fi
+          gh release create "$TAG_NAME" \
+            dist/*.whl dist/*.tar.gz dist/release-metadata.json dist/SHA256SUMS \
+            --repo "$REPOSITORY" \
+            --verify-tag \
+            --title "$TAG_NAME" \
+            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,24 @@ concurrency:
 permissions: {}
 
 jobs:
+  release-preflight:
+    name: Preflight immutable release enforcement
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - name: Require repository-enforced immutable releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          test "$(gh api "repos/$REPOSITORY/immutable-releases" --jq .enabled)" = true
+
   build:
     name: Build and attest release artifacts
+    needs: release-preflight
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -46,7 +62,8 @@ jobs:
             test/unit/core/test_lammps_progress.py \
             test/unit/core/test_lammps_package_runtime.py \
             test/unit/core/test_scheduler_submission.py \
-            test/unit/core/test_pipeline_hostfile.py
+            test/unit/core/test_pipeline_hostfile.py \
+            test/unit/test_release_workflow.py
 
       - name: Build and inspect distributions
         env:
@@ -241,32 +258,119 @@ jobs:
             test "$type" = "commit"
             printf '%s\n' "$sha"
           }
-          if gh release view "$TAG_NAME" --repo "$REPOSITORY" >/dev/null 2>&1; then
-            echo "release already exists: $TAG_NAME" >&2
+          test "$(resolve_remote_tag)" = "$GITHUB_SHA"
+          test "$(gh api "repos/$REPOSITORY/immutable-releases" --jq .enabled)" = true
+          (cd dist && sha256sum --check --strict SHA256SUMS)
+
+          mapfile -t artifacts < <(
+            find dist -maxdepth 1 -type f -printf '%f\n' | sort
+          )
+          test "${#artifacts[@]}" -eq 5
+          declare -A expected_sha=()
+          wheel_count=0
+          sdist_count=0
+          for name in "${artifacts[@]}"; do
+            [[ "$name" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]*$ ]]
+            case "$name" in
+              *.whl) wheel_count=$((wheel_count + 1)) ;;
+              *.tar.gz) sdist_count=$((sdist_count + 1)) ;;
+              release-metadata.json|runtime-requirements.txt|SHA256SUMS) ;;
+              *) echo "unexpected local release artifact: $name" >&2; exit 1 ;;
+            esac
+            expected_sha["$name"]="$(sha256sum "dist/$name" | cut -d' ' -f1)"
+          done
+          test "$wheel_count" -eq 1
+          test "$sdist_count" -eq 1
+          [[ -v 'expected_sha[release-metadata.json]' ]]
+          [[ -v 'expected_sha[runtime-requirements.txt]' ]]
+          [[ -v 'expected_sha[SHA256SUMS]' ]]
+
+          release_tmp="$(mktemp -d)"
+          trap 'rm -rf "$release_tmp"' EXIT
+          release_json="$release_tmp/release.json"
+          release_error="$release_tmp/release.error"
+
+          fetch_release() {
+            gh api "repos/$REPOSITORY/releases/tags/$TAG_NAME" >"$release_json"
+            test "$(jq -r .tag_name "$release_json")" = "$TAG_NAME"
+          }
+
+          load_and_verify_assets() {
+            local allow_missing="$1" id name declared_digest downloaded
+            declare -gA asset_ids=()
+            while IFS=$'\t' read -r id name declared_digest; do
+              [[ "$name" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]*$ ]]
+              if [[ ! -v "expected_sha[$name]" ]]; then
+                echo "unexpected release asset: $name" >&2
+                return 1
+              fi
+              if [[ -v "asset_ids[$name]" ]]; then
+                echo "duplicate release asset: $name" >&2
+                return 1
+              fi
+              if [ -n "$declared_digest" ] && \
+                 [ "$declared_digest" != "sha256:${expected_sha[$name]}" ]; then
+                echo "release asset digest mismatch: $name" >&2
+                return 1
+              fi
+              asset_ids["$name"]="$id"
+            done < <(
+              jq -r '.assets[] | [.id, .name, (.digest // "")] | @tsv' \
+                "$release_json"
+            )
+
+            for name in "${artifacts[@]}"; do
+              if [[ ! -v "asset_ids[$name]" ]]; then
+                if [ "$allow_missing" = true ]; then
+                  gh release upload "$TAG_NAME" "dist/$name" --repo "$REPOSITORY"
+                  continue
+                fi
+                echo "missing release asset: $name" >&2
+                return 1
+              fi
+              downloaded="$release_tmp/download-$name"
+              gh api \
+                -H 'Accept: application/octet-stream' \
+                "repos/$REPOSITORY/releases/assets/${asset_ids[$name]}" \
+                >"$downloaded"
+              cmp --silent "dist/$name" "$downloaded"
+            done
+          }
+
+          if fetch_release 2>"$release_error"; then
+            :
+          elif grep -Fq 'HTTP 404' "$release_error"; then
+            gh release create "$TAG_NAME" \
+              --repo "$REPOSITORY" \
+              --verify-tag \
+              --title "$TAG_NAME" \
+              --generate-notes \
+              --draft
+            fetch_release
+          else
+            cat "$release_error" >&2
             exit 1
           fi
+
+          draft="$(jq -r .draft "$release_json")"
+          immutable="$(jq -r .immutable "$release_json")"
+          if [ "$draft" = true ]; then
+            test "$immutable" = false
+            load_and_verify_assets true
+            fetch_release
+            load_and_verify_assets false
+            test "$(resolve_remote_tag)" = "$GITHUB_SHA"
+            gh release edit "$TAG_NAME" --repo "$REPOSITORY" --draft=false
+          else
+            test "$immutable" = true
+            load_and_verify_assets false
+          fi
+
           test "$(resolve_remote_tag)" = "$GITHUB_SHA"
-          gh release create "$TAG_NAME" \
-            --repo "$REPOSITORY" \
-            --verify-tag \
-            --title "$TAG_NAME" \
-            --generate-notes \
-            --draft
-          gh release upload "$TAG_NAME" \
-            dist/*.whl \
-            dist/*.tar.gz \
-            dist/release-metadata.json \
-            dist/runtime-requirements.txt \
-            dist/SHA256SUMS \
-            --repo "$REPOSITORY"
-          test "$(resolve_remote_tag)" = "$GITHUB_SHA"
-          gh release edit "$TAG_NAME" \
-            --repo "$REPOSITORY" \
-            --draft=false
-          test "$(gh release view "$TAG_NAME" \
-            --repo "$REPOSITORY" \
-            --json isImmutable \
-            --jq .isImmutable)" = true
+          fetch_release
+          test "$(jq -r .draft "$release_json")" = false
+          test "$(jq -r .immutable "$release_json")" = true
+          load_and_verify_assets false
           verified=false
           for attempt in {1..12}; do
             if gh release verify "$TAG_NAME" --repo "$REPOSITORY"; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,18 +241,10 @@ jobs:
             test "$type" = "commit"
             printf '%s\n' "$sha"
           }
-          require_immutable_releases() {
-            test "$(gh api \
-              -H 'Accept: application/vnd.github+json' \
-              -H 'X-GitHub-Api-Version: 2026-03-10' \
-              "repos/$REPOSITORY/immutable-releases" \
-              --jq .enabled)" = true
-          }
           if gh release view "$TAG_NAME" --repo "$REPOSITORY" >/dev/null 2>&1; then
             echo "release already exists: $TAG_NAME" >&2
             exit 1
           fi
-          require_immutable_releases
           test "$(resolve_remote_tag)" = "$GITHUB_SHA"
           gh release create "$TAG_NAME" \
             --repo "$REPOSITORY" \
@@ -267,7 +259,6 @@ jobs:
             dist/runtime-requirements.txt \
             dist/SHA256SUMS \
             --repo "$REPOSITORY"
-          require_immutable_releases
           test "$(resolve_remote_tag)" = "$GITHUB_SHA"
           gh release edit "$TAG_NAME" \
             --repo "$REPOSITORY" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           test "$(git rev-list -n 1 "$TAG_NAME")" = "$GITHUB_SHA"
           git fetch --no-tags origin \
             +refs/heads/main:refs/remotes/origin/main
-          git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main
+          test "$GITHUB_SHA" = "$(git rev-parse refs/remotes/origin/main)"
           uv build
           uv run --frozen twine check dist/*
           uv export --quiet --frozen \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-      artifact-metadata: write
 
     steps:
       - name: Check out exact tag
@@ -34,15 +33,18 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
+          version: "0.11.28"
 
       - name: Run release-contract tests
         shell: bash
         run: |
-          uv run pytest -q \
+          uv lock --check
+          uv run --frozen pytest -q \
             test/unit/core/test_lammps_progress.py \
+            test/unit/core/test_lammps_package_runtime.py \
             test/unit/core/test_scheduler_submission.py \
             test/unit/core/test_pipeline_hostfile.py
 
@@ -53,8 +55,17 @@ jobs:
         run: |
           test "$GITHUB_REF_TYPE" = "tag"
           test "$(git rev-list -n 1 "$TAG_NAME")" = "$GITHUB_SHA"
+          git fetch --no-tags origin \
+            +refs/heads/main:refs/remotes/origin/main
+          git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main
           uv build
-          uvx --from 'twine==6.2.0' twine check dist/*
+          uv run --frozen twine check dist/*
+          uv export --quiet --frozen \
+            --no-dev \
+            --no-emit-project \
+            --format requirements.txt \
+            --output-file dist/runtime-requirements.txt
+          test -s dist/runtime-requirements.txt
           mapfile -t wheels < <(find dist -maxdepth 1 -type f -name '*.whl' -print | sort)
           mapfile -t sdists < <(find dist -maxdepth 1 -type f -name '*.tar.gz' -print | sort)
           test "${#wheels[@]}" -eq 1
@@ -83,18 +94,24 @@ jobs:
         run: |
           wheel="$(find dist -maxdepth 1 -type f -name '*.whl' -print -quit)"
           uv venv --python 3.11 .release-smoke
-          uv pip install --python .release-smoke/bin/python "$wheel"
-          .release-smoke/bin/python - <<'PY'
+          uv pip install \
+            --python .release-smoke/bin/python \
+            --require-hashes \
+            --requirements dist/runtime-requirements.txt
+          uv pip install --python .release-smoke/bin/python --no-deps "$wheel"
+          (
+          cd .release-smoke
+          bin/python - <<'PY'
           from importlib.metadata import entry_points
 
           from jarvis_cd.progress.lammps import adapter_from_package
 
           selected = entry_points().select(
               group='clio_relay.package_progress_adapters',
-              name='jarvis_lammps',
+              name='lammps',
           )
           if len(selected) != 1:
-              raise SystemExit('jarvis_lammps entry point is missing or duplicated')
+              raise SystemExit('lammps entry point is missing or duplicated')
           if selected[0].value != 'jarvis_cd.progress.lammps:adapter_from_package':
               raise SystemExit(f'unexpected entry point target: {selected[0].value}')
           adapter = adapter_from_package(
@@ -102,7 +119,10 @@ jobs:
           )
           if adapter is None or adapter.adapter_name != 'lammps':
               raise SystemExit('installed LAMMPS progress provider is not functional')
+          exec(adapter.package_load_probe_python(), {})
           PY
+          )
+          .release-smoke/bin/jarvis --help >/dev/null
 
       - name: Create release manifest
         env:
@@ -124,9 +144,10 @@ jobs:
                       'source_commit': commit,
                       'progress_entry_point': {
                           'group': 'clio_relay.package_progress_adapters',
-                          'name': 'jarvis_lammps',
+                          'name': 'lammps',
                           'value': 'jarvis_cd.progress.lammps:adapter_from_package',
                       },
+                      'runtime_lock': 'runtime-requirements.txt',
                   },
                   indent=2,
                   sort_keys=True,
@@ -137,7 +158,11 @@ jobs:
           PY
           (
             cd dist
-            sha256sum --binary ./*.whl ./*.tar.gz release-metadata.json > SHA256SUMS
+            sha256sum --binary \
+              ./*.whl \
+              ./*.tar.gz \
+              release-metadata.json \
+              runtime-requirements.txt > SHA256SUMS
             sha256sum --check --strict SHA256SUMS
           )
 
@@ -154,6 +179,7 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
             dist/release-metadata.json
+            dist/runtime-requirements.txt
             dist/SHA256SUMS
           if-no-files-found: error
 
@@ -180,7 +206,11 @@ jobs:
         shell: bash
         run: |
           (cd dist && sha256sum --check --strict SHA256SUMS)
-          for subject in dist/*.whl dist/*.tar.gz dist/release-metadata.json; do
+          for subject in \
+            dist/*.whl \
+            dist/*.tar.gz \
+            dist/release-metadata.json \
+            dist/runtime-requirements.txt; do
             gh attestation verify "$subject" \
               --repo "$REPOSITORY" \
               --signer-workflow "$REPOSITORY/.github/workflows/release.yml" \
@@ -196,13 +226,63 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
         shell: bash
         run: |
+          resolve_remote_tag() {
+            local sha type
+            read -r sha type < <(
+              gh api "repos/$REPOSITORY/git/ref/tags/$TAG_NAME" \
+                --jq '[.object.sha, .object.type] | @tsv'
+            )
+            while [ "$type" = "tag" ]; do
+              read -r sha type < <(
+                gh api "repos/$REPOSITORY/git/tags/$sha" \
+                  --jq '[.object.sha, .object.type] | @tsv'
+              )
+            done
+            test "$type" = "commit"
+            printf '%s\n' "$sha"
+          }
+          require_immutable_releases() {
+            test "$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "repos/$REPOSITORY/immutable-releases" \
+              --jq .enabled)" = true
+          }
           if gh release view "$TAG_NAME" --repo "$REPOSITORY" >/dev/null 2>&1; then
             echo "release already exists: $TAG_NAME" >&2
             exit 1
           fi
+          require_immutable_releases
+          test "$(resolve_remote_tag)" = "$GITHUB_SHA"
           gh release create "$TAG_NAME" \
-            dist/*.whl dist/*.tar.gz dist/release-metadata.json dist/SHA256SUMS \
             --repo "$REPOSITORY" \
             --verify-tag \
             --title "$TAG_NAME" \
-            --generate-notes
+            --generate-notes \
+            --draft
+          gh release upload "$TAG_NAME" \
+            dist/*.whl \
+            dist/*.tar.gz \
+            dist/release-metadata.json \
+            dist/runtime-requirements.txt \
+            dist/SHA256SUMS \
+            --repo "$REPOSITORY"
+          require_immutable_releases
+          test "$(resolve_remote_tag)" = "$GITHUB_SHA"
+          gh release edit "$TAG_NAME" \
+            --repo "$REPOSITORY" \
+            --draft=false
+          test "$(gh release view "$TAG_NAME" \
+            --repo "$REPOSITORY" \
+            --json isImmutable \
+            --jq .isImmutable)" = true
+          verified=false
+          for attempt in {1..12}; do
+            if gh release verify "$TAG_NAME" --repo "$REPOSITORY"; then
+              verified=true
+              break
+            fi
+            echo "release attestation not ready (attempt $attempt/12)" >&2
+            sleep 5
+          done
+          test "$verified" = true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,134 @@ permissions: {}
 
 jobs:
   release-preflight:
-    name: Preflight immutable release enforcement
+    name: Validate exact release request
     runs-on: ubuntu-24.04
     permissions:
+      actions: read
       contents: read
+    outputs:
+      request: ${{ steps.request.outputs.request }}
 
     steps:
-      - name: Require repository-enforced immutable releases
+      - name: Check out exact tag request validator
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Verify protected release controls
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_ACTOR: ${{ github.actor }}
           REPOSITORY: ${{ github.repository }}
         shell: bash
         run: |
-          test "$(gh api "repos/$REPOSITORY/immutable-releases" --jq .enabled)" = true
+          case "$RELEASE_ACTOR" in
+            JaimeCernuda|akougkas|iameneko|lukemartinlogan) ;;
+            *) echo "tag actor is not an approved release administrator" >&2; exit 1 ;;
+          esac
+          controls="$(mktemp -d)"
+          trap 'rm -rf "$controls"' EXIT
+          for release_admin in \
+            JaimeCernuda \
+            akougkas \
+            iameneko \
+            lukemartinlogan; do
+            gh api "repos/$REPOSITORY/collaborators/$release_admin/permission" \
+              > "$controls/permission-$release_admin.json"
+            jq -e \
+              '.permission == "admin" and .role_name == "admin"' \
+              "$controls/permission-$release_admin.json" >/dev/null
+          done
+          gh api "repos/$REPOSITORY/environments/immutable-release" \
+            > "$controls/environment.json"
+          gh api \
+            "repos/$REPOSITORY/environments/immutable-release/deployment-branch-policies?per_page=100" \
+            > "$controls/environment-policies.json"
+          jq -e '
+            .can_admins_bypass == false
+            and .deployment_branch_policy == {
+              "custom_branch_policies": true,
+              "protected_branches": false
+            }
+            and (
+              [.protection_rules[] | select(.type == "required_reviewers")]
+              | length
+            ) == 1
+            and (
+              .protection_rules[]
+              | select(.type == "required_reviewers")
+              | .prevent_self_review == true
+              and ([.reviewers[].reviewer.login] | sort) == [
+                "akougkas",
+                "iameneko",
+                "lukemartinlogan"
+              ]
+            )
+          ' "$controls/environment.json" >/dev/null
+          jq -e '
+            .total_count == 1
+            and .branch_policies == [{
+              "id": 54450144,
+              "name": "v*",
+              "node_id": "MDE2OkdhdGVCcmFuY2hQb2xpY3k1NDQ1MDE0NA==",
+              "type": "tag"
+            }]
+          ' "$controls/environment-policies.json" >/dev/null
+
+          mapfile -t immutable_ruleset_ids < <(
+            gh api "repos/$REPOSITORY/rulesets?per_page=100" --jq \
+              '.[] | select(.name == "Protect immutable version tags") | .id'
+          )
+          mapfile -t creation_ruleset_ids < <(
+            gh api "repos/$REPOSITORY/rulesets?per_page=100" --jq \
+              '.[] | select(.name == "Restrict immutable version tag creation") | .id'
+          )
+          test "${#immutable_ruleset_ids[@]}" -eq 1
+          test "${#creation_ruleset_ids[@]}" -eq 1
+          gh api "repos/$REPOSITORY/rulesets/${immutable_ruleset_ids[0]}" \
+            > "$controls/immutable-ruleset.json"
+          gh api "repos/$REPOSITORY/rulesets/${creation_ruleset_ids[0]}" \
+            > "$controls/creation-ruleset.json"
+          jq -e '
+            .target == "tag"
+            and .enforcement == "active"
+            and .conditions.ref_name == {
+              "exclude": [],
+              "include": ["refs/tags/v*"]
+            }
+            and ([.rules[].type] | sort) == ["deletion", "update"]
+          ' "$controls/immutable-ruleset.json" >/dev/null
+          jq -e '
+            .target == "tag"
+            and .enforcement == "active"
+            and .conditions.ref_name == {
+              "exclude": [],
+              "include": ["refs/tags/v*"]
+            }
+            and [.rules[].type] == ["creation"]
+          ' "$controls/creation-ruleset.json" >/dev/null
+
+      - name: Require fresh exact release request
+        id: request
+        env:
+          RELEASE_REQUEST: ${{ vars.JARVIS_RELEASE_REQUEST }}
+          REPOSITORY: ${{ github.repository }}
+          TAG_NAME: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          request="$(
+            printf '%s\n' "$RELEASE_REQUEST" | python ci/release_request.py \
+              --repository "$REPOSITORY" \
+              --tag "$TAG_NAME" \
+              --commit "$GITHUB_SHA" \
+              --max-age-seconds 3600
+          )"
+          printf 'request=%s\n' "$request" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build and attest release artifacts
@@ -63,6 +178,7 @@ jobs:
             test/unit/core/test_lammps_package_runtime.py \
             test/unit/core/test_scheduler_submission.py \
             test/unit/core/test_pipeline_hostfile.py \
+            test/unit/test_release_request.py \
             test/unit/test_release_workflow.py
 
       - name: Build and inspect distributions
@@ -143,15 +259,18 @@ jobs:
 
       - name: Create release manifest
         env:
+          RELEASE_REQUEST: ${{ needs.release-preflight.outputs.request }}
           TAG_NAME: ${{ github.ref_name }}
         shell: bash
         run: |
           python - "$TAG_NAME" "$GITHUB_SHA" <<'PY'
           import json
+          import os
           import sys
           from pathlib import Path
 
           tag, commit = sys.argv[1:]
+          release_request = json.loads(os.environ['RELEASE_REQUEST'])
           Path('dist/release-metadata.json').write_text(
               json.dumps(
                   {
@@ -159,6 +278,7 @@ jobs:
                       'tag': tag,
                       'version': tag.removeprefix('v'),
                       'source_commit': commit,
+                      'release_request': release_request,
                       'progress_entry_point': {
                           'group': 'clio_relay.package_progress_adapters',
                           'name': 'lammps',
@@ -204,11 +324,23 @@ jobs:
     name: Publish GitHub release
     needs: build
     runs-on: ubuntu-24.04
+    environment: immutable-release
     permissions:
       contents: write
       attestations: read
 
     steps:
+      - name: Check out exact tag request validator
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
       - name: Download release bundle
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -236,6 +368,39 @@ jobs:
               --deny-self-hosted-runners
           done
 
+      - name: Revalidate fresh request and current main
+        env:
+          REPOSITORY: ${{ github.repository }}
+          TAG_NAME: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          git fetch --no-tags origin \
+            +refs/heads/main:refs/remotes/origin/main
+          test "$GITHUB_SHA" = "$(git rev-parse refs/remotes/origin/main)"
+          request="$(python - dist/release-metadata.json "$TAG_NAME" "$GITHUB_SHA" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          path, tag, commit = sys.argv[1:]
+          metadata = json.loads(Path(path).read_text(encoding='utf-8'))
+          if metadata.get('tag') != tag or metadata.get('source_commit') != commit:
+              raise SystemExit('release metadata does not match the exact tag commit')
+          request = metadata.get('release_request')
+          if not isinstance(request, dict):
+              raise SystemExit('release metadata has no request record')
+          print(json.dumps(request, ensure_ascii=True, separators=(',', ':'), sort_keys=True))
+          PY
+          )"
+          validated="$(
+            printf '%s\n' "$request" | python ci/release_request.py \
+              --repository "$REPOSITORY" \
+              --tag "$TAG_NAME" \
+              --commit "$GITHUB_SHA" \
+              --max-age-seconds 3600
+          )"
+          test "$validated" = "$request"
+
       - name: Publish immutable release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -259,7 +424,6 @@ jobs:
             printf '%s\n' "$sha"
           }
           test "$(resolve_remote_tag)" = "$GITHUB_SHA"
-          test "$(gh api "repos/$REPOSITORY/immutable-releases" --jq .enabled)" = true
           (cd dist && sha256sum --check --strict SHA256SUMS)
 
           mapfile -t artifacts < <(
@@ -289,10 +453,19 @@ jobs:
           trap 'rm -rf "$release_tmp"' EXIT
           release_json="$release_tmp/release.json"
           release_error="$release_tmp/release.error"
+          release_body="JARVIS-CD $TAG_NAME immutable release."
 
           fetch_release() {
             gh api "repos/$REPOSITORY/releases/tags/$TAG_NAME" >"$release_json"
-            test "$(jq -r .tag_name "$release_json")" = "$TAG_NAME"
+            jq -e \
+              --arg tag "$TAG_NAME" \
+              --arg body "$release_body" '
+                .tag_name == $tag
+                and .name == $tag
+                and .body == $body
+                and .prerelease == false
+                and .author.login == "github-actions[bot]"
+              ' "$release_json" >/dev/null
           }
 
           load_and_verify_assets() {
@@ -344,7 +517,8 @@ jobs:
               --repo "$REPOSITORY" \
               --verify-tag \
               --title "$TAG_NAME" \
-              --generate-notes \
+              --notes "$release_body" \
+              --latest \
               --draft
             fetch_release
           else
@@ -360,7 +534,10 @@ jobs:
             fetch_release
             load_and_verify_assets false
             test "$(resolve_remote_tag)" = "$GITHUB_SHA"
-            gh release edit "$TAG_NAME" --repo "$REPOSITORY" --draft=false
+            gh release edit "$TAG_NAME" \
+              --repo "$REPOSITORY" \
+              --draft=false \
+              --latest
           else
             test "$immutable" = true
             load_and_verify_assets false
@@ -370,6 +547,8 @@ jobs:
           fetch_release
           test "$(jq -r .draft "$release_json")" = false
           test "$(jq -r .immutable "$release_json")" = true
+          test "$(gh api "repos/$REPOSITORY/releases/latest" --jq .tag_name)" = \
+            "$TAG_NAME"
           load_and_verify_assets false
           verified=false
           for attempt in {1..12}; do

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "awesome-scienctific-applications"]
 	path = awesome-scienctific-applications
-	url = git@github.com:grc-iit/awesome-scienctific-applications.git
+	url = https://github.com/grc-iit/awesome-scienctific-applications.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "awesome-scienctific-applications"]
-	path = awesome-scienctific-applications
-	url = https://github.com/grc-iit/awesome-scienctific-applications.git

--- a/builtin/builtin/ior/pkg.py
+++ b/builtin/builtin/ior/pkg.py
@@ -4,6 +4,7 @@ Ior is a benchmark tool for measuring the performance of I/O systems.
 It is a simple tool that can be used to measure the performance of a file system.
 It is mainly targeted for HPC systems and parallel I/O.
 """
+
 import os
 import pathlib
 import re
@@ -29,82 +30,82 @@ class Ior(Application):
         """
         return [
             {
-                'name': 'write',
-                'msg': 'Perform a write workload',
-                'type': bool,
-                'default': True,
-                'choices': [],
-                'args': [],
+                "name": "write",
+                "msg": "Perform a write workload",
+                "type": bool,
+                "default": True,
+                "choices": [],
+                "args": [],
             },
             {
-                'name': 'read',
-                'msg': 'Perform a read workload',
-                'type': bool,
-                'default': False,
+                "name": "read",
+                "msg": "Perform a read workload",
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'xfer',
-                'msg': 'The size of data transfer',
-                'type': str,
-                'default': '1m',
+                "name": "xfer",
+                "msg": "The size of data transfer",
+                "type": str,
+                "default": "1m",
             },
             {
-                'name': 'block',
-                'msg': 'Amount of data to generate per-process',
-                'type': str,
-                'default': '32m',
-                'aliases': ['block_size']
+                "name": "block",
+                "msg": "Amount of data to generate per-process",
+                "type": str,
+                "default": "32m",
+                "aliases": ["block_size"],
             },
             {
-                'name': 'api',
-                'msg': 'The I/O api to use',
-                'type': str,
-                'choices': ['posix', 'mpiio', 'hdf5'],
-                'default': 'posix',
+                "name": "api",
+                "msg": "The I/O api to use",
+                "type": str,
+                "choices": ["posix", "mpiio", "hdf5"],
+                "default": "posix",
             },
             {
-                'name': 'fpp',
-                'msg': 'Use file-per-process',
-                'type': bool,
-                'default': False,
+                "name": "fpp",
+                "msg": "Use file-per-process",
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'reps',
-                'msg': 'Number of times to repeat',
-                'type': int,
-                'default': 1,
+                "name": "reps",
+                "msg": "Number of times to repeat",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'nprocs',
-                'msg': 'Number of processes',
-                'type': int,
-                'default': 1,
+                "name": "nprocs",
+                "msg": "Number of processes",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'ppn',
-                'msg': 'The number of processes per node',
-                'type': int,
-                'default': 16,
+                "name": "ppn",
+                "msg": "The number of processes per node",
+                "type": int,
+                "default": 16,
             },
             {
-                'name': 'out',
-                'msg': 'Path to the output file',
-                'type': str,
-                'default': '/tmp/ior.bin',
-                'aliases': ['output']
+                "name": "out",
+                "msg": "Path to the output file",
+                "type": str,
+                "default": "/tmp/ior.bin",
+                "aliases": ["output"],
             },
             {
-                'name': 'log',
-                'msg': 'Path to IOR output log',
-                'type': str,
-                'default': '',
+                "name": "log",
+                "msg": "Path to IOR output log",
+                "type": str,
+                "default": "",
             },
             {
-                'name': 'direct',
-                'msg': 'Use direct I/O (O_DIRECT) for POSIX API, bypassing I/O buffers',
-                'type': bool,
-                'default': False,
-            }
+                "name": "direct",
+                "msg": "Use direct I/O (O_DIRECT) for POSIX API, bypassing I/O buffers",
+                "type": bool,
+                "default": False,
+            },
         ]
 
     # ------------------------------------------------------------------
@@ -112,22 +113,28 @@ class Ior(Application):
     # ------------------------------------------------------------------
 
     def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+        if self.config.get("deploy_mode") != "container":
             return None
-        base = getattr(self.pipeline, 'container_base', 'ubuntu:24.04')
-        content = self._read_build_script('build.sh', {
-            'BASE_IMAGE': base,
-        })
-        return content, 'mpi'
+        base = getattr(self.pipeline, "container_base", "ubuntu:24.04")
+        content = self._read_build_script(
+            "build.sh",
+            {
+                "BASE_IMAGE": base,
+            },
+        )
+        return content, "mpi"
 
     def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+        if self.config.get("deploy_mode") != "container":
             return None
-        suffix = getattr(self, '_build_suffix', '')
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': 'ubuntu:24.04',
-        })
+        suffix = getattr(self, "_build_suffix", "")
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {
+                "BUILD_IMAGE": self.build_image_name(),
+                "DEPLOY_BASE": "ubuntu:24.04",
+            },
+        )
         return content, suffix
 
     # ------------------------------------------------------------------
@@ -149,18 +156,27 @@ class Ior(Application):
         # Default the log path to <shared_dir>/ior.log so _get_stat has
         # something to parse even when the YAML omits `log:`. Users who
         # set `log:` explicitly keep their override.
-        if not self.config.get('log'):
-            self.config['log'] = str(pathlib.Path(self.shared_dir) / 'ior.log')
+        if not self.config.get("log"):
+            self.config["log"] = str(pathlib.Path(self.shared_dir) / "ior.log")
 
-        if self.config.get('deploy_mode') == 'default':
-            self.config['api'] = self.config['api'].upper()
+        if self.config.get("deploy_mode") == "default":
+            self.config["api"] = self.config["api"].upper()
 
             # Create parent directory of output file on all nodes
-            out = os.path.expandvars(self.config['out'])
+            out = os.path.expandvars(self.config["out"])
             parent_dir = str(pathlib.Path(out).parent)
-            Mkdir(parent_dir,
-                  PsshExecInfo(env=self.mod_env,
-                               hostfile=self.hostfile)).run()
+            hostfile = self.hostfile
+            if hostfile is None or hostfile.is_local():
+                pathlib.Path(parent_dir).mkdir(parents=True, exist_ok=True)
+            else:
+                Mkdir(
+                    parent_dir,
+                    PsshExecInfo(
+                        env=self.mod_env,
+                        hostfile=hostfile,
+                        timeout=30,
+                    ),
+                ).run()
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -171,44 +187,51 @@ class Ior(Application):
         cfg = self.config
 
         cmd = [
-            'ior',
-            '-k',
-            f'-b {cfg["block"]}',
-            f'-t {cfg["xfer"]}',
-            f'-a {cfg["api"].upper()}',
-            f'-o {cfg["out"]}',
+            "ior",
+            "-k",
+            f"-b {cfg['block']}",
+            f"-t {cfg['xfer']}",
+            f"-a {cfg['api'].upper()}",
+            f"-o {cfg['out']}",
         ]
-        if cfg.get('write', True):
-            cmd.append('-w')
-        if cfg.get('read'):
-            cmd.append('-r')
-        if cfg.get('fpp'):
-            cmd.append('-F')
-        if cfg.get('reps', 1) > 1:
-            cmd.append(f'-i {cfg["reps"]}')
-        if cfg.get('direct'):
-            cmd.append('-O useO_DIRECT=1')
+        if cfg.get("write", True):
+            cmd.append("-w")
+        if cfg.get("read"):
+            cmd.append("-r")
+        if cfg.get("fpp"):
+            cmd.append("-F")
+        if cfg.get("reps", 1) > 1:
+            cmd.append(f"-i {cfg['reps']}")
+        if cfg.get("direct"):
+            cmd.append("-O useO_DIRECT=1")
 
-        ior_cmd = ' '.join(cmd)
-        if cfg.get('log'):
-            ior_cmd += f' 2>&1 | tee {cfg["log"]}'
+        ior_cmd = " ".join(cmd)
+        if cfg.get("log"):
+            ior_cmd += f" 2>&1 | tee {cfg['log']}"
 
-        gdb_server = GdbServer(ior_cmd, cfg.get('dbg_port', 4000))
+        gdb_server = GdbServer(ior_cmd, cfg.get("dbg_port", 4000))
         cmd_list = [
-            {'cmd': gdb_server.get_cmd(), 'nprocs': 1 if cfg.get('do_dbg') else 0, 'disable_preload': True},
-            {'cmd': ior_cmd, 'nprocs': None},
+            {
+                "cmd": gdb_server.get_cmd(),
+                "nprocs": 1 if cfg.get("do_dbg") else 0,
+                "disable_preload": True,
+            },
+            {"cmd": ior_cmd, "nprocs": None},
         ]
-        Exec(cmd_list, MpiExecInfo(
-            nprocs=cfg['nprocs'],
-            ppn=cfg['ppn'],
-            hostfile=self.hostfile,
-            port=self.ssh_port,
-            container=self._container_engine,
-            container_image=self.deploy_image_name(),
-            shared_dir=self.shared_dir,
-            private_dir=self.private_dir,
-            env=self.mod_env,
-        )).run()
+        Exec(
+            cmd_list,
+            MpiExecInfo(
+                nprocs=cfg["nprocs"],
+                ppn=cfg["ppn"],
+                hostfile=self.hostfile,
+                port=self.ssh_port,
+                container=self._container_engine,
+                container_image=self.deploy_image_name(),
+                shared_dir=self.shared_dir,
+                private_dir=self.private_dir,
+                env=self.mod_env,
+            ),
+        ).run()
 
     def stop(self):
         """Stop IOR (no-op — IOR runs to completion)."""
@@ -216,9 +239,9 @@ class Ior(Application):
 
     def clean(self):
         """Remove IOR output files."""
-        Rm(self.config['out'] + '*',
-           PsshExecInfo(env=self.env,
-                        hostfile=self.hostfile)).run()
+        Rm(
+            self.config["out"] + "*", PsshExecInfo(env=self.env, hostfile=self.hostfile)
+        ).run()
 
     # ------------------------------------------------------------------
     # Output parsing
@@ -228,9 +251,9 @@ class Ior(Application):
     # MB/sec figure in parens is decimal-megabytes (1e6 bytes/sec); IOR
     # also prints binary MiB/sec (2^20 bytes/sec). We expose both.
     _MAX_RE = re.compile(
-        r'^Max\s+(?P<op>Write|Read):\s+'
-        r'(?P<mib>[0-9.]+)\s+MiB/sec\s+'
-        r'\((?P<mb>[0-9.]+)\s+MB/sec\)',
+        r"^Max\s+(?P<op>Write|Read):\s+"
+        r"(?P<mib>[0-9.]+)\s+MiB/sec\s+"
+        r"\((?P<mb>[0-9.]+)\s+MB/sec\)",
         re.MULTILINE,
     )
 
@@ -239,11 +262,11 @@ class Ior(Application):
     # StdDev Max(OPs) Min(OPs) Mean(OPs) StdDev Mean(s) ... — we keep
     # the MiB stats (first four numeric columns after the op name).
     _SUMMARY_RE = re.compile(
-        r'^(?P<op>write|read)\s+'
-        r'(?P<max>[0-9.]+)\s+'
-        r'(?P<min>[0-9.]+)\s+'
-        r'(?P<mean>[0-9.]+)\s+'
-        r'(?P<stddev>[0-9.]+)\s+',
+        r"^(?P<op>write|read)\s+"
+        r"(?P<max>[0-9.]+)\s+"
+        r"(?P<min>[0-9.]+)\s+"
+        r"(?P<mean>[0-9.]+)\s+"
+        r"(?P<stddev>[0-9.]+)\s+",
         re.MULTILINE,
     )
 
@@ -260,16 +283,16 @@ class Ior(Application):
         prefix = self.pkg_id
 
         for m in self._MAX_RE.finditer(text):
-            op = m.group('op').lower()
-            stats[f'{prefix}.{op}_max_mibs'] = float(m.group('mib'))
-            stats[f'{prefix}.{op}_max_mbs'] = float(m.group('mb'))
+            op = m.group("op").lower()
+            stats[f"{prefix}.{op}_max_mibs"] = float(m.group("mib"))
+            stats[f"{prefix}.{op}_max_mbs"] = float(m.group("mb"))
 
         for m in self._SUMMARY_RE.finditer(text):
-            op = m.group('op')
-            stats[f'{prefix}.{op}_max_mibs'] = float(m.group('max'))
-            stats[f'{prefix}.{op}_min_mibs'] = float(m.group('min'))
-            stats[f'{prefix}.{op}_mean_mibs'] = float(m.group('mean'))
-            stats[f'{prefix}.{op}_stddev_mibs'] = float(m.group('stddev'))
+            op = m.group("op")
+            stats[f"{prefix}.{op}_max_mibs"] = float(m.group("max"))
+            stats[f"{prefix}.{op}_min_mibs"] = float(m.group("min"))
+            stats[f"{prefix}.{op}_mean_mibs"] = float(m.group("mean"))
+            stats[f"{prefix}.{op}_stddev_mibs"] = float(m.group("stddev"))
 
         return stats
 
@@ -280,14 +303,14 @@ class Ior(Application):
         by ``_configure``) and adds Max/Min/Mean/StdDev MiB/sec entries
         per operation. Missing or unparseable log → only runtime is set.
         """
-        stat_dict[f'{self.pkg_id}.runtime'] = getattr(self, 'start_time', None)
+        stat_dict[f"{self.pkg_id}.runtime"] = getattr(self, "start_time", None)
 
-        log_path = self.config.get('log')
+        log_path = self.config.get("log")
         if not log_path or not os.path.isfile(log_path):
             return
 
         try:
-            with open(log_path, 'r') as f:
+            with open(log_path, "r") as f:
                 text = f.read()
         except OSError:
             return

--- a/builtin/builtin/lammps/pkg.py
+++ b/builtin/builtin/lammps/pkg.py
@@ -3,6 +3,9 @@ This module provides classes and methods to launch the LAMMPS application.
 LAMMPS (Large-scale Atomic/Molecular Massively Parallel Simulator) is a
 classical molecular-dynamics code from Sandia National Laboratories.
 """
+import os
+import shlex
+
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
@@ -159,6 +162,36 @@ class Lammps(Application):
     # Lifecycle
     # ------------------------------------------------------------------
 
+    def _log_path(self) -> str:
+        """Return the deterministic package-owned LAMMPS thermo log path."""
+        output_dir = os.path.expandvars(self.config.get('out') or '.')
+        return os.path.join(os.path.abspath(output_dir), 'log.lammps')
+
+    def _remove_stale_log(self) -> None:
+        """Remove the previous log before relay polling and LAMMPS startup."""
+        exec_args = {
+            'hostfile': self.hostfile,
+            'env': self.mod_env,
+        }
+        if self.config.get('deploy_mode') == 'container':
+            exec_args.update({
+                'container': self._container_engine,
+                'container_image': self.deploy_image_name(),
+                'gpu': self.config.get('kokkos_gpu', False),
+                'private_dir': self.private_dir,
+                'shared_dir': self.shared_dir,
+            })
+        cleanup = Exec(
+            f'rm -f {shlex.quote(self._log_path())}',
+            PsshExecInfo(**exec_args),
+        ).run()
+        failures = {
+            host: code for host, code in cleanup.exit_code.items() if code != 0
+        }
+        if failures:
+            raise RuntimeError(
+                f'Failed to remove stale LAMMPS log {self._log_path()}: {failures}')
+
     def start(self):
         """
         Launch LAMMPS.
@@ -166,10 +199,10 @@ class Lammps(Application):
         Branches on deploy_mode: uses MpiExecInfo with container engine for
         container mode, MpiExecInfo with hostfile for default mode.
         """
+        self._remove_stale_log()
         if self.config.get('deploy_mode') == 'container':
             script_path = self.config.get('script')
             if self.config.get('io_dump_interval', 0) > 0:
-                import os
                 n = self.config.get('io_lattice_size', 20)
                 steps = self.config.get('io_run_steps', 100)
                 interval = self.config['io_dump_interval']
@@ -196,14 +229,18 @@ class Lammps(Application):
                         f"thermo {interval}\n"
                         f"timestep 0.005\nrun {steps}\n"
                     )
-            cmd = ['/usr/local/bin/lmp']
+            cmd = ['/usr/local/bin/lmp', f'-log {shlex.quote(self._log_path())}']
             if script_path:
-                cmd.append(f"-in {script_path}")
+                cmd.append(f"-in {shlex.quote(os.path.expandvars(script_path))}")
             if self.config.get('kokkos_gpu'):
                 n_gpus = self.config.get('num_gpus', 1)
                 cmd += [f'-k on g {n_gpus}', '-sf kk', '-pk kokkos cuda/aware on']
 
-            Exec(' '.join(cmd), MpiExecInfo(
+            lammps_command = ' '.join(cmd)
+            output_dir = shlex.quote(os.path.dirname(self._log_path()))
+            container_command = shlex.quote(
+                f'mkdir -p {output_dir} && exec {lammps_command}')
+            Exec(f'bash -c {container_command}', MpiExecInfo(
                 nprocs=self.config['nprocs'],
                 ppn=self.config['ppn'],
                 hostfile=self.hostfile,
@@ -216,9 +253,13 @@ class Lammps(Application):
                 env=self.mod_env,
             )).run()
         else:
-            cmd = [self.config['lmp_bin']]
+            cmd = [
+                self.config['lmp_bin'],
+                f'-log {shlex.quote(self._log_path())}',
+            ]
             if self.config['script']:
-                cmd.append(f"-in {self.config['script']}")
+                cmd.append(
+                    f"-in {shlex.quote(os.path.expandvars(self.config['script']))}")
             if self.config.get('kokkos_gpu'):
                 n_gpus = self.config.get('num_gpus', 1)
                 cmd += [f'-k on g {n_gpus}', '-sf kk', '-pk kokkos cuda/aware on']

--- a/builtin/builtin/lammps/pkg.py
+++ b/builtin/builtin/lammps/pkg.py
@@ -3,6 +3,7 @@ This module provides classes and methods to launch the LAMMPS application.
 LAMMPS (Large-scale Atomic/Molecular Massively Parallel Simulator) is a
 classical molecular-dynamics code from Sandia National Laboratories.
 """
+
 import os
 import shlex
 
@@ -26,76 +27,76 @@ class Lammps(Application):
     def _configure_menu(self):
         return [
             {
-                'name': 'nprocs',
-                'msg': 'Number of MPI processes',
-                'type': int,
-                'default': 4,
+                "name": "nprocs",
+                "msg": "Number of MPI processes",
+                "type": int,
+                "default": 4,
             },
             {
-                'name': 'ppn',
-                'msg': 'Processes per node',
-                'type': int,
-                'default': 4,
+                "name": "ppn",
+                "msg": "Processes per node",
+                "type": int,
+                "default": 4,
             },
             {
-                'name': 'script',
-                'msg': 'Path to LAMMPS input script (e.g., in.lj)',
-                'type': str,
-                'default': None,
+                "name": "script",
+                "msg": "Path to LAMMPS input script (e.g., in.lj)",
+                "type": str,
+                "default": None,
             },
             {
-                'name': 'lmp_bin',
-                'msg': 'Path to LAMMPS binary (default: lmp in PATH)',
-                'type': str,
-                'default': 'lmp',
+                "name": "lmp_bin",
+                "msg": "Path to LAMMPS binary (default: lmp in PATH)",
+                "type": str,
+                "default": "lmp",
             },
             {
-                'name': 'cuda_arch',
-                'msg': 'CUDA architecture code (80=A100, 90=H100, 70=V100)',
-                'type': int,
-                'default': 80,
+                "name": "cuda_arch",
+                "msg": "CUDA architecture code (80=A100, 90=H100, 70=V100)",
+                "type": int,
+                "default": 80,
             },
             {
-                'name': 'base_image',
-                'msg': 'Base Docker image for build container',
-                'type': str,
-                'default': 'sci-hpc-base',
+                "name": "base_image",
+                "msg": "Base Docker image for build container",
+                "type": str,
+                "default": "sci-hpc-base",
             },
             {
-                'name': 'out',
-                'msg': 'Output directory for results',
-                'type': str,
-                'default': '/tmp/lammps_out',
+                "name": "out",
+                "msg": "Output directory for results",
+                "type": str,
+                "default": "/tmp/lammps_out",
             },
             {
-                'name': 'kokkos_gpu',
-                'msg': 'Enable Kokkos GPU (CUDA) acceleration',
-                'type': bool,
-                'default': True,
+                "name": "kokkos_gpu",
+                "msg": "Enable Kokkos GPU (CUDA) acceleration",
+                "type": bool,
+                "default": True,
             },
             {
-                'name': 'num_gpus',
-                'msg': 'Number of GPUs per node',
-                'type': int,
-                'default': 1,
+                "name": "num_gpus",
+                "msg": "Number of GPUs per node",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'io_dump_interval',
-                'msg': 'If >0, auto-generate LJ input with dump every N steps',
-                'type': int,
-                'default': 0,
+                "name": "io_dump_interval",
+                "msg": "If >0, auto-generate LJ input with dump every N steps",
+                "type": int,
+                "default": 0,
             },
             {
-                'name': 'io_lattice_size',
-                'msg': 'FCC lattice size per dim (4*N^3 atoms) for auto-generated IO input',
-                'type': int,
-                'default': 80,
+                "name": "io_lattice_size",
+                "msg": "FCC lattice size per dim (4*N^3 atoms) for auto-generated IO input",
+                "type": int,
+                "default": 80,
             },
             {
-                'name': 'io_run_steps',
-                'msg': 'Total steps for auto-generated IO input',
-                'type': int,
-                'default': 5000,
+                "name": "io_run_steps",
+                "msg": "Total steps for auto-generated IO input",
+                "type": int,
+                "default": 5000,
             },
         ]
 
@@ -104,38 +105,45 @@ class Lammps(Application):
     # ------------------------------------------------------------------
 
     def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+        if self.config.get("deploy_mode") != "container":
             return None
-        base = self.config.get('base_image', 'sci-hpc-base')
-        use_gpu = self.config.get('kokkos_gpu', True)
-        cuda_arch = self.config.get('cuda_arch', 80)
+        base = self.config.get("base_image", "sci-hpc-base")
+        use_gpu = self.config.get("kokkos_gpu", True)
+        cuda_arch = self.config.get("cuda_arch", 80)
         if use_gpu:
             cmake_extra = (
-                f'-DPKG_KOKKOS=ON '
-                f'-DKokkos_ENABLE_CUDA=ON '
+                f"-DPKG_KOKKOS=ON "
+                f"-DKokkos_ENABLE_CUDA=ON "
                 f'"-DKokkos_ARCH_AMPERE{cuda_arch}=ON" '
             )
-            suffix = f'kokkos-gpu-{cuda_arch}'
+            suffix = f"kokkos-gpu-{cuda_arch}"
         else:
-            cmake_extra = ''
-            suffix = 'cpu'
-        content = self._read_build_script('build.sh', {
-            'BASE_IMAGE': base,
-            'CMAKE_EXTRA': cmake_extra,
-        })
+            cmake_extra = ""
+            suffix = "cpu"
+        content = self._read_build_script(
+            "build.sh",
+            {
+                "BASE_IMAGE": base,
+                "CMAKE_EXTRA": cmake_extra,
+            },
+        )
         return content, suffix
 
     def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+        if self.config.get("deploy_mode") != "container":
             return None
-        use_gpu = self.config.get('kokkos_gpu', True)
-        deploy_base = ('nvidia/cuda:12.6.0-runtime-ubuntu24.04'
-                       if use_gpu else 'ubuntu:24.04')
-        suffix = getattr(self, '_build_suffix', '')
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': deploy_base,
-        })
+        use_gpu = self.config.get("kokkos_gpu", True)
+        deploy_base = (
+            "nvidia/cuda:12.6.0-runtime-ubuntu24.04" if use_gpu else "ubuntu:24.04"
+        )
+        suffix = getattr(self, "_build_suffix", "")
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {
+                "BUILD_IMAGE": self.build_image_name(),
+                "DEPLOY_BASE": deploy_base,
+            },
+        )
         return content, suffix
 
     # ------------------------------------------------------------------
@@ -153,10 +161,12 @@ class Lammps(Application):
         """
         super()._configure(**kwargs)
 
-        if self.config.get('deploy_mode') == 'default':
-            if self.config['out']:
-                Mkdir(self.config['out'],
-                      PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+        if self.config.get("deploy_mode") == "default":
+            if self.config["out"]:
+                Mkdir(
+                    self.config["out"],
+                    PsshExecInfo(hostfile=self.hostfile, env=self.env),
+                ).run()
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -164,33 +174,34 @@ class Lammps(Application):
 
     def _log_path(self) -> str:
         """Return the deterministic package-owned LAMMPS thermo log path."""
-        output_dir = os.path.expandvars(self.config.get('out') or '.')
-        return os.path.join(os.path.abspath(output_dir), 'log.lammps')
+        output_dir = os.path.expandvars(self.config.get("out") or ".")
+        return os.path.join(os.path.abspath(output_dir), "log.lammps")
 
     def _remove_stale_log(self) -> None:
         """Remove the previous log before relay polling and LAMMPS startup."""
         exec_args = {
-            'hostfile': self.hostfile,
-            'env': self.mod_env,
+            "hostfile": self.hostfile,
+            "env": self.mod_env,
         }
-        if self.config.get('deploy_mode') == 'container':
-            exec_args.update({
-                'container': self._container_engine,
-                'container_image': self.deploy_image_name(),
-                'gpu': self.config.get('kokkos_gpu', False),
-                'private_dir': self.private_dir,
-                'shared_dir': self.shared_dir,
-            })
+        if self.config.get("deploy_mode") == "container":
+            exec_args.update(
+                {
+                    "container": self._container_engine,
+                    "container_image": self.deploy_image_name(),
+                    "gpu": self.config.get("kokkos_gpu", False),
+                    "private_dir": self.private_dir,
+                    "shared_dir": self.shared_dir,
+                }
+            )
         cleanup = Exec(
-            f'rm -f {shlex.quote(self._log_path())}',
+            f"rm -f {shlex.quote(self._log_path())}",
             PsshExecInfo(**exec_args),
         ).run()
-        failures = {
-            host: code for host, code in cleanup.exit_code.items() if code != 0
-        }
+        failures = {host: code for host, code in cleanup.exit_code.items() if code != 0}
         if failures:
             raise RuntimeError(
-                f'Failed to remove stale LAMMPS log {self._log_path()}: {failures}')
+                f"Failed to remove stale LAMMPS log {self._log_path()}: {failures}"
+            )
 
     def start(self):
         """
@@ -200,16 +211,18 @@ class Lammps(Application):
         container mode, MpiExecInfo with hostfile for default mode.
         """
         self._remove_stale_log()
-        if self.config.get('deploy_mode') == 'container':
-            script_path = self.config.get('script')
-            if self.config.get('io_dump_interval', 0) > 0:
-                n = self.config.get('io_lattice_size', 20)
-                steps = self.config.get('io_run_steps', 100)
-                interval = self.config['io_dump_interval']
-                out_dir = self.config.get('out', '/tmp/lammps_out')
+        line_callback = self.progress_line_callback()
+        if self.config.get("deploy_mode") == "container":
+            script_path = self.config.get("script")
+            if self.config.get("io_dump_interval", 0) > 0:
+                n = self.config.get("io_lattice_size", 20)
+                steps = self.config.get("io_run_steps", 100)
+                interval = self.config["io_dump_interval"]
+                out_dir = self.config.get("out", "/tmp/lammps_out")
                 script_path = os.path.join(
-                    str(self.shared_dir), 'generated_io_input.lmp')
-                with open(script_path, 'w') as f:
+                    str(self.shared_dir), "generated_io_input.lmp"
+                )
+                with open(script_path, "w") as f:
                     f.write(
                         f"shell mkdir -p {out_dir}\n"
                         f"units lj\natom_style atomic\n"
@@ -229,47 +242,61 @@ class Lammps(Application):
                         f"thermo {interval}\n"
                         f"timestep 0.005\nrun {steps}\n"
                     )
-            cmd = ['/usr/local/bin/lmp', f'-log {shlex.quote(self._log_path())}']
+            cmd = ["/usr/local/bin/lmp", f"-log {shlex.quote(self._log_path())}"]
             if script_path:
                 cmd.append(f"-in {shlex.quote(os.path.expandvars(script_path))}")
-            if self.config.get('kokkos_gpu'):
-                n_gpus = self.config.get('num_gpus', 1)
-                cmd += [f'-k on g {n_gpus}', '-sf kk', '-pk kokkos cuda/aware on']
+            if self.config.get("kokkos_gpu"):
+                n_gpus = self.config.get("num_gpus", 1)
+                cmd += [f"-k on g {n_gpus}", "-sf kk", "-pk kokkos cuda/aware on"]
 
-            lammps_command = ' '.join(cmd)
+            lammps_command = " ".join(cmd)
             output_dir = shlex.quote(os.path.dirname(self._log_path()))
             container_command = shlex.quote(
-                f'mkdir -p {output_dir} && exec {lammps_command}')
-            Exec(f'bash -c {container_command}', MpiExecInfo(
-                nprocs=self.config['nprocs'],
-                ppn=self.config['ppn'],
-                hostfile=self.hostfile,
-                port=self.ssh_port,
-                container=self._container_engine,
-                container_image=self.deploy_image_name(),
-                shared_dir=self.shared_dir,
-                private_dir=self.private_dir,
-                gpu=self.config.get('kokkos_gpu', False),
-                env=self.mod_env,
-            )).run()
+                f"mkdir -p {output_dir} && exec {lammps_command}"
+            )
+            result = Exec(
+                f"bash -c {container_command}",
+                MpiExecInfo(
+                    nprocs=self.config["nprocs"],
+                    ppn=self.config["ppn"],
+                    hostfile=self.hostfile,
+                    port=self.ssh_port,
+                    container=self._container_engine,
+                    container_image=self.deploy_image_name(),
+                    shared_dir=self.shared_dir,
+                    private_dir=self.private_dir,
+                    gpu=self.config.get("kokkos_gpu", False),
+                    env=self.mod_env,
+                    line_callback=line_callback,
+                ),
+            ).run()
         else:
             cmd = [
-                self.config['lmp_bin'],
-                f'-log {shlex.quote(self._log_path())}',
+                self.config["lmp_bin"],
+                f"-log {shlex.quote(self._log_path())}",
             ]
-            if self.config['script']:
+            if self.config["script"]:
                 cmd.append(
-                    f"-in {shlex.quote(os.path.expandvars(self.config['script']))}")
-            if self.config.get('kokkos_gpu'):
-                n_gpus = self.config.get('num_gpus', 1)
-                cmd += [f'-k on g {n_gpus}', '-sf kk', '-pk kokkos cuda/aware on']
+                    f"-in {shlex.quote(os.path.expandvars(self.config['script']))}"
+                )
+            if self.config.get("kokkos_gpu"):
+                n_gpus = self.config.get("num_gpus", 1)
+                cmd += [f"-k on g {n_gpus}", "-sf kk", "-pk kokkos cuda/aware on"]
 
-            Exec(' '.join(cmd),
-                 MpiExecInfo(nprocs=self.config['nprocs'],
-                             ppn=self.config['ppn'],
-                             hostfile=self.hostfile,
-                             env=self.mod_env,
-                             cwd=self.config.get('out'))).run()
+            result = Exec(
+                " ".join(cmd),
+                MpiExecInfo(
+                    nprocs=self.config["nprocs"],
+                    ppn=self.config["ppn"],
+                    hostfile=self.hostfile,
+                    env=self.mod_env,
+                    cwd=self.config.get("out"),
+                    line_callback=line_callback,
+                ),
+            ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"LAMMPS execution failed: {failures}")
 
     def stop(self):
         """Stop LAMMPS (no-op — LAMMPS runs to completion)."""
@@ -277,6 +304,8 @@ class Lammps(Application):
 
     def clean(self):
         """Remove LAMMPS output directory."""
-        if self.config['out']:
-            Rm(self.config['out'] + '*',
-               PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+        if self.config["out"]:
+            Rm(
+                self.config["out"] + "*",
+                PsshExecInfo(hostfile=self.hostfile, env=self.env),
+            ).run()

--- a/builtin/builtin/lammps/progress.py
+++ b/builtin/builtin/lammps/progress.py
@@ -1,0 +1,512 @@
+"""LAMMPS progress semantics owned beside the builtin package launcher."""
+
+from __future__ import annotations
+
+import math
+import os
+import statistics
+from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, cast
+
+from jarvis_cd.progress.provider import ProgressObservation
+from jarvis_cd.progress.schema import JsonValue, ProgressState
+
+
+@dataclass
+class LammpsThermoProgressAdapter:
+    """Parse live LAMMPS thermo records under the JARVIS package boundary."""
+
+    package_name: str = "builtin.lammps"
+    package_id: str = "lammps"
+    package_version: str = "builtin"
+    run_id: str = ""
+    adapter_name: str = "lammps"
+    application_profile: str | None = "jarvis-cd.builtin.lammps"
+    log_visibility: str = "scoped_stdout"
+    total_steps: float | None = None
+    output_dir: Path | None = None
+    warmup_samples: int = 2
+    sample_window: int = 8
+    active_columns: list[str] = field(default_factory=list)
+    active_step_column: int | None = None
+    active_time_column: int | None = None
+    active_time_column_name: str | None = None
+    samples: list[tuple[float, float]] = field(default_factory=list)
+    last_step: float | None = None
+    completed_steps: float = 0.0
+    active_run_steps: float | None = None
+    active_run_start_step: float | None = None
+    active_package_stdout: bool = False
+    authoritative_source: str | None = None
+    stdout_fragment: str = ""
+    jarvis_stdout_fragment: str = ""
+    last_emitted_key: tuple[float, float, float, float | None] | None = None
+
+    def observe_progress(self, text: str) -> list[ProgressObservation]:
+        """Interpret application stdout for the JARVIS-owned typed SPI."""
+        return [_record_to_observation(record) for record in self.observe_stdout(text)]
+
+    def finalize_progress(self) -> list[ProgressObservation]:
+        """Flush the final application-output fragment for JARVIS core."""
+        return [_record_to_observation(record) for record in self.finalize_stdout()]
+
+    def reset_progress(self) -> None:
+        """Reset the JARVIS-owned application stream parser."""
+        self.reset_stdout()
+
+    def observe_stdout(self, text: str) -> list[dict[str, object]]:
+        """Extract progress from an already trusted package-owned log."""
+        return self._observe_stdout(text, finalize=False)
+
+    def finalize_stdout(self) -> list[dict[str, object]]:
+        """Flush the final package-log fragment at end of stream."""
+        return self._observe_stdout("", finalize=True)
+
+    def reset_stdout(self) -> None:
+        """Reset package-log parser state after file replacement or truncation."""
+        if self.authoritative_source not in (None, "package_log"):
+            return
+        self.authoritative_source = None
+        self.stdout_fragment = ""
+        self.active_columns = []
+        self.active_step_column = None
+        self.active_time_column = None
+        self.active_time_column_name = None
+        self.samples = []
+        self.last_step = None
+        self.completed_steps = 0.0
+        self.active_run_steps = None
+        self.active_run_start_step = None
+        self.last_emitted_key = None
+
+    def _observe_stdout(
+        self,
+        text: str,
+        *,
+        finalize: bool,
+    ) -> list[dict[str, object]]:
+        if self.authoritative_source == "jarvis_stdout":
+            if finalize:
+                self.stdout_fragment = ""
+            return []
+        if text and self.authoritative_source is None:
+            self.authoritative_source = "package_log"
+        records: list[dict[str, object]] = []
+        for line in self._complete_lines(
+            text,
+            fragment_name="stdout_fragment",
+            finalize=finalize,
+        ):
+            record = self.observe_line(line)
+            if record is not None:
+                records.append(record)
+        return records
+
+    def observe_jarvis_stdout(self, text: str) -> list[dict[str, object]]:
+        """Extract records only while JARVIS identifies ``builtin.lammps``."""
+        return self._observe_jarvis_stdout(text, finalize=False)
+
+    def finalize_jarvis_stdout(self) -> list[dict[str, object]]:
+        """Flush the final JARVIS-scoped fragment at end of stream."""
+        return self._observe_jarvis_stdout("", finalize=True)
+
+    def _observe_jarvis_stdout(
+        self,
+        text: str,
+        *,
+        finalize: bool,
+    ) -> list[dict[str, object]]:
+        if self.authoritative_source == "package_log":
+            if finalize:
+                self.jarvis_stdout_fragment = ""
+                self.active_package_stdout = False
+            return []
+        records: list[dict[str, object]] = []
+        for line in self._complete_lines(
+            text,
+            fragment_name="jarvis_stdout_fragment",
+            finalize=finalize,
+        ):
+            stripped = line.strip()
+            if stripped == f"[{self.package_name}] [START] BEGIN":
+                if self.authoritative_source is None:
+                    self.authoritative_source = "jarvis_stdout"
+                self.active_package_stdout = True
+                continue
+            if stripped == f"[{self.package_name}] [START] END":
+                self.active_package_stdout = False
+                continue
+            if not self.active_package_stdout:
+                continue
+            record = self.observe_line(line)
+            if record is not None:
+                records.append(record)
+        if finalize:
+            self.active_package_stdout = False
+        return records
+
+    def _complete_lines(
+        self,
+        text: str,
+        *,
+        fragment_name: str,
+        finalize: bool,
+    ) -> list[str]:
+        fragment = cast(str, getattr(self, fragment_name))
+        lines = (fragment + text).splitlines(keepends=True)
+        if not finalize and lines and not lines[-1].endswith(("\n", "\r")):
+            setattr(self, fragment_name, lines.pop())
+        else:
+            setattr(self, fragment_name, "")
+        return [line.rstrip("\r\n") for line in lines]
+
+    def progress_log_paths(self) -> list[Path]:
+        """Return the LAMMPS thermo log owned by this package execution."""
+        if self.output_dir is None:
+            return []
+        return [self.output_dir / "log.lammps"]
+
+    def package_load_probe_python(self) -> str:
+        """Return a probe that locates the installed builtin LAMMPS package."""
+        return (
+            "from pathlib import Path\n"
+            "import jarvis_cd\n"
+            "root = Path(jarvis_cd.__file__).resolve().parent.parent\n"
+            "path = root / 'builtin' / 'builtin' / 'lammps' / 'pkg.py'\n"
+            "if not path.is_file():\n"
+            "    raise SystemExit(f'JARVIS builtin LAMMPS package missing: {path}')\n"
+            "print(path)"
+        )
+
+    def acceptance_progress_valid(self, metadata: dict[str, Any]) -> bool:
+        """Require observed LAMMPS timing rather than a claimed percentage."""
+        eta = metadata.get("eta_seconds")
+        absolute_step = metadata.get("absolute_step")
+        eta_value = _finite_number(eta)
+        absolute_step_value = _finite_number(absolute_step)
+        return (
+            metadata.get("adapter") == self.adapter_name
+            and metadata.get("prediction_status") == "observed_lammps_timing"
+            and metadata.get("timing_source") == "lammps_thermo_cpu"
+            and eta_value is not None
+            and eta_value >= 0
+            and absolute_step_value is not None
+            and absolute_step_value >= 0
+        )
+
+    def observe_line(self, line: str) -> dict[str, object] | None:
+        """Extract one progress observation from a LAMMPS output line."""
+        stripped = line.strip()
+        if stripped == "":
+            return None
+        reset_step = _parse_reset_timestep(stripped)
+        if reset_step is not None:
+            self.active_run_start_step = reset_step
+            self.last_step = reset_step
+            return None
+        run_command = _parse_run_command(stripped)
+        if run_command is not None:
+            run_steps, run_upto = run_command
+            self.active_run_steps = None if run_upto else run_steps
+            self.active_run_start_step = None
+            return None
+        if _looks_like_thermo_header(stripped):
+            self.active_columns = stripped.split()
+            self.active_step_column = self.active_columns.index("Step")
+            self.active_time_column = None
+            self.active_time_column_name = None
+            for candidate in ("CPU", "Cpu", "cpu"):
+                if candidate in self.active_columns:
+                    self.active_time_column = self.active_columns.index(candidate)
+                    self.active_time_column_name = candidate
+                    break
+            return None
+        if stripped.startswith("Loop time of "):
+            completed_steps = self.completed_steps
+            if self.active_run_steps is not None:
+                completed_steps += self.active_run_steps
+            elif self.active_run_start_step is not None and self.last_step is not None:
+                completed_steps += max(0.0, self.last_step - self.active_run_start_step)
+            if math.isfinite(completed_steps):
+                self.completed_steps = completed_steps
+            self.active_run_steps = None
+            self.active_run_start_step = None
+            self.active_columns = []
+            self.active_step_column = None
+            self.active_time_column = None
+            self.active_time_column_name = None
+            return None
+        if self.active_step_column is None:
+            return None
+        if (
+            self.total_steps is not None
+            and self.completed_steps >= self.total_steps
+            and self.active_run_steps is None
+        ):
+            return None
+        parts = stripped.split()
+        if len(parts) != len(self.active_columns):
+            return None
+        step = _optional_float(parts[self.active_step_column])
+        if step is None:
+            return None
+        if step < 0:
+            return None
+        elapsed_seconds = None
+        if self.active_time_column is not None:
+            elapsed_seconds = _optional_float(parts[self.active_time_column])
+            if elapsed_seconds is not None and elapsed_seconds < 0:
+                elapsed_seconds = None
+        if self.active_run_start_step is None:
+            self.active_run_start_step = step
+        self.last_step = step
+        current = self.completed_steps + max(0.0, step - self.active_run_start_step)
+        if self.active_run_steps is not None:
+            current = min(self.completed_steps + self.active_run_steps, current)
+        if not math.isfinite(current):
+            return None
+        progress_key = (self.completed_steps, current, step, elapsed_seconds)
+        if progress_key == self.last_emitted_key:
+            return None
+        self.last_emitted_key = progress_key
+        if elapsed_seconds is not None:
+            self.samples.append((current, elapsed_seconds))
+            self.samples = self.samples[-self.sample_window :]
+        prediction = self._prediction(current, elapsed_seconds=elapsed_seconds)
+        return _drop_none(
+            {
+                "label": "timestep",
+                "current": current,
+                "total": self.total_steps,
+                "unit": "step",
+                "message": _lammps_message(current, self.total_steps),
+                "metadata": {
+                    "adapter": self.adapter_name,
+                    "columns": self.active_columns,
+                    "step_column": "Step",
+                    "absolute_step": step,
+                    "run_start_step": self.active_run_start_step,
+                    "run_steps": self.active_run_steps,
+                    "completed_prior_runs": self.completed_steps,
+                    "timing_column": self.active_time_column_name,
+                    **prediction,
+                    "source": "jarvis_package",
+                    "progress_source": self.authoritative_source,
+                    "log_visibility": self.log_visibility,
+                    "package_name": self.package_name,
+                    "package_id": self.package_id,
+                    "package_version": self.package_version,
+                    "run_id": self.run_id,
+                    "execution_id": self.run_id,
+                },
+            }
+        )
+
+    def _prediction(
+        self,
+        current_step: float,
+        *,
+        elapsed_seconds: float | None,
+    ) -> dict[str, object]:
+        if elapsed_seconds is None:
+            return {
+                "confidence": "timing_unavailable",
+                "samples": len(self.samples),
+                "prediction_status": "no_lammps_timing_column",
+            }
+        if self.total_steps is None or len(self.samples) <= self.warmup_samples:
+            return {
+                "confidence": "warming_up",
+                "samples": len(self.samples),
+                "prediction_status": "warming_up",
+                "elapsed_seconds": elapsed_seconds,
+            }
+        rates: list[float] = []
+        for (previous_step, previous_time), (step, timestamp) in zip(
+            self.samples,
+            self.samples[1:],
+        ):
+            step_delta = step - previous_step
+            time_delta = timestamp - previous_time
+            if step_delta <= 0 or time_delta <= 0:
+                continue
+            rate = time_delta / step_delta
+            if math.isfinite(rate):
+                rates.append(rate)
+        if not rates:
+            return {
+                "confidence": "warming_up",
+                "samples": len(self.samples),
+                "prediction_status": "warming_up",
+                "elapsed_seconds": elapsed_seconds,
+            }
+        ordered = sorted(rates)
+        trimmed = ordered[1:-1] if len(ordered) > 2 else ordered
+        seconds_per_step = statistics.mean(trimmed)
+        remaining_steps = max(0.0, self.total_steps - current_step)
+        eta_seconds = remaining_steps * seconds_per_step
+        if not all(
+            math.isfinite(value)
+            for value in (seconds_per_step, remaining_steps, eta_seconds)
+        ):
+            return {
+                "confidence": "timing_unavailable",
+                "samples": len(self.samples),
+                "prediction_status": "nonfinite_prediction_rejected",
+                "elapsed_seconds": elapsed_seconds,
+            }
+        return {
+            "prediction_method": "trimmed_mean_step_time_after_warmup",
+            "rate_samples": len(rates),
+            "trimmed_rate_samples": len(trimmed),
+            "min_seconds_per_step": min(trimmed),
+            "max_seconds_per_step": max(trimmed),
+            "seconds_per_step": seconds_per_step,
+            "eta_seconds": eta_seconds,
+            "elapsed_seconds": elapsed_seconds,
+            "remaining_steps": remaining_steps,
+            "samples": len(self.samples),
+            "prediction_status": "observed_lammps_timing",
+            "timing_source": "lammps_thermo_cpu",
+            "confidence": "observed" if len(rates) >= 2 else "low_sample",
+        }
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> LammpsThermoProgressAdapter | None:
+    """Create the provider only for the builtin JARVIS LAMMPS package."""
+    package_type = package.get("pkg_type")
+    if package_type != "builtin.lammps":
+        return None
+    output = package.get("out")
+    deploy_mode = package.get("effective_deploy_mode") or package.get("deploy_mode")
+    progress = package.get("progress")
+    shared_log = _nested_progress_value(progress, "log_visibility") == "shared"
+    output_dir = (
+        Path(os.path.expandvars(output))
+        if deploy_mode != "container"
+        and shared_log
+        and isinstance(output, str)
+        and output.strip()
+        else None
+    )
+    return LammpsThermoProgressAdapter(
+        package_name=str(package_type),
+        package_id=str(package.get("pkg_id") or "lammps"),
+        package_version=_distribution_version(),
+        log_visibility="shared" if output_dir is not None else "scoped_stdout",
+        total_steps=_optional_float(
+            package.get("total_steps")
+            or package.get("steps")
+            or (
+                package.get("io_run_steps")
+                if _optional_float(package.get("io_dump_interval"))
+                else None
+            )
+            or _nested_progress_total(progress)
+        ),
+        output_dir=output_dir,
+    )
+
+
+def _nested_progress_total(value: object) -> object:
+    return _nested_progress_value(value, "total_steps") or _nested_progress_value(
+        value, "total"
+    )
+
+
+def _nested_progress_value(value: object, key: str) -> object:
+    if not isinstance(value, dict):
+        return None
+    typed = cast("dict[str, object]", value)
+    return typed.get(key)
+
+
+def _distribution_version() -> str:
+    try:
+        return version("jarvis_cd")
+    except PackageNotFoundError:
+        return "source-checkout"
+
+
+def _optional_float(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return _finite_number(value)
+    if isinstance(value, str) and value != "":
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        return parsed if math.isfinite(parsed) else None
+    return None
+
+
+def _finite_number(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _looks_like_thermo_header(line: str) -> bool:
+    columns = line.split()
+    return "Step" in columns and len(columns) >= 2
+
+
+def _parse_run_command(line: str) -> tuple[float, bool] | None:
+    parts = line.split()
+    if len(parts) < 2 or parts[0] != "run":
+        return None
+    run_value = _optional_float(parts[1])
+    if run_value is None or run_value < 0:
+        return None
+    return run_value, "upto" in parts[2:]
+
+
+def _parse_reset_timestep(line: str) -> float | None:
+    parts = line.split()
+    if len(parts) < 2 or parts[0] != "reset_timestep":
+        return None
+    return _optional_float(parts[1])
+
+
+def _lammps_message(step: float, total_steps: float | None) -> str:
+    if total_steps is None:
+        return f"LAMMPS step {int(step)}"
+    return f"LAMMPS step {int(step)} of {int(total_steps)}"
+
+
+def _drop_none(value: dict[str, object | None]) -> dict[str, object]:
+    return {key: item for key, item in value.items() if item is not None}
+
+
+def _record_to_observation(record: dict[str, object]) -> ProgressObservation:
+    """Project the legacy relay record into the typed JARVIS core contract."""
+    metadata = record.get("metadata", {})
+    if not isinstance(metadata, dict):
+        raise ValueError("LAMMPS progress metadata must be an object")
+    state_value = metadata.get("progress_state", ProgressState.RUNNING.value)
+    try:
+        state = ProgressState(str(state_value))
+    except ValueError as exc:
+        raise ValueError(f"invalid LAMMPS progress state: {state_value!r}") from exc
+    label = record.get("label")
+    if not isinstance(label, str) or not label:
+        raise ValueError("LAMMPS progress requires a non-empty label")
+    return ProgressObservation(
+        label=label,
+        state=state,
+        current=cast(float | None, record.get("current")),
+        total=cast(float | None, record.get("total")),
+        unit=cast(str | None, record.get("unit")),
+        message=cast(str | None, record.get("message")),
+        metadata=cast(dict[str, JsonValue], metadata),
+    )

--- a/builtin/builtin/paraview/pkg.py
+++ b/builtin/builtin/paraview/pkg.py
@@ -1,15 +1,21 @@
-"""
-This module provides classes and methods to launch the Paraview application.
-Paraview is ....
-"""
+"""Launch generic ParaView servers or user-supplied pvbatch scripts."""
+
+import os
+import shlex
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo
+from jarvis_cd.shell import Exec, ExecInfo, LocalExecInfo, MpiExecInfo
 
 
 class Paraview(Application):
     """
     This class provides methods to launch the Paraview application.
     """
+
     def _init(self):
         """
         Initialize paths
@@ -26,34 +32,70 @@ class Paraview(Application):
         """
         return [
             {
-                'name': 'nprocs',
-                'msg': 'Number of processes',
-                'type': int,
-                'default': 1,
+                "name": "mode",
+                "msg": "ParaView mode: server or batch",
+                "type": str,
+                "default": "server",
             },
             {
-                'name': 'ppn',
-                'msg': 'The number of processes per node',
-                'type': int,
-                'default': 16,
+                "name": "nprocs",
+                "msg": "Number of processes",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'time_out',
-                'msg': 'Set a timeout period for idle client sessions',
-                'type': int,
-                'default': 10000,
+                "name": "ppn",
+                "msg": "The number of processes per node",
+                "type": int,
+                "default": 16,
             },
             {
-                'name': 'force_offscreen_rendering',
-                'msg': 'Useful for headless environments (no display)',
-                'type': bool,
-                'default': False,
+                "name": "time_out",
+                "msg": "Set a timeout period for idle client sessions",
+                "type": int,
+                "default": 10000,
             },
             {
-                'name': 'port_id',
-                'msg': 'Set the port the server listens on',
-                'type': int,
-                'default': 11111,
+                "name": "force_offscreen_rendering",
+                "msg": "Useful for headless environments (no display)",
+                "type": bool,
+                "default": False,
+            },
+            {
+                "name": "port_id",
+                "msg": "Set the port the server listens on",
+                "type": int,
+                "default": 11111,
+            },
+            {
+                "name": "script",
+                "msg": "Generic Python script passed to pvbatch in batch mode",
+                "type": str,
+                "default": "",
+            },
+            {
+                "name": "pvbatch_bin",
+                "msg": "Path or command used to launch pvbatch",
+                "type": str,
+                "default": "pvbatch",
+            },
+            {
+                "name": "pvbatch_options",
+                "msg": "Options passed to pvbatch (for example --mesa)",
+                "type": str,
+                "default": "",
+            },
+            {
+                "name": "script_args",
+                "msg": "Arguments passed unchanged to the pvbatch script",
+                "type": str,
+                "default": "",
+            },
+            {
+                "name": "cwd",
+                "msg": "Working directory for pvbatch (empty uses current directory)",
+                "type": str,
+                "default": "",
             },
         ]
 
@@ -75,19 +117,153 @@ class Paraview(Application):
 
         :return: None
         """
-        port_Id = self.config["port_id"]
+        mode = self.config.get("mode", "server")
+        environment = dict(self.mod_env)
+        environment.setdefault("JARVIS_PACKAGE_NAME", "builtin.paraview")
+        environment.setdefault("JARVIS_PACKAGE_ID", str(self.pkg_id or "paraview"))
+        reporter_path = self._stage_progress_reporter()
+        reporter_dir = str(reporter_path.parent)
+        current_pythonpath = environment.get("PYTHONPATH", "")
+        environment["PYTHONPATH"] = (
+            reporter_dir
+            if not current_pythonpath
+            else reporter_dir + os.pathsep + current_pythonpath
+        )
+        environment["JARVIS_PARAVIEW_REPORTER"] = str(reporter_path)
+        environment["JARVIS_PROGRESS_TRANSPORT"] = "stdout"
+        self.mod_env.update(
+            {
+                "JARVIS_PACKAGE_NAME": environment["JARVIS_PACKAGE_NAME"],
+                "JARVIS_PACKAGE_ID": environment["JARVIS_PACKAGE_ID"],
+                "JARVIS_PROGRESS_TRANSPORT": "stdout",
+            }
+        )
+        line_callback = self.progress_line_callback()
+        exec_info = self._execution_info(environment, line_callback)
+        if mode == "batch":
+            script = os.path.expandvars(cast(str, self.config.get("script") or ""))
+            if not script:
+                raise ValueError("ParaView batch mode requires a script")
+            pvbatch_bin = os.path.expandvars(
+                cast(str, self.config.get("pvbatch_bin") or "pvbatch")
+            )
+            command = [shlex.quote(pvbatch_bin)]
+            pvbatch_options = cast(
+                str,
+                self.config.get("pvbatch_options") or "",
+            )
+            command.extend(shlex.quote(item) for item in shlex.split(pvbatch_options))
+            if self.config["force_offscreen_rendering"]:
+                command.append("--force-offscreen-rendering")
+            command.append(shlex.quote(script))
+            script_args = cast(str, self.config.get("script_args") or "")
+            if script_args:
+                command.extend(shlex.quote(item) for item in shlex.split(script_args))
+            result = Exec(" ".join(command), exec_info).run()
+            self._raise_for_exec_failure(result, operation="ParaView batch")
+            return
+        if mode != "server":
+            raise ValueError(f"Unsupported ParaView mode: {mode!r}")
+
+        port_id = self.config["port_id"]
         time_out = self.config["time_out"]
-        condition = ''
-        if self.config['force_offscreen_rendering']:
-            condition += ' --force-offscreen-rendering'
+        condition = ""
+        if self.config["force_offscreen_rendering"]:
+            condition += " --force-offscreen-rendering"
+        result = Exec(
+            f"pvserver --server-port={port_id} --timeout={time_out}{condition}",
+            exec_info,
+        ).run()
+        self._raise_for_exec_failure(result, operation="ParaView server")
 
-        Exec(f'pvserver --server-port={port_Id} --timeout={time_out}{condition}',
-             MpiExecInfo(nprocs=self.config['nprocs'],
-                         ppn=self.config['ppn'],
-                         env=self.mod_env
-                        )).run()
+    def _stage_progress_reporter(self) -> Path:
+        """Copy the standalone reporter into the package's mounted shared path."""
+        if not self.shared_dir:
+            raise RuntimeError("ParaView package has no shared directory")
+        source = Path(__file__).resolve().parent / "progress_reporter.py"
+        payload = source.read_bytes()
+        reporter_dir = Path(self.shared_dir) / ".jarvis-progress"
+        reporter_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        target = reporter_dir / "progress_reporter.py"
+        descriptor, temporary_name = tempfile.mkstemp(
+            dir=reporter_dir,
+            prefix=".progress_reporter.",
+            suffix=".tmp",
+        )
+        temporary = Path(temporary_name)
+        descriptor_open = True
+        try:
+            try:
+                stream = os.fdopen(descriptor, "wb")
+            except BaseException:
+                os.close(descriptor)
+                descriptor_open = False
+                raise
+            descriptor_open = False
+            with stream:
+                stream.write(payload)
+                stream.flush()
+                os.fsync(stream.fileno())
+            temporary.chmod(0o600)
+            os.replace(temporary, target)
+            if os.name != "nt":
+                target.chmod(0o600)
+        finally:
+            if descriptor_open:
+                os.close(descriptor)
+            temporary.unlink(missing_ok=True)
+        return target
 
-        pass
+    def _execution_info(
+        self,
+        environment: dict[str, str],
+        line_callback: Callable[[str, str], None] | None,
+    ) -> ExecInfo:
+        """Select direct execution for one rank and MPI for multiple ranks."""
+        nprocs = int(self.config["nprocs"])
+        common: dict[str, Any] = {
+            "env": environment,
+            "cwd": os.path.expandvars(cast(str, self.config.get("cwd") or "")) or None,
+            "hostfile": self.hostfile,
+            "line_callback": line_callback,
+        }
+        if self.config.get("deploy_mode") == "container":
+            common.update(
+                {
+                    "container": self._container_engine,
+                    "container_image": self.deploy_image_name(),
+                    "shared_dir": self.shared_dir,
+                    "private_dir": self.private_dir,
+                    "bind_mounts": self.container_mounts,
+                }
+            )
+        if nprocs == 1:
+            return LocalExecInfo(**common)
+        return MpiExecInfo(
+            nprocs=nprocs,
+            ppn=self.config["ppn"],
+            port=(
+                self.ssh_port if self.config.get("deploy_mode") == "container" else 22
+            ),
+            **common,
+        )
+
+    @staticmethod
+    def _raise_for_exec_failure(result: Any, *, operation: str) -> None:
+        """Raise when an execution has no status or any host exits nonzero."""
+        exit_codes = getattr(result, "exit_code", None)
+        if not isinstance(exit_codes, dict) or not exit_codes:
+            raise RuntimeError(f"{operation} returned no process exit status")
+        failures = {
+            str(host): code
+            for host, code in exit_codes.items()
+            if isinstance(code, bool) or not isinstance(code, int) or code != 0
+        }
+        if failures:
+            details = ", ".join(
+                f"{host}={code!r}" for host, code in sorted(failures.items())
+            )
+            raise RuntimeError(f"{operation} failed with exit status: {details}")
 
     def stop(self):
         """
@@ -97,6 +273,7 @@ class Paraview(Application):
         :return: None
         """
         pass
+
     def clean(self):
         """
         Destroy all data for an application. E.g., OrangeFS will delete all
@@ -105,4 +282,3 @@ class Paraview(Application):
         :return: None
         """
         pass
-

--- a/builtin/builtin/paraview/progress.py
+++ b/builtin/builtin/paraview/progress.py
@@ -1,0 +1,322 @@
+"""Truthful ParaView progress semantics for pvbatch and pvserver."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, cast
+
+from jarvis_cd.progress import (
+    LineBuffer,
+    PackageScopeFilter,
+    ProgressEvent,
+    ProgressObservation,
+    ProgressState,
+    event_from_progress_line,
+)
+from jarvis_cd.progress.schema import JsonValue
+
+from .progress_reporter import ParaViewProgressReporter
+
+__all__ = [
+    "ParaViewProgressAdapter",
+    "ParaViewProgressReporter",
+    "adapter_from_package",
+]
+
+
+@dataclass
+class ParaViewProgressAdapter:
+    """Parse package-scoped structured pvbatch events and pvserver readiness."""
+
+    package_name: str = "builtin.paraview"
+    package_id: str = "paraview"
+    package_version: str = "builtin"
+    run_id: str = ""
+    adapter_name: str = "paraview"
+    application_profile: str | None = "jarvis-cd.builtin.paraview"
+    output_dir: Path | None = None
+    progress_path: Path | None = None
+    authoritative_source: str | None = None
+    _stdout: LineBuffer = field(default_factory=LineBuffer)
+    _jarvis_stdout: LineBuffer = field(default_factory=LineBuffer)
+    _scope: PackageScopeFilter = field(init=False)
+    _readiness_sequence: int = 0
+    _last_sequence: int = 0
+
+    def __post_init__(self) -> None:
+        self._scope = PackageScopeFilter(self.package_name)
+
+    def observe_progress(self, text: str) -> list[ProgressObservation]:
+        """Interpret application stdout for the JARVIS-owned typed SPI."""
+        return [_record_to_observation(record) for record in self.observe_stdout(text)]
+
+    def finalize_progress(self) -> list[ProgressObservation]:
+        """Flush the final application-output fragment for JARVIS core."""
+        return [_record_to_observation(record) for record in self.finalize_stdout()]
+
+    def reset_progress(self) -> None:
+        """Reset the JARVIS-owned application stream parser."""
+        self.reset_stdout()
+
+    def observe_stdout(self, text: str) -> list[dict[str, object]]:
+        """Read a trusted package JSONL sidecar or stdout stream."""
+        return self._observe_package_stream(text, finalize=False)
+
+    def finalize_stdout(self) -> list[dict[str, object]]:
+        """Flush an unterminated package-owned progress line."""
+        return self._observe_package_stream("", finalize=True)
+
+    def reset_stdout(self) -> None:
+        """Reset state after a sidecar replacement or truncation."""
+        if self.authoritative_source not in (None, "package_log"):
+            return
+        self.authoritative_source = None
+        self._stdout.reset()
+        self._last_sequence = 0
+
+    def observe_jarvis_stdout(self, text: str) -> list[dict[str, object]]:
+        """Read only output inside this ParaView package's JARVIS markers."""
+        return self._observe_jarvis_stream(text, finalize=False)
+
+    def finalize_jarvis_stdout(self) -> list[dict[str, object]]:
+        """Flush a final JARVIS-scoped line and close its scope."""
+        return self._observe_jarvis_stream("", finalize=True)
+
+    def progress_log_paths(self) -> list[Path]:
+        """Return only an explicitly shared package progress sidecar."""
+        return [self.progress_path] if self.progress_path is not None else []
+
+    def package_load_probe_python(self) -> str:
+        """Return a probe for the installed builtin ParaView package provider."""
+        return (
+            "from pathlib import Path\n"
+            "import jarvis_cd\n"
+            "root = Path(jarvis_cd.__file__).resolve().parent.parent\n"
+            "path = root / 'builtin' / 'builtin' / 'paraview' / 'progress.py'\n"
+            "if not path.is_file():\n"
+            "    raise SystemExit(f'JARVIS builtin ParaView progress missing: {path}')\n"
+            "print(path)"
+        )
+
+    def acceptance_progress_valid(self, metadata: dict[str, Any]) -> bool:
+        """Accept only real completed ParaView units or observed server readiness."""
+        if metadata.get("adapter") != self.adapter_name:
+            return False
+        kind = metadata.get("progress_kind")
+        if kind == "pvserver_ready":
+            return (
+                metadata.get("readiness_signal")
+                in {
+                    "instrumented_server_ready",
+                    "pvserver_accepting_connections",
+                    "pvserver_waiting_for_client",
+                }
+                and metadata.get("determinate") is False
+            )
+        if kind != "pvbatch_completed_unit":
+            return False
+        current = _finite_number(metadata.get("completed_units"))
+        total = _finite_number(metadata.get("total_units"))
+        if current is None or current < 1:
+            return False
+        if total is not None and (total <= 0 or current > total):
+            return False
+        unit = metadata.get("unit")
+        if unit == "frame":
+            completion_valid = (
+                metadata.get("completion_signal") == "render_returned"
+                and metadata.get("completed_after_render") is True
+            )
+        elif unit == "timestep":
+            completion_valid = (
+                metadata.get("completion_signal") == "pipeline_update_returned"
+                and metadata.get("completed_after_update") is True
+            )
+        else:
+            return False
+        return (
+            metadata.get("renderer") == "paraview"
+            and completion_valid
+            and metadata.get("determinate") is (total is not None)
+        )
+
+    def _observe_package_stream(
+        self, text: str, *, finalize: bool
+    ) -> list[dict[str, object]]:
+        if self.authoritative_source == "jarvis_stdout":
+            if finalize:
+                self._stdout.reset()
+            return []
+        if text and self.authoritative_source is None:
+            self.authoritative_source = "package_log"
+        records: list[dict[str, object]] = []
+        for line in self._stdout.feed(text, finalize=finalize):
+            record = self._observe_line(line)
+            if record is not None:
+                records.append(record)
+        return records
+
+    def _observe_jarvis_stream(
+        self, text: str, *, finalize: bool
+    ) -> list[dict[str, object]]:
+        if self.authoritative_source == "package_log":
+            if finalize:
+                self._jarvis_stdout.reset()
+                self._scope.reset()
+            return []
+        records: list[dict[str, object]] = []
+        for line in self._jarvis_stdout.feed(text, finalize=finalize):
+            was_active = self._scope.active
+            scoped = self._scope.observe(line)
+            if (
+                not was_active
+                and self._scope.active
+                and self.authoritative_source is None
+            ):
+                self.authoritative_source = "jarvis_stdout"
+            if scoped is None:
+                continue
+            record = self._observe_line(scoped)
+            if record is not None:
+                records.append(record)
+        if finalize:
+            self._scope.reset()
+        return records
+
+    def _observe_line(self, line: str) -> dict[str, object] | None:
+        lowered = line.casefold()
+        readiness_signal = None
+        if "accepting connection(s)" in lowered:
+            readiness_signal = "pvserver_accepting_connections"
+        elif "waiting for client" in lowered:
+            readiness_signal = "pvserver_waiting_for_client"
+        if readiness_signal is not None:
+            if not self.run_id:
+                raise ValueError("ParaView readiness requires a JARVIS execution ID")
+            self._readiness_sequence += 1
+            readiness_message = (
+                "ParaView server is accepting client connections"
+                if readiness_signal == "pvserver_accepting_connections"
+                else "ParaView server is waiting for a client"
+            )
+            event = ProgressEvent(
+                package_name=self.package_name,
+                package_id=self.package_id,
+                execution_id=self.run_id,
+                label="pvserver",
+                state=ProgressState.READY,
+                sequence=self._readiness_sequence,
+                message=readiness_message,
+                metadata={
+                    "progress_kind": "pvserver_ready",
+                    "renderer": "paraview",
+                    "readiness_signal": readiness_signal,
+                },
+            )
+            return self._adapter_record(event)
+        structured_event = event_from_progress_line(line)
+        if structured_event is None:
+            return None
+        if structured_event.package_name != self.package_name:
+            raise ValueError(
+                "ParaView progress package identity does not match provider"
+            )
+        if structured_event.package_id != self.package_id:
+            raise ValueError("ParaView progress package ID does not match provider")
+        if self.run_id and structured_event.execution_id != self.run_id:
+            raise ValueError(
+                "ParaView progress execution identity does not match provider"
+            )
+        if structured_event.sequence <= self._last_sequence:
+            raise ValueError("ParaView progress sequences must increase strictly")
+        self._last_sequence = structured_event.sequence
+        return self._adapter_record(structured_event)
+
+    def _adapter_record(self, event: ProgressEvent) -> dict[str, object]:
+        if event.label not in {"frame", "timestep", "pvserver"}:
+            raise ValueError(f"unsupported ParaView progress label: {event.label!r}")
+        if event.label == "pvserver":
+            if event.state is not ProgressState.READY or event.determinate:
+                raise ValueError("pvserver readiness must be indeterminate and ready")
+        else:
+            if event.current is None or event.current < 1:
+                raise ValueError("pvbatch progress requires a completed unit")
+            if event.unit != event.label:
+                raise ValueError("pvbatch progress unit must match its label")
+        record = event.as_adapter_record()
+        metadata = cast(dict[str, object], record["metadata"])
+        metadata.update(
+            {
+                "adapter": self.adapter_name,
+                "source": "jarvis_package",
+                "package_name": self.package_name,
+                "package_id": self.package_id,
+                "package_version": self.package_version,
+                "run_id": self.run_id or event.execution_id,
+                "execution_id": self.run_id or event.execution_id,
+                "progress_source": self.authoritative_source,
+                "completed_units": event.current,
+                "total_units": event.total,
+                "unit": event.unit,
+            }
+        )
+        if event.label == "pvserver":
+            record["current"] = 0.0
+            metadata["compatibility_projection"] = "indeterminate_state_ordinal"
+        return record
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> ParaViewProgressAdapter | None:
+    """Create a provider only for the generic builtin ParaView package."""
+    if package.get("pkg_type") != "builtin.paraview":
+        return None
+    return ParaViewProgressAdapter(
+        package_id=str(package.get("pkg_id") or "paraview"),
+        package_version=_distribution_version(),
+    )
+
+
+def _finite_number(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _distribution_version() -> str:
+    try:
+        return version("jarvis_cd")
+    except PackageNotFoundError:
+        return "source-checkout"
+
+
+def _record_to_observation(record: dict[str, object]) -> ProgressObservation:
+    """Project the legacy relay record into the typed JARVIS core contract."""
+    metadata = record.get("metadata", {})
+    if not isinstance(metadata, dict):
+        raise ValueError("ParaView progress metadata must be an object")
+    state_value = metadata.get("progress_state", ProgressState.RUNNING.value)
+    try:
+        state = ProgressState(str(state_value))
+    except ValueError as exc:
+        raise ValueError(f"invalid ParaView progress state: {state_value!r}") from exc
+    label = record.get("label")
+    if not isinstance(label, str) or not label:
+        raise ValueError("ParaView progress requires a non-empty label")
+    return ProgressObservation(
+        label=label,
+        state=state,
+        current=cast(float | None, record.get("current")),
+        total=cast(float | None, record.get("total")),
+        unit=cast(str | None, record.get("unit")),
+        message=cast(str | None, record.get("message")),
+        metadata=cast(dict[str, JsonValue], metadata),
+    )

--- a/builtin/builtin/paraview/progress_reporter.py
+++ b/builtin/builtin/paraview/progress_reporter.py
@@ -1,0 +1,219 @@
+"""Python 3.10-compatible structured reporter for standalone pvbatch scripts.
+
+This file intentionally imports no JARVIS modules. ParaView bundles its own
+Python runtime, which can be older than the Python used to run JARVIS itself.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import sys
+import time
+from typing import Any, Dict, Optional, TextIO
+
+PROGRESS_SCHEMA_VERSION = "jarvis.progress.v1"
+PROGRESS_LINE_PREFIX = "JARVIS_PROGRESS "
+PROGRESS_PATH_ENV = "JARVIS_PROGRESS_PATH"
+PROGRESS_TRANSPORT_ENV = "JARVIS_PROGRESS_TRANSPORT"
+EXECUTION_ID_ENV = "JARVIS_EXECUTION_ID"
+PACKAGE_NAME_ENV = "JARVIS_PACKAGE_NAME"
+PACKAGE_ID_ENV = "JARVIS_PACKAGE_ID"
+MAX_PROGRESS_EVENT_BYTES = 64 * 1024
+_MPI_RANK_ENV = (
+    "OMPI_COMM_WORLD_RANK",
+    "PMI_RANK",
+    "PMIX_RANK",
+    "SLURM_PROCID",
+    "MV2_COMM_WORLD_RANK",
+)
+
+
+class ParaViewProgressReporter:
+    """Report completed ParaView units without estimating percentages."""
+
+    def __init__(
+        self,
+        package_name: Optional[str] = None,
+        package_id: Optional[str] = None,
+        execution_id: Optional[str] = None,
+        path: Optional[str] = None,
+        stream: Optional[TextIO] = None,
+        rank: Optional[int] = None,
+    ) -> None:
+        self.package_name = package_name or os.environ.get(PACKAGE_NAME_ENV, "")
+        self.package_id = package_id or os.environ.get(PACKAGE_ID_ENV, "")
+        self.execution_id = execution_id or os.environ.get(EXECUTION_ID_ENV, "")
+        configured_path = (
+            path if path is not None else os.environ.get(PROGRESS_PATH_ENV)
+        )
+        transport = os.environ.get(PROGRESS_TRANSPORT_ENV)
+        if configured_path and transport != "stdout":
+            raise ValueError(
+                "standalone pvbatch progress must use stdout so JARVIS owns "
+                "sidecar validation and persistence"
+            )
+        self.stream = stream or sys.stdout
+        self.rank = _progress_rank(rank)
+        self.enabled = self.rank is None or self.rank == 0
+        self.sequence = 0
+        if not self.package_name or not self.package_id or not self.execution_id:
+            raise ValueError(
+                "ParaView progress requires JARVIS_PACKAGE_NAME, "
+                "JARVIS_PACKAGE_ID, and JARVIS_EXECUTION_ID"
+            )
+
+    def frame_completed(
+        self,
+        completed_frames: int,
+        total_frames: Optional[int] = None,
+        timestep: Optional[float] = None,
+        output_path: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Report a frame after the script's render/write call has returned."""
+        metadata: Dict[str, Any] = {
+            "progress_kind": "pvbatch_completed_unit",
+            "renderer": "paraview",
+            "completion_signal": "render_returned",
+            "completed_after_render": True,
+        }
+        if timestep is not None:
+            if not math.isfinite(timestep):
+                raise ValueError("ParaView timestep must be finite")
+            metadata["timestep"] = timestep
+        if output_path:
+            metadata["output_path"] = output_path
+        return self._completed_unit(
+            label="frame",
+            completed=completed_frames,
+            total=total_frames,
+            metadata=metadata,
+        )
+
+    def timestep_completed(
+        self,
+        completed_timesteps: int,
+        total_timesteps: Optional[int] = None,
+        timestep: Optional[float] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Report a timestep after the script's pipeline update has returned."""
+        metadata: Dict[str, Any] = {
+            "progress_kind": "pvbatch_completed_unit",
+            "renderer": "paraview",
+            "completion_signal": "pipeline_update_returned",
+            "completed_after_update": True,
+        }
+        if timestep is not None:
+            if not math.isfinite(timestep):
+                raise ValueError("ParaView timestep must be finite")
+            metadata["timestep"] = timestep
+        return self._completed_unit(
+            label="timestep",
+            completed=completed_timesteps,
+            total=total_timesteps,
+            metadata=metadata,
+        )
+
+    def _completed_unit(
+        self,
+        label: str,
+        completed: int,
+        total: Optional[int],
+        metadata: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        if isinstance(completed, bool) or completed < 1:
+            raise ValueError("completed ParaView units must be a positive integer")
+        if total is not None:
+            if isinstance(total, bool) or total < 1:
+                raise ValueError("total ParaView units must be a positive integer")
+            if completed > total:
+                raise ValueError("completed ParaView units cannot exceed total")
+        return self._emit(
+            label=label,
+            state="completed"
+            if total is not None and completed == total
+            else "running",
+            current=float(completed),
+            total=float(total) if total is not None else None,
+            unit=label,
+            message=(
+                f"ParaView completed {label} {completed}"
+                if total is None
+                else f"ParaView completed {label} {completed} of {total}"
+            ),
+            metadata=metadata,
+        )
+
+    def _emit(
+        self,
+        label: str,
+        state: str,
+        current: Optional[float],
+        total: Optional[float],
+        unit: Optional[str],
+        message: str,
+        metadata: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        if not self.enabled:
+            return None
+        self.sequence += 1
+        event: Dict[str, Any] = {
+            "schema_version": PROGRESS_SCHEMA_VERSION,
+            "package_name": self.package_name,
+            "package_id": self.package_id,
+            "execution_id": self.execution_id,
+            "label": label,
+            "state": state,
+            "sequence": self.sequence,
+            "observed_at_epoch": time.time(),
+            "determinate": total is not None,
+            "message": message,
+            "metadata": metadata,
+        }
+        if current is not None:
+            event["current"] = current
+        if total is not None:
+            event["total"] = total
+        if unit is not None:
+            event["unit"] = unit
+        payload = json.dumps(
+            event,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        encoded = (payload + "\n").encode("utf-8")
+        if len(encoded) > MAX_PROGRESS_EVENT_BYTES:
+            raise ValueError("ParaView progress event exceeds maximum encoded size")
+        self.stream.write(PROGRESS_LINE_PREFIX + payload + "\n")
+        self.stream.flush()
+        return event
+
+
+def _progress_rank(explicit_rank: Optional[int]) -> Optional[int]:
+    """Resolve one non-negative MPI rank without guessing across conflicts."""
+    if explicit_rank is not None:
+        if (
+            isinstance(explicit_rank, bool)
+            or not isinstance(explicit_rank, int)
+            or explicit_rank < 0
+        ):
+            raise ValueError("ParaView progress rank must be a non-negative integer")
+        return explicit_rank
+    observed = set()
+    for name in _MPI_RANK_ENV:
+        value = os.environ.get(name)
+        if value is None:
+            continue
+        try:
+            parsed = int(value, 10)
+        except ValueError as exc:
+            raise ValueError(f"invalid ParaView MPI rank in {name}: {value!r}") from exc
+        if parsed < 0:
+            raise ValueError(f"invalid ParaView MPI rank in {name}: {value!r}")
+        observed.add(parsed)
+    if len(observed) > 1:
+        raise ValueError("conflicting ParaView MPI rank environment values")
+    return next(iter(observed)) if observed else None

--- a/ci/__init__.py
+++ b/ci/__init__.py
@@ -1,0 +1,1 @@
+"""Release and continuous-integration support code."""

--- a/ci/install_jarvis.sh
+++ b/ci/install_jarvis.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-pip install -e .
-pip install pytest pytest-cov
+uv lock --check
+uv sync --frozen

--- a/ci/release_request.py
+++ b/ci/release_request.py
@@ -1,0 +1,146 @@
+"""Validate a short-lived operator request for an immutable release."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from collections.abc import Sequence
+from typing import Any, cast
+
+REQUEST_SCHEMA = "jarvis.release.request.v1"
+MAX_REQUEST_BYTES = 4_096
+REQUEST_KEYS = {
+    "commit",
+    "immutable_releases_enabled",
+    "repository",
+    "schema_version",
+    "tag",
+    "verified_at_epoch",
+}
+STABLE_TAG_PATTERN = re.compile(
+    r"^v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$"
+)
+COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+class ReleaseRequestError(ValueError):
+    """Raised when an operator release request is invalid."""
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Build a JSON object while rejecting duplicate member names."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ReleaseRequestError(
+                f"release request contains duplicate field: {key}"
+            )
+        result[key] = value
+    return result
+
+
+def validate_release_request(
+    raw: str,
+    *,
+    repository: str,
+    tag: str,
+    commit: str,
+    now_epoch: int,
+    max_age_seconds: int,
+) -> dict[str, Any]:
+    """Return an exact release request after validating every field."""
+    if len(raw.encode("utf-8")) > MAX_REQUEST_BYTES:
+        raise ReleaseRequestError("release request exceeds its byte limit")
+    if STABLE_TAG_PATTERN.fullmatch(tag) is None:
+        raise ReleaseRequestError("release tag must be a stable vX.Y.Z tag")
+    if COMMIT_PATTERN.fullmatch(commit) is None:
+        raise ReleaseRequestError("release commit must be a lowercase 40-byte hex SHA")
+    if max_age_seconds <= 0:
+        raise ReleaseRequestError("maximum request age must be positive")
+    try:
+        document = json.loads(raw, object_pairs_hook=_unique_object)
+    except ReleaseRequestError:
+        raise
+    except json.JSONDecodeError as exc:
+        raise ReleaseRequestError("release request is not valid JSON") from exc
+    if not isinstance(document, dict):
+        raise ReleaseRequestError("release request must be a JSON object")
+    record = cast(dict[str, Any], document)
+    if set(record) != REQUEST_KEYS:
+        raise ReleaseRequestError("release request field set is not exact")
+    if record["schema_version"] != REQUEST_SCHEMA:
+        raise ReleaseRequestError("release request schema is not supported")
+    if record["repository"] != repository:
+        raise ReleaseRequestError("release request repository does not match")
+    if record["tag"] != tag:
+        raise ReleaseRequestError("release request tag does not match")
+    if record["commit"] != commit:
+        raise ReleaseRequestError("release request commit does not match")
+    if record["immutable_releases_enabled"] is not True:
+        raise ReleaseRequestError("immutable releases were not observed as enabled")
+    verified_at = record["verified_at_epoch"]
+    if type(verified_at) is not int:
+        raise ReleaseRequestError("release request time must be an integer epoch")
+    age = now_epoch - verified_at
+    if age < 0:
+        raise ReleaseRequestError("release request time is in the future")
+    if age > max_age_seconds:
+        raise ReleaseRequestError("release request has expired")
+    return record
+
+
+def canonical_release_request(
+    raw: str,
+    *,
+    repository: str,
+    tag: str,
+    commit: str,
+    now_epoch: int,
+    max_age_seconds: int,
+) -> str:
+    """Validate and return a canonical single-line release request."""
+    record = validate_release_request(
+        raw,
+        repository=repository,
+        tag=tag,
+        commit=commit,
+        now_epoch=now_epoch,
+        max_age_seconds=max_age_seconds,
+    )
+    return json.dumps(record, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--max-age-seconds", required=True, type=int)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Validate the standard-input request and print its canonical form."""
+    parser = _parser()
+    arguments = parser.parse_args(argv)
+    raw = sys.stdin.read(MAX_REQUEST_BYTES + 1)
+    try:
+        canonical = canonical_release_request(
+            raw,
+            repository=arguments.repository,
+            tag=arguments.tag,
+            commit=arguments.commit,
+            now_epoch=int(time.time()),
+            max_age_seconds=arguments.max_age_seconds,
+        )
+    except ReleaseRequestError as exc:
+        parser.error(str(exc))
+    print(canonical)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-python -m pytest test/unit/ \
+uv run --frozen pytest test/unit/ \
     --cov=jarvis_cd \
     --cov=builtin \
     --cov-report=xml:coverage.xml \

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Jarvis-CD is a unified platform for deploying scientific applications, storage s
 - [Pipeline Configuration](pipelines.md) — Full YAML format, install managers (container/spack), environment management, multi-node, devcontainers
 - [Package Development Guide](package_dev_guide.md) — Create new packages, Dockerfile templates, container and spack support
 - [Pipeline Tests](pipeline_tests.md) — Automated testing with grid search and parameter sweeps
+- [Execution Handles](executions.md) — Durable direct and scheduler run identities, status records, and JSON queries
 - [Hostfile Configuration](hostfile.md) — Multi-node setup, pattern expansion, IP resolution
 - [Scheduler Integration](scheduler.md) — Submit pipelines as SLURM jobs, automatic hostfile from `$SLURM_JOB_NODELIST`
 - [Resource Graph](resource_graph.md) — Storage and network topology discovery

--- a/docs/executions.md
+++ b/docs/executions.md
@@ -1,0 +1,71 @@
+# Pipeline execution handles
+
+Every `Pipeline.run()` and `Pipeline.submit()` operation owns a JARVIS
+execution identity and returns an `ExecutionHandle`. The handle is a stable
+reference, not a snapshot of status. It always contains the JARVIS
+`execution_id`, `pipeline_id`, and execution `mode`. Scheduler fields are
+explicitly null for a direct run. A scheduler submission also identifies its
+provider and, after acceptance, its provider-native job ID and optional
+cluster.
+
+```python
+handle = pipeline.run(execution_id="render-2018-asteroid")
+print(handle.execution_id)
+record = handle.refresh()
+
+live = pipeline.run(wait=False)
+while not live.refresh().terminal:
+    print(live.progress().to_dict())
+
+scheduled = pipeline.submit(wait=False)
+print(scheduled.scheduler_provider)   # "slurm"
+print(scheduled.scheduler_native_id)  # e.g. "104857"
+```
+
+The changing `ExecutionRecord` is stored at
+`<pipeline_shared_dir>/executions/<execution_id>/.jarvis-execution.json`.
+Records are per execution; `last_submission` remains only a compatibility
+projection of the most recent scheduler submission. Creating another run does
+not overwrite earlier execution records.
+
+Direct `run()` remains blocking by default. Its record transitions through
+`preparing`, `running`, and `completed` or `failed`. A scheduler record moves
+through submission and then the isolated runtime snapshot advances that same
+record to `running`. The generated scheduler script finalizes it as `completed`
+or `failed`, including failures in pre-run hooks, hostfile construction, and
+post-run hooks.
+
+## Querying records
+
+Python clients can query an exact ID or list a named pipeline's history:
+
+```python
+record = pipeline.get_execution(handle.execution_id)
+records = pipeline.list_executions()
+progress = handle.progress()
+```
+
+CLI queries accept `--pipeline-id`, so a handle remains queryable after the
+operator changes the current pipeline:
+
+```bash
+jarvis ppl run current --execution-id render-2018-asteroid +json
+jarvis ppl run current +no_wait +json
+jarvis ppl submit visualization.yaml --execution-id render-2018-asteroid +json
+jarvis execution get render-2018-asteroid --pipeline-id visualization +json
+jarvis execution list --pipeline-id visualization +json
+jarvis execution progress render-2018-asteroid --pipeline-id visualization +json
+```
+
+`execution get +json` and `execution list +json` emit clean machine-readable
+JSON. `execution progress +json` returns the latest identity-checked event and
+event count for each package alias without exposing storage paths. `ppl run
++json` and `ppl submit +json` emit the handle JSON as their final
+line because package and scheduler logs remain visible before it.
+
+During a run, JARVIS binds package shared/private paths to the owned execution
+root. It also exports authoritative `JARVIS_EXECUTION_ID`, `JARVIS_PACKAGE_ID`,
+`JARVIS_PACKAGE_NAME`, `JARVIS_PROGRESS_PATH`, and
+`JARVIS_PROGRESS_TRANSPORT` values before each package starts. Application
+packages may report through the selected sidecar/stdout transport, but cannot
+choose the authoritative execution or sidecar identity.

--- a/docs/package-progress.md
+++ b/docs/package-progress.md
@@ -1,0 +1,77 @@
+# Package progress providers
+
+JARVIS progress has two layers. Execution core owns identity, persistence, and
+queryable state. A package may add application-specific observations through a
+`progress.py` file beside its `pkg.py`; it does not own the execution ID or the
+sidecar path.
+
+Before a package starts, JARVIS supplies these environment variables:
+
+- `JARVIS_EXECUTION_ID`: the stable JARVIS execution reference;
+- `JARVIS_PACKAGE_NAME`: the package type, such as `builtin.paraview`;
+- `JARVIS_PACKAGE_ID`: the package instance or pipeline alias, which remains
+  distinct when a pipeline uses the same package more than once;
+- `JARVIS_PROGRESS_PATH`: an exact JSONL sidecar inside the JARVIS-owned
+  execution root;
+- `JARVIS_PROGRESS_TRANSPORT`: `sidecar` for directly reachable shared paths,
+  or `stdout` when the application runs inside a container and JARVIS must
+  validate and persist framed output from the host.
+
+Filesystem repositories added with `jarvis repo add` can implement
+`<repository>/<package>/progress.py` and export
+`adapter_from_package(package: dict[str, Any])`. JARVIS resolves this sibling
+module from the package class already loaded from the repository. Publishing a
+Python distribution or entry point is not required.
+
+The package-local factory returns the minimal JARVIS provider protocol:
+`observe_progress(text)`, `finalize_progress()`, and `reset_progress()`. The
+first two methods return typed `ProgressObservation` values. Package providers
+interpret application output only; JARVIS adds execution/package identity,
+assigns sequence numbers, validates the event schema, and owns persistence.
+Relay-specific acceptance hooks remain available only through the separate
+`clio_relay.package_progress_adapters` compatibility entry points and are not
+required of ordinary JARVIS repository packages.
+
+## Event contract
+
+Each JSONL line is a `jarvis.progress.v1` event. It identifies both
+`package_name` and `package_id`, the JARVIS `execution_id`, a lifecycle `state`,
+and a monotonically increasing `sequence`. Quantitative `current`, `total`, and
+`unit` fields are optional. An event is determinate only when the application
+provides a real positive total; JARVIS does not turn elapsed time, log volume,
+or lifecycle states into estimated percentages.
+
+The generic JARVIS-side `ProgressReporter` uses only the Python standard
+library and can emit either `JARVIS_PROGRESS {json}` lines or the
+execution-owned sidecar. Application launchers should use the generic reporter
+while application interpretation stays in their package-local provider. The
+reporter honors `JARVIS_PROGRESS_TRANSPORT`; container applications emit stdout
+so they never need direct access to a host-only execution path.
+
+## ParaView
+
+`builtin.paraview` supports both `server` and generic `batch` modes. Batch mode
+accepts a user or site-owned script, `pvbatch_bin`, and `pvbatch_options` (for
+example `--mesa` on a compatible installation). The bundled
+`progress_reporter.py` is intentionally Python 3.10-compatible and imports no
+JARVIS modules because ParaView may bundle an older Python than JARVIS. It emits
+structured stdout only; the JARVIS parent validates identity and sequence, then
+persists the event to the exact execution-owned sidecar. The embedded ParaView
+runtime never opens that authoritative file itself.
+
+A pvbatch script calls `frame_completed` only after its render/write operation,
+or `timestep_completed` only after updating the real ParaView pipeline. It may
+provide the actual total when known. Without a total, JARVIS truthfully records
+completed units as indeterminate progress. Only MPI rank zero emits the shared
+progress stream. `pvserver` reports readiness only after observing its real
+waiting-for-client or accepting-connections output; readiness is a state, never
+a percentage. Dataset selection, camera configuration, and rendering semantics
+remain in the user or site script rather than the generic package.
+
+## LAMMPS
+
+LAMMPS parsing lives in `builtin/builtin/lammps/progress.py`, beside the package
+launcher. It interprets LAMMPS run blocks and thermo timing, while the central
+`jarvis_cd.progress` package remains application-independent. The former
+`jarvis_cd.progress.lammps` import is a compatibility shim for integrations
+that have not yet migrated.

--- a/docs/release.md
+++ b/docs/release.md
@@ -20,15 +20,26 @@ The immutable-release endpoint requires repository administration read access;
 the ephemeral `GITHUB_TOKEN` cannot be granted that permission. Do not create or
 push the version tag unless this preflight succeeds.
 
-Then verify that the release commit is the current remote `main`, that the tag
-matches the project version, and push the new tag:
+Then verify that the release commit is the current remote `main`, select the
+stable release version explicitly, and push the new tag:
 
 ```bash
 git fetch origin main --tags
 test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
-version="$(uv run python -c \
-  'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
-test ! "$(git tag -l "v${version}")"
+# JARVIS-CD derives its package version from the immutable Git tag through
+# setuptools-scm, so the release operator must select and review the intended
+# version explicitly rather than reading a nonexistent static project.version.
+: "${RELEASE_VERSION:?set RELEASE_VERSION to a stable X.Y.Z version, for example 2.0.0}"
+version="$RELEASE_VERSION"
+uv run python - "$version" <<'PY'
+import re
+import sys
+
+component = r"(?:0|[1-9][0-9]*)"
+if re.fullmatch(rf"{component}\.{component}\.{component}", sys.argv[1]) is None:
+    raise SystemExit("release version must be a stable X.Y.Z version")
+PY
+test -z "$(git tag -l "v${version}")"
 git tag "v${version}" HEAD
 git push origin "v${version}"
 ```

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,44 @@
+# Release procedure
+
+JARVIS-CD releases are built only from a version tag whose commit is already on
+`main`. The release workflow builds the wheel and source distribution, tests an
+isolated installed wheel, publishes checksums and runtime requirements, attests
+every artifact, and verifies the published immutable release.
+
+Before creating a tag, an administrator must verify the repository control that
+the Actions token cannot inspect:
+
+```bash
+test "$(gh api \
+  -H 'Accept: application/vnd.github+json' \
+  -H 'X-GitHub-Api-Version: 2026-03-10' \
+  repos/grc-iit/jarvis-cd/immutable-releases \
+  --jq .enabled)" = true
+```
+
+The immutable-release endpoint requires repository administration read access;
+the ephemeral `GITHUB_TOKEN` cannot be granted that permission. Do not create or
+push the version tag unless this preflight succeeds.
+
+Then verify that the release commit is the current remote `main`, that the tag
+matches the project version, and push the new tag:
+
+```bash
+git fetch origin main --tags
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+version="$(uv run python -c \
+  'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+test ! "$(git tag -l "v${version}")"
+git tag "v${version}" HEAD
+git push origin "v${version}"
+```
+
+The workflow fails if the tag is not on `main`, artifact metadata differs from
+the tag, the remote tag moves, the published release is not immutable, or GitHub
+cannot verify the release attestation. After it completes, verify independently:
+
+```bash
+gh release verify "v${version}" --repo grc-iit/jarvis-cd
+gh release view "v${version}" --repo grc-iit/jarvis-cd \
+  --json tagName,targetCommitish,isDraft,isImmutable,assets
+```

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,8 +17,30 @@ test "$(gh api \
 ```
 
 The immutable-release endpoint requires repository administration read access;
-the ephemeral `GITHUB_TOKEN` cannot be granted that permission. Do not create or
-push the version tag unless this preflight succeeds.
+the ephemeral `GITHUB_TOKEN` cannot be granted that permission. The operator must
+therefore publish a short-lived, exact release-request variable after this check.
+The workflow accepts only a request bound to the repository, intended tag, exact
+current `main` commit, observed setting, and verification time. It rejects future
+records, records older than one hour, unknown fields, and reuse for a different
+tag or commit. Repository variables are an audit transport, not an administrator
+boundary. Publication is separately gated by the protected
+`immutable-release` environment, whose independent reviewer must repeat the
+immutable-release setting check and verify the exact tag and commit before
+approving the deployment.
+
+The tag workflow reads the live environment and tag rulesets before building.
+It requires `can_admins_bypass=false`, self-review prevention, explicit admin
+reviewers, a `v*` tag-only deployment policy, admin-only version-tag creation,
+and no-bypass tag update/deletion protection. Do not tag if those controls have
+been removed or changed. Inspect them directly before proceeding:
+
+```bash
+gh api repos/grc-iit/jarvis-cd/environments/immutable-release
+gh api \
+  'repos/grc-iit/jarvis-cd/environments/immutable-release/deployment-branch-policies?per_page=100'
+gh api repos/grc-iit/jarvis-cd/rulesets/18798594
+gh api repos/grc-iit/jarvis-cd/rulesets/18834187
+```
 
 Then verify that the release commit is the current remote `main`, select the
 stable release version explicitly, and push the new tag:
@@ -39,9 +61,35 @@ component = r"(?:0|[1-9][0-9]*)"
 if re.fullmatch(rf"{component}\.{component}\.{component}", sys.argv[1]) is None:
     raise SystemExit("release version must be a stable X.Y.Z version")
 PY
-test -z "$(git tag -l "v${version}")"
-git tag "v${version}" HEAD
-git push origin "v${version}"
+tag="v${version}"
+commit="$(git rev-parse HEAD)"
+test -z "$(git tag -l "$tag")"
+test -z "$(git ls-remote --tags origin "refs/tags/$tag")"
+test "$(gh api \
+  -H 'Accept: application/vnd.github+json' \
+  -H 'X-GitHub-Api-Version: 2026-03-10' \
+  repos/grc-iit/jarvis-cd/immutable-releases \
+  --jq .enabled)" = true
+request="$(jq -cSn \
+  --arg repository grc-iit/jarvis-cd \
+  --arg tag "$tag" \
+  --arg commit "$commit" \
+  --argjson verified_at_epoch "$(date +%s)" \
+  '{
+    schema_version: "jarvis.release.request.v1",
+    repository: $repository,
+    tag: $tag,
+    commit: $commit,
+    immutable_releases_enabled: true,
+    verified_at_epoch: $verified_at_epoch
+  }')"
+gh variable set JARVIS_RELEASE_REQUEST \
+  --repo grc-iit/jarvis-cd \
+  --body "$request"
+test "$(gh variable get JARVIS_RELEASE_REQUEST \
+  --repo grc-iit/jarvis-cd)" = "$request"
+git tag "$tag" "$commit"
+git push origin "refs/tags/$tag"
 ```
 
 The workflow fails if the tag is not on `main`, artifact metadata differs from

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -5,19 +5,36 @@ resource manager (SLURM today; PBS / others can be added by subclassing
 `Scheduler`). The integration lives in `jarvis_cd/core/scheduler.py` and
 is driven by a top-level `scheduler:` key in the YAML.
 
-When `scheduler:` is set, `jarvis ppl submit` writes a job script into
-the pipeline's shared directory and (by default) hands it off to the
-scheduler's submit command (`sbatch` for SLURM). Inside the allocation
-the script:
+When `scheduler:` is set, `jarvis ppl submit` creates a unique execution
+directory under `<pipeline_shared_dir>/executions/`, seals the pipeline and
+environment that were current at submission time, writes an execution-scoped
+job script, and (by default) hands it off to the scheduler's submit command
+(`sbatch` for SLURM). Inside the allocation the script:
 
 1. Builds a hostfile from the scheduler's nodelist
    (`scontrol show hostnames "$SLURM_JOB_NODELIST"` for SLURM)
-2. Writes it to the path declared by `scheduler.hostfile`
-   (default: `${SHARED_DIR}/hostfile.txt`, where `${SHARED_DIR}` is the
-   pipeline's shared directory)
-3. Runs the pipeline (`jarvis ppl run yaml <file>` for a YAML-loaded
-   pipeline; `jarvis cd <name> && jarvis ppl run` for a current
-   pipeline)
+2. Writes it to that execution's private `hostfile.txt`
+3. Runs the execution's isolated `runtime/pipeline.yaml` working copy
+
+Changing or deleting the named pipeline after submission cannot change an
+already queued execution. Each execution directory contains:
+
+- `input/`: a read-only copy of the submitted `pipeline.yaml` and
+  `environment.yaml`, used as durable provenance
+- `runtime/`: the private working copy loaded inside the allocation; package
+  state written during the run stays here rather than mutating the named
+  pipeline
+- `shared/`: package-visible shared runtime files for this execution only
+- `private/`: package-visible machine-private runtime files for this execution
+  only
+- `submit.slurm`: the exact script handed to SLURM
+- `hostfile.txt`: the allocation hostfile created when the job starts
+- `.jarvis-execution.json`: the ownership and terminal-state marker used by
+  explicit cleanup
+
+The pipeline's structured `last_submission` record includes the execution ID,
+the execution root, the sealed input and runtime paths, the script and hostfile
+paths, and a SHA-256 digest of the two sealed input documents.
 
 The pipeline binds `self.hostfile` to that same path at load time, so
 every package in the pipeline that consults `self.hostfile` reads the
@@ -51,7 +68,7 @@ pkgs:
 | Key                | SBATCH flag             | Notes                               |
 |--------------------|-------------------------|-------------------------------------|
 | `name`             | (selects backend)       | Required: `slurm`                   |
-| `hostfile`         | (used by Jarvis)        | Defaults to `${SHARED_DIR}/hostfile.txt` |
+| `hostfile`         | (used by Jarvis)        | Direct scheduler use defaults to `${SHARED_DIR}/hostfile.txt`; `Pipeline.submit` isolates it per execution |
 | `suffix`           | (used by Jarvis)        | Appended to every hostname pulled from the allocation, e.g. `-40g` to target a 40GbE NIC |
 | `job_name`         | `--job-name`            |                                     |
 | `nodes`            | `--nodes`               |                                     |
@@ -184,7 +201,39 @@ jarvis ppl submit +no_submit
 jarvis ppl submit path/to/pipeline.yaml +no_submit
 ```
 
-The generated script is written to `<pipeline_shared_dir>/submit.slurm`.
+The generated script is written to
+`<pipeline_shared_dir>/executions/<execution-id>/submit.slurm`. A fresh
+execution ID is generated for every CLI submission; API callers may provide a
+bounded path-safe ID for end-to-end correlation.
+
+## Execution cleanup and pipeline destruction
+
+Scheduler execution roots are never removed by age, count, or "keep latest"
+retention. An old root may still belong to a queued or running job. Cleanup is
+therefore an explicit, bounded API operation over exact execution IDs:
+
+```python
+pipeline.cleanup_executions(["run-2026-07-11"])
+```
+
+JARVIS accepts an ID without an override only when its owned execution marker
+is terminal. For a nonterminal marker, the operator must first check the
+scheduler's authoritative state and then name that same ID in
+`terminal_verified`:
+
+```python
+pipeline.cleanup_executions(
+    ["run-2026-07-11"],
+    terminal_verified=["run-2026-07-11"],
+)
+```
+
+`force=True` is the explicit emergency override; it does not broaden the set
+of IDs being removed. Cleanup validates the ownership marker and quarantines
+each exact root before deletion. `Pipeline.destroy()` refuses to destroy a
+named pipeline while *any* execution-root entries remain, including queued
+jobs and incomplete or unrecognized entries. A runtime snapshot cannot clean
+execution roots or destroy its named source pipeline.
 
 ## Multi-node SSH inside an allocation
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -29,10 +29,12 @@ already queued execution. Each execution directory contains:
   only
 - `submit.slurm`: the exact script handed to SLURM
 - `hostfile.txt`: the allocation hostfile created when the job starts
-- `.jarvis-execution.json`: the ownership and terminal-state marker used by
-  explicit cleanup
+- `.jarvis-execution.json`: the typed durable execution record used by status
+  queries and explicit cleanup
 
-The pipeline's structured `last_submission` record includes the execution ID,
+`Pipeline.submit()` returns a typed execution handle containing the JARVIS
+execution ID plus the provider-native scheduler ID when submission succeeds.
+The pipeline's compatibility `last_submission` record includes the execution ID,
 the execution root, the sealed input and runtime paths, the script and hostfile
 paths, and a SHA-256 digest of the two sealed input documents.
 
@@ -199,6 +201,12 @@ jarvis ppl submit path/to/pipeline_test.yaml      # YAML test
 # Generate script only, no sbatch
 jarvis ppl submit +no_submit
 jarvis ppl submit path/to/pipeline.yaml +no_submit
+
+# Submit asynchronously and print the handle as the final JSON line
+jarvis ppl submit +json
+
+# Block until the scheduler workload finishes
+jarvis ppl submit +wait +json
 ```
 
 The generated script is written to

--- a/jarvis_cd/core/__init__.py
+++ b/jarvis_cd/core/__init__.py
@@ -1,13 +1,40 @@
-"""
-Core Jarvis-CD classes and utilities.
-"""
+"""Core JARVIS-CD classes and utilities with lazy compatibility exports."""
 
-from .pkg import Application, Service
-from .container_pkg import ContainerApplication, ContainerService
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .container_pkg import ContainerApplication, ContainerService
+    from .pkg import Application, Service
 
 __all__ = [
-    'Application',
-    'Service',
-    'ContainerApplication',
-    'ContainerService',
+    "Application",
+    "Service",
+    "ContainerApplication",
+    "ContainerService",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve legacy public classes without eager package import cycles."""
+    if name in {"Application", "Service"}:
+        from .pkg import Application, Service
+
+        value = {"Application": Application, "Service": Service}[name]
+    elif name in {"ContainerApplication", "ContainerService"}:
+        from .container_pkg import ContainerApplication, ContainerService
+
+        value = {
+            "ContainerApplication": ContainerApplication,
+            "ContainerService": ContainerService,
+        }[name]
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Include lazy compatibility exports in module introspection."""
+    return sorted(set(globals()) | set(__all__))

--- a/jarvis_cd/core/cli.py
+++ b/jarvis_cd/core/cli.py
@@ -1,10 +1,12 @@
+import json
 import sys
 import os
 from pathlib import Path
 from jarvis_cd.util.argparse import ArgParse
 from jarvis_cd.core.config import Jarvis
+from jarvis_cd.core.execution import ExecutionHandle
 from jarvis_cd.core.pipeline import Pipeline
-from jarvis_cd.core.pipeline_test import is_pipeline_test, PipelineTest, load_yaml_auto, run_yaml_auto
+from jarvis_cd.core.pipeline_test import load_yaml_auto
 from jarvis_cd.core.pipeline_index import PipelineIndexManager
 from jarvis_cd.core.repository import RepositoryManager
 from jarvis_cd.core.pkg import Pkg
@@ -17,7 +19,7 @@ class JarvisCLI(ArgParse):
     Main Jarvis CLI using the custom ArgParse class.
     Provides commands for initialization, pipeline management, repository management, etc.
     """
-    
+
     def __init__(self):
         super().__init__()
         self.jarvis = None
@@ -29,906 +31,1188 @@ class JarvisCLI(ArgParse):
         self.env_manager = None
         self.rg_manager = None
         self.module_manager = None
-        
+
     def define_options(self):
         """Define the complete Jarvis CLI command structure"""
-        
+
         # Main menu (empty command for global options)
-        self.add_menu('')
-        self.add_cmd('', keep_remainder=True)
-        self.add_args([
-            {
-                'name': 'help',
-                'msg': 'Show help information',
-                'type': bool,
-                'default': False,
-                'aliases': ['h']
-            }
-        ])
-        
+        self.add_menu("")
+        self.add_cmd("", keep_remainder=True)
+        self.add_args(
+            [
+                {
+                    "name": "help",
+                    "msg": "Show help information",
+                    "type": bool,
+                    "default": False,
+                    "aliases": ["h"],
+                }
+            ]
+        )
+
         # Init command
-        self.add_menu('init', msg="Initialize Jarvis configuration")
-        self.add_cmd('init', msg="Initialize Jarvis configuration directories", keep_remainder=False)
-        self.add_args([
-            {
-                'name': 'config_dir',
-                'msg': 'Configuration directory',
-                'type': str,
-                'pos': True,
-                'default': '~/.ppi-jarvis/config',
-                'class': 'dirs',
-                'rank': 0
-            },
-            {
-                'name': 'private_dir',
-                'msg': 'Private data directory',
-                'type': str,
-                'pos': True,
-                'default': '~/.ppi-jarvis/private',
-                'class': 'dirs',
-                'rank': 1
-            },
-            {
-                'name': 'shared_dir',
-                'msg': 'Shared data directory',
-                'type': str,
-                'pos': True,
-                'default': '~/.ppi-jarvis/shared',
-                'class': 'dirs',
-                'rank': 2
-            },
-            {
-                'name': 'force',
-                'msg': 'Force override of existing repos and resource_graph',
-                'type': bool,
-                'default': False,
-            }
-        ])
-        
+        self.add_menu("init", msg="Initialize Jarvis configuration")
+        self.add_cmd(
+            "init",
+            msg="Initialize Jarvis configuration directories",
+            keep_remainder=False,
+        )
+        self.add_args(
+            [
+                {
+                    "name": "config_dir",
+                    "msg": "Configuration directory",
+                    "type": str,
+                    "pos": True,
+                    "default": "~/.ppi-jarvis/config",
+                    "class": "dirs",
+                    "rank": 0,
+                },
+                {
+                    "name": "private_dir",
+                    "msg": "Private data directory",
+                    "type": str,
+                    "pos": True,
+                    "default": "~/.ppi-jarvis/private",
+                    "class": "dirs",
+                    "rank": 1,
+                },
+                {
+                    "name": "shared_dir",
+                    "msg": "Shared data directory",
+                    "type": str,
+                    "pos": True,
+                    "default": "~/.ppi-jarvis/shared",
+                    "class": "dirs",
+                    "rank": 2,
+                },
+                {
+                    "name": "force",
+                    "msg": "Force override of existing repos and resource_graph",
+                    "type": bool,
+                    "default": False,
+                },
+            ]
+        )
+
         # Pipeline commands
-        self.add_menu('ppl', msg="Pipeline management commands")
-        
-        self.add_cmd('ppl create', msg="Create a new pipeline", aliases=['ppl c'])
-        self.add_args([
-            {
-                'name': 'pipeline_name',
-                'msg': 'Name of the pipeline to create',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('ppl append', msg="Add a package to current pipeline", aliases=['ppl a'], keep_remainder=True)
-        self.add_args([
-            {
-                'name': 'package_spec',
-                'msg': 'Package specification (repo.pkg or just pkg)',
-                'type': str,
-                'required': True,
-                'pos': True,
-                'class': 'pkg',
-                'rank': 0
-            },
-            {
-                'name': 'package_alias',
-                'msg': 'Alias for the package in pipeline',
-                'type': str,
-                'pos': True,
-                'class': 'pkg', 
-                'rank': 1
-            }
-        ])
-        
-        self.add_cmd('ppl run', msg="Run a pipeline", aliases=['ppl r'])
-        self.add_args([
-            {
-                'name': 'load_type',
-                'msg': 'Type of pipeline to load (yaml) or current',
-                'type': str,
-                'pos': True,
-                'default': 'current'
-            },
-            {
-                'name': 'pipeline_file',
-                'msg': 'Pipeline YAML file to run (required if load_type is yaml)',
-                'type': str,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('ppl start', msg="Start current pipeline")
-        self.add_args([])
-        
-        self.add_cmd('ppl stop', msg="Stop current pipeline")
-        self.add_args([])
-        
-        self.add_cmd('ppl kill', msg="Force kill current pipeline")
-        self.add_args([])
-        
-        self.add_cmd('ppl clean', msg="Clean current pipeline data")
-        self.add_args([])
+        self.add_menu("ppl", msg="Pipeline management commands")
 
-        self.add_cmd('ppl rerun', msg="Destroy pipeline output and re-run")
-        self.add_args([
-            {
-                'name': 'load_type',
-                'msg': 'Type of pipeline to load (yaml) or current',
-                'type': str,
-                'pos': True,
-                'default': 'current'
-            },
-            {
-                'name': 'pipeline_file',
-                'msg': 'Pipeline YAML file to run (required if load_type is yaml)',
-                'type': str,
-                'pos': True
-            }
-        ])
+        self.add_cmd("ppl create", msg="Create a new pipeline", aliases=["ppl c"])
+        self.add_args(
+            [
+                {
+                    "name": "pipeline_name",
+                    "msg": "Name of the pipeline to create",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
 
-        self.add_cmd('ppl retest', msg="Destroy test output and re-run all tests")
-        self.add_args([
-            {
-                'name': 'load_type',
-                'msg': 'Type of pipeline to load (yaml) or current',
-                'type': str,
-                'pos': True,
-                'default': 'current'
-            },
-            {
-                'name': 'pipeline_file',
-                'msg': 'Pipeline test YAML file to run (required if load_type is yaml)',
-                'type': str,
-                'pos': True
-            }
-        ])
+        self.add_cmd(
+            "ppl append",
+            msg="Add a package to current pipeline",
+            aliases=["ppl a"],
+            keep_remainder=True,
+        )
+        self.add_args(
+            [
+                {
+                    "name": "package_spec",
+                    "msg": "Package specification (repo.pkg or just pkg)",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                    "class": "pkg",
+                    "rank": 0,
+                },
+                {
+                    "name": "package_alias",
+                    "msg": "Alias for the package in pipeline",
+                    "type": str,
+                    "pos": True,
+                    "class": "pkg",
+                    "rank": 1,
+                },
+            ]
+        )
 
-        self.add_cmd('ppl status', msg="Show current pipeline status")
-        self.add_args([])
-        
-        self.add_cmd('ppl load', msg="Load a pipeline from file")
-        self.add_args([
-            {
-                'name': 'load_type',
-                'msg': 'Type of pipeline to load (yaml)',
-                'type': str,
-                'required': True,
-                'pos': True
-            },
-            {
-                'name': 'pipeline_file',
-                'msg': 'Pipeline file to load',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('ppl submit',
-                     msg="Generate (and optionally submit) a scheduler "
-                         "job script for the current pipeline or a YAML "
-                         "test file")
-        self.add_args([
-            {
-                'name': 'pipeline_file',
-                'msg': 'Optional pipeline / test YAML to submit (defaults '
-                       'to the current pipeline)',
-                'type': str,
-                'pos': True,
-                'required': False,
-            },
-            {
-                'name': 'no_submit',
-                'msg': 'Only write the job script, do not run sbatch',
-                'type': bool,
-                'default': False,
-                'prefix': '+',
-            },
-        ])
+        self.add_cmd("ppl run", msg="Run a pipeline", aliases=["ppl r"])
+        self.add_args(
+            [
+                {
+                    "name": "load_type",
+                    "msg": "Type of pipeline to load (yaml) or current",
+                    "type": str,
+                    "pos": True,
+                    "default": "current",
+                },
+                {
+                    "name": "pipeline_file",
+                    "msg": "Pipeline YAML file to run (required if load_type is yaml)",
+                    "type": str,
+                    "pos": True,
+                },
+                {
+                    "name": "execution_id",
+                    "aliases": ["execution-id"],
+                    "msg": "Optional caller-selected JARVIS execution identity",
+                    "type": str,
+                    "required": False,
+                },
+                {
+                    "name": "json",
+                    "msg": "Print the execution handle as JSON",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+                {
+                    "name": "no_wait",
+                    "msg": "Return a live handle after launching an owned local process",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+            ]
+        )
 
-        self.add_cmd('ppl update', msg="Update current pipeline")
-        self.add_args([
-            {
-                'name': 'update_type',
-                'msg': 'Type of update (yaml)',
-                'type': str,
-                'pos': True,
-                'default': 'yaml'
-            },
-            {
-                'name': 'container',
-                'msg': 'Rebuild container image',
-                'type': bool,
-                'default': False
-            },
-            {
-                'name': 'no_cache',
-                'msg': 'Disable cache during container rebuild',
-                'type': bool,
-                'default': False
-            }
-        ])
-
-        self.add_cmd('ppl conf', msg="Configure pipeline parameters")
-        self.add_args([
-            {
-                'name': 'hostfile',
-                'msg': 'Path to pipeline-specific hostfile',
-                'type': str,
-                'default': None,
-            },
-            {
-                'name': 'container_image',
-                'msg': 'Pre-built container image to use',
-                'type': str,
-                'default': None,
-            },
-            {
-                'name': 'container_engine',
-                'msg': 'Container engine (docker/podman)',
-                'type': str,
-                'default': None,
-            },
-            {
-                'name': 'container_base',
-                'msg': 'Base container image',
-                'type': str,
-                'default': None,
-            },
-            {
-                'name': 'container_ssh_port',
-                'msg': 'SSH port for containers',
-                'type': int,
-                'default': None,
-            }
-        ])
-
-        self.add_cmd('ppl list', msg="List all pipelines", aliases=['ppl ls'])
-        self.add_args([])
-        
-        self.add_cmd('ppl print', msg="Print current pipeline configuration")
+        self.add_cmd("ppl start", msg="Start current pipeline")
         self.add_args([])
 
-        self.add_cmd('ppl path', msg="Print pipeline directory paths")
-        self.add_args([
-            {
-                'name': 'shared',
-                'msg': 'Print only shared directory',
-                'type': bool,
-                'default': False,
-                'prefix': '+'
-            },
-            {
-                'name': 'private',
-                'msg': 'Print only private directory',
-                'type': bool,
-                'default': False,
-                'prefix': '+'
-            },
-            {
-                'name': 'config',
-                'msg': 'Print only config directory',
-                'type': bool,
-                'default': False,
-                'prefix': '+'
-            }
-        ])
+        self.add_cmd("ppl stop", msg="Stop current pipeline")
+        self.add_args([])
 
-        self.add_cmd('ppl rm', msg="Remove a package from current pipeline", aliases=['ppl remove'])
-        self.add_args([
-            {
-                'name': 'package_spec',
-                'msg': 'Package to remove (pkg_id or pipeline.pkg_id)',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('ppl destroy', msg="Destroy a pipeline")
-        self.add_args([
-            {
-                'name': 'pipeline_name',
-                'msg': 'Name of pipeline to destroy (optional, defaults to current)',
-                'type': str,
-                'pos': True
-            }
-        ])
-        
+        self.add_cmd("ppl kill", msg="Force kill current pipeline")
+        self.add_args([])
+
+        self.add_cmd("ppl clean", msg="Clean current pipeline data")
+        self.add_args([])
+
+        self.add_cmd("ppl rerun", msg="Destroy pipeline output and re-run")
+        self.add_args(
+            [
+                {
+                    "name": "load_type",
+                    "msg": "Type of pipeline to load (yaml) or current",
+                    "type": str,
+                    "pos": True,
+                    "default": "current",
+                },
+                {
+                    "name": "pipeline_file",
+                    "msg": "Pipeline YAML file to run (required if load_type is yaml)",
+                    "type": str,
+                    "pos": True,
+                },
+            ]
+        )
+
+        self.add_cmd("ppl retest", msg="Destroy test output and re-run all tests")
+        self.add_args(
+            [
+                {
+                    "name": "load_type",
+                    "msg": "Type of pipeline to load (yaml) or current",
+                    "type": str,
+                    "pos": True,
+                    "default": "current",
+                },
+                {
+                    "name": "pipeline_file",
+                    "msg": "Pipeline test YAML file to run (required if load_type is yaml)",
+                    "type": str,
+                    "pos": True,
+                },
+            ]
+        )
+
+        self.add_cmd("ppl status", msg="Show current pipeline status")
+        self.add_args([])
+
+        self.add_cmd("ppl load", msg="Load a pipeline from file")
+        self.add_args(
+            [
+                {
+                    "name": "load_type",
+                    "msg": "Type of pipeline to load (yaml)",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                },
+                {
+                    "name": "pipeline_file",
+                    "msg": "Pipeline file to load",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                },
+            ]
+        )
+
+        self.add_cmd(
+            "ppl submit",
+            msg="Generate (and optionally submit) a scheduler "
+            "job script for the current pipeline or a YAML "
+            "test file",
+        )
+        self.add_args(
+            [
+                {
+                    "name": "pipeline_file",
+                    "msg": "Optional pipeline / test YAML to submit (defaults "
+                    "to the current pipeline)",
+                    "type": str,
+                    "pos": True,
+                    "required": False,
+                },
+                {
+                    "name": "no_submit",
+                    "msg": "Only write the job script, do not run sbatch",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+                {
+                    "name": "wait",
+                    "msg": "Wait for the scheduler workload to finish",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+                {
+                    "name": "execution_id",
+                    "aliases": ["execution-id"],
+                    "msg": "Optional caller-selected JARVIS execution identity",
+                    "type": str,
+                    "required": False,
+                },
+                {
+                    "name": "json",
+                    "msg": "Print the execution handle as JSON",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+            ]
+        )
+
+        self.add_menu("execution", msg="Durable pipeline execution records")
+        self.add_cmd(
+            "execution get",
+            msg="Get one exact execution record",
+            aliases=["execution query"],
+        )
+        self.add_args(
+            [
+                {
+                    "name": "execution_id",
+                    "msg": "JARVIS execution identity",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                },
+                {
+                    "name": "pipeline_id",
+                    "aliases": ["pipeline-id"],
+                    "msg": "Pipeline identity (defaults to current pipeline)",
+                    "type": str,
+                    "required": False,
+                },
+                {
+                    "name": "json",
+                    "msg": "Print the complete record as JSON",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+            ]
+        )
+
+        self.add_cmd("execution list", msg="List pipeline execution records")
+        self.add_args(
+            [
+                {
+                    "name": "pipeline_id",
+                    "aliases": ["pipeline-id"],
+                    "msg": "Pipeline identity (defaults to current pipeline)",
+                    "type": str,
+                    "required": False,
+                },
+                {
+                    "name": "json",
+                    "msg": "Print the complete record list as JSON",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+            ]
+        )
+
+        self.add_cmd(
+            "execution progress",
+            msg="Get validated package progress for one execution",
+        )
+        self.add_args(
+            [
+                {
+                    "name": "execution_id",
+                    "msg": "JARVIS execution identity",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                },
+                {
+                    "name": "pipeline_id",
+                    "aliases": ["pipeline-id"],
+                    "msg": "Pipeline identity (defaults to current pipeline)",
+                    "type": str,
+                    "required": False,
+                },
+                {
+                    "name": "json",
+                    "msg": "Print the complete progress snapshot as JSON",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+            ]
+        )
+
+        self.add_cmd("ppl update", msg="Update current pipeline")
+        self.add_args(
+            [
+                {
+                    "name": "update_type",
+                    "msg": "Type of update (yaml)",
+                    "type": str,
+                    "pos": True,
+                    "default": "yaml",
+                },
+                {
+                    "name": "container",
+                    "msg": "Rebuild container image",
+                    "type": bool,
+                    "default": False,
+                },
+                {
+                    "name": "no_cache",
+                    "msg": "Disable cache during container rebuild",
+                    "type": bool,
+                    "default": False,
+                },
+            ]
+        )
+
+        self.add_cmd("ppl conf", msg="Configure pipeline parameters")
+        self.add_args(
+            [
+                {
+                    "name": "hostfile",
+                    "msg": "Path to pipeline-specific hostfile",
+                    "type": str,
+                    "default": None,
+                },
+                {
+                    "name": "container_image",
+                    "msg": "Pre-built container image to use",
+                    "type": str,
+                    "default": None,
+                },
+                {
+                    "name": "container_engine",
+                    "msg": "Container engine (docker/podman)",
+                    "type": str,
+                    "default": None,
+                },
+                {
+                    "name": "container_base",
+                    "msg": "Base container image",
+                    "type": str,
+                    "default": None,
+                },
+                {
+                    "name": "container_ssh_port",
+                    "msg": "SSH port for containers",
+                    "type": int,
+                    "default": None,
+                },
+            ]
+        )
+
+        self.add_cmd("ppl list", msg="List all pipelines", aliases=["ppl ls"])
+        self.add_args([])
+
+        self.add_cmd("ppl print", msg="Print current pipeline configuration")
+        self.add_args([])
+
+        self.add_cmd("ppl path", msg="Print pipeline directory paths")
+        self.add_args(
+            [
+                {
+                    "name": "shared",
+                    "msg": "Print only shared directory",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+                {
+                    "name": "private",
+                    "msg": "Print only private directory",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+                {
+                    "name": "config",
+                    "msg": "Print only config directory",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+            ]
+        )
+
+        self.add_cmd(
+            "ppl rm",
+            msg="Remove a package from current pipeline",
+            aliases=["ppl remove"],
+        )
+        self.add_args(
+            [
+                {
+                    "name": "package_spec",
+                    "msg": "Package to remove (pkg_id or pipeline.pkg_id)",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("ppl destroy", msg="Destroy a pipeline")
+        self.add_args(
+            [
+                {
+                    "name": "pipeline_name",
+                    "msg": "Name of pipeline to destroy (optional, defaults to current)",
+                    "type": str,
+                    "pos": True,
+                }
+            ]
+        )
+
         # Pipeline environment commands - need to add menu first
-        self.add_menu('ppl env', msg="Pipeline environment management")
-        
-        self.add_cmd('ppl env build', msg="Build environment for current pipeline", keep_remainder=True)
+        self.add_menu("ppl env", msg="Pipeline environment management")
+
+        self.add_cmd(
+            "ppl env build",
+            msg="Build environment for current pipeline",
+            keep_remainder=True,
+        )
         self.add_args([])
-        
-        self.add_cmd('ppl env copy', msg="Copy named environment to current pipeline")
-        self.add_args([
-            {
-                'name': 'env_name',
-                'msg': 'Name of environment to copy',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('ppl env show', msg="Show current pipeline environment")
+
+        self.add_cmd("ppl env copy", msg="Copy named environment to current pipeline")
+        self.add_args(
+            [
+                {
+                    "name": "env_name",
+                    "msg": "Name of environment to copy",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("ppl env show", msg="Show current pipeline environment")
         self.add_args([])
-        
+
         # Pipeline index commands
-        self.add_menu('ppl index', msg="Pipeline index management")
-        
-        self.add_cmd('ppl index load', msg="Load a pipeline script from an index")
-        self.add_args([
-            {
-                'name': 'index_query',
-                'msg': 'Index query (e.g., repo.subdir.script)',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('ppl index copy', msg="Copy a pipeline script from an index")
-        self.add_args([
-            {
-                'name': 'index_query',
-                'msg': 'Index query (e.g., repo.subdir.script)',
-                'type': str,
-                'required': True,
-                'pos': True
-            },
-            {
-                'name': 'output',
-                'msg': 'Output directory or file (optional)',
-                'type': str,
-                'required': False,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('ppl index list', msg="List available pipeline scripts in indexes", aliases=['ppl index ls'])
-        self.add_args([
-            {
-                'name': 'repo_name',
-                'msg': 'Repository name to list (optional)',
-                'type': str,
-                'required': False,
-                'pos': True
-            }
-        ])
-        
+        self.add_menu("ppl index", msg="Pipeline index management")
+
+        self.add_cmd("ppl index load", msg="Load a pipeline script from an index")
+        self.add_args(
+            [
+                {
+                    "name": "index_query",
+                    "msg": "Index query (e.g., repo.subdir.script)",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("ppl index copy", msg="Copy a pipeline script from an index")
+        self.add_args(
+            [
+                {
+                    "name": "index_query",
+                    "msg": "Index query (e.g., repo.subdir.script)",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                },
+                {
+                    "name": "output",
+                    "msg": "Output directory or file (optional)",
+                    "type": str,
+                    "required": False,
+                    "pos": True,
+                },
+            ]
+        )
+
+        self.add_cmd(
+            "ppl index list",
+            msg="List available pipeline scripts in indexes",
+            aliases=["ppl index ls"],
+        )
+        self.add_args(
+            [
+                {
+                    "name": "repo_name",
+                    "msg": "Repository name to list (optional)",
+                    "type": str,
+                    "required": False,
+                    "pos": True,
+                }
+            ]
+        )
+
         # Change directory (switch current pipeline)
-        self.add_cmd('cd', msg="Change current pipeline")
-        self.add_args([
-            {
-                'name': 'pipeline_name',
-                'msg': 'Name of pipeline to switch to',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
+        self.add_cmd("cd", msg="Change current pipeline")
+        self.add_args(
+            [
+                {
+                    "name": "pipeline_name",
+                    "msg": "Name of pipeline to switch to",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
         # Repository commands
-        self.add_menu('repo', msg="Repository management commands")
-        
-        self.add_cmd('repo add', msg="Add a repository to Jarvis")
-        self.add_args([
-            {
-                'name': 'repo_path',
-                'msg': 'Path to repository directory',
-                'type': str,
-                'required': True,
-                'pos': True
-            },
-            {
-                'name': 'force',
-                'msg': 'Force overwrite if repository already exists',
-                'type': bool,
-                'default': False,
-                'aliases': ['f']
-            }
-        ])
-        
-        self.add_cmd('repo remove', msg="Remove a repository from Jarvis", aliases=['repo rm'])
-        self.add_args([
-            {
-                'name': 'repo_name',
-                'msg': 'Name of repository to remove (not full path)',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('repo list', msg="List all registered repositories", aliases=['repo ls'])
+        self.add_menu("repo", msg="Repository management commands")
+
+        self.add_cmd("repo add", msg="Add a repository to Jarvis")
+        self.add_args(
+            [
+                {
+                    "name": "repo_path",
+                    "msg": "Path to repository directory",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                },
+                {
+                    "name": "force",
+                    "msg": "Force overwrite if repository already exists",
+                    "type": bool,
+                    "default": False,
+                    "aliases": ["f"],
+                },
+            ]
+        )
+
+        self.add_cmd(
+            "repo remove", msg="Remove a repository from Jarvis", aliases=["repo rm"]
+        )
+        self.add_args(
+            [
+                {
+                    "name": "repo_name",
+                    "msg": "Name of repository to remove (not full path)",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd(
+            "repo list", msg="List all registered repositories", aliases=["repo ls"]
+        )
         self.add_args([])
-        
-        self.add_cmd('repo create', msg="Create a new package in repository")
-        self.add_args([
-            {
-                'name': 'package_name',
-                'msg': 'Name of package to create',
-                'type': str,
-                'required': True,
-                'pos': True,
-                'class': 'pkg',
-                'rank': 0
-            },
-            {
-                'name': 'package_type',
-                'msg': 'Type of package (service, app, interceptor)',
-                'type': str,
-                'required': True,
-                'pos': True,
-                'choices': ['service', 'app', 'interceptor'],
-                'class': 'pkg',
-                'rank': 1
-            }
-        ])
+
+        self.add_cmd("repo create", msg="Create a new package in repository")
+        self.add_args(
+            [
+                {
+                    "name": "package_name",
+                    "msg": "Name of package to create",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                    "class": "pkg",
+                    "rank": 0,
+                },
+                {
+                    "name": "package_type",
+                    "msg": "Type of package (service, app, interceptor)",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                    "choices": ["service", "app", "interceptor"],
+                    "class": "pkg",
+                    "rank": 1,
+                },
+            ]
+        )
 
         # Container commands
-        self.add_menu('container', msg="Container image management commands")
+        self.add_menu("container", msg="Container image management commands")
 
-        self.add_cmd('container list', msg="List all container images", aliases=['container ls'])
+        self.add_cmd(
+            "container list", msg="List all container images", aliases=["container ls"]
+        )
         self.add_args([])
 
-        self.add_cmd('container remove', msg="Remove a container image", aliases=['container rm'])
-        self.add_args([
-            {
-                'name': 'container_name',
-                'msg': 'Name of container to remove',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
+        self.add_cmd(
+            "container remove", msg="Remove a container image", aliases=["container rm"]
+        )
+        self.add_args(
+            [
+                {
+                    "name": "container_name",
+                    "msg": "Name of container to remove",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
 
-        self.add_cmd('container update', msg="Force rebuild a container image")
-        self.add_args([
-            {
-                'name': 'container_name',
-                'msg': 'Name of container to rebuild',
-                'type': str,
-                'required': True,
-                'pos': True
-            },
-            {
-                'name': 'no_cache',
-                'msg': 'Disable cache during rebuild',
-                'type': bool,
-                'default': False
-            },
-            {
-                'name': 'engine',
-                'msg': 'Container engine to use (docker or podman)',
-                'type': str,
-                'default': None,
-                'choices': ['docker', 'podman']
-            }
-        ])
+        self.add_cmd("container update", msg="Force rebuild a container image")
+        self.add_args(
+            [
+                {
+                    "name": "container_name",
+                    "msg": "Name of container to rebuild",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                },
+                {
+                    "name": "no_cache",
+                    "msg": "Disable cache during rebuild",
+                    "type": bool,
+                    "default": False,
+                },
+                {
+                    "name": "engine",
+                    "msg": "Container engine to use (docker or podman)",
+                    "type": str,
+                    "default": None,
+                    "choices": ["docker", "podman"],
+                },
+            ]
+        )
 
         # Package commands
-        self.add_menu('pkg', msg="Package management commands")
-        
-        self.add_cmd('pkg configure', msg="Configure a package", aliases=['pkg conf'], keep_remainder=True)
-        self.add_args([
-            {
-                'name': 'package_spec',
-                'msg': 'Package to configure (pkg or pipeline.pkg)',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('pkg readme', msg="Show package README")
-        self.add_args([
-            {
-                'name': 'package_spec',
-                'msg': 'Package to show README for (pkg or repo.pkg)',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('pkg path', msg="Show package directory paths")
-        self.add_args([
-            {
-                'name': 'package_spec',
-                'msg': 'Package to show paths for (pkg or repo.pkg)',
-                'type': str,
-                'required': True,
-                'pos': True
-            },
-            {
-                'name': 'shared',
-                'msg': 'Print only shared directory',
-                'type': bool,
-                'default': False,
-                'prefix': '+'
-            },
-            {
-                'name': 'private',
-                'msg': 'Print only private directory',
-                'type': bool,
-                'default': False,
-                'prefix': '+'
-            },
-            {
-                'name': 'config',
-                'msg': 'Print only config directory',
-                'type': bool,
-                'default': False,
-                'prefix': '+'
-            }
-        ])
+        self.add_menu("pkg", msg="Package management commands")
 
-        self.add_cmd('pkg help', msg="Show package configuration help")
-        self.add_args([
-            {
-                'name': 'package_spec',
-                'msg': 'Package to show help for (pkg or repo.pkg)',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
+        self.add_cmd(
+            "pkg configure",
+            msg="Configure a package",
+            aliases=["pkg conf"],
+            keep_remainder=True,
+        )
+        self.add_args(
+            [
+                {
+                    "name": "package_spec",
+                    "msg": "Package to configure (pkg or pipeline.pkg)",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("pkg readme", msg="Show package README")
+        self.add_args(
+            [
+                {
+                    "name": "package_spec",
+                    "msg": "Package to show README for (pkg or repo.pkg)",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("pkg path", msg="Show package directory paths")
+        self.add_args(
+            [
+                {
+                    "name": "package_spec",
+                    "msg": "Package to show paths for (pkg or repo.pkg)",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                },
+                {
+                    "name": "shared",
+                    "msg": "Print only shared directory",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+                {
+                    "name": "private",
+                    "msg": "Print only private directory",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+                {
+                    "name": "config",
+                    "msg": "Print only config directory",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+            ]
+        )
+
+        self.add_cmd("pkg help", msg="Show package configuration help")
+        self.add_args(
+            [
+                {
+                    "name": "package_spec",
+                    "msg": "Package to show help for (pkg or repo.pkg)",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
 
         # Package container inspection commands
-        self.add_menu('pkg container',
-                     msg="Inspect a package's container build artifacts")
+        self.add_menu(
+            "pkg container", msg="Inspect a package's container build artifacts"
+        )
 
-        self.add_cmd('pkg container build',
-                     msg="Print the build.sh jarvis would run inside the build container")
-        self.add_args([
-            {
-                'name': 'package_spec',
-                'msg': 'Package to inspect (pkg, pipeline.pkg, or repo.pkg)',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
+        self.add_cmd(
+            "pkg container build",
+            msg="Print the build.sh jarvis would run inside the build container",
+        )
+        self.add_args(
+            [
+                {
+                    "name": "package_spec",
+                    "msg": "Package to inspect (pkg, pipeline.pkg, or repo.pkg)",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
 
-        self.add_cmd('pkg container deploy',
-                     msg="Print the Dockerfile.deploy jarvis would use to build the deploy image")
-        self.add_args([
-            {
-                'name': 'package_spec',
-                'msg': 'Package to inspect (pkg, pipeline.pkg, or repo.pkg)',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
+        self.add_cmd(
+            "pkg container deploy",
+            msg="Print the Dockerfile.deploy jarvis would use to build the deploy image",
+        )
+        self.add_args(
+            [
+                {
+                    "name": "package_spec",
+                    "msg": "Package to inspect (pkg, pipeline.pkg, or repo.pkg)",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
 
         # Environment commands
-        self.add_menu('env', msg="Named environment management")
-        
-        self.add_cmd('env build', msg="Build a named environment", keep_remainder=True)
-        self.add_args([
-            {
-                'name': 'env_name',
-                'msg': 'Name of environment to create',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('env list', msg="List all named environments", aliases=['env ls'])
-        self.add_args([])
-        
-        self.add_cmd('env show', msg="Show a named environment")
-        self.add_args([
-            {
-                'name': 'env_name',
-                'msg': 'Name of environment to show',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        # Set hostfile command
-        self.add_menu('hostfile', msg="Hostfile management")
-        self.add_cmd('hostfile set', msg="Set the hostfile for deployments")
-        self.add_args([
-            {
-                'name': 'hostfile_path',
-                'msg': 'Path to hostfile',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
+        self.add_menu("env", msg="Named environment management")
 
-        self.add_cmd('hostfile unset',
-                     msg="Unset the hostfile (revert to default: localhost)")
+        self.add_cmd("env build", msg="Build a named environment", keep_remainder=True)
+        self.add_args(
+            [
+                {
+                    "name": "env_name",
+                    "msg": "Name of environment to create",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("env list", msg="List all named environments", aliases=["env ls"])
+        self.add_args([])
+
+        self.add_cmd("env show", msg="Show a named environment")
+        self.add_args(
+            [
+                {
+                    "name": "env_name",
+                    "msg": "Name of environment to show",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
+        # Set hostfile command
+        self.add_menu("hostfile", msg="Hostfile management")
+        self.add_cmd("hostfile set", msg="Set the hostfile for deployments")
+        self.add_args(
+            [
+                {
+                    "name": "hostfile_path",
+                    "msg": "Path to hostfile",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd(
+            "hostfile unset", msg="Unset the hostfile (revert to default: localhost)"
+        )
 
         # Resource graph commands
-        self.add_menu('rg', msg="Resource graph management")
-        
-        self.add_cmd('rg build', msg="Build resource graph from hostfile")
-        self.add_args([
-            {
-                'name': 'no_benchmark',
-                'msg': 'Skip performance benchmarking',
-                'type': bool,
-                'default': False
-            },
-            {
-                'name': 'duration',
-                'msg': 'Benchmark duration in seconds',
-                'type': int,
-                'default': 25
-            }
-        ])
-        
-        self.add_cmd('rg show', msg="Show resource graph summary")
+        self.add_menu("rg", msg="Resource graph management")
+
+        self.add_cmd("rg build", msg="Build resource graph from hostfile")
+        self.add_args(
+            [
+                {
+                    "name": "no_benchmark",
+                    "msg": "Skip performance benchmarking",
+                    "type": bool,
+                    "default": False,
+                },
+                {
+                    "name": "duration",
+                    "msg": "Benchmark duration in seconds",
+                    "type": int,
+                    "default": 25,
+                },
+            ]
+        )
+
+        self.add_cmd("rg show", msg="Show resource graph summary")
         self.add_args([])
-        
-        self.add_cmd('rg nodes', msg="List nodes in resource graph")
+
+        self.add_cmd("rg nodes", msg="List nodes in resource graph")
         self.add_args([])
-        
-        self.add_cmd('rg node', msg="Show detailed node information")
-        self.add_args([
-            {
-                'name': 'hostname',
-                'msg': 'Hostname to show details for',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('rg filter', msg="Filter storage by device type")
-        self.add_args([
-            {
-                'name': 'dev_type',
-                'msg': 'Device type to filter by (ssd, hdd, etc.)',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('rg load', msg="Load resource graph from file")
-        self.add_args([
-            {
-                'name': 'file_path',
-                'msg': 'Path to resource graph file',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('rg path', msg="Show path to current resource graph file")
+
+        self.add_cmd("rg node", msg="Show detailed node information")
+        self.add_args(
+            [
+                {
+                    "name": "hostname",
+                    "msg": "Hostname to show details for",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("rg filter", msg="Filter storage by device type")
+        self.add_args(
+            [
+                {
+                    "name": "dev_type",
+                    "msg": "Device type to filter by (ssd, hdd, etc.)",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("rg load", msg="Load resource graph from file")
+        self.add_args(
+            [
+                {
+                    "name": "file_path",
+                    "msg": "Path to resource graph file",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("rg path", msg="Show path to current resource graph file")
         self.add_args([])
-        
+
         # Build commands
-        self.add_menu('build', msg="Build environment profiles and configurations")
-        
-        self.add_cmd('build profile', msg="Build environment profile")
-        self.add_args([
-            {
-                'name': 'm',
-                'msg': 'Output method (dotenv, cmake, clion, vscode)',
-                'type': str,
-                'default': 'dotenv'
-            },
-            {
-                'name': 'path',
-                'msg': 'Output file path (prints to console if not specified)',
-                'type': str,
-                'required': False
-            }
-        ])
-        
+        self.add_menu("build", msg="Build environment profiles and configurations")
+
+        self.add_cmd("build profile", msg="Build environment profile")
+        self.add_args(
+            [
+                {
+                    "name": "m",
+                    "msg": "Output method (dotenv, cmake, clion, vscode)",
+                    "type": str,
+                    "default": "dotenv",
+                },
+                {
+                    "name": "path",
+                    "msg": "Output file path (prints to console if not specified)",
+                    "type": str,
+                    "required": False,
+                },
+            ]
+        )
+
         # Module management commands
-        self.add_menu('mod', msg="Module management commands")
-        
-        self.add_cmd('mod create', msg="Create a new module")
-        self.add_args([
-            {
-                'name': 'mod_name',
-                'msg': 'Module name',
-                'type': str,
-                'required': False,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('mod cd', msg="Set current module")
-        self.add_args([
-            {
-                'name': 'mod_name',
-                'msg': 'Module name',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('mod prepend', msg="Prepend environment variables to module", keep_remainder=True)
-        self.add_args([
-            {
-                'name': 'mod_name',
-                'msg': 'Module name (optional, uses current)',
-                'type': str,
-                'required': False,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('mod setenv', msg="Set environment variables in module", keep_remainder=True)
-        self.add_args([
-            {
-                'name': 'mod_name',
-                'msg': 'Module name (optional, uses current)',
-                'type': str,
-                'required': False,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('mod destroy', msg="Destroy a module")
-        self.add_args([
-            {
-                'name': 'mod_name',
-                'msg': 'Module name (optional, uses current)',
-                'type': str,
-                'required': False,
-                'pos': True
-            }
-        ])
+        self.add_menu("mod", msg="Module management commands")
 
-        self.add_cmd('mod clear', msg="Clear module directory except src/")
-        self.add_args([
-            {
-                'name': 'mod_name',
-                'msg': 'Module name (optional, uses current)',
-                'type': str,
-                'required': False,
-                'pos': True
-            }
-        ])
+        self.add_cmd("mod create", msg="Create a new module")
+        self.add_args(
+            [
+                {
+                    "name": "mod_name",
+                    "msg": "Module name",
+                    "type": str,
+                    "required": False,
+                    "pos": True,
+                }
+            ]
+        )
 
-        self.add_cmd('mod src', msg="Show module source directory")
-        self.add_args([
-            {
-                'name': 'mod_name',
-                'msg': 'Module name (optional, uses current)',
-                'type': str,
-                'required': False,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('mod root', msg="Show module root directory")
-        self.add_args([
-            {
-                'name': 'mod_name',
-                'msg': 'Module name (optional, uses current)',
-                'type': str,
-                'required': False,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('mod tcl', msg="Show module TCL file path")
-        self.add_args([
-            {
-                'name': 'mod_name',
-                'msg': 'Module name (optional, uses current)',
-                'type': str,
-                'required': False,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('mod yaml', msg="Show module YAML file path")
-        self.add_args([
-            {
-                'name': 'mod_name',
-                'msg': 'Module name (optional, uses current)',
-                'type': str,
-                'required': False,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('mod dir', msg="Show modules directory")
+        self.add_cmd("mod cd", msg="Set current module")
+        self.add_args(
+            [
+                {
+                    "name": "mod_name",
+                    "msg": "Module name",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd(
+            "mod prepend",
+            msg="Prepend environment variables to module",
+            keep_remainder=True,
+        )
+        self.add_args(
+            [
+                {
+                    "name": "mod_name",
+                    "msg": "Module name (optional, uses current)",
+                    "type": str,
+                    "required": False,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd(
+            "mod setenv", msg="Set environment variables in module", keep_remainder=True
+        )
+        self.add_args(
+            [
+                {
+                    "name": "mod_name",
+                    "msg": "Module name (optional, uses current)",
+                    "type": str,
+                    "required": False,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("mod destroy", msg="Destroy a module")
+        self.add_args(
+            [
+                {
+                    "name": "mod_name",
+                    "msg": "Module name (optional, uses current)",
+                    "type": str,
+                    "required": False,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("mod clear", msg="Clear module directory except src/")
+        self.add_args(
+            [
+                {
+                    "name": "mod_name",
+                    "msg": "Module name (optional, uses current)",
+                    "type": str,
+                    "required": False,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("mod src", msg="Show module source directory")
+        self.add_args(
+            [
+                {
+                    "name": "mod_name",
+                    "msg": "Module name (optional, uses current)",
+                    "type": str,
+                    "required": False,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("mod root", msg="Show module root directory")
+        self.add_args(
+            [
+                {
+                    "name": "mod_name",
+                    "msg": "Module name (optional, uses current)",
+                    "type": str,
+                    "required": False,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("mod tcl", msg="Show module TCL file path")
+        self.add_args(
+            [
+                {
+                    "name": "mod_name",
+                    "msg": "Module name (optional, uses current)",
+                    "type": str,
+                    "required": False,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("mod yaml", msg="Show module YAML file path")
+        self.add_args(
+            [
+                {
+                    "name": "mod_name",
+                    "msg": "Module name (optional, uses current)",
+                    "type": str,
+                    "required": False,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("mod dir", msg="Show modules directory")
         self.add_args([])
-        
-        self.add_cmd('mod list', msg="List all modules")
+
+        self.add_cmd("mod list", msg="List all modules")
         self.add_args([])
-        
-        self.add_cmd('mod profile', msg="Build environment profile", keep_remainder=True)
+
+        self.add_cmd(
+            "mod profile", msg="Build environment profile", keep_remainder=True
+        )
         self.add_args([])
-        
-        self.add_cmd('mod import', msg="Import module from command", keep_remainder=True)
-        self.add_args([
-            {
-                'name': 'mod_name',
-                'msg': 'Module name',
-                'type': str,
-                'required': True,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('mod update', msg="Update module using stored command")
-        self.add_args([
-            {
-                'name': 'mod_name',
-                'msg': 'Module name (optional, uses current)',
-                'type': str,
-                'required': False,
-                'pos': True
-            }
-        ])
-        
-        self.add_cmd('mod build profile', msg="Build environment profile")
-        self.add_args([
-            {
-                'name': 'm',
-                'msg': 'Output method (dotenv, cmake, clion, vscode)',
-                'type': str,
-                'default': 'dotenv',
-                'aliases': ['method']
-            },
-            {
-                'name': 'path',
-                'msg': 'Output file path (optional)',
-                'type': str,
-                'required': False
-            }
-        ])
+
+        self.add_cmd(
+            "mod import", msg="Import module from command", keep_remainder=True
+        )
+        self.add_args(
+            [
+                {
+                    "name": "mod_name",
+                    "msg": "Module name",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("mod update", msg="Update module using stored command")
+        self.add_args(
+            [
+                {
+                    "name": "mod_name",
+                    "msg": "Module name (optional, uses current)",
+                    "type": str,
+                    "required": False,
+                    "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("mod build profile", msg="Build environment profile")
+        self.add_args(
+            [
+                {
+                    "name": "m",
+                    "msg": "Output method (dotenv, cmake, clion, vscode)",
+                    "type": str,
+                    "default": "dotenv",
+                    "aliases": ["method"],
+                },
+                {
+                    "name": "path",
+                    "msg": "Output file path (optional)",
+                    "type": str,
+                    "required": False,
+                },
+            ]
+        )
 
         # Module dependency commands
-        self.add_menu('mod dep', msg="Module dependency management")
+        self.add_menu("mod dep", msg="Module dependency management")
 
-        self.add_cmd('mod dep add', msg="Add a module dependency")
-        self.add_args([
-            {
-                'name': 'dep_name',
-                'msg': 'Dependency module name',
-                'type': str,
-                'required': True,
-                'pos': True
-            },
-            {
-                'name': 'mod_name',
-                'msg': 'Module name (optional, uses current)',
-                'type': str,
-                'required': False,
-                'pos': True
-            }
-        ])
+        self.add_cmd("mod dep add", msg="Add a module dependency")
+        self.add_args(
+            [
+                {
+                    "name": "dep_name",
+                    "msg": "Dependency module name",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                },
+                {
+                    "name": "mod_name",
+                    "msg": "Module name (optional, uses current)",
+                    "type": str,
+                    "required": False,
+                    "pos": True,
+                },
+            ]
+        )
 
-        self.add_cmd('mod dep remove', msg="Remove a module dependency")
-        self.add_args([
-            {
-                'name': 'dep_name',
-                'msg': 'Dependency module name',
-                'type': str,
-                'required': True,
-                'pos': True
-            },
-            {
-                'name': 'mod_name',
-                'msg': 'Module name (optional, uses current)',
-                'type': str,
-                'required': False,
-                'pos': True
-            }
-        ])
-        
+        self.add_cmd("mod dep remove", msg="Remove a module dependency")
+        self.add_args(
+            [
+                {
+                    "name": "dep_name",
+                    "msg": "Dependency module name",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                },
+                {
+                    "name": "mod_name",
+                    "msg": "Module name (optional, uses current)",
+                    "type": str,
+                    "required": False,
+                    "pos": True,
+                },
+            ]
+        )
+
     def _ensure_config_loaded(self):
         """Ensure Jarvis is loaded (doesn't require full initialization)"""
         if self.jarvis_config is None:
@@ -950,7 +1234,7 @@ class JarvisCLI(ArgParse):
         # Get Jarvis singleton instance (same as jarvis_config now)
         if self.jarvis is None:
             self.jarvis = self.jarvis_config
-            
+
         # Initialize managers
         if self.repo_manager is None:
             self.repo_manager = RepositoryManager(self.jarvis_config)
@@ -962,8 +1246,9 @@ class JarvisCLI(ArgParse):
             self.pipeline_index_manager = PipelineIndexManager(self.jarvis_config)
         if self.module_manager is None:
             from jarvis_cd.core.module_manager import ModuleManager
+
             self.module_manager = ModuleManager(self.jarvis_config)
-        
+
         # Load current pipeline if one exists
         current_pipeline_name = self.jarvis_config.get_current_pipeline()
         if current_pipeline_name:
@@ -972,28 +1257,28 @@ class JarvisCLI(ArgParse):
             except Exception:
                 # Pipeline may not exist or be corrupted, continue without it
                 self.current_pipeline = None
-    
+
     def main_menu(self):
         """Handle main menu / help"""
-        if self.kwargs.get('help', False) or not self.remainder:
+        if self.kwargs.get("help", False) or not self.remainder:
             self._show_help()
         else:
             print(f"Unknown arguments: {' '.join(self.remainder)}")
             self._show_help()
-            
+
     def _show_help(self):
         """Show help information"""
         print("Jarvis-CD: Unified platform for deploying applications and benchmarks")
         print()
         self.print_general_help()
-    
+
     # Command handlers
     def init(self):
         """Initialize Jarvis configuration"""
-        config_dir = os.path.expanduser(self.kwargs['config_dir'])
-        private_dir = os.path.expanduser(self.kwargs['private_dir'])
-        shared_dir = os.path.expanduser(self.kwargs['shared_dir'])
-        force = self.kwargs.get('force', False)
+        config_dir = os.path.expanduser(self.kwargs["config_dir"])
+        private_dir = os.path.expanduser(self.kwargs["private_dir"])
+        shared_dir = os.path.expanduser(self.kwargs["shared_dir"])
+        force = self.kwargs.get("force", False)
 
         jarvis = Jarvis.get_instance()
         jarvis.initialize(config_dir, private_dir, shared_dir, force=force)
@@ -1002,26 +1287,26 @@ class JarvisCLI(ArgParse):
         self.jarvis_config = jarvis
         self.jarvis = jarvis
 
-        print(f"Jarvis initialized successfully!")
+        print("Jarvis initialized successfully!")
         print(f"Config dir: {config_dir}")
         print(f"Private dir: {private_dir}")
         print(f"Shared dir: {shared_dir}")
-        
+
     def ppl_create(self):
         """Create a new pipeline"""
         self._ensure_initialized()
-        pipeline_name = self.kwargs['pipeline_name']
-        
+        pipeline_name = self.kwargs["pipeline_name"]
+
         # Create new pipeline
         pipeline = Pipeline()
         pipeline.create(pipeline_name)
         self.current_pipeline = pipeline
-        
+
     def ppl_append(self):
         """Append package to current pipeline"""
         self._ensure_initialized()
-        package_spec = self.kwargs['package_spec']
-        package_alias = self.kwargs.get('package_alias')
+        package_spec = self.kwargs["package_spec"]
+        package_alias = self.kwargs.get("package_alias")
 
         if not self.current_pipeline:
             # Try to load current pipeline
@@ -1029,42 +1314,75 @@ class JarvisCLI(ArgParse):
             if current_name:
                 self.current_pipeline = Pipeline(current_name)
             else:
-                raise ValueError("No current pipeline. Create one with 'jarvis ppl create <name>'")
+                raise ValueError(
+                    "No current pipeline. Create one with 'jarvis ppl create <name>'"
+                )
 
         # Pass remainder as config_args if any were provided
         config_args = self.remainder if self.remainder else None
         self.current_pipeline.append(package_spec, package_alias, config_args)
-        
-    def ppl_run(self):
+
+    @staticmethod
+    def _emit_execution_handle(
+        handle: ExecutionHandle,
+        *,
+        json_output: bool,
+    ) -> None:
+        """Print one execution handle for an operator or machine client."""
+        if json_output:
+            print(json.dumps(handle.to_dict(), separators=(",", ":"), sort_keys=True))
+            return
+        scheduler_identity = ""
+        if handle.scheduler_provider is not None:
+            scheduler_identity = f"; scheduler={handle.scheduler_provider}"
+            if handle.scheduler_native_id is not None:
+                scheduler_identity += f":{handle.scheduler_native_id}"
+        print(
+            f"JARVIS execution {handle.execution_id} "
+            f"({handle.mode}{scheduler_identity})"
+        )
+
+    def _require_current_pipeline(self) -> Pipeline:
+        """Load and return the current pipeline or raise a clear error."""
+        if self.current_pipeline is not None:
+            return self.current_pipeline
+        current_name = self.jarvis_config.get_current_pipeline()
+        if not current_name:
+            raise ValueError("No current pipeline")
+        self.current_pipeline = Pipeline(current_name)
+        return self.current_pipeline
+
+    def ppl_run(self) -> None:
         """Run pipeline (auto-detects regular pipeline vs pipeline test)"""
         self._ensure_initialized()
-        load_type = self.kwargs.get('load_type', 'current')
-        pipeline_file = self.kwargs.get('pipeline_file')
+        load_type = self.kwargs.get("load_type", "current")
+        pipeline_file = self.kwargs.get("pipeline_file")
+        execution_id = self.kwargs.get("execution_id")
+        json_output = bool(self.kwargs.get("json", False))
+        wait = not bool(self.kwargs.get("no_wait", False))
 
-        if load_type == 'yaml':
+        if load_type == "yaml":
             if not pipeline_file:
                 raise ValueError("Pipeline file is required when load_type is 'yaml'")
-            # Auto-detect and run pipeline file
-            run_yaml_auto(pipeline_file)
+            is_test, obj = load_yaml_auto(pipeline_file)
+            if is_test:
+                obj.run()
+                return
+            handle = obj.run(execution_id=execution_id, wait=wait)
+            self._emit_execution_handle(handle, json_output=json_output)
         else:
             # Check if we have a loaded pipeline test
-            if hasattr(self, '_current_test') and self._current_test is not None:
+            if hasattr(self, "_current_test") and self._current_test is not None:
                 # Run the loaded pipeline test
                 self._current_test.run()
                 self._current_test = None
                 return
 
-            # Run current pipeline
-            if not self.current_pipeline:
-                current_name = self.jarvis_config.get_current_pipeline()
-                if current_name:
-                    self.current_pipeline = Pipeline(current_name)
-                else:
-                    raise ValueError("No current pipeline to run")
+            pipeline = self._require_current_pipeline()
+            handle = pipeline.run(execution_id=execution_id, wait=wait)
+            self._emit_execution_handle(handle, json_output=json_output)
 
-            self.current_pipeline.run()
-        
-    def ppl_submit(self):
+    def ppl_submit(self) -> None:
         """Generate (and optionally submit) a scheduler job script.
 
         Resolves a target Pipeline / PipelineTest in this order:
@@ -1074,27 +1392,117 @@ class JarvisCLI(ArgParse):
         3. the current pipeline
         """
         self._ensure_initialized()
-        pipeline_file = self.kwargs.get('pipeline_file')
-        submit = not self.kwargs.get('no_submit', False)
+        pipeline_file = self.kwargs.get("pipeline_file")
+        submit = not self.kwargs.get("no_submit", False)
+        wait = bool(self.kwargs.get("wait", False))
+        execution_id = self.kwargs.get("execution_id")
+        json_output = bool(self.kwargs.get("json", False))
 
         if pipeline_file:
             is_test, obj = load_yaml_auto(pipeline_file)
-            obj.submit(submit=submit)
+            if is_test:
+                obj.submit(submit=submit)
+                return
+            handle = obj.submit(
+                submit=submit,
+                wait=wait,
+                execution_id=execution_id,
+            )
+            self._emit_execution_handle(handle, json_output=json_output)
             return
 
-        if getattr(self, '_current_test', None) is not None:
+        if getattr(self, "_current_test", None) is not None:
             self._current_test.submit(submit=submit)
             return
 
-        if not self.current_pipeline:
-            current_name = self.jarvis_config.get_current_pipeline()
-            if current_name:
-                self.current_pipeline = Pipeline(current_name)
-            else:
-                raise ValueError(
-                    "No pipeline to submit. Pass a YAML path or load a "
-                    "pipeline first.")
-        self.current_pipeline.submit(submit=submit)
+        try:
+            pipeline = self._require_current_pipeline()
+        except ValueError as exc:
+            raise ValueError(
+                "No pipeline to submit. Pass a YAML path or load a pipeline first."
+            ) from exc
+        handle = pipeline.submit(
+            submit=submit,
+            wait=wait,
+            execution_id=execution_id,
+        )
+        self._emit_execution_handle(handle, json_output=json_output)
+
+    def execution_get(self) -> None:
+        """Print one durable record for a named or current pipeline."""
+        self._ensure_initialized()
+        pipeline_id = self.kwargs.get("pipeline_id")
+        pipeline = (
+            Pipeline(pipeline_id) if pipeline_id else self._require_current_pipeline()
+        )
+        record = pipeline.get_execution(self.kwargs["execution_id"])
+        if self.kwargs.get("json", False):
+            print(json.dumps(record.to_dict(), separators=(",", ":"), sort_keys=True))
+            return
+        scheduler_identity = ""
+        if record.scheduler_provider is not None:
+            scheduler_identity = f" {record.scheduler_provider}"
+            if record.scheduler_native_id is not None:
+                scheduler_identity += f":{record.scheduler_native_id}"
+        print(
+            f"{record.execution_id}: {record.state} ({record.mode}{scheduler_identity})"
+        )
+
+    def execution_list(self) -> None:
+        """Print all durable records for a named or current pipeline."""
+        self._ensure_initialized()
+        pipeline_id = self.kwargs.get("pipeline_id")
+        pipeline = (
+            Pipeline(pipeline_id) if pipeline_id else self._require_current_pipeline()
+        )
+        records = pipeline.list_executions()
+        if self.kwargs.get("json", False):
+            print(
+                json.dumps(
+                    {
+                        "schema_version": "jarvis.execution.list.v1",
+                        "pipeline_id": pipeline.name,
+                        "executions": [record.to_dict() for record in records],
+                    },
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+            )
+            return
+        if not records:
+            print("No executions recorded")
+            return
+        for record in records:
+            print(f"{record.execution_id}: {record.state} ({record.mode})")
+
+    def execution_progress(self) -> None:
+        """Print validated package progress for a named or current pipeline."""
+        self._ensure_initialized()
+        pipeline_id = self.kwargs.get("pipeline_id")
+        pipeline = (
+            Pipeline(pipeline_id) if pipeline_id else self._require_current_pipeline()
+        )
+        snapshot = pipeline.get_execution_progress(self.kwargs["execution_id"])
+        if self.kwargs.get("json", False):
+            print(json.dumps(snapshot.to_dict(), separators=(",", ":"), sort_keys=True))
+            return
+        print(
+            f"{snapshot.execution_id}: {snapshot.execution_state} "
+            f"({len(snapshot.packages)} packages)"
+        )
+        for package in snapshot.packages:
+            if package.latest is None:
+                print(f"  {package.package_id}: no progress events")
+                continue
+            latest = package.latest
+            amount = latest.state.value
+            if latest.current is not None:
+                amount = str(latest.current)
+                if latest.total is not None:
+                    amount += f"/{latest.total}"
+                if latest.unit:
+                    amount += f" {latest.unit}"
+            print(f"  {package.package_id}: {amount}")
 
     def ppl_start(self):
         """Start current pipeline"""
@@ -1105,9 +1513,9 @@ class JarvisCLI(ArgParse):
                 self.current_pipeline = Pipeline(current_name)
             else:
                 raise ValueError("No current pipeline to start")
-        
+
         self.current_pipeline.start()
-        
+
     def ppl_stop(self):
         """Stop current pipeline"""
         self._ensure_initialized()
@@ -1117,9 +1525,9 @@ class JarvisCLI(ArgParse):
                 self.current_pipeline = Pipeline(current_name)
             else:
                 raise ValueError("No current pipeline to stop")
-        
+
         self.current_pipeline.stop()
-        
+
     def ppl_kill(self):
         """Kill current pipeline"""
         self._ensure_initialized()
@@ -1129,9 +1537,9 @@ class JarvisCLI(ArgParse):
                 self.current_pipeline = Pipeline(current_name)
             else:
                 raise ValueError("No current pipeline to kill")
-        
+
         self.current_pipeline.kill()
-        
+
     def ppl_clean(self):
         """Clean current pipeline"""
         self._ensure_initialized()
@@ -1141,17 +1549,18 @@ class JarvisCLI(ArgParse):
                 self.current_pipeline = Pipeline(current_name)
             else:
                 raise ValueError("No current pipeline to clean")
-        
+
         self.current_pipeline.clean()
 
     def ppl_rerun(self):
         """Destroy pipeline output directory and re-run the pipeline"""
         import shutil
-        self._ensure_initialized()
-        load_type = self.kwargs.get('load_type', 'current')
-        pipeline_file = self.kwargs.get('pipeline_file')
 
-        if load_type == 'yaml':
+        self._ensure_initialized()
+        load_type = self.kwargs.get("load_type", "current")
+        pipeline_file = self.kwargs.get("pipeline_file")
+
+        if load_type == "yaml":
             if not pipeline_file:
                 raise ValueError("Pipeline file is required when load_type is 'yaml'")
             # Load the YAML to get the pipeline, clean it, then run
@@ -1183,11 +1592,12 @@ class JarvisCLI(ArgParse):
     def ppl_retest(self):
         """Destroy test output directory and re-run all pipeline tests"""
         import shutil
-        self._ensure_initialized()
-        load_type = self.kwargs.get('load_type', 'current')
-        pipeline_file = self.kwargs.get('pipeline_file')
 
-        if load_type == 'yaml':
+        self._ensure_initialized()
+        load_type = self.kwargs.get("load_type", "current")
+        pipeline_file = self.kwargs.get("pipeline_file")
+
+        if load_type == "yaml":
             if not pipeline_file:
                 raise ValueError("Pipeline file is required when load_type is 'yaml'")
             # Load the YAML - expect a pipeline test
@@ -1204,9 +1614,13 @@ class JarvisCLI(ArgParse):
             obj.run()
         else:
             # Use the currently loaded pipeline test
-            if hasattr(self, '_current_test') and self._current_test is not None:
-                if self._current_test.output and os.path.exists(self._current_test.output):
-                    print(f"Destroying test output directory: {self._current_test.output}")
+            if hasattr(self, "_current_test") and self._current_test is not None:
+                if self._current_test.output and os.path.exists(
+                    self._current_test.output
+                ):
+                    print(
+                        f"Destroying test output directory: {self._current_test.output}"
+                    )
                     shutil.rmtree(self._current_test.output)
                 self._current_test.run()
                 self._current_test = None
@@ -1226,17 +1640,17 @@ class JarvisCLI(ArgParse):
             else:
                 print("No current pipeline")
                 return
-        
+
         status = self.current_pipeline.status()
         print(status)
-        
+
     def ppl_load(self):
         """Load pipeline from file (auto-detects regular pipeline vs pipeline test)"""
         self._ensure_initialized()
-        load_type = self.kwargs['load_type']
-        pipeline_file = self.kwargs['pipeline_file']
+        load_type = self.kwargs["load_type"]
+        pipeline_file = self.kwargs["pipeline_file"]
 
-        if load_type == 'yaml':
+        if load_type == "yaml":
             # Auto-detect pipeline type
             is_test, obj = load_yaml_auto(pipeline_file)
 
@@ -1244,7 +1658,7 @@ class JarvisCLI(ArgParse):
                 # Pipeline test (or suite of tests) - store for later run
                 self._current_test = obj
                 self.current_pipeline = None
-                if hasattr(obj, 'experiments'):
+                if hasattr(obj, "experiments"):
                     print(f"Loaded pipeline test suite: {obj.name}")
                     print(f"  Experiments: {len(obj.experiments)}")
                     print(f"  Total runs: {obj.total_runs}")
@@ -1266,7 +1680,7 @@ class JarvisCLI(ArgParse):
             pipeline.configure_all_packages()
             self.current_pipeline = pipeline
             self._current_test = None
-        
+
     def ppl_update(self):
         """Update pipeline from last loaded file"""
         self._ensure_initialized()
@@ -1296,37 +1710,38 @@ class JarvisCLI(ArgParse):
         needs_rebuild = False
 
         # Update hostfile
-        if self.kwargs.get('hostfile') is not None:
+        if self.kwargs.get("hostfile") is not None:
             from jarvis_cd.util.hostfile import Hostfile
-            hostfile_path = self.kwargs['hostfile']
+
+            hostfile_path = self.kwargs["hostfile"]
             self.current_pipeline.hostfile = Hostfile(path=hostfile_path)
             print(f"Set pipeline hostfile: {hostfile_path}")
             params_provided = True
             needs_rebuild = True
 
         # Update container_image
-        if self.kwargs.get('container_image') is not None:
-            self.current_pipeline.container_image = self.kwargs['container_image']
+        if self.kwargs.get("container_image") is not None:
+            self.current_pipeline.container_image = self.kwargs["container_image"]
             print(f"Set container_image: {self.kwargs['container_image']}")
             params_provided = True
             needs_rebuild = False  # Using pre-built image, no rebuild needed
 
         # Update container_engine
-        if self.kwargs.get('container_engine') is not None:
-            self.current_pipeline.container_engine = self.kwargs['container_engine']
+        if self.kwargs.get("container_engine") is not None:
+            self.current_pipeline.container_engine = self.kwargs["container_engine"]
             print(f"Set container_engine: {self.kwargs['container_engine']}")
             params_provided = True
 
         # Update container_base
-        if self.kwargs.get('container_base') is not None:
-            self.current_pipeline.container_base = self.kwargs['container_base']
+        if self.kwargs.get("container_base") is not None:
+            self.current_pipeline.container_base = self.kwargs["container_base"]
             print(f"Set container_base: {self.kwargs['container_base']}")
             params_provided = True
             needs_rebuild = True
 
         # Update container_ssh_port
-        if self.kwargs.get('container_ssh_port') is not None:
-            self.current_pipeline.container_ssh_port = self.kwargs['container_ssh_port']
+        if self.kwargs.get("container_ssh_port") is not None:
+            self.current_pipeline.container_ssh_port = self.kwargs["container_ssh_port"]
             print(f"Set container_ssh_port: {self.kwargs['container_ssh_port']}")
             params_provided = True
 
@@ -1344,81 +1759,94 @@ class JarvisCLI(ArgParse):
     def ppl_list(self):
         """List all pipelines"""
         self._ensure_initialized()
-        
+
         pipelines_dir = self.jarvis_config.get_pipelines_dir()
-        
+
         if not pipelines_dir.exists():
-            print("No pipelines directory found. Create a pipeline first with 'jarvis ppl create'.")
+            print(
+                "No pipelines directory found. Create a pipeline first with 'jarvis ppl create'."
+            )
             return
-            
+
         pipeline_dirs = [d for d in pipelines_dir.iterdir() if d.is_dir()]
-        
+
         if not pipeline_dirs:
-            print("No pipelines found. Create a pipeline first with 'jarvis ppl create'.")
+            print(
+                "No pipelines found. Create a pipeline first with 'jarvis ppl create'."
+            )
             return
-            
+
         current_pipeline_name = self.jarvis_config.get_current_pipeline()
-        
+
         print("Available pipelines:")
         for pipeline_dir in sorted(pipeline_dirs):
             pipeline_name = pipeline_dir.name
-            config_file = pipeline_dir / 'pipeline.yaml'
-            
+            config_file = pipeline_dir / "pipeline.yaml"
+
             if config_file.exists():
                 try:
                     import yaml
-                    with open(config_file, 'r') as f:
+
+                    with open(config_file, "r") as f:
                         pipeline_config = yaml.safe_load(f) or {}
-                    
-                    num_packages = len(pipeline_config.get('packages', []))
+
+                    num_packages = len(pipeline_config.get("packages", []))
                     marker = "* " if pipeline_name == current_pipeline_name else "  "
                     print(f"{marker}{pipeline_name} ({num_packages} packages)")
-                    
+
                 except Exception as e:
                     marker = "* " if pipeline_name == current_pipeline_name else "  "
                     print(f"{marker}{pipeline_name} (error reading config: {e})")
             else:
                 marker = "* " if pipeline_name == current_pipeline_name else "  "
                 print(f"{marker}{pipeline_name} (no config file)")
-                
+
         if current_pipeline_name:
             print(f"\nCurrent pipeline: {current_pipeline_name}")
         else:
             print("\nNo current pipeline set. Use 'jarvis cd <pipeline>' to switch.")
-        
+
     def ppl_print(self):
         """Print current pipeline configuration"""
         self._ensure_initialized()
-        
+
         current_pipeline_name = self.jarvis_config.get_current_pipeline()
-        
+
         if not current_pipeline_name:
             print("No current pipeline set. Use 'jarvis cd <pipeline>' to switch.")
             return
-            
+
         if not self.current_pipeline:
             try:
                 self.current_pipeline = Pipeline(current_pipeline_name)
             except Exception as e:
                 print(f"Error loading current pipeline: {e}")
                 return
-        
+
         print(f"Pipeline: {self.current_pipeline.name}")
-        print(f"Directory: {self.jarvis_config.get_pipeline_dir(current_pipeline_name)}")
+        print(
+            f"Directory: {self.jarvis_config.get_pipeline_dir(current_pipeline_name)}"
+        )
 
         # Show hostfile configuration
-        if hasattr(self.current_pipeline, 'hostfile') and self.current_pipeline.hostfile:
+        if (
+            hasattr(self.current_pipeline, "hostfile")
+            and self.current_pipeline.hostfile
+        ):
             print(f"Hostfile: {self.current_pipeline.hostfile.path or '(in-memory)'}")
             print(f"  Hosts: {', '.join(self.current_pipeline.hostfile.hosts)}")
         else:
             # Show that it falls back to jarvis global hostfile
             jarvis_hostfile = self.jarvis.hostfile
-            print(f"Hostfile: (using global jarvis hostfile)")
+            print("Hostfile: (using global jarvis hostfile)")
             print(f"  Hosts: {', '.join(jarvis_hostfile.hosts)}")
 
         # Show container configuration if set
-        if hasattr(self.current_pipeline, 'is_containerized') and self.current_pipeline.is_containerized():
-            print(f"Container Configuration:")
+        if (
+            hasattr(self.current_pipeline, "is_containerized")
+            and self.current_pipeline.is_containerized()
+        ):
+            print("Container Configuration:")
             if self.current_pipeline.container_image:
                 print(f"  Image: {self.current_pipeline.container_image}")
                 print(f"  Base: {self.current_pipeline.container_base}")
@@ -1428,15 +1856,15 @@ class JarvisCLI(ArgParse):
         if self.current_pipeline.packages:
             print("Packages:")
             for pkg_def in self.current_pipeline.packages:
-                pkg_id = pkg_def.get('pkg_id', 'unknown')
-                pkg_type = pkg_def.get('pkg_type', 'unknown')
-                global_id = pkg_def.get('global_id', pkg_id)
-                config = pkg_def.get('config', {})
-                
+                pkg_id = pkg_def.get("pkg_id", "unknown")
+                pkg_type = pkg_def.get("pkg_type", "unknown")
+                global_id = pkg_def.get("global_id", pkg_id)
+                config = pkg_def.get("config", {})
+
                 print(f"  {pkg_id}:")
                 print(f"    Type: {pkg_type}")
                 print(f"    Global ID: {global_id}")
-                
+
                 if config:
                     print("    Configuration:")
                     for key, value in config.items():
@@ -1445,19 +1873,25 @@ class JarvisCLI(ArgParse):
                     print("    Configuration: None")
         else:
             print("No packages in pipeline")
-        
+
         # Print interceptors if they exist
-        if hasattr(self.current_pipeline, 'interceptors') and self.current_pipeline.interceptors:
+        if (
+            hasattr(self.current_pipeline, "interceptors")
+            and self.current_pipeline.interceptors
+        ):
             print("Interceptors:")
-            for interceptor_name, interceptor_def in self.current_pipeline.interceptors.items():
-                interceptor_type = interceptor_def.get('pkg_type', 'unknown')
-                global_id = interceptor_def.get('global_id', interceptor_name)
-                config = interceptor_def.get('config', {})
-                
+            for (
+                interceptor_name,
+                interceptor_def,
+            ) in self.current_pipeline.interceptors.items():
+                interceptor_type = interceptor_def.get("pkg_type", "unknown")
+                global_id = interceptor_def.get("global_id", interceptor_name)
+                config = interceptor_def.get("config", {})
+
                 print(f"  {interceptor_name}:")
                 print(f"    Type: {interceptor_type}")
                 print(f"    Global ID: {global_id}")
-                
+
                 if config:
                     print("    Configuration:")
                     for key, value in config.items():
@@ -1467,7 +1901,10 @@ class JarvisCLI(ArgParse):
         else:
             print("No interceptors in pipeline")
 
-        if hasattr(self.current_pipeline, 'last_loaded_file') and self.current_pipeline.last_loaded_file:
+        if (
+            hasattr(self.current_pipeline, "last_loaded_file")
+            and self.current_pipeline.last_loaded_file
+        ):
             print(f"Last loaded from: {self.current_pipeline.last_loaded_file}")
 
     def ppl_path(self):
@@ -1477,7 +1914,10 @@ class JarvisCLI(ArgParse):
         current_pipeline_name = self.jarvis_config.get_current_pipeline()
 
         if not current_pipeline_name:
-            print("No current pipeline set. Use 'jarvis cd <pipeline>' to switch.", file=sys.stderr)
+            print(
+                "No current pipeline set. Use 'jarvis cd <pipeline>' to switch.",
+                file=sys.stderr,
+            )
             sys.exit(1)
 
         # Get directories
@@ -1486,9 +1926,9 @@ class JarvisCLI(ArgParse):
         private_dir = self.jarvis_config.get_pipeline_private_dir(current_pipeline_name)
 
         # Check which flags are set
-        show_shared = self.kwargs.get('shared', False)
-        show_private = self.kwargs.get('private', False)
-        show_config = self.kwargs.get('config', False)
+        show_shared = self.kwargs.get("shared", False)
+        show_private = self.kwargs.get("private", False)
+        show_config = self.kwargs.get("config", False)
 
         # If no flags set, show all directories
         if not (show_shared or show_private or show_config):
@@ -1507,22 +1947,22 @@ class JarvisCLI(ArgParse):
     def ppl_rm(self):
         """Remove package from current pipeline"""
         self._ensure_initialized()
-        package_spec = self.kwargs['package_spec']
-        
+        package_spec = self.kwargs["package_spec"]
+
         if not self.current_pipeline:
             current_name = self.jarvis_config.get_current_pipeline()
             if current_name:
                 self.current_pipeline = Pipeline(current_name)
             else:
                 raise ValueError("No current pipeline")
-        
+
         self.current_pipeline.rm(package_spec)
-        
+
     def ppl_destroy(self):
         """Destroy a pipeline"""
         self._ensure_initialized()
-        pipeline_name = self.kwargs.get('pipeline_name')
-        
+        pipeline_name = self.kwargs.get("pipeline_name")
+
         if pipeline_name:
             # Destroy specific pipeline
             pipeline = Pipeline()
@@ -1536,54 +1976,54 @@ class JarvisCLI(ArgParse):
                 else:
                     print("No current pipeline to destroy. Specify a pipeline name.")
                     return
-            
+
             self.current_pipeline.destroy()
             self.current_pipeline = None
-        
+
     def cd(self):
         """Change current pipeline"""
         self._ensure_initialized()
-        pipeline_name = self.kwargs['pipeline_name']
-        
+        pipeline_name = self.kwargs["pipeline_name"]
+
         pipeline_dir = self.jarvis_config.get_pipeline_dir(pipeline_name)
-        
+
         if not pipeline_dir.exists():
             print(f"Pipeline '{pipeline_name}' not found.")
             self.ppl_list()
             return
-            
-        config_file = pipeline_dir / 'pipeline.yaml'
+
+        config_file = pipeline_dir / "pipeline.yaml"
         if not config_file.exists():
             print(f"Pipeline '{pipeline_name}' exists but has no configuration file.")
             print("You may need to recreate this pipeline.")
             return
-            
+
         # Set current pipeline in configuration
         self.jarvis_config.set_current_pipeline(pipeline_name)
-        
+
         # Load the new current pipeline
         self.current_pipeline = Pipeline(pipeline_name)
-        
+
         print(f"Switched to pipeline: {pipeline_name}")
-        
+
         # Show basic info about the pipeline
         try:
             num_packages = len(self.current_pipeline.packages)
             print(f"Pipeline has {num_packages} packages")
         except Exception as e:
             print(f"Warning: Could not read pipeline configuration: {e}")
-        
+
     def repo_add(self):
         """Add repository"""
         self._ensure_config_loaded()
-        repo_path = self.kwargs['repo_path']
-        force = self.kwargs.get('force', False)
+        repo_path = self.kwargs["repo_path"]
+        force = self.kwargs.get("force", False)
         self.repo_manager.add_repository(repo_path, force=force)
 
     def repo_remove(self):
         """Remove repository by name"""
         self._ensure_config_loaded()
-        repo_name = self.kwargs['repo_name']
+        repo_name = self.kwargs["repo_name"]
         self.repo_manager.remove_repository_by_name(repo_name)
 
     def repo_list(self):
@@ -1594,35 +2034,37 @@ class JarvisCLI(ArgParse):
     def repo_create(self):
         """Create new package in repository"""
         self._ensure_config_loaded()
-        package_name = self.kwargs['package_name']
-        package_type = self.kwargs['package_type']
+        package_name = self.kwargs["package_name"]
+        package_type = self.kwargs["package_type"]
         self.repo_manager.create_package(package_name, package_type)
 
     def container_list(self):
         """List all container images"""
         self._ensure_initialized()
         from jarvis_cd.core.container import ContainerManager
+
         container_manager = ContainerManager()
         container_manager.list_containers()
 
     def container_remove(self):
         """Remove a container image"""
         self._ensure_initialized()
-        container_name = self.kwargs['container_name']
+        container_name = self.kwargs["container_name"]
         from jarvis_cd.core.container import ContainerManager
+
         container_manager = ContainerManager()
         container_manager.remove_container(container_name)
 
     def container_update(self):
         """Force rebuild a container image"""
         self._ensure_initialized()
-        container_name = self.kwargs['container_name']
-        no_cache = self.kwargs.get('no_cache', False)
-        engine = self.kwargs.get('engine')
+        container_name = self.kwargs["container_name"]
+        no_cache = self.kwargs.get("no_cache", False)
+        engine = self.kwargs.get("engine")
         from pathlib import Path
 
-        containers_dir = Path.home() / '.ppi-jarvis' / 'containers'
-        dockerfile_path = containers_dir / f'{container_name}.Dockerfile'
+        containers_dir = Path.home() / ".ppi-jarvis" / "containers"
+        dockerfile_path = containers_dir / f"{container_name}.Dockerfile"
 
         if not dockerfile_path.exists():
             print(f"Error: Container '{container_name}' not found")
@@ -1636,29 +2078,31 @@ class JarvisCLI(ArgParse):
         if engine:
             # Use specified engine
             use_engine = engine
-        elif shutil.which('podman'):
-            use_engine = 'podman'
+        elif shutil.which("podman"):
+            use_engine = "podman"
         else:
-            use_engine = 'docker'
+            use_engine = "docker"
 
         # Build command with optional --no-cache flag
         no_cache_flag = " --no-cache" if no_cache else ""
         build_cmd = f"{use_engine} build{no_cache_flag} -t {container_name} -f {dockerfile_path} {containers_dir}"
 
         cache_msg = " (no cache)" if no_cache else " (with cache)"
-        print(f"Rebuilding container image: {container_name}{cache_msg} using {use_engine}")
+        print(
+            f"Rebuilding container image: {container_name}{cache_msg} using {use_engine}"
+        )
         Exec(build_cmd, LocalExecInfo()).run()
         print(f"Container image rebuilt: {container_name}")
 
     def pkg_configure(self):
         """Configure package"""
         self._ensure_initialized()
-        package_spec = self.kwargs['package_spec']
+        package_spec = self.kwargs["package_spec"]
 
         # Parse package specification
-        if '.' in package_spec:
+        if "." in package_spec:
             # pipeline.pkg format
-            pipeline_name, pkg_id = package_spec.split('.', 1)
+            pipeline_name, pkg_id = package_spec.split(".", 1)
             pipeline = Pipeline(pipeline_name)
             pipeline.configure_package(pkg_id, self.remainder)
         else:
@@ -1668,25 +2112,27 @@ class JarvisCLI(ArgParse):
                 if current_name:
                     self.current_pipeline = Pipeline(current_name)
                 else:
-                    raise ValueError("No current pipeline. Specify as pipeline.pkg or create a pipeline first.")
+                    raise ValueError(
+                        "No current pipeline. Specify as pipeline.pkg or create a pipeline first."
+                    )
 
             self.current_pipeline.configure_package(package_spec, self.remainder)
-        
+
     def pkg_readme(self):
         """Show package README"""
         self._ensure_initialized()
-        package_spec = self.kwargs['package_spec']
-        
+        package_spec = self.kwargs["package_spec"]
+
         # Parse package specification
-        if '.' in package_spec:
+        if "." in package_spec:
             # Check if it's a pipeline.pkg or repo.pkg format
-            parts = package_spec.split('.')
+            parts = package_spec.split(".")
             if len(parts) == 2:
                 # Could be either pipeline.pkg or repo.pkg
                 # Try to determine based on whether it's an existing pipeline
                 potential_pipeline = parts[0]
                 pipeline_dir = self.jarvis_config.get_pipeline_dir(potential_pipeline)
-                
+
                 if pipeline_dir.exists():
                     # It's a pipeline.pkg format
                     pipeline_name, pkg_id = parts
@@ -1695,11 +2141,13 @@ class JarvisCLI(ArgParse):
                 else:
                     # It's a repo.pkg format - load standalone
                     from jarvis_cd.core.pkg import Pkg
+
                     pkg_instance = Pkg.load_standalone(package_spec)
                     pkg_instance.show_readme()
             else:
                 # It's a repo.pkg format - load standalone
                 from jarvis_cd.core.pkg import Pkg
+
                 pkg_instance = Pkg.load_standalone(package_spec)
                 pkg_instance.show_readme()
         else:
@@ -1709,36 +2157,38 @@ class JarvisCLI(ArgParse):
                 if not self.current_pipeline:
                     current_name = self.jarvis_config.get_current_pipeline()
                     self.current_pipeline = Pipeline(current_name)
-                
+
                 try:
                     self.current_pipeline.show_package_readme(package_spec)
                 except ValueError:
                     # Package not in pipeline, try standalone
                     from jarvis_cd.core.pkg import Pkg
+
                     pkg_instance = Pkg.load_standalone(package_spec)
                     pkg_instance.show_readme()
             else:
                 # No pipeline, load standalone
                 from jarvis_cd.core.pkg import Pkg
+
                 pkg_instance = Pkg.load_standalone(package_spec)
                 pkg_instance.show_readme()
-        
+
     def pkg_path(self):
         """Show package directory paths"""
         self._ensure_initialized()
-        package_spec = self.kwargs['package_spec']
+        package_spec = self.kwargs["package_spec"]
 
         # Get the requested paths
         path_flags = {
-            'shared': self.kwargs.get('shared', False),
-            'private': self.kwargs.get('private', False),
-            'config': self.kwargs.get('config', False)
+            "shared": self.kwargs.get("shared", False),
+            "private": self.kwargs.get("private", False),
+            "config": self.kwargs.get("config", False),
         }
 
         # Parse package specification
-        if '.' in package_spec:
+        if "." in package_spec:
             # Check if it's a pipeline.pkg or repo.pkg format
-            parts = package_spec.split('.')
+            parts = package_spec.split(".")
             if len(parts) == 2:
                 # Could be either pipeline.pkg or repo.pkg
                 # Try to determine based on whether it's an existing pipeline
@@ -1753,11 +2203,13 @@ class JarvisCLI(ArgParse):
                 else:
                     # It's a repo.pkg format - load standalone
                     from jarvis_cd.core.pkg import Pkg
+
                     pkg_instance = Pkg.load_standalone(package_spec)
                     pkg_instance.show_paths(path_flags)
             else:
                 # It's a repo.pkg format - load standalone
                 from jarvis_cd.core.pkg import Pkg
+
                 pkg_instance = Pkg.load_standalone(package_spec)
                 pkg_instance.show_paths(path_flags)
         else:
@@ -1773,29 +2225,32 @@ class JarvisCLI(ArgParse):
                 except ValueError:
                     # Package not in pipeline, try standalone
                     from jarvis_cd.core.pkg import Pkg
+
                     pkg_instance = Pkg.load_standalone(package_spec)
                     pkg_instance.show_paths(path_flags)
             else:
                 # No pipeline, load standalone
                 from jarvis_cd.core.pkg import Pkg
+
                 pkg_instance = Pkg.load_standalone(package_spec)
                 pkg_instance.show_paths(path_flags)
 
     def pkg_help(self):
         """Show package configuration help"""
         self._ensure_initialized()
-        package_spec = self.kwargs['package_spec']
+        package_spec = self.kwargs["package_spec"]
 
         # Load the package standalone (repo.pkg format like builtin.ior)
-        from jarvis_cd.core.pkg import Pkg
+
         pkg_instance = Pkg.load_standalone(package_spec)
 
         # Get the argparse instance and print help
         argparse = pkg_instance.get_argparse()
         argparse.print_help()
 
-    def _resolve_package_for_inspect(self, package_spec, pipeline_action,
-                                     standalone_action):
+    def _resolve_package_for_inspect(
+        self, package_spec, pipeline_action, standalone_action
+    ):
         """
         Mirror the resolution logic of pkg_readme/pkg_path: try
         pipeline.pkg, then repo.pkg, then bare pkg in current pipeline,
@@ -1804,10 +2259,9 @@ class JarvisCLI(ArgParse):
         :param pipeline_action: callable(pipeline, pkg_id) for pipeline-resolved
         :param standalone_action: callable(pkg_instance) for standalone
         """
-        from jarvis_cd.core.pkg import Pkg
 
-        if '.' in package_spec:
-            parts = package_spec.split('.')
+        if "." in package_spec:
+            parts = package_spec.split(".")
             if len(parts) == 2:
                 potential_pipeline = parts[0]
                 pipeline_dir = self.jarvis_config.get_pipeline_dir(potential_pipeline)
@@ -1834,7 +2288,7 @@ class JarvisCLI(ArgParse):
     def pkg_container_build(self):
         """Print the build.sh jarvis would run for a package."""
         self._ensure_initialized()
-        package_spec = self.kwargs['package_spec']
+        package_spec = self.kwargs["package_spec"]
         self._resolve_package_for_inspect(
             package_spec,
             lambda ppl, pid: ppl.show_package_build_script(pid),
@@ -1844,7 +2298,7 @@ class JarvisCLI(ArgParse):
     def pkg_container_deploy(self):
         """Print the Dockerfile.deploy jarvis would use for a package."""
         self._ensure_initialized()
-        package_spec = self.kwargs['package_spec']
+        package_spec = self.kwargs["package_spec"]
         self._resolve_package_for_inspect(
             package_spec,
             lambda ppl, pid: ppl.show_package_deploy_dockerfile(pid),
@@ -1864,35 +2318,37 @@ class JarvisCLI(ArgParse):
 
         if self.current_pipeline:
             # Reload environment from env.yaml (don't reload full pipeline to avoid inline dict error)
-            from pathlib import Path
             import yaml
-            pipeline_dir = self.jarvis_config.get_pipeline_dir(self.current_pipeline.name)
-            env_file = pipeline_dir / 'env.yaml'
+
+            pipeline_dir = self.jarvis_config.get_pipeline_dir(
+                self.current_pipeline.name
+            )
+            env_file = pipeline_dir / "env.yaml"
             if env_file.exists():
-                with open(env_file, 'r') as f:
+                with open(env_file, "r") as f:
                     self.current_pipeline.env = yaml.safe_load(f)
 
             # Reconfigure all packages with the new environment
             self.current_pipeline.configure_all_packages()
             print("Pipeline reconfigured with new environment")
-        
+
     def ppl_env_copy(self):
         """Copy named environment to current pipeline"""
         self._ensure_initialized()
-        env_name = self.kwargs['env_name']
+        env_name = self.kwargs["env_name"]
         self.env_manager.copy_named_environment(env_name)
-        
+
     def ppl_env_show(self):
         """Show current pipeline environment"""
         self._ensure_initialized()
         self.env_manager.show_pipeline_environment()
-        
+
     def env_build(self):
         """Build a named environment"""
         self._ensure_initialized()
-        env_name = self.kwargs['env_name']
+        env_name = self.kwargs["env_name"]
         self.env_manager.build_named_environment(env_name, self.remainder)
-        
+
     def env_list(self):
         """List all named environments"""
         self._ensure_initialized()
@@ -1902,233 +2358,240 @@ class JarvisCLI(ArgParse):
             for env_name in sorted(envs):
                 print(f"  {env_name}")
         else:
-            print("No named environments found. Create one with 'jarvis env build <name>'")
-            
+            print(
+                "No named environments found. Create one with 'jarvis env build <name>'"
+            )
+
     def env_show(self):
         """Show a named environment"""
         self._ensure_initialized()
-        env_name = self.kwargs['env_name']
+        env_name = self.kwargs["env_name"]
         self.env_manager.show_named_environment(env_name)
-        
+
     def hostfile_set(self):
         """Set hostfile"""
         self._ensure_initialized()
-        hostfile_path = self.kwargs['hostfile_path']
+        hostfile_path = self.kwargs["hostfile_path"]
         self.jarvis_config.set_hostfile(hostfile_path)
 
     def hostfile_unset(self):
         """Unset hostfile (clear to empty hostfile)"""
         self._ensure_initialized()
         self.jarvis_config.unset_hostfile()
-        
+
     def rg_build(self):
         """Build resource graph"""
         self._ensure_initialized()
-        benchmark = not self.kwargs.get('no_benchmark', False)
-        duration = self.kwargs.get('duration', 25)
+        benchmark = not self.kwargs.get("no_benchmark", False)
+        duration = self.kwargs.get("duration", 25)
         self.rg_manager.build(benchmark=benchmark, duration=duration)
-        
+
     def build_profile(self):
         """Build environment profile"""
         self._ensure_initialized()
-        method = self.kwargs.get('m', 'dotenv')
-        path = self.kwargs.get('path')
+        method = self.kwargs.get("m", "dotenv")
+        path = self.kwargs.get("path")
         self.module_manager.build_profile(path, method)
-        
+
     def rg_show(self):
         """Show resource graph summary"""
         self._ensure_initialized()
         self.rg_manager.show()
-        
+
     def rg_nodes(self):
         """List nodes in resource graph"""
         self._ensure_initialized()
         self.rg_manager.list_nodes()
-        
+
     def rg_node(self):
         """Show detailed node information"""
         self._ensure_initialized()
-        hostname = self.kwargs['hostname']
+        hostname = self.kwargs["hostname"]
         self.rg_manager.show_node_details(hostname)
-        
+
     def rg_filter(self):
         """Filter storage by device type"""
         self._ensure_initialized()
-        dev_type = self.kwargs['dev_type']
+        dev_type = self.kwargs["dev_type"]
         self.rg_manager.filter_by_type(dev_type)
-        
+
     def rg_load(self):
         """Load resource graph from file"""
         self._ensure_initialized()
-        file_path = Path(self.kwargs['file_path'])
+        file_path = Path(self.kwargs["file_path"])
         self.rg_manager.load(file_path)
-        
+
     def rg_path(self):
         """Show path to current resource graph file"""
         self._ensure_initialized()
         self.rg_manager.show_path()
-        
+
     # Module management commands
     def mod_create(self):
         """Create a new module"""
         self._ensure_initialized()
-        mod_name = self.kwargs.get('mod_name')
+        mod_name = self.kwargs.get("mod_name")
         if not mod_name:
             # Generate a unique module name or prompt user
             import time
+
             mod_name = f"module_{int(time.time())}"
             print(f"No module name provided, using: {mod_name}")
         self.module_manager.create_module(mod_name)
-        
+
     def mod_cd(self):
         """Set current module"""
         self._ensure_initialized()
-        mod_name = self.kwargs['mod_name']
+        mod_name = self.kwargs["mod_name"]
         self.module_manager.set_current_module(mod_name)
-        
+
     def mod_prepend(self):
         """Prepend environment variables to module"""
         self._ensure_initialized()
-        mod_name = self.kwargs.get('mod_name')
+        mod_name = self.kwargs.get("mod_name")
         self.module_manager.prepend_env_vars(mod_name, self.remainder)
-        
+
     def mod_setenv(self):
         """Set environment variables in module"""
         self._ensure_initialized()
-        mod_name = self.kwargs.get('mod_name')
+        mod_name = self.kwargs.get("mod_name")
         self.module_manager.set_env_vars(mod_name, self.remainder)
-        
+
     def mod_destroy(self):
         """Destroy a module"""
         self._ensure_initialized()
-        mod_name = self.kwargs.get('mod_name')
+        mod_name = self.kwargs.get("mod_name")
         self.module_manager.destroy_module(mod_name)
 
     def mod_clear(self):
         """Clear module directory except src/"""
         self._ensure_initialized()
-        mod_name = self.kwargs.get('mod_name')
+        mod_name = self.kwargs.get("mod_name")
         self.module_manager.clear_module(mod_name)
 
     def mod_src(self):
         """Show module source directory"""
         self._ensure_initialized()
-        mod_name = self.kwargs.get('mod_name')
+        mod_name = self.kwargs.get("mod_name")
         print(self.module_manager.get_module_src_dir(mod_name))
-        
+
     def mod_root(self):
         """Show module root directory"""
         self._ensure_initialized()
-        mod_name = self.kwargs.get('mod_name')
+        mod_name = self.kwargs.get("mod_name")
         print(self.module_manager.get_module_root_dir(mod_name))
-        
+
     def mod_tcl(self):
         """Show module TCL file path"""
         self._ensure_initialized()
-        mod_name = self.kwargs.get('mod_name')
+        mod_name = self.kwargs.get("mod_name")
         print(self.module_manager.get_module_tcl_path(mod_name))
-        
+
     def mod_yaml(self):
         """Show module YAML file path"""
         self._ensure_initialized()
-        mod_name = self.kwargs.get('mod_name')
+        mod_name = self.kwargs.get("mod_name")
         print(self.module_manager.get_module_yaml_path(mod_name))
-        
+
     def mod_dir(self):
         """Show modules directory"""
         self._ensure_initialized()
         print(self.module_manager.modules_dir)
-        
+
     def mod_list(self):
         """List all modules"""
         self._ensure_initialized()
         self.module_manager.list_modules()
-        
+
     def mod_profile(self):
         """Build environment profile"""
         self._ensure_initialized()
         # Parse remainder arguments for m= and path= format
-        method = 'dotenv'  # default
+        method = "dotenv"  # default
         path = None
-        
-        if hasattr(self, 'remainder') and self.remainder:
+
+        if hasattr(self, "remainder") and self.remainder:
             for arg in self.remainder:
-                if arg.startswith('m='):
+                if arg.startswith("m="):
                     method = arg[2:]
-                elif arg.startswith('path='):
+                elif arg.startswith("path="):
                     path = arg[5:]
-        
+
         self.module_manager.build_profile_new(path, method)
-        
+
     def mod_import(self):
         """Import module from command"""
         self._ensure_initialized()
-        mod_name = self.kwargs.get('mod_name')
-        
-        if not hasattr(self, 'remainder') or not self.remainder:
-            raise ValueError("No command provided. Usage: jarvis mod import <mod_name> <command>")
-        
+        mod_name = self.kwargs.get("mod_name")
+
+        if not hasattr(self, "remainder") or not self.remainder:
+            raise ValueError(
+                "No command provided. Usage: jarvis mod import <mod_name> <command>"
+            )
+
         # Join remainder as the command to execute
-        command = ' '.join(self.remainder)
+        command = " ".join(self.remainder)
         self.module_manager.import_module(mod_name, command)
-        
+
     def mod_update(self):
         """Update module using stored command"""
         self._ensure_initialized()
-        mod_name = self.kwargs.get('mod_name')
+        mod_name = self.kwargs.get("mod_name")
         self.module_manager.update_module(mod_name)
-        
+
     def mod_build_profile(self):
         """Build environment profile"""
         self._ensure_initialized()
-        method = self.kwargs.get('m', 'dotenv')
-        path = self.kwargs.get('path')
+        method = self.kwargs.get("m", "dotenv")
+        path = self.kwargs.get("path")
         self.module_manager.build_profile(path, method)
 
     def mod_dep_add(self):
         """Add a module dependency"""
         self._ensure_initialized()
-        dep_name = self.kwargs['dep_name']
-        mod_name = self.kwargs.get('mod_name')
+        dep_name = self.kwargs["dep_name"]
+        mod_name = self.kwargs.get("mod_name")
         self.module_manager.add_dependency(mod_name, dep_name)
 
     def mod_dep_remove(self):
         """Remove a module dependency"""
         self._ensure_initialized()
-        dep_name = self.kwargs['dep_name']
-        mod_name = self.kwargs.get('mod_name')
+        dep_name = self.kwargs["dep_name"]
+        mod_name = self.kwargs.get("mod_name")
         self.module_manager.remove_dependency(mod_name, dep_name)
 
     def ppl_index_load(self):
         """Load a pipeline script from an index"""
         self._ensure_initialized()
-        index_query = self.kwargs['index_query']
+        index_query = self.kwargs["index_query"]
         self.pipeline_index_manager.load_pipeline_from_index(index_query)
-        
+
     def ppl_index_copy(self):
         """Copy a pipeline script from an index"""
         self._ensure_initialized()
-        index_query = self.kwargs['index_query']
-        output = self.kwargs.get('output')
+        index_query = self.kwargs["index_query"]
+        output = self.kwargs.get("output")
         self.pipeline_index_manager.copy_pipeline_from_index(index_query, output)
-        
+
     def ppl_index_list(self):
         """List available pipeline scripts in indexes"""
         from jarvis_cd.util.logger import logger, Color
-        
+
         self._ensure_initialized()
-        repo_name = self.kwargs.get('repo_name')
-        available_scripts = self.pipeline_index_manager.list_available_scripts(repo_name)
-        
+        repo_name = self.kwargs.get("repo_name")
+        available_scripts = self.pipeline_index_manager.list_available_scripts(
+            repo_name
+        )
+
         if not available_scripts:
             print("No pipeline indexes found in any repositories.")
             return
-            
+
         if repo_name:
             print(f"Available pipeline scripts in {repo_name}:")
         else:
             print("Available pipeline scripts:")
-            
+
         for repo, entries in available_scripts.items():
             if repo_name and repo != repo_name:
                 continue
@@ -2136,10 +2599,10 @@ class JarvisCLI(ArgParse):
                 print(f"  {repo}:")
             for entry in entries:
                 indent = "  " if repo_name else "    "
-                if entry['type'] == 'file':
+                if entry["type"] == "file":
                     # Print files in default color
                     print(f"{indent}{entry['name']}")
-                elif entry['type'] == 'directory':
+                elif entry["type"] == "directory":
                     # Print directories in cyan color with (directory) label
                     logger.print(Color.CYAN, f"{indent}{entry['name']} (directory)")
 
@@ -2149,7 +2612,7 @@ def main():
     try:
         cli = JarvisCLI()
         cli.define_options()
-        result = cli.parse(sys.argv[1:])
+        cli.parse(sys.argv[1:])
     except KeyboardInterrupt:
         print("\nOperation cancelled by user")
         sys.exit(1)
@@ -2158,5 +2621,5 @@ def main():
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/jarvis_cd/core/config.py
+++ b/jarvis_cd/core/config.py
@@ -1,7 +1,8 @@
 import os
 import yaml
 from pathlib import Path
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional
+from jarvis_cd.core.execution import validate_pipeline_id
 from jarvis_cd.util.hostfile import Hostfile
 
 
@@ -16,35 +17,41 @@ def load_class(import_str: str, path: str, class_name: str):
     :return: The class data type
     """
     import sys
-    
-    fullpath = os.path.join(path, import_str.replace('.', '/') + '.py')
-    
+
+    fullpath = os.path.join(path, import_str.replace(".", "/") + ".py")
+
     # If the exact path doesn't exist, try replacing the last component
     if not os.path.exists(fullpath):
         # Handle legacy naming: if looking for "package.py", try "pkg.py"
-        if import_str.endswith('.package'):
-            legacy_import_str = import_str[:-8] + '.pkg'  # Replace .package with .pkg
-            fullpath = os.path.join(path, legacy_import_str.replace('.', '/') + '.py')
+        if import_str.endswith(".package"):
+            legacy_import_str = import_str[:-8] + ".pkg"  # Replace .package with .pkg
+            fullpath = os.path.join(path, legacy_import_str.replace(".", "/") + ".py")
             if os.path.exists(fullpath):
                 import_str = legacy_import_str
             else:
                 return None
         else:
             return None
-    
+
     sys.path.insert(0, path)
     try:
         module = __import__(import_str, fromlist=[class_name])
         cls = getattr(module, class_name, None)
         if cls is None:
-            raise AttributeError(f"Class '{class_name}' not found in module '{import_str}'")
+            raise AttributeError(
+                f"Class '{class_name}' not found in module '{import_str}'"
+            )
         return cls
     except ImportError as e:
         # Re-raise ImportError with more context instead of silently returning None
-        raise ImportError(f"Failed to import module '{import_str}' from path '{path}': {e}") from e
+        raise ImportError(
+            f"Failed to import module '{import_str}' from path '{path}': {e}"
+        ) from e
     except AttributeError as e:
         # Re-raise AttributeError with more context instead of silently returning None
-        raise AttributeError(f"Failed to get class '{class_name}' from module '{import_str}': {e}") from e
+        raise AttributeError(
+            f"Failed to get class '{class_name}' from module '{import_str}': {e}"
+        ) from e
     finally:
         sys.path.pop(0)
 
@@ -54,6 +61,7 @@ class Jarvis:
     Singleton class that manages Jarvis configuration and provides global access.
     Combines configuration management with singleton pattern.
     """
+
     _instance = None
 
     def __new__(cls, jarvis_root: Optional[str] = None):
@@ -69,13 +77,13 @@ class Jarvis:
 
         # Set up jarvis root directory
         if jarvis_root is None:
-            self.jarvis_root = Path.home() / '.ppi-jarvis'
+            self.jarvis_root = Path.home() / ".ppi-jarvis"
         else:
             self.jarvis_root = Path(jarvis_root)
 
-        self.config_file = self.jarvis_root / 'jarvis_config.yaml'
-        self.repos_file = self.jarvis_root / 'repos.yaml'
-        self.resource_graph_file = self.jarvis_root / 'resource_graph.yaml'
+        self.config_file = self.jarvis_root / "jarvis_config.yaml"
+        self.repos_file = self.jarvis_root / "repos.yaml"
+        self.resource_graph_file = self.jarvis_root / "resource_graph.yaml"
 
         # Lazy-loaded properties
         self._config = None
@@ -91,9 +99,11 @@ class Jarvis:
         # Try to automatically load configuration if it exists
         if self.is_initialized():
             config = self.config
-            self.config_dir = config.get('config_dir', str(self.jarvis_root))
-            self.private_dir = config.get('private_dir', str(self.jarvis_root / 'private'))
-            self.shared_dir = config.get('shared_dir', str(self.jarvis_root / 'shared'))
+            self.config_dir = config.get("config_dir", str(self.jarvis_root))
+            self.private_dir = config.get(
+                "private_dir", str(self.jarvis_root / "private")
+            )
+            self.shared_dir = config.get("shared_dir", str(self.jarvis_root / "shared"))
 
         self._initialized = True
 
@@ -104,7 +114,9 @@ class Jarvis:
             cls._instance = cls(jarvis_root)
         return cls._instance
 
-    def initialize(self, config_dir: str, private_dir: str, shared_dir: str, force: bool = False):
+    def initialize(
+        self, config_dir: str, private_dir: str, shared_dir: str, force: bool = False
+    ):
         """
         Initialize Jarvis configuration directories and files.
 
@@ -125,33 +137,35 @@ class Jarvis:
 
         # Initialize default configuration
         default_config = {
-            'config_dir': str(Path(config_dir).absolute()),
-            'private_dir': str(Path(private_dir).absolute()),
-            'shared_dir': str(Path(shared_dir).absolute()),
-            'current_pipeline': None,
-            'hostfile': None
+            "config_dir": str(Path(config_dir).absolute()),
+            "private_dir": str(Path(private_dir).absolute()),
+            "shared_dir": str(Path(shared_dir).absolute()),
+            "current_pipeline": None,
+            "hostfile": None,
         }
 
         # Save configuration
         self.save_config(default_config)
 
         # Update instance attributes
-        self.config_dir = default_config['config_dir']
-        self.private_dir = default_config['private_dir']
-        self.shared_dir = default_config['shared_dir']
+        self.config_dir = default_config["config_dir"]
+        self.private_dir = default_config["private_dir"]
+        self.shared_dir = default_config["shared_dir"]
 
         # Handle repos.yaml
         repos_exists = self.repos_file.exists()
         if repos_exists and not force:
-            logger.warning(f"Existing repos.yaml detected - preserving (use +force to override)")
+            logger.warning(
+                "Existing repos.yaml detected - preserving (use +force to override)"
+            )
         elif repos_exists and force:
-            logger.warning(f"Existing repos.yaml detected - overriding due to +force")
+            logger.warning("Existing repos.yaml detected - overriding due to +force")
             builtin_repo_path = self.get_builtin_repo_path()
             if builtin_repo_path.exists():
                 builtin_repo_path_str = str(builtin_repo_path.absolute())
             else:
-                builtin_repo_path_str = str((self.jarvis_root / 'builtin').absolute())
-            default_repos = {'repos': [builtin_repo_path_str]}
+                builtin_repo_path_str = str((self.jarvis_root / "builtin").absolute())
+            default_repos = {"repos": [builtin_repo_path_str]}
             self.save_repos(default_repos)
         else:
             # File doesn't exist, create it
@@ -159,21 +173,25 @@ class Jarvis:
             if builtin_repo_path.exists():
                 builtin_repo_path_str = str(builtin_repo_path.absolute())
             else:
-                builtin_repo_path_str = str((self.jarvis_root / 'builtin').absolute())
-            default_repos = {'repos': [builtin_repo_path_str]}
+                builtin_repo_path_str = str((self.jarvis_root / "builtin").absolute())
+            default_repos = {"repos": [builtin_repo_path_str]}
             self.save_repos(default_repos)
 
         # Handle resource_graph.yaml
         resource_graph_exists = self.resource_graph_file.exists()
         if resource_graph_exists and not force:
-            logger.warning(f"Existing resource_graph.yaml detected - preserving (use +force to override)")
+            logger.warning(
+                "Existing resource_graph.yaml detected - preserving (use +force to override)"
+            )
         elif resource_graph_exists and force:
-            logger.warning(f"Existing resource_graph.yaml detected - overriding due to +force")
-            default_resource_graph = {'storage': {}, 'network': {}}
+            logger.warning(
+                "Existing resource_graph.yaml detected - overriding due to +force"
+            )
+            default_resource_graph = {"storage": {}, "network": {}}
             self.save_resource_graph(default_resource_graph)
         else:
             # File doesn't exist, create it
-            default_resource_graph = {'storage': {}, 'network': {}}
+            default_resource_graph = {"storage": {}, "network": {}}
             self.save_resource_graph(default_resource_graph)
 
         print(f"Jarvis initialized at {self.jarvis_root}")
@@ -206,7 +224,7 @@ class Jarvis:
     def hostfile(self) -> Hostfile:
         """Get current hostfile"""
         if self._hostfile is None:
-            hostfile_path = self.config.get('hostfile')
+            hostfile_path = self.config.get("hostfile")
             if hostfile_path and os.path.exists(hostfile_path):
                 self._hostfile = Hostfile(path=hostfile_path)
             else:
@@ -217,45 +235,45 @@ class Jarvis:
     def load_config(self) -> Dict[str, Any]:
         """Load jarvis configuration from file"""
         if not self.config_file.exists():
-            raise FileNotFoundError(f"Jarvis not initialized. Run 'jarvis init' first.")
+            raise FileNotFoundError("Jarvis not initialized. Run 'jarvis init' first.")
 
-        with open(self.config_file, 'r') as f:
+        with open(self.config_file, "r") as f:
             return yaml.safe_load(f) or {}
 
     def load_repos(self) -> Dict[str, Any]:
         """Load repos configuration from file"""
         if not self.repos_file.exists():
-            return {'repos': []}
+            return {"repos": []}
 
-        with open(self.repos_file, 'r') as f:
-            return yaml.safe_load(f) or {'repos': []}
+        with open(self.repos_file, "r") as f:
+            return yaml.safe_load(f) or {"repos": []}
 
     def load_resource_graph(self) -> Dict[str, Any]:
         """Load resource graph from file"""
         if not self.resource_graph_file.exists():
-            return {'storage': {}, 'network': {}}
+            return {"storage": {}, "network": {}}
 
-        with open(self.resource_graph_file, 'r') as f:
-            return yaml.safe_load(f) or {'storage': {}, 'network': {}}
+        with open(self.resource_graph_file, "r") as f:
+            return yaml.safe_load(f) or {"storage": {}, "network": {}}
 
     def save_config(self, config: Dict[str, Any]):
         """Save jarvis configuration to file"""
         self.jarvis_root.mkdir(parents=True, exist_ok=True)
-        with open(self.config_file, 'w') as f:
+        with open(self.config_file, "w") as f:
             yaml.dump(config, f, default_flow_style=False)
         self._config = config
 
     def save_repos(self, repos: Dict[str, Any]):
         """Save repos configuration to file"""
         self.jarvis_root.mkdir(parents=True, exist_ok=True)
-        with open(self.repos_file, 'w') as f:
+        with open(self.repos_file, "w") as f:
             yaml.dump(repos, f, default_flow_style=False)
         self._repos = repos
 
     def save_resource_graph(self, resource_graph: Dict[str, Any]):
         """Save resource graph to file"""
         self.jarvis_root.mkdir(parents=True, exist_ok=True)
-        with open(self.resource_graph_file, 'w') as f:
+        with open(self.resource_graph_file, "w") as f:
             yaml.dump(resource_graph, f, default_flow_style=False)
         self._resource_graph = resource_graph
 
@@ -267,15 +285,16 @@ class Jarvis:
         # Check for existing repository with same name (not just same path)
         repo_name = Path(repo_path).name
         existing_repos_with_same_name = [
-            existing_path for existing_path in repos['repos']
+            existing_path
+            for existing_path in repos["repos"]
             if Path(existing_path).name == repo_name
         ]
 
-        if repo_path in repos['repos']:
+        if repo_path in repos["repos"]:
             if force:
                 # Repository path already exists - remove and re-add to update order
-                repos['repos'].remove(repo_path)
-                repos['repos'].insert(0, repo_path)
+                repos["repos"].remove(repo_path)
+                repos["repos"].insert(0, repo_path)
                 self.save_repos(repos)
                 print(f"Repository already exists - updated position: {repo_path}")
             else:
@@ -285,10 +304,10 @@ class Jarvis:
             if force:
                 # Remove existing repositories with same name
                 for existing_path in existing_repos_with_same_name:
-                    repos['repos'].remove(existing_path)
+                    repos["repos"].remove(existing_path)
                     print(f"Removed existing repository: {existing_path}")
                 # Add new repository
-                repos['repos'].insert(0, repo_path)
+                repos["repos"].insert(0, repo_path)
                 self.save_repos(repos)
                 print(f"Added repository (replacing existing): {repo_path}")
             else:
@@ -297,7 +316,7 @@ class Jarvis:
                     print(f"  {existing_path}")
                 print("Use --force to replace existing repository")
         else:
-            repos['repos'].insert(0, repo_path)  # Add to front for priority
+            repos["repos"].insert(0, repo_path)  # Add to front for priority
             self.save_repos(repos)
             print(f"Added repository: {repo_path}")
 
@@ -306,8 +325,8 @@ class Jarvis:
         repo_path = str(Path(repo_path).absolute())
         repos = self.repos.copy()
 
-        if repo_path in repos['repos']:
-            repos['repos'].remove(repo_path)
+        if repo_path in repos["repos"]:
+            repos["repos"].remove(repo_path)
             self.save_repos(repos)
             print(f"Removed repository: {repo_path}")
         else:
@@ -321,19 +340,18 @@ class Jarvis:
         :return: Number of repositories removed
         """
         repos = self.repos.copy()
-        initial_count = len(repos['repos'])
         removed_repos = []
 
         # Find all repositories with matching name
         remaining_repos = []
-        for repo_path in repos['repos']:
+        for repo_path in repos["repos"]:
             if Path(repo_path).name == repo_name:
                 removed_repos.append(repo_path)
             else:
                 remaining_repos.append(repo_path)
 
         if removed_repos:
-            repos['repos'] = remaining_repos
+            repos["repos"] = remaining_repos
             self.save_repos(repos)
 
             print(f"Removed {len(removed_repos)} repository(ies) named '{repo_name}':")
@@ -347,12 +365,11 @@ class Jarvis:
     def cleanup_nonexistent_repos(self):
         """Remove any repositories from configuration that no longer exist on disk"""
         repos = self.repos.copy()
-        initial_count = len(repos['repos'])
         removed_repos = []
 
         # Filter out non-existent repositories
         existing_repos = []
-        for repo_path in repos['repos']:
+        for repo_path in repos["repos"]:
             if Path(repo_path).exists():
                 existing_repos.append(repo_path)
             else:
@@ -360,10 +377,12 @@ class Jarvis:
 
         # Update repos if any were removed
         if removed_repos:
-            repos['repos'] = existing_repos
+            repos["repos"] = existing_repos
             self.save_repos(repos)
 
-            print(f"Automatically removed {len(removed_repos)} non-existent repositories:")
+            print(
+                f"Automatically removed {len(removed_repos)} non-existent repositories:"
+            )
             for repo_path in removed_repos:
                 print(f"  - {repo_path}")
 
@@ -376,7 +395,7 @@ class Jarvis:
             raise FileNotFoundError(f"Hostfile not found: {hostfile_path}")
 
         config = self.config.copy()
-        config['hostfile'] = hostfile_path
+        config["hostfile"] = hostfile_path
         self.save_config(config)
         self._hostfile = None  # Reset cached hostfile
         print(f"Set hostfile: {hostfile_path}")
@@ -384,18 +403,18 @@ class Jarvis:
     def unset_hostfile(self):
         """Clear the hostfile, reverting to the default (localhost)"""
         config = self.config.copy()
-        config['hostfile'] = None
+        config["hostfile"] = None
         self.save_config(config)
         self._hostfile = None  # Reset cached hostfile
         print("Unset hostfile (reverted to default: localhost)")
 
     def get_pipeline_dir(self, pipeline_name: str) -> Path:
         """Get the config directory for a specific pipeline"""
-        return Path(self.config_dir) / 'pipelines' / pipeline_name
+        return Path(self.config_dir) / "pipelines" / validate_pipeline_id(pipeline_name)
 
     def get_pipeline_shared_dir(self, pipeline_name: str) -> Path:
         """Get the shared directory for a specific pipeline"""
-        return Path(self.shared_dir) / pipeline_name
+        return Path(self.shared_dir) / validate_pipeline_id(pipeline_name)
 
     def get_containers_dir(self) -> Path:
         """Centralized SIF cache shared by every pipeline.
@@ -405,29 +424,29 @@ class Jarvis:
         pipelines reuse the same image without rebuilding or
         re-pulling.
         """
-        return Path(self.shared_dir) / 'containers'
+        return Path(self.shared_dir) / "containers"
 
     def get_pipeline_private_dir(self, pipeline_name: str) -> Path:
         """Get the private directory for a specific pipeline"""
-        return Path(self.private_dir) / pipeline_name
+        return Path(self.private_dir) / validate_pipeline_id(pipeline_name)
 
     def get_current_pipeline_dir(self) -> Optional[Path]:
         """Get the config directory for the current pipeline"""
-        current_pipeline = self.config.get('current_pipeline')
+        current_pipeline = self.config.get("current_pipeline")
         if current_pipeline:
             return self.get_pipeline_dir(current_pipeline)
         return None
 
     def get_current_pipeline_shared_dir(self) -> Optional[Path]:
         """Get the shared directory for the current pipeline"""
-        current_pipeline = self.config.get('current_pipeline')
+        current_pipeline = self.config.get("current_pipeline")
         if current_pipeline:
             return self.get_pipeline_shared_dir(current_pipeline)
         return None
 
     def get_current_pipeline_private_dir(self) -> Optional[Path]:
         """Get the private directory for the current pipeline"""
-        current_pipeline = self.config.get('current_pipeline')
+        current_pipeline = self.config.get("current_pipeline")
         if current_pipeline:
             return self.get_pipeline_private_dir(current_pipeline)
         return None
@@ -435,43 +454,43 @@ class Jarvis:
     def set_current_pipeline(self, pipeline_name: str):
         """Set the current active pipeline"""
         config = self.config.copy()
-        config['current_pipeline'] = pipeline_name
+        config["current_pipeline"] = validate_pipeline_id(pipeline_name)
         self.save_config(config)
 
     def get_current_pipeline(self) -> Optional[str]:
         """Get the name of the current active pipeline"""
-        return self.config.get('current_pipeline')
+        return self.config.get("current_pipeline")
 
     def set_current_module(self, module_name: Optional[str]):
         """Set the current active module"""
         config = self.config.copy()
-        config['current_module'] = module_name
+        config["current_module"] = module_name
         self.save_config(config)
 
     def get_current_module(self) -> Optional[str]:
         """Get the name of the current active module"""
-        return self.config.get('current_module')
+        return self.config.get("current_module")
 
     def get_pipelines_dir(self) -> Path:
         """Get the directory where all pipelines are stored"""
-        config_dir = Path(self.config['config_dir'])
-        return config_dir / 'pipelines'
+        config_dir = Path(self.config["config_dir"])
+        return config_dir / "pipelines"
 
     def get_builtin_repo_path(self) -> Path:
         """Get path to builtin repository"""
         # First check if builtin repo is registered in repos
-        for repo_path_str in self.repos['repos']:
+        for repo_path_str in self.repos["repos"]:
             repo_path = Path(repo_path_str)
-            if repo_path.name == 'builtin' and repo_path.exists():
+            if repo_path.name == "builtin" and repo_path.exists():
                 return repo_path
 
         # Fall back to builtin repo installed to ~/.ppi-jarvis/builtin
-        user_builtin = self.jarvis_root / 'builtin'
+        user_builtin = self.jarvis_root / "builtin"
         if user_builtin.exists():
             return user_builtin
 
         # Fall back to builtin repo in the same directory as this file (development)
-        dev_builtin = Path(__file__).parent.parent.parent / 'builtin'
+        dev_builtin = Path(__file__).parent.parent.parent / "builtin"
         if dev_builtin.exists():
             return dev_builtin
 
@@ -484,6 +503,7 @@ class Jarvis:
             # Method 1: Try to find builtin package directly
             try:
                 import builtin
+
                 builtin_module_path = Path(builtin.__file__).parent
                 if builtin_module_path.exists():
                     return builtin_module_path
@@ -492,12 +512,16 @@ class Jarvis:
 
             # Method 2: Look for builtin in installed package files
             try:
-                dist = importlib.metadata.distribution('jarvis_cd')
-                if hasattr(dist, 'files') and dist.files:
+                dist = importlib.metadata.distribution("jarvis_cd")
+                if hasattr(dist, "files") and dist.files:
                     for file in dist.files:
-                        if 'builtin' in str(file) and str(file).endswith('builtin/__init__.py'):
+                        if "builtin" in str(file) and str(file).endswith(
+                            "builtin/__init__.py"
+                        ):
                             # Get the actual installation path
-                            for path in site.getsitepackages() + [site.getusersitepackages()]:
+                            for path in site.getsitepackages() + [
+                                site.getusersitepackages()
+                            ]:
                                 if path:
                                     candidate = Path(path) / file.parent
                                     if candidate.exists():
@@ -508,8 +532,11 @@ class Jarvis:
             # Method 3: Search in site-packages
             for path in site.getsitepackages() + [site.getusersitepackages()]:
                 if path:
-                    builtin_path = Path(path) / 'builtin'
-                    if builtin_path.exists() and (builtin_path / '__init__.py').exists():
+                    builtin_path = Path(path) / "builtin"
+                    if (
+                        builtin_path.exists()
+                        and (builtin_path / "__init__.py").exists()
+                    ):
                         return builtin_path
 
         except Exception:
@@ -525,27 +552,31 @@ class Jarvis:
         Searches repositories in order, respecting priority.
         """
         # Check all registered repos in order
-        for repo_path in self.repos['repos']:
+        for repo_path in self.repos["repos"]:
             repo_name = Path(repo_path).name
             if self._check_package_exists(repo_path, repo_name, pkg_name):
-                return f'{repo_name}.{pkg_name}'
+                return f"{repo_name}.{pkg_name}"
 
         # Also check the builtin repo (may not be in repos list)
         builtin_path = self.get_builtin_repo_path()
-        if builtin_path and self._check_package_exists(str(builtin_path), 'builtin', pkg_name):
-            return f'builtin.{pkg_name}'
+        if builtin_path and self._check_package_exists(
+            str(builtin_path), "builtin", pkg_name
+        ):
+            return f"builtin.{pkg_name}"
 
         return None
 
-    def _check_package_exists(self, repo_path: str, repo_name: str, pkg_name: str) -> bool:
+    def _check_package_exists(
+        self, repo_path: str, repo_name: str, pkg_name: str
+    ) -> bool:
         """Check if a package exists in a repository"""
         # Try both package.py and pkg.py (legacy naming)
-        package_file = Path(repo_path) / repo_name / pkg_name / 'package.py'
+        package_file = Path(repo_path) / repo_name / pkg_name / "package.py"
         if package_file.exists():
             return True
 
         # Check for legacy pkg.py naming
-        legacy_package_file = Path(repo_path) / repo_name / pkg_name / 'pkg.py'
+        legacy_package_file = Path(repo_path) / repo_name / pkg_name / "pkg.py"
         return legacy_package_file.exists()
 
     def is_initialized(self) -> bool:

--- a/jarvis_cd/core/execution.py
+++ b/jarvis_cd/core/execution.py
@@ -1,0 +1,1499 @@
+"""Durable execution identities and lifecycle records for JARVIS pipelines."""
+
+from __future__ import annotations
+
+import json
+import errno
+import os
+import re
+import stat
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from time import monotonic, sleep
+from typing import Any, Iterator, Literal, Mapping, Optional, cast
+from uuid import uuid4
+
+from jarvis_cd.progress import ProgressEvent, ProgressStore
+from jarvis_cd.util.private_path import (
+    ensure_private_descriptor,
+    ensure_private_path,
+    reject_private_path_redirection,
+)
+
+
+HANDLE_SCHEMA = "jarvis.execution.handle.v1"
+RECORD_SCHEMA = "jarvis.execution.record.v1"
+LEGACY_RECORD_SCHEMA = "jarvis.execution.v1"
+RECORD_NAME = ".jarvis-execution.json"
+MAX_RECORD_BYTES = 65_536
+PROGRESS_SNAPSHOT_SCHEMA = "jarvis.execution.progress.v1"
+DIRECT_LAUNCH_SCHEMA = "jarvis.direct-launch.v1"
+DIRECT_LEASE_NAME = ".jarvis-direct-execution.lease"
+
+ExecutionMode = Literal["direct", "scheduler"]
+
+_EXECUTION_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_SLURM_NATIVE_ID_PATTERN = re.compile(r"^[0-9]{1,64}$")
+_SLURM_CLUSTER_PATTERN = re.compile(r"^[A-Za-z0-9_.-]{1,255}$")
+_WINDOWS_RESERVED_COMPONENTS = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    "CLOCK$",
+    *(f"COM{index}" for index in range(1, 10)),
+    *(f"LPT{index}" for index in range(1, 10)),
+}
+_STATES = {
+    "preparing",
+    "scripted",
+    "submitting",
+    "submitted",
+    "running",
+    "completed",
+    "failed",
+    "canceled",
+    "unknown",
+}
+_TERMINAL_STATES = {"scripted", "completed", "failed", "canceled"}
+_TRANSITIONS = {
+    "preparing": {"scripted", "submitting", "running", "failed"},
+    "scripted": {"failed"},
+    "submitting": {"submitted", "running", "completed", "failed", "unknown"},
+    "submitted": {"running", "completed", "failed", "canceled", "unknown"},
+    "running": {"completed", "failed", "canceled", "unknown"},
+    "completed": set(),
+    "failed": set(),
+    "canceled": set(),
+    "unknown": {"submitted", "running", "completed", "failed", "canceled"},
+}
+_UNSET = object()
+_TRANSACTION_LOCK_PREFIX = ".jarvis-execution-lock-"
+_DIRECT_STARTUP_GRACE_SECONDS = 60.0
+
+
+@dataclass(frozen=True)
+class PackageProgressSnapshot:
+    """Latest validated progress for one package alias in an execution."""
+
+    package_id: str
+    package_name: str
+    event_count: int
+    latest: Optional[ProgressEvent]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this package snapshot without exposing storage paths."""
+        return {
+            "package_id": self.package_id,
+            "package_name": self.package_name,
+            "event_count": self.event_count,
+            "latest": self.latest.as_dict() if self.latest is not None else None,
+        }
+
+
+@dataclass(frozen=True)
+class ExecutionProgressSnapshot:
+    """Queryable aggregate of package progress for one durable execution."""
+
+    execution_id: str
+    pipeline_id: str
+    execution_state: str
+    terminal: bool
+    packages: tuple[PackageProgressSnapshot, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the stable agent-facing progress snapshot schema."""
+        return {
+            "schema_version": PROGRESS_SNAPSHOT_SCHEMA,
+            "execution_id": self.execution_id,
+            "pipeline_id": self.pipeline_id,
+            "execution_state": self.execution_state,
+            "terminal": self.terminal,
+            "packages": [package.to_dict() for package in self.packages],
+        }
+
+
+def validate_execution_id(value: Optional[str] = None) -> str:
+    """Return a path-safe execution identity, generating one when omitted."""
+    execution_id = value or f"jarvis_{uuid4().hex}"
+    reserved_stem = execution_id.split(".", 1)[0].upper()
+    if (
+        _EXECUTION_ID_PATTERN.fullmatch(execution_id) is None
+        or execution_id.endswith(".")
+        or reserved_stem in _WINDOWS_RESERVED_COMPONENTS
+    ):
+        raise ValueError(
+            "execution_id must be 1-128 ASCII letters, digits, dots, underscores, "
+            "or hyphens, cannot begin with punctuation or end with a dot, and "
+            "cannot be a reserved Windows path alias"
+        )
+    return execution_id
+
+
+def validate_pipeline_id(value: str) -> str:
+    """Return a bounded, portable pipeline path component."""
+    if not isinstance(value, str) or _EXECUTION_ID_PATTERN.fullmatch(value) is None:
+        raise ValueError(
+            "pipeline_id must be 1-128 ASCII letters, digits, dots, underscores, "
+            "or hyphens and cannot begin with punctuation"
+        )
+    reserved_stem = value.split(".", 1)[0].upper()
+    if value.endswith(".") or reserved_stem in _WINDOWS_RESERVED_COMPONENTS:
+        raise ValueError("pipeline_id is not a portable path component")
+    return value
+
+
+def is_execution_transaction_lock(path: Path) -> bool:
+    """Return whether a directory entry is one valid persistent ID lock."""
+    if not path.name.startswith(_TRANSACTION_LOCK_PREFIX):
+        return False
+    execution_id = path.name[len(_TRANSACTION_LOCK_PREFIX) :]
+    validate_execution_id(execution_id)
+    ensure_private_path(path, directory=False)
+    status = path.lstat()
+    if not stat.S_ISREG(status.st_mode) or status.st_nlink != 1 or status.st_size > 1:
+        raise RuntimeError(f"invalid execution transaction lock: {path}")
+    return True
+
+
+def _validated_text(
+    value: Any,
+    *,
+    field_name: str,
+    maximum: int = 4096,
+    nullable: bool = False,
+) -> Optional[str]:
+    """Validate one bounded printable record field."""
+    if value is None and nullable:
+        return None
+    if not isinstance(value, str) or not value or len(value.encode("utf-8")) > maximum:
+        raise ValueError(f"{field_name} must be a non-empty bounded string")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise ValueError(f"{field_name} cannot contain control characters")
+    return value
+
+
+def _utc_now() -> str:
+    """Return a stable UTC timestamp suitable for persisted records."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _validate_timestamp(value: Any, *, field_name: str) -> str:
+    """Validate one timezone-aware ISO-8601 timestamp."""
+    rendered = _validated_text(value, field_name=field_name, maximum=64)
+    assert rendered is not None
+    try:
+        parsed = datetime.fromisoformat(rendered.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name} must include a timezone")
+    return rendered
+
+
+@dataclass(frozen=True)
+class ExecutionHandle:
+    """Stable identity returned by every top-level pipeline execution."""
+
+    execution_id: str
+    pipeline_id: str
+    mode: ExecutionMode
+    scheduler_provider: Optional[str] = None
+    scheduler_native_id: Optional[str] = None
+    cluster: Optional[str] = None
+    _record_path: Optional[Path] = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        """Reject malformed handles before they can become public references."""
+        validate_execution_id(self.execution_id)
+        validate_pipeline_id(self.pipeline_id)
+        if self.mode not in {"direct", "scheduler"}:
+            raise ValueError("mode must be 'direct' or 'scheduler'")
+        _validated_text(
+            self.scheduler_provider,
+            field_name="scheduler_provider",
+            nullable=True,
+        )
+        _validated_text(
+            self.scheduler_native_id,
+            field_name="scheduler_native_id",
+            nullable=True,
+        )
+        _validated_text(self.cluster, field_name="cluster", nullable=True)
+        if self.mode == "direct" and any(
+            value is not None
+            for value in (
+                self.scheduler_provider,
+                self.scheduler_native_id,
+                self.cluster,
+            )
+        ):
+            raise ValueError(
+                "direct execution handles cannot contain scheduler identity"
+            )
+        if self.mode == "scheduler" and self.scheduler_provider is None:
+            raise ValueError("scheduler execution handles require scheduler_provider")
+
+    @property
+    def native_id(self) -> Optional[str]:
+        """Return the provider-native identity using the deprecated short name."""
+        return self.scheduler_native_id
+
+    @property
+    def script_path(self) -> Optional[Path]:
+        """Return the generated scheduler script path for compatibility."""
+        record = self.refresh()
+        value = record.metadata.get("script_path")
+        return Path(value) if isinstance(value, str) and value else None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this handle using the stable agent-facing schema."""
+        return {
+            "schema_version": HANDLE_SCHEMA,
+            "execution_id": self.execution_id,
+            "pipeline_id": self.pipeline_id,
+            "mode": self.mode,
+            "scheduler_provider": self.scheduler_provider,
+            "scheduler_native_id": self.scheduler_native_id,
+            "cluster": self.cluster,
+        }
+
+    @classmethod
+    def from_dict(cls, document: Mapping[str, Any]) -> "ExecutionHandle":
+        """Decode an exact serialized handle from an API client."""
+        expected_fields = {
+            "schema_version",
+            "execution_id",
+            "pipeline_id",
+            "mode",
+            "scheduler_provider",
+            "scheduler_native_id",
+            "cluster",
+        }
+        if set(document) != expected_fields or document.get("schema_version") != (
+            HANDLE_SCHEMA
+        ):
+            raise ValueError("invalid execution handle schema")
+        mode = document.get("mode")
+        if mode not in {"direct", "scheduler"}:
+            raise ValueError("invalid execution handle mode")
+        execution_id = _validated_text(
+            document.get("execution_id"), field_name="execution_id"
+        )
+        pipeline_id = _validated_text(
+            document.get("pipeline_id"), field_name="pipeline_id"
+        )
+        assert execution_id is not None and pipeline_id is not None
+        return cls(
+            execution_id=execution_id,
+            pipeline_id=pipeline_id,
+            mode=cast(ExecutionMode, mode),
+            scheduler_provider=document.get("scheduler_provider"),
+            scheduler_native_id=document.get("scheduler_native_id"),
+            cluster=document.get("cluster"),
+        )
+
+    def refresh(self) -> "ExecutionRecord":
+        """Read the current durable record associated with this handle."""
+        if self._record_path is None:
+            raise RuntimeError("execution handle is not bound to a durable record")
+        record = ExecutionStore(
+            self._record_path.parent.parent,
+            self.pipeline_id,
+        ).get(self.execution_id)
+        if record.pipeline_id != self.pipeline_id or record.mode != self.mode:
+            raise RuntimeError("execution record identity changed")
+        return record
+
+    def progress(self) -> ExecutionProgressSnapshot:
+        """Return validated package progress for this exact execution."""
+        record = self.refresh()
+        assert record._record_path is not None
+        store = ExecutionStore(record._record_path.parent.parent, self.pipeline_id)
+        return store.progress(self.execution_id)
+
+
+@dataclass(frozen=True)
+class ExecutionRecord:
+    """Durable, changing lifecycle state associated with an execution handle."""
+
+    execution_id: str
+    pipeline_id: str
+    mode: ExecutionMode
+    scheduler_provider: Optional[str]
+    scheduler_native_id: Optional[str]
+    cluster: Optional[str]
+    state: str
+    submitted: bool
+    terminal: bool
+    created_at: str
+    updated_at: str
+    return_code: Optional[int] = None
+    error: Optional[str] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    _record_path: Optional[Path] = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        """Validate the complete record as one coherent state document."""
+        ExecutionHandle(
+            execution_id=self.execution_id,
+            pipeline_id=self.pipeline_id,
+            mode=self.mode,
+            scheduler_provider=self.scheduler_provider,
+            scheduler_native_id=self.scheduler_native_id,
+            cluster=self.cluster,
+        )
+        if self.state not in _STATES:
+            raise ValueError(f"unsupported execution state: {self.state}")
+        if not isinstance(self.submitted, bool) or not isinstance(self.terminal, bool):
+            raise ValueError("submitted and terminal must be booleans")
+        if self.terminal and self.state not in _TERMINAL_STATES:
+            raise ValueError("terminal execution record has a nonterminal state")
+        if self.state in {"completed", "failed", "canceled"} and not self.terminal:
+            raise ValueError("terminal execution state must set terminal=true")
+        _validate_timestamp(self.created_at, field_name="created_at")
+        _validate_timestamp(self.updated_at, field_name="updated_at")
+        if self.return_code is not None and (
+            isinstance(self.return_code, bool) or not isinstance(self.return_code, int)
+        ):
+            raise ValueError("return_code must be an integer or null")
+        if self.state == "completed" and self.return_code != 0:
+            raise ValueError("completed execution records require return_code=0")
+        if self.state == "failed" and (
+            self.return_code is None or self.return_code == 0
+        ):
+            raise ValueError("failed execution records require a nonzero return_code")
+        if self.error is not None:
+            if (
+                not isinstance(self.error, str)
+                or not self.error
+                or len(self.error.encode("utf-8")) > 16_384
+                or any(
+                    ord(character) < 32 and character not in {"\n", "\r", "\t"}
+                    for character in self.error
+                )
+                or any(ord(character) == 127 for character in self.error)
+            ):
+                raise ValueError("error must be a bounded printable diagnostic")
+        if not isinstance(self.metadata, Mapping) or not all(
+            isinstance(key, str) for key in self.metadata
+        ):
+            raise ValueError("metadata must be a string-keyed mapping")
+        try:
+            encoded_metadata = json.dumps(
+                self.metadata,
+                allow_nan=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        except (TypeError, ValueError, RecursionError) as exc:
+            raise ValueError("metadata must contain bounded JSON values") from exc
+        if len(encoded_metadata) > 48_000:
+            raise ValueError("metadata exceeds the execution record limit")
+
+    @classmethod
+    def new(
+        cls,
+        *,
+        execution_id: str,
+        pipeline_id: str,
+        mode: ExecutionMode,
+        scheduler_provider: Optional[str] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> "ExecutionRecord":
+        """Construct a new preparing execution record."""
+        now = _utc_now()
+        return cls(
+            execution_id=execution_id,
+            pipeline_id=pipeline_id,
+            mode=mode,
+            scheduler_provider=scheduler_provider,
+            scheduler_native_id=None,
+            cluster=None,
+            state="preparing",
+            submitted=False,
+            terminal=False,
+            created_at=now,
+            updated_at=now,
+            metadata=dict(metadata or {}),
+        )
+
+    @property
+    def handle(self) -> ExecutionHandle:
+        """Return the stable, queryable handle projected from this record."""
+        return ExecutionHandle(
+            execution_id=self.execution_id,
+            pipeline_id=self.pipeline_id,
+            mode=self.mode,
+            scheduler_provider=self.scheduler_provider,
+            scheduler_native_id=self.scheduler_native_id,
+            cluster=self.cluster,
+            _record_path=self._record_path,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this record for durable storage and JSON CLI output."""
+        return {
+            "schema_version": RECORD_SCHEMA,
+            "execution_id": self.execution_id,
+            "pipeline_id": self.pipeline_id,
+            # Keep the historic key so existing cleanup receipts retain their
+            # pipeline ownership check while the public handle says pipeline_id.
+            "pipeline_name": self.pipeline_id,
+            "mode": self.mode,
+            "scheduler_provider": self.scheduler_provider,
+            "scheduler_native_id": self.scheduler_native_id,
+            "cluster": self.cluster,
+            "state": self.state,
+            "submitted": self.submitted,
+            "terminal": self.terminal,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "return_code": self.return_code,
+            "error": self.error,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        document: Mapping[str, Any],
+        *,
+        record_path: Optional[Path] = None,
+    ) -> "ExecutionRecord":
+        """Validate and decode one execution record document."""
+        expected_fields = {
+            "schema_version",
+            "execution_id",
+            "pipeline_id",
+            "pipeline_name",
+            "mode",
+            "scheduler_provider",
+            "scheduler_native_id",
+            "cluster",
+            "state",
+            "submitted",
+            "terminal",
+            "created_at",
+            "updated_at",
+            "return_code",
+            "error",
+            "metadata",
+        }
+        if (
+            set(document) != expected_fields
+            or document.get("schema_version") != RECORD_SCHEMA
+        ):
+            raise ValueError("unsupported execution record schema")
+        pipeline_id = document.get("pipeline_id")
+        if document.get("pipeline_name") != pipeline_id:
+            raise ValueError("execution record pipeline identity mismatch")
+        mode = document.get("mode")
+        if mode not in {"direct", "scheduler"}:
+            raise ValueError("invalid execution mode")
+        metadata = document.get("metadata")
+        if not isinstance(metadata, dict):
+            raise ValueError("execution record metadata must be a mapping")
+        execution_id = _validated_text(
+            document.get("execution_id"), field_name="execution_id"
+        )
+        validated_pipeline_id = _validated_text(pipeline_id, field_name="pipeline_id")
+        state = document.get("state")
+        submitted = document.get("submitted")
+        terminal = document.get("terminal")
+        created_at = document.get("created_at")
+        updated_at = document.get("updated_at")
+        return_code = document.get("return_code")
+        if not isinstance(state, str):
+            raise ValueError("execution record state must be a string")
+        if not isinstance(submitted, bool) or not isinstance(terminal, bool):
+            raise ValueError("execution record lifecycle flags must be booleans")
+        if not isinstance(created_at, str) or not isinstance(updated_at, str):
+            raise ValueError("execution record timestamps must be strings")
+        if return_code is not None and (
+            not isinstance(return_code, int) or isinstance(return_code, bool)
+        ):
+            raise ValueError("execution record return_code must be an integer or null")
+        assert execution_id is not None and validated_pipeline_id is not None
+        return cls(
+            execution_id=execution_id,
+            pipeline_id=validated_pipeline_id,
+            mode=cast(ExecutionMode, mode),
+            scheduler_provider=document.get("scheduler_provider"),
+            scheduler_native_id=document.get("scheduler_native_id"),
+            cluster=document.get("cluster"),
+            state=state,
+            submitted=submitted,
+            terminal=terminal,
+            created_at=created_at,
+            updated_at=updated_at,
+            return_code=return_code,
+            error=document.get("error"),
+            metadata=dict(metadata),
+            _record_path=record_path,
+        )
+
+
+def _effective_uid() -> int:
+    """Return the effective POSIX uid or fail closed."""
+    getter = getattr(os, "geteuid", None)
+    if not callable(getter):
+        raise RuntimeError("POSIX ownership checks are unavailable")
+    value: Any = getter()
+    return int(value)
+
+
+def _validate_private_regular_file(
+    descriptor: int,
+    path: Path,
+    *,
+    maximum_size: int,
+) -> os.stat_result:
+    """Validate a no-follow descriptor against its path identity."""
+    ensure_private_descriptor(path, descriptor, directory=False)
+    descriptor_status = os.fstat(descriptor)
+    path_status = path.lstat()
+    if (
+        not stat.S_ISREG(descriptor_status.st_mode)
+        or stat.S_ISLNK(path_status.st_mode)
+        or (descriptor_status.st_dev, descriptor_status.st_ino)
+        != (path_status.st_dev, path_status.st_ino)
+        or descriptor_status.st_nlink != 1
+        or descriptor_status.st_size > maximum_size
+    ):
+        raise RuntimeError(f"invalid execution record: {path}")
+    if os.name != "nt" and (
+        descriptor_status.st_uid != _effective_uid()
+        or stat.S_IMODE(descriptor_status.st_mode) & 0o077
+    ):
+        raise RuntimeError(f"execution record is not private: {path}")
+    return descriptor_status
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject ambiguous JSON objects at every record nesting level."""
+    document: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in document:
+            raise ValueError(f"duplicate execution record key: {key}")
+        document[key] = value
+    return document
+
+
+def read_execution_record(
+    execution_root: Path,
+    *,
+    expected_execution_id: Optional[str] = None,
+) -> ExecutionRecord:
+    """Read a bounded execution record without following path replacements."""
+    execution_root = Path(execution_root)
+    ensure_private_path(execution_root, directory=True)
+    root_status = execution_root.lstat()
+    if not stat.S_ISDIR(root_status.st_mode) or stat.S_ISLNK(root_status.st_mode):
+        raise RuntimeError(f"execution root is not a real directory: {execution_root}")
+    if os.name != "nt" and (
+        root_status.st_uid != _effective_uid()
+        or stat.S_IMODE(root_status.st_mode) & 0o077
+    ):
+        raise RuntimeError(f"execution root is not owner-controlled: {execution_root}")
+    record_path = execution_root / RECORD_NAME
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(record_path, flags)
+    try:
+        _validate_private_regular_file(
+            descriptor,
+            record_path,
+            maximum_size=MAX_RECORD_BYTES,
+        )
+        payload = os.read(descriptor, MAX_RECORD_BYTES + 1)
+        if len(payload) > MAX_RECORD_BYTES:
+            raise RuntimeError(f"execution record is too large: {record_path}")
+    finally:
+        os.close(descriptor)
+    try:
+        document = json.loads(
+            payload.decode("utf-8", errors="strict"),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise RuntimeError(f"invalid execution record: {record_path}") from exc
+    if not isinstance(document, dict):
+        raise RuntimeError(f"invalid execution record: {record_path}")
+    try:
+        record = ExecutionRecord.from_dict(document, record_path=record_path)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"invalid execution record: {record_path}") from exc
+    expected = expected_execution_id or execution_root.name
+    if validate_execution_id(expected) != expected or record.execution_id != expected:
+        raise RuntimeError(f"execution record identity mismatch: {record_path}")
+    return record
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist directory-entry changes on platforms supporting directory fsync."""
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _durable_replace(source: Path, destination: Path) -> None:
+    """Atomically replace a record and request write-through on Windows."""
+    if os.name != "nt":
+        os.replace(source, destination)
+        return
+    import win32con
+    import win32file
+    import pywintypes
+
+    deadline = monotonic() + 30.0
+    while True:
+        try:
+            win32file.MoveFileEx(
+                str(source),
+                str(destination),
+                win32con.MOVEFILE_REPLACE_EXISTING | win32file.MOVEFILE_WRITE_THROUGH,
+            )
+            return
+        except pywintypes.error as exc:
+            if exc.winerror not in {5, 32} or monotonic() >= deadline:
+                raise
+            sleep(0.01)
+
+
+def _atomic_write_record(path: Path, record: ExecutionRecord) -> None:
+    """Durably replace one validated execution record."""
+    payload = (
+        json.dumps(record.to_dict(), separators=(",", ":"), sort_keys=True) + "\n"
+    ).encode("utf-8")
+    if len(payload) > MAX_RECORD_BYTES:
+        raise ValueError("execution record exceeds the storage limit")
+    temporary_path: Optional[Path] = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+        )
+        temporary_path = Path(temporary_name)
+        try:
+            if os.name != "nt":
+                os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "wb", closefd=True) as stream:
+                stream.write(payload)
+                stream.flush()
+                os.fsync(stream.fileno())
+                ensure_private_descriptor(
+                    temporary_path,
+                    stream.fileno(),
+                    directory=False,
+                )
+        except BaseException:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+            raise
+        _durable_replace(temporary_path, path)
+        temporary_path = None
+        ensure_private_path(path, directory=False)
+        _fsync_directory(path.parent)
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+@contextmanager
+def execution_transaction_lock(
+    executions_dir: Path,
+    execution_id: str,
+    *,
+    timeout: float = 30.0,
+) -> Iterator[None]:
+    """Serialize record writers and cleanup for one durable execution.
+
+    The lock is a persistent sibling of the execution root. Keeping it outside
+    the root lets cleanup rename and delete the root on Windows, while ensuring
+    that a writer waiting on POSIX cannot continue against the detached root.
+
+    The lock file is intentionally retained after cleanup. Unlinking a locked
+    file can create two independent lock objects when another process already
+    has the old file open.
+    """
+    validated_id = validate_execution_id(execution_id)
+    lock_path = Path(executions_dir) / f"{_TRANSACTION_LOCK_PREFIX}{validated_id}"
+    flags = (
+        os.O_RDWR
+        | os.O_CREAT
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(lock_path, flags, 0o600)
+    try:
+        _validate_private_regular_file(descriptor, lock_path, maximum_size=1)
+        if os.name == "nt":
+            import msvcrt
+
+            if os.fstat(descriptor).st_size == 0:
+                os.write(descriptor, b"0")
+                os.fsync(descriptor)
+            deadline = monotonic() + timeout
+            while True:
+                try:
+                    os.lseek(descriptor, 0, os.SEEK_SET)
+                    msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
+                    break
+                except OSError:
+                    if monotonic() >= deadline:
+                        raise TimeoutError("timed out locking execution record")
+                    sleep(0.01)
+            try:
+                yield
+            finally:
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
+
+
+def _lock_direct_lease(descriptor: int, *, blocking: bool) -> bool:
+    """Acquire a direct-run lease, returning false only when it is held."""
+    if os.name == "nt":
+        import msvcrt
+
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        mode = msvcrt.LK_LOCK if blocking else msvcrt.LK_NBLCK
+        try:
+            msvcrt.locking(descriptor, mode, 1)
+        except OSError as exc:
+            if not blocking and exc.errno in {
+                errno.EACCES,
+                errno.EAGAIN,
+                errno.EDEADLK,
+            }:
+                return False
+            raise
+        return True
+
+    import fcntl
+
+    operation = fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB)
+    try:
+        fcntl.flock(descriptor, operation)
+    except OSError as exc:
+        if not blocking and exc.errno in {errno.EACCES, errno.EAGAIN}:
+            return False
+        raise
+    return True
+
+
+def _unlock_direct_lease(descriptor: int) -> None:
+    """Release one direct-run lease held by this descriptor."""
+    if os.name == "nt":
+        import msvcrt
+
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(descriptor, fcntl.LOCK_UN)
+
+
+def prepare_direct_execution_lease(execution_root: Path) -> Path:
+    """Create the private lease used to prove an async direct child is alive."""
+    root = Path(execution_root)
+    ensure_private_path(root, directory=True)
+    lease_path = root / DIRECT_LEASE_NAME
+    flags = (
+        os.O_RDWR
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(lease_path, flags, 0o600)
+    try:
+        if os.name != "nt":
+            os.fchmod(descriptor, 0o600)
+        os.write(descriptor, b"0")
+        os.fsync(descriptor)
+        _validate_private_regular_file(descriptor, lease_path, maximum_size=1)
+    except BaseException:
+        os.close(descriptor)
+        lease_path.unlink(missing_ok=True)
+        raise
+    os.close(descriptor)
+    ensure_private_path(lease_path, directory=False)
+    _fsync_directory(root)
+    return lease_path
+
+
+@contextmanager
+def direct_execution_lease(execution_root: Path) -> Iterator[None]:
+    """Hold the process lease for exactly one async direct snapshot runner."""
+    root = Path(execution_root)
+    ensure_private_path(root, directory=True)
+    lease_path = root / DIRECT_LEASE_NAME
+    flags = os.O_RDWR | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(lease_path, flags)
+    acquired = False
+    try:
+        status = _validate_private_regular_file(
+            descriptor,
+            lease_path,
+            maximum_size=1,
+        )
+        if status.st_size != 1:
+            raise RuntimeError("direct execution lease is not initialized")
+        acquired = _lock_direct_lease(descriptor, blocking=False)
+        if not acquired:
+            raise RuntimeError("direct execution snapshot is already running")
+        yield
+    finally:
+        if acquired:
+            _unlock_direct_lease(descriptor)
+        os.close(descriptor)
+
+
+def _direct_execution_lease_is_held(execution_root: Path) -> bool:
+    """Return whether another process currently owns the direct-run lease."""
+    root = Path(execution_root)
+    ensure_private_path(root, directory=True)
+    lease_path = root / DIRECT_LEASE_NAME
+    flags = os.O_RDWR | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(lease_path, flags)
+    acquired = False
+    try:
+        status = _validate_private_regular_file(
+            descriptor,
+            lease_path,
+            maximum_size=1,
+        )
+        if status.st_size != 1:
+            raise RuntimeError("direct execution lease is not initialized")
+        acquired = _lock_direct_lease(descriptor, blocking=False)
+        return not acquired
+    finally:
+        if acquired:
+            _unlock_direct_lease(descriptor)
+        os.close(descriptor)
+
+
+def _process_is_running(process_id: int) -> Optional[bool]:
+    """Return local process liveness, or null when the OS cannot establish it."""
+    if (
+        isinstance(process_id, bool)
+        or not isinstance(process_id, int)
+        or process_id <= 0
+    ):
+        raise ValueError("process identity must be a positive integer")
+    if os.name != "nt":
+        try:
+            os.kill(process_id, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        except OSError:
+            return None
+        return True
+
+    import ctypes
+    from ctypes import wintypes
+
+    process_query_limited_information = 0x1000
+    still_active = 259
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = [wintypes.HANDLE, wintypes.LPDWORD]
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    handle = kernel32.OpenProcess(
+        process_query_limited_information,
+        False,
+        process_id,
+    )
+    if not handle:
+        error = ctypes.get_last_error()
+        if error == 5:  # Access denied proves that the process identity exists.
+            return True
+        if error == 87:  # Invalid parameter is returned for a missing PID.
+            return False
+        return None
+    try:
+        exit_code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return None
+        return exit_code.value == still_active
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+class ExecutionStore:
+    """Own and query execution roots for one named pipeline."""
+
+    def __init__(self, executions_dir: Path, pipeline_id: str):
+        self.executions_dir = Path(executions_dir)
+        self.pipeline_id = validate_pipeline_id(pipeline_id)
+
+    def _prepare_parent(self) -> None:
+        """Create and validate the private execution collection directory."""
+        reject_private_path_redirection(self.executions_dir)
+        self.executions_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        ensure_private_path(self.executions_dir, directory=True)
+        status = self.executions_dir.lstat()
+        if not stat.S_ISDIR(status.st_mode) or stat.S_ISLNK(status.st_mode):
+            raise RuntimeError("pipeline executions path is not a real directory")
+        if os.name != "nt":
+            if status.st_uid != _effective_uid():
+                raise RuntimeError("pipeline executions path is not owner-controlled")
+            self.executions_dir.chmod(0o700)
+        _fsync_directory(self.executions_dir.parent)
+
+    def create(
+        self,
+        execution_id: str,
+        *,
+        mode: ExecutionMode,
+        scheduler_provider: Optional[str] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> ExecutionRecord:
+        """Create one unique owned execution root and initial durable record."""
+        validated_id = validate_execution_id(execution_id)
+        self._prepare_parent()
+        execution_root = self.executions_dir / validated_id
+        reject_private_path_redirection(execution_root)
+        with execution_transaction_lock(self.executions_dir, validated_id):
+            execution_root.mkdir(mode=0o700)
+            try:
+                ensure_private_path(execution_root, directory=True)
+                if os.name != "nt":
+                    execution_root.chmod(0o700)
+                record = ExecutionRecord.new(
+                    execution_id=validated_id,
+                    pipeline_id=self.pipeline_id,
+                    mode=mode,
+                    scheduler_provider=scheduler_provider,
+                    metadata=metadata,
+                )
+                _atomic_write_record(execution_root / RECORD_NAME, record)
+                _fsync_directory(self.executions_dir)
+                return replace(record, _record_path=execution_root / RECORD_NAME)
+            except BaseException:
+                try:
+                    for child in execution_root.iterdir():
+                        child.unlink()
+                    execution_root.rmdir()
+                    _fsync_directory(self.executions_dir)
+                except OSError:
+                    pass
+                raise
+
+    def get(self, execution_id: str) -> ExecutionRecord:
+        """Read and reconcile one exact durable execution record."""
+        validated_id = validate_execution_id(execution_id)
+        record = read_execution_record(
+            self.executions_dir / validated_id,
+            expected_execution_id=validated_id,
+        )
+        return self._reconcile_direct_execution(record)
+
+    def _reconcile_direct_execution(
+        self,
+        record: ExecutionRecord,
+    ) -> ExecutionRecord:
+        """Terminalize an owned async child that died without finalizing."""
+        if record.mode != "direct" or record.terminal:
+            return record
+        launch = record.metadata.get("direct_launch")
+        if launch is None:
+            # Blocking direct runs predate and do not use a detached lease.
+            return record
+        expected_fields = {
+            "schema_version",
+            "phase",
+            "launcher_pid",
+            "child_pid",
+        }
+        if not isinstance(launch, dict) or set(launch) != expected_fields:
+            raise RuntimeError("direct execution launch metadata is invalid")
+        if launch.get("schema_version") != DIRECT_LAUNCH_SCHEMA:
+            raise RuntimeError("direct execution launch metadata is invalid")
+        phase = launch.get("phase")
+        if phase not in {"launching", "prepared", "spawned", "failed", "orphaned"}:
+            raise RuntimeError("direct execution launch metadata is invalid")
+        launcher_pid = launch.get("launcher_pid")
+        child_pid = launch.get("child_pid")
+        for field_name, value, nullable in (
+            ("launcher_pid", launcher_pid, False),
+            ("child_pid", child_pid, True),
+        ):
+            if value is None and nullable:
+                continue
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise RuntimeError(f"direct execution {field_name} metadata is invalid")
+
+        execution_root = self.executions_dir / record.execution_id
+        lease_path = execution_root / DIRECT_LEASE_NAME
+        if lease_path.exists() or lease_path.is_symlink():
+            if _direct_execution_lease_is_held(execution_root):
+                return record
+        elif phase in {"prepared", "spawned"}:
+            raise RuntimeError("direct execution lease is missing")
+
+        orphaned = False
+        if record.state == "running" or phase in {"failed", "orphaned"}:
+            orphaned = True
+        elif phase in {"launching", "prepared"}:
+            orphaned = _process_is_running(cast(int, launcher_pid)) is False
+        elif phase == "spawned":
+            assert isinstance(child_pid, int)
+            child_running = _process_is_running(child_pid)
+            if child_running is False:
+                orphaned = True
+            elif child_running is None:
+                created = datetime.fromisoformat(
+                    record.created_at.replace("Z", "+00:00")
+                )
+                age = (datetime.now(timezone.utc) - created).total_seconds()
+                orphaned = age >= _DIRECT_STARTUP_GRACE_SECONDS
+        if not orphaned:
+            return record
+
+        failed_launch = dict(launch)
+        failed_launch["phase"] = "orphaned"
+        try:
+            return self.update(
+                record.execution_id,
+                state="failed",
+                terminal=True,
+                return_code=1,
+                error="owned direct execution exited without finalizing its record",
+                metadata={
+                    "direct_launch": failed_launch,
+                    "failure_stage": "direct_orphan_reconciliation",
+                },
+            )
+        except ValueError:
+            # A normal finalizer may win after the liveness probe.
+            latest = read_execution_record(
+                execution_root,
+                expected_execution_id=record.execution_id,
+            )
+            if latest.terminal:
+                return latest
+            raise
+
+    def list(self) -> list[ExecutionRecord]:
+        """Return every owned execution record in stable creation order."""
+        if not self.executions_dir.exists():
+            return []
+        status = self.executions_dir.lstat()
+        if not stat.S_ISDIR(status.st_mode) or stat.S_ISLNK(status.st_mode):
+            raise RuntimeError("pipeline executions path is not a real directory")
+        records: list[ExecutionRecord] = []
+        for path in self.executions_dir.iterdir():
+            if path.name.startswith("."):
+                continue
+            validate_execution_id(path.name)
+            records.append(self.get(path.name))
+        return sorted(
+            records, key=lambda record: (record.created_at, record.execution_id)
+        )
+
+    def progress(self, execution_id: str) -> ExecutionProgressSnapshot:
+        """Return the latest validated event for every bound package alias."""
+        record = self.get(execution_id)
+        progress_files = record.metadata.get("progress_files", {})
+        if not isinstance(progress_files, dict):
+            raise RuntimeError("execution progress index is invalid")
+        execution_root = self.executions_dir / record.execution_id
+        progress_root = execution_root / "progress"
+        if progress_root.exists() or progress_root.is_symlink():
+            status = progress_root.lstat()
+            if not stat.S_ISDIR(status.st_mode) or stat.S_ISLNK(status.st_mode):
+                raise RuntimeError("execution progress path is not a real directory")
+        snapshots: list[PackageProgressSnapshot] = []
+        for package_id, entry in sorted(progress_files.items()):
+            if (
+                not isinstance(package_id, str)
+                or not package_id
+                or not isinstance(entry, dict)
+                or set(entry) != {"filename", "package_name"}
+                or not isinstance(entry.get("filename"), str)
+                or not entry["filename"]
+                or not isinstance(entry.get("package_name"), str)
+                or not entry["package_name"]
+            ):
+                raise RuntimeError("execution progress index is invalid")
+            filename = entry["filename"]
+            package_name = entry["package_name"]
+            relative = Path(filename)
+            if (
+                relative.name != filename
+                or relative.is_absolute()
+                or relative.suffix != ".jsonl"
+            ):
+                raise RuntimeError("execution progress index contains an invalid path")
+            sidecar = progress_root / filename
+            try:
+                events = ProgressStore(sidecar).read_all()
+            except (OSError, PermissionError, ValueError) as exc:
+                raise RuntimeError(
+                    f"invalid progress sidecar for package {package_id!r}"
+                ) from exc
+            for event in events:
+                if (
+                    event.execution_id != record.execution_id
+                    or event.package_id != package_id
+                    or event.package_name != package_name
+                ):
+                    raise RuntimeError(
+                        f"progress identity mismatch for package {package_id!r}"
+                    )
+            snapshots.append(
+                PackageProgressSnapshot(
+                    package_id=package_id,
+                    package_name=package_name,
+                    event_count=len(events),
+                    latest=events[-1] if events else None,
+                )
+            )
+        return ExecutionProgressSnapshot(
+            execution_id=record.execution_id,
+            pipeline_id=record.pipeline_id,
+            execution_state=record.state,
+            terminal=record.terminal,
+            packages=tuple(snapshots),
+        )
+
+    def update(
+        self,
+        execution_id: str,
+        *,
+        state: Optional[str] = None,
+        submitted: Optional[bool] = None,
+        terminal: Optional[bool] = None,
+        scheduler_provider: object = _UNSET,
+        native_id: object = _UNSET,
+        cluster: object = _UNSET,
+        return_code: object = _UNSET,
+        error: object = _UNSET,
+        metadata: Optional[Mapping[str, Any]] = None,
+        _script_activation: bool = False,
+    ) -> ExecutionRecord:
+        """Atomically merge one lifecycle transition into the durable record."""
+        validated_id = validate_execution_id(execution_id)
+        execution_root = self.executions_dir / validated_id
+        with execution_transaction_lock(self.executions_dir, validated_id):
+            current = read_execution_record(
+                execution_root,
+                expected_execution_id=validated_id,
+            )
+            if current.pipeline_id != self.pipeline_id:
+                raise RuntimeError("execution record belongs to another pipeline")
+            next_state = state or current.state
+            if next_state not in _STATES:
+                raise ValueError(f"unsupported execution state: {next_state}")
+            next_submitted = current.submitted if submitted is None else submitted
+            next_terminal = current.terminal if terminal is None else terminal
+            next_provider = (
+                current.scheduler_provider
+                if scheduler_provider is _UNSET
+                else scheduler_provider
+            )
+            next_native_id = (
+                current.scheduler_native_id if native_id is _UNSET else native_id
+            )
+            next_cluster = current.cluster if cluster is _UNSET else cluster
+            scripted_activation = (
+                _script_activation
+                and current.mode == "scheduler"
+                and current.state == "scripted"
+                and next_state == "running"
+                and next_submitted is True
+                and next_terminal is False
+                and next_provider is not None
+                and next_native_id is not None
+            )
+            if (
+                next_state != current.state
+                and next_state not in _TRANSITIONS[current.state]
+                and not scripted_activation
+            ):
+                raise ValueError(
+                    f"invalid execution state transition: {current.state} -> {next_state}"
+                )
+            if current.terminal and not next_terminal and not scripted_activation:
+                raise ValueError("terminal execution records cannot become nonterminal")
+            for field_name, old_value, new_value in (
+                ("scheduler_provider", current.scheduler_provider, next_provider),
+                ("scheduler_native_id", current.scheduler_native_id, next_native_id),
+                ("cluster", current.cluster, next_cluster),
+            ):
+                if old_value is not None and new_value != old_value:
+                    raise ValueError(f"{field_name} cannot change once assigned")
+            merged_metadata = dict(current.metadata)
+            if metadata:
+                merged_metadata.update(metadata)
+            next_return_code = cast(
+                Optional[int],
+                current.return_code if return_code is _UNSET else return_code,
+            )
+            next_error = cast(
+                Optional[str],
+                current.error if error is _UNSET else error,
+            )
+            updated = ExecutionRecord(
+                execution_id=current.execution_id,
+                pipeline_id=current.pipeline_id,
+                mode=current.mode,
+                scheduler_provider=next_provider,  # type: ignore[arg-type]
+                scheduler_native_id=next_native_id,  # type: ignore[arg-type]
+                cluster=next_cluster,  # type: ignore[arg-type]
+                state=next_state,
+                submitted=next_submitted,
+                terminal=next_terminal,
+                created_at=current.created_at,
+                updated_at=_utc_now(),
+                return_code=next_return_code,
+                error=next_error,
+                metadata=merged_metadata,
+                _record_path=execution_root / RECORD_NAME,
+            )
+            _atomic_write_record(execution_root / RECORD_NAME, updated)
+            return updated
+
+    def activate_scheduler(
+        self,
+        execution_id: str,
+        *,
+        provider: str,
+        native_id: str,
+        cluster: Optional[str] = None,
+    ) -> ExecutionRecord:
+        """Bind scheduler-owned identity and mark an allocated script running.
+
+        This is the only operation allowed to activate a terminal ``scripted``
+        record produced by ``submit=False``. It is also idempotent for a normal
+        submission whose submitter and allocation race to persist the same
+        provider identity.
+        """
+        validated_provider = _validated_text(
+            provider,
+            field_name="scheduler_provider",
+            maximum=64,
+        )
+        validated_native_id = _validated_text(
+            native_id,
+            field_name="scheduler_native_id",
+            maximum=256,
+        )
+        validated_cluster = _validated_text(
+            cluster,
+            field_name="cluster",
+            maximum=255,
+            nullable=True,
+        )
+        assert validated_provider is not None and validated_native_id is not None
+        if validated_provider == "slurm":
+            if _SLURM_NATIVE_ID_PATTERN.fullmatch(validated_native_id) is None:
+                raise ValueError("SLURM native execution identity must be numeric")
+            if validated_cluster is not None and (
+                _SLURM_CLUSTER_PATTERN.fullmatch(validated_cluster) is None
+            ):
+                raise ValueError("SLURM cluster identity is invalid")
+        metadata = {
+            "scheduler_activation": {
+                "provider": validated_provider,
+                "native_id": validated_native_id,
+                "cluster": validated_cluster,
+                "identity_source": "scheduler_runtime_environment",
+            }
+        }
+        return self.update(
+            execution_id,
+            state="running",
+            submitted=True,
+            terminal=False,
+            scheduler_provider=validated_provider,
+            native_id=validated_native_id,
+            cluster=validated_cluster if validated_cluster is not None else _UNSET,
+            metadata=metadata,
+            _script_activation=True,
+        )
+
+
+def finalize_execution(
+    execution_root: Path,
+    execution_id: str,
+    return_code: int,
+) -> ExecutionRecord:
+    """Finalize one scheduler script using its exact durable execution record."""
+    validated_id = validate_execution_id(execution_id)
+    root = Path(execution_root)
+    if root.name != validated_id:
+        raise RuntimeError("scheduler execution root does not match execution_id")
+    current = read_execution_record(root, expected_execution_id=validated_id)
+    if current.mode != "scheduler":
+        raise RuntimeError("scheduler finalizer cannot update a direct execution")
+    if current.terminal:
+        return current
+    store = ExecutionStore(root.parent, current.pipeline_id)
+    if return_code == 0:
+        return store.update(
+            validated_id,
+            state="completed",
+            terminal=True,
+            return_code=0,
+            error=None,
+        )
+    return store.update(
+        validated_id,
+        state="failed",
+        terminal=True,
+        return_code=return_code,
+        error=f"scheduler script exited with status {return_code}",
+    )
+
+
+def run_execution_snapshot(
+    execution_root: Path,
+    execution_id: str,
+    snapshot_dir: Path,
+) -> ExecutionRecord:
+    """Run one owned direct snapshot in a child process."""
+    validated_id = validate_execution_id(execution_id)
+    root = Path(execution_root).resolve(strict=True)
+    runtime = Path(snapshot_dir).resolve(strict=True)
+    if root.name != validated_id or runtime != root / "runtime":
+        raise RuntimeError("direct execution snapshot identity mismatch")
+    with direct_execution_lease(root):
+        current = read_execution_record(root, expected_execution_id=validated_id)
+        if current.mode != "direct" or current.terminal:
+            raise RuntimeError("direct execution snapshot is not runnable")
+        os.environ["JARVIS_PIPELINE_SNAPSHOT_DIR"] = str(runtime)
+        try:
+            from jarvis_cd.core.pipeline import Pipeline
+
+            pipeline = Pipeline()
+            pipeline.load("yaml", str(runtime / "pipeline.yaml"))
+            handle = pipeline.run()
+            return handle.refresh()
+        except BaseException as error:
+            try:
+                current = read_execution_record(
+                    root,
+                    expected_execution_id=validated_id,
+                )
+                if not current.terminal:
+                    diagnostic = str(error) or type(error).__name__
+                    encoded = diagnostic.encode("utf-8")
+                    if len(encoded) > 16_384:
+                        diagnostic = "[truncated]\n" + encoded[-16_000:].decode(
+                            "utf-8", errors="ignore"
+                        )
+                    ExecutionStore(root.parent, current.pipeline_id).update(
+                        validated_id,
+                        state="failed",
+                        terminal=True,
+                        return_code=1,
+                        error=diagnostic,
+                        metadata={"failure_stage": "direct_snapshot"},
+                    )
+            except Exception as record_error:
+                error.add_note(
+                    f"could not persist failed direct snapshot state: {record_error}"
+                )
+            raise
+
+
+def activate_scheduler_execution(
+    execution_root: Path,
+    execution_id: str,
+    provider: str,
+    native_id: str,
+    cluster: Optional[str] = None,
+) -> ExecutionRecord:
+    """Activate one scheduler script using provider-owned runtime identity."""
+    validated_id = validate_execution_id(execution_id)
+    root = Path(execution_root)
+    if root.name != validated_id:
+        raise RuntimeError("scheduler execution root does not match execution_id")
+    current = read_execution_record(root, expected_execution_id=validated_id)
+    if current.mode != "scheduler":
+        raise RuntimeError("scheduler activation cannot update a direct execution")
+    return ExecutionStore(root.parent, current.pipeline_id).activate_scheduler(
+        validated_id,
+        provider=provider,
+        native_id=native_id,
+        cluster=cluster,
+    )
+
+
+def _main(argv: Optional[list[str]] = None) -> int:
+    """Run the private scheduler-script lifecycle helper."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="python -m jarvis_cd.core.execution")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    finalize = subparsers.add_parser("finalize")
+    finalize.add_argument("--execution-root", required=True)
+    finalize.add_argument("--execution-id", required=True)
+    finalize.add_argument("--return-code", required=True, type=int)
+    run_snapshot = subparsers.add_parser("run-snapshot")
+    run_snapshot.add_argument("--execution-root", required=True)
+    run_snapshot.add_argument("--execution-id", required=True)
+    run_snapshot.add_argument("--snapshot-dir", required=True)
+    activate = subparsers.add_parser("activate")
+    activate.add_argument("--execution-root", required=True)
+    activate.add_argument("--execution-id", required=True)
+    activate.add_argument("--provider", required=True)
+    activate.add_argument("--native-id", required=True)
+    activate.add_argument("--cluster")
+    arguments = parser.parse_args(argv)
+    if arguments.command == "finalize":
+        finalize_execution(
+            Path(arguments.execution_root),
+            arguments.execution_id,
+            arguments.return_code,
+        )
+        return 0
+    if arguments.command == "run-snapshot":
+        run_execution_snapshot(
+            Path(arguments.execution_root),
+            arguments.execution_id,
+            Path(arguments.snapshot_dir),
+        )
+        return 0
+    if arguments.command == "activate":
+        activate_scheduler_execution(
+            Path(arguments.execution_root),
+            arguments.execution_id,
+            arguments.provider,
+            arguments.native_id,
+            arguments.cluster,
+        )
+        return 0
+    raise RuntimeError("unsupported execution helper command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -204,6 +204,47 @@ def _read_execution_marker(
     return document
 
 
+def _set_execution_input_mode(
+    execution_root: Path,
+    *,
+    mode: Optional[int] = None,
+) -> Optional[int]:
+    """Open the sealed input directory without following links and set its mode.
+
+    Execution inputs are intentionally sealed read-only on POSIX.  Exact
+    cleanup temporarily adds owner write/execute permission so the directory
+    entries can be unlinked.  The prior mode is returned so a failed cleanup
+    can restore the seal before putting the execution back in service.
+    """
+    if os.name == "nt":
+        return None
+    input_dir = execution_root / "input"
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(input_dir, flags)
+    try:
+        status = os.fstat(descriptor)
+        path_status = input_dir.lstat()
+        if (
+            not stat.S_ISDIR(status.st_mode)
+            or stat.S_ISLNK(path_status.st_mode)
+            or (status.st_dev, status.st_ino)
+            != (path_status.st_dev, path_status.st_ino)
+        ):
+            raise RuntimeError(f"execution input is not a real directory: {input_dir}")
+        previous = stat.S_IMODE(status.st_mode)
+        target = mode if mode is not None else previous | stat.S_IWUSR | stat.S_IXUSR
+        os.fchmod(descriptor, target)
+        os.fsync(descriptor)
+        return previous
+    finally:
+        os.close(descriptor)
+
+
 class Pipeline:
     """
     Consolidated pipeline management class.
@@ -627,6 +668,7 @@ class Pipeline:
         for execution_id, candidate in candidates:
             quarantine = executions_dir / f".remove-{execution_id}-{uuid4().hex}"
             os.replace(candidate, quarantine)
+            sealed_input_mode: Optional[int] = None
             try:
                 marker = _read_execution_marker(
                     quarantine,
@@ -636,10 +678,19 @@ class Pipeline:
                     raise RuntimeError(
                         f"execution changed before cleanup: {execution_id}"
                     )
+                sealed_input_mode = _set_execution_input_mode(quarantine)
                 shutil.rmtree(quarantine)
                 _fsync_directory(executions_dir)
             except BaseException:
                 if quarantine.exists() and not candidate.exists():
+                    if sealed_input_mode is not None:
+                        try:
+                            _set_execution_input_mode(
+                                quarantine,
+                                mode=sealed_input_mode,
+                            )
+                        except FileNotFoundError:
+                            pass
                     os.replace(quarantine, candidate)
                     _fsync_directory(executions_dir)
                 raise

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -25,6 +25,7 @@ _EXECUTION_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _SNAPSHOT_ENVIRONMENT = "JARVIS_PIPELINE_SNAPSHOT_DIR"
 _EXECUTION_MARKER = ".jarvis-execution.json"
 _EXECUTION_MARKER_SCHEMA = "jarvis.execution.v1"
+_EXECUTION_CLEANUP_SCHEMA = "jarvis.execution-cleanup.v1"
 _MAX_EXPLICIT_EXECUTION_CLEANUP = 1024
 _WINDOWS_RESERVED_COMPONENTS = {
     "CON",
@@ -126,6 +127,22 @@ def _fsync_directory(path: Path) -> None:
         os.close(descriptor)
 
 
+def _posix_effective_uid() -> int:
+    """Return the effective POSIX uid or fail closed on unsupported platforms."""
+    getter = getattr(os, "geteuid", None)
+    if not callable(getter):
+        raise RuntimeError("POSIX ownership checks are unavailable")
+    return int(getter())
+
+
+def _posix_fchmod(descriptor: int, mode: int) -> None:
+    """Change a POSIX descriptor mode or fail closed when unavailable."""
+    changer = getattr(os, "fchmod", None)
+    if not callable(changer):
+        raise RuntimeError("POSIX descriptor permissions are unavailable")
+    changer(descriptor, mode)
+
+
 def _validated_execution_id(value: Optional[str]) -> str:
     """Return a bounded path-safe scheduler execution identifier."""
     execution_id = value or f"jarvis_{uuid4().hex}"
@@ -174,75 +191,764 @@ def _read_execution_marker(
             )
     finally:
         os.close(descriptor)
+    return _validate_execution_marker_payload(
+        payload,
+        marker_label=str(marker_path),
+        expected_name=expected_execution_id or execution_root.name,
+    )
+
+
+def _validate_execution_marker_payload(
+    payload: bytes,
+    *,
+    marker_label: str,
+    expected_name: str,
+) -> Dict[str, Any]:
+    """Decode and validate a bounded execution marker payload."""
     try:
         document = json.loads(payload.decode("utf-8", errors="strict"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise RuntimeError(
-            f"invalid execution ownership marker: {marker_path}"
+            f"invalid execution ownership marker: {marker_label}"
         ) from exc
     if not isinstance(document, dict) or document.get("schema_version") != (
         _EXECUTION_MARKER_SCHEMA
     ):
-        raise RuntimeError(f"invalid execution ownership marker: {marker_path}")
+        raise RuntimeError(f"invalid execution ownership marker: {marker_label}")
     execution_id = document.get("execution_id")
     if (
         not isinstance(execution_id, str)
         or _validated_execution_id(execution_id) != execution_id
     ):
-        raise RuntimeError(f"invalid execution ownership marker: {marker_path}")
-    expected_name = expected_execution_id or execution_root.name
+        raise RuntimeError(f"invalid execution ownership marker: {marker_label}")
     if expected_name != execution_id:
-        raise RuntimeError(f"execution marker identity mismatch: {execution_root}")
+        raise RuntimeError(f"execution marker identity mismatch: {marker_label}")
     if not isinstance(document.get("pipeline_name"), str):
-        raise RuntimeError(f"invalid execution ownership marker: {marker_path}")
+        raise RuntimeError(f"invalid execution ownership marker: {marker_label}")
     if not isinstance(document.get("state"), str):
-        raise RuntimeError(f"invalid execution ownership marker: {marker_path}")
+        raise RuntimeError(f"invalid execution ownership marker: {marker_label}")
     if not isinstance(document.get("submitted"), bool) or not isinstance(
         document.get("terminal"), bool
     ):
-        raise RuntimeError(f"invalid execution ownership marker: {marker_path}")
+        raise RuntimeError(f"invalid execution ownership marker: {marker_label}")
     return document
 
 
-def _set_execution_input_mode(
-    execution_root: Path,
-    *,
-    mode: Optional[int] = None,
-) -> Optional[int]:
-    """Open the sealed input directory without following links and set its mode.
-
-    Execution inputs are intentionally sealed read-only on POSIX.  Exact
-    cleanup temporarily adds owner write/execute permission so the directory
-    entries can be unlinked.  The prior mode is returned so a failed cleanup
-    can restore the seal before putting the execution back in service.
-    """
-    if os.name == "nt":
-        return None
-    input_dir = execution_root / "input"
+def _open_directory_at(parent_descriptor: int, name: str, *, label: Path) -> int:
+    """Open one real child directory relative to an already trusted directory."""
+    no_follow = getattr(os, "O_NOFOLLOW", 0)
+    if no_follow == 0:
+        raise RuntimeError("secure directory-relative cleanup is unavailable")
     flags = (
         os.O_RDONLY
         | getattr(os, "O_DIRECTORY", 0)
         | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
+        | no_follow
     )
-    descriptor = os.open(input_dir, flags)
+    descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+    status = os.fstat(descriptor)
+    if not stat.S_ISDIR(status.st_mode):
+        os.close(descriptor)
+        raise RuntimeError(f"execution path is not a real directory: {label}")
+    return descriptor
+
+
+def _read_execution_marker_at(
+    execution_descriptor: int,
+    *,
+    execution_label: Path,
+    expected_execution_id: str,
+) -> Dict[str, Any]:
+    """Read an execution marker relative to a held, no-follow root handle."""
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(_EXECUTION_MARKER, flags, dir_fd=execution_descriptor)
     try:
         status = os.fstat(descriptor)
-        path_status = input_dir.lstat()
         if (
-            not stat.S_ISDIR(status.st_mode)
+            not stat.S_ISREG(status.st_mode)
+            or status.st_nlink != 1
+            or status.st_size > 65_536
+        ):
+            raise RuntimeError(f"invalid execution ownership marker: {execution_label}")
+        payload = os.read(descriptor, 65_537)
+        if len(payload) > 65_536:
+            raise RuntimeError(
+                f"execution ownership marker is too large: {execution_label}"
+            )
+    finally:
+        os.close(descriptor)
+    return _validate_execution_marker_payload(
+        payload,
+        marker_label=str(execution_label / _EXECUTION_MARKER),
+        expected_name=expected_execution_id,
+    )
+
+
+def _cleanup_receipt_document(
+    marker: Dict[str, Any],
+    *,
+    tombstone_identity: tuple[int, int],
+    nonce: str,
+) -> Dict[str, Any]:
+    """Return the durable sibling receipt that authorizes tombstone retries."""
+    return {
+        "schema_version": _EXECUTION_CLEANUP_SCHEMA,
+        "pipeline_name": marker["pipeline_name"],
+        "execution_id": marker["execution_id"],
+        "state": marker["state"],
+        "submitted": marker["submitted"],
+        "terminal": marker["terminal"],
+        "cleanup_nonce": nonce,
+        "tombstone_device": tombstone_identity[0],
+        "tombstone_inode": tombstone_identity[1],
+    }
+
+
+def _validate_execution_cleanup_receipt(
+    payload: bytes,
+    *,
+    receipt_label: str,
+    expected_nonce: str,
+    expected_execution_id: str,
+) -> Dict[str, Any]:
+    """Decode one cleanup receipt and validate identity-bound fields."""
+    try:
+        document = json.loads(payload.decode("utf-8", errors="strict"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"invalid execution cleanup receipt: {receipt_label}"
+        ) from exc
+    if (
+        not isinstance(document, dict)
+        or document.get("schema_version") != _EXECUTION_CLEANUP_SCHEMA
+        or document.get("execution_id") != expected_execution_id
+        or document.get("cleanup_nonce") != expected_nonce
+        or not isinstance(document.get("pipeline_name"), str)
+        or not isinstance(document.get("state"), str)
+        or not isinstance(document.get("submitted"), bool)
+        or not isinstance(document.get("terminal"), bool)
+        or not isinstance(document.get("tombstone_device"), int)
+        or document["tombstone_device"] < 0
+        or not isinstance(document.get("tombstone_inode"), int)
+        or document["tombstone_inode"] <= 0
+    ):
+        raise RuntimeError(f"invalid execution cleanup receipt: {receipt_label}")
+    return document
+
+
+def _read_execution_cleanup_receipt(
+    path: Path,
+    *,
+    expected_nonce: str,
+    expected_execution_id: str,
+) -> Dict[str, Any]:
+    """Read one bounded no-follow cleanup receipt by path on Windows."""
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        status = os.fstat(descriptor)
+        path_status = path.lstat()
+        if (
+            not stat.S_ISREG(status.st_mode)
             or stat.S_ISLNK(path_status.st_mode)
             or (status.st_dev, status.st_ino)
             != (path_status.st_dev, path_status.st_ino)
+            or status.st_nlink != 1
+            or status.st_size > 65_536
         ):
-            raise RuntimeError(f"execution input is not a real directory: {input_dir}")
-        previous = stat.S_IMODE(status.st_mode)
-        target = mode if mode is not None else previous | stat.S_IWUSR | stat.S_IXUSR
-        os.fchmod(descriptor, target)
-        os.fsync(descriptor)
-        return previous
+            raise RuntimeError(f"invalid execution cleanup receipt: {path}")
+        if os.name != "nt" and (
+            stat.S_IMODE(status.st_mode) & 0o077
+            or status.st_uid != _posix_effective_uid()
+        ):
+            raise RuntimeError(f"execution cleanup receipt is not private: {path}")
+        payload = os.read(descriptor, 65_537)
+        if len(payload) > 65_536:
+            raise RuntimeError(f"execution cleanup receipt is too large: {path}")
     finally:
         os.close(descriptor)
+    return _validate_execution_cleanup_receipt(
+        payload,
+        receipt_label=str(path),
+        expected_nonce=expected_nonce,
+        expected_execution_id=expected_execution_id,
+    )
+
+
+def _read_execution_cleanup_receipt_at(
+    executions_descriptor: int,
+    receipt_name: str,
+    *,
+    expected_nonce: str,
+    expected_execution_id: str,
+) -> Dict[str, Any]:
+    """Read one cleanup receipt relative to a held executions directory."""
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(receipt_name, flags, dir_fd=executions_descriptor)
+    try:
+        status = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(status.st_mode)
+            or status.st_nlink != 1
+            or status.st_size > 65_536
+        ):
+            raise RuntimeError(f"invalid execution cleanup receipt: {receipt_name}")
+        if (
+            stat.S_IMODE(status.st_mode) & 0o077
+            or status.st_uid != _posix_effective_uid()
+        ):
+            raise RuntimeError(
+                f"execution cleanup receipt is not private: {receipt_name}"
+            )
+        payload = os.read(descriptor, 65_537)
+        if len(payload) > 65_536:
+            raise RuntimeError(
+                f"execution cleanup receipt is too large: {receipt_name}"
+            )
+    finally:
+        os.close(descriptor)
+    return _validate_execution_cleanup_receipt(
+        payload,
+        receipt_label=receipt_name,
+        expected_nonce=expected_nonce,
+        expected_execution_id=expected_execution_id,
+    )
+
+
+def _write_execution_cleanup_receipt_at(
+    executions_descriptor: int,
+    receipt_name: str,
+    document: Dict[str, Any],
+) -> None:
+    """Create one durable nonce-named receipt relative to a held root."""
+    payload = (
+        json.dumps(document, separators=(",", ":"), sort_keys=True) + "\n"
+    ).encode("utf-8")
+    temporary_name = f".{receipt_name}.{uuid4().hex}.tmp"
+    descriptor = os.open(
+        temporary_name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0),
+        0o600,
+        dir_fd=executions_descriptor,
+    )
+    published = False
+    try:
+        offset = 0
+        while offset < len(payload):
+            written = os.write(descriptor, payload[offset:])
+            if written <= 0:
+                raise OSError("could not persist execution cleanup receipt")
+            offset += written
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        os.replace(
+            temporary_name,
+            receipt_name,
+            src_dir_fd=executions_descriptor,
+            dst_dir_fd=executions_descriptor,
+        )
+        published = True
+        os.fsync(executions_descriptor)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if not published:
+            try:
+                os.unlink(temporary_name, dir_fd=executions_descriptor)
+            except FileNotFoundError:
+                pass
+
+
+def _cleanup_receipt_nonce(execution_id: str, receipt_name: str) -> Optional[str]:
+    """Return the nonce encoded by one exact cleanup receipt name."""
+    prefix = f".remove-{execution_id}-"
+    suffix = ".json"
+    if not receipt_name.startswith(prefix) or not receipt_name.endswith(suffix):
+        return None
+    nonce = receipt_name[len(prefix) : -len(suffix)]
+    if len(nonce) != 32 or any(
+        character not in "0123456789abcdef" for character in nonce
+    ):
+        return None
+    return nonce
+
+
+def _find_cleanup_receipts(
+    executions_dir: Path,
+    execution_id: str,
+    *,
+    executions_descriptor: Optional[int],
+) -> list[tuple[Path, str]]:
+    """Find the single identity-bearing receipt allowed for an execution."""
+    receipts: list[tuple[Path, str]] = []
+    if executions_descriptor is None:
+        entries_context = os.scandir(executions_dir)
+    else:
+        entries_context = os.scandir(executions_descriptor)
+    with entries_context as entries:
+        for entry in entries:
+            nonce = _cleanup_receipt_nonce(execution_id, entry.name)
+            if nonce is not None:
+                receipts.append((executions_dir / entry.name, nonce))
+                if len(receipts) > 1:
+                    raise RuntimeError(
+                        f"multiple cleanup receipts exist: {execution_id}"
+                    )
+    return receipts
+
+
+def _require_exact_cleanup_receipt(
+    executions_dir: Path,
+    execution_id: str,
+    *,
+    executions_descriptor: Optional[int],
+    expected_path: Path,
+    expected_nonce: str,
+    expected_identity: tuple[int, int],
+) -> None:
+    """Reopen and revalidate the sole identity-bound transaction receipt."""
+    receipts = _find_cleanup_receipts(
+        executions_dir,
+        execution_id,
+        executions_descriptor=executions_descriptor,
+    )
+    if receipts != [(expected_path, expected_nonce)]:
+        raise RuntimeError(f"execution cleanup receipt set changed: {execution_id}")
+    receipt = _read_cleanup_receipt_bound(
+        expected_path,
+        expected_nonce,
+        executions_descriptor=executions_descriptor,
+        expected_execution_id=execution_id,
+    )
+    if _receipt_tombstone_identity(receipt) != expected_identity:
+        raise RuntimeError(
+            f"execution cleanup receipt identity changed: {execution_id}"
+        )
+
+
+def _entry_exists(
+    path: Path,
+    *,
+    parent_descriptor: Optional[int],
+) -> bool:
+    """Check one child without following it when a trusted parent is available."""
+    if parent_descriptor is None:
+        return os.path.lexists(path)
+    try:
+        os.stat(path.name, dir_fd=parent_descriptor, follow_symlinks=False)
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def _inspect_execution_root(
+    path: Path,
+    *,
+    executions_descriptor: Optional[int],
+    expected_execution_id: str,
+) -> tuple[Dict[str, Any], tuple[int, int]]:
+    """Read a root marker and return the exact directory identity it belongs to."""
+    if executions_descriptor is None:
+        status = path.lstat()
+        if not stat.S_ISDIR(status.st_mode) or stat.S_ISLNK(status.st_mode):
+            raise RuntimeError(f"execution root is not a real directory: {path}")
+        marker = _read_execution_marker(
+            path,
+            expected_execution_id=expected_execution_id,
+        )
+        return marker, (status.st_dev, status.st_ino)
+    root_descriptor = _open_directory_at(
+        executions_descriptor,
+        path.name,
+        label=path,
+    )
+    try:
+        status = os.fstat(root_descriptor)
+        marker = _read_execution_marker_at(
+            root_descriptor,
+            execution_label=path,
+            expected_execution_id=expected_execution_id,
+        )
+        return marker, (status.st_dev, status.st_ino)
+    finally:
+        os.close(root_descriptor)
+
+
+def _execution_root_identity(
+    path: Path,
+    *,
+    executions_descriptor: Optional[int],
+) -> tuple[int, int]:
+    """Return one no-follow execution directory identity."""
+    if executions_descriptor is None:
+        status = path.lstat()
+        if not stat.S_ISDIR(status.st_mode) or stat.S_ISLNK(status.st_mode):
+            raise RuntimeError(f"execution root is not a real directory: {path}")
+        return status.st_dev, status.st_ino
+    root_descriptor = _open_directory_at(
+        executions_descriptor,
+        path.name,
+        label=path,
+    )
+    try:
+        status = os.fstat(root_descriptor)
+        return status.st_dev, status.st_ino
+    finally:
+        os.close(root_descriptor)
+
+
+def _read_cleanup_receipt_bound(
+    path: Path,
+    nonce: str,
+    *,
+    executions_descriptor: Optional[int],
+    expected_execution_id: str,
+) -> Dict[str, Any]:
+    """Read a receipt through the trusted executions descriptor when possible."""
+    if executions_descriptor is None:
+        return _read_execution_cleanup_receipt(
+            path,
+            expected_nonce=nonce,
+            expected_execution_id=expected_execution_id,
+        )
+    return _read_execution_cleanup_receipt_at(
+        executions_descriptor,
+        path.name,
+        expected_nonce=nonce,
+        expected_execution_id=expected_execution_id,
+    )
+
+
+def _receipt_tombstone_identity(receipt: Dict[str, Any]) -> tuple[int, int]:
+    """Return the validated tombstone identity carried by a receipt."""
+    return (
+        int(receipt["tombstone_device"]),
+        int(receipt["tombstone_inode"]),
+    )
+
+
+def _unlock_execution_input_for_cleanup(
+    execution_root: Path,
+    *,
+    root_descriptor: Optional[int] = None,
+) -> None:
+    """Open the sealed input directory without following links and unlock it.
+
+    Execution inputs are intentionally sealed read-only on POSIX.  Exact
+    cleanup temporarily adds owner write/execute permission so the directory
+    entries can be unlinked.  Once cleanup starts, the execution remains under
+    its deterministic tombstone and is never returned to the live identity.
+    """
+    if os.name == "nt":
+        return
+    owns_root_descriptor = root_descriptor is None
+    if root_descriptor is None:
+        parent = execution_root.parent
+        parent_descriptor = os.open(
+            parent,
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
+        )
+        try:
+            root_descriptor = _open_directory_at(
+                parent_descriptor,
+                execution_root.name,
+                label=execution_root,
+            )
+        finally:
+            os.close(parent_descriptor)
+    assert root_descriptor is not None
+    descriptor = _open_directory_at(
+        root_descriptor,
+        "input",
+        label=execution_root / "input",
+    )
+    try:
+        status = os.fstat(descriptor)
+        previous = stat.S_IMODE(status.st_mode)
+        target = previous | stat.S_IWUSR | stat.S_IXUSR
+        _posix_fchmod(descriptor, target)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+        if owns_root_descriptor:
+            os.close(root_descriptor)
+
+
+def _remove_directory_contents_at(
+    directory_descriptor: int,
+    *,
+    directory_label: Path,
+) -> None:
+    """Recursively remove children relative to a held no-follow directory."""
+    with os.scandir(directory_descriptor) as entries:
+        snapshot = list(entries)
+    for entry in snapshot:
+        name = entry.name
+        try:
+            observed = entry.stat(follow_symlinks=False)
+        except FileNotFoundError:
+            continue
+        if stat.S_ISDIR(observed.st_mode) and not stat.S_ISLNK(observed.st_mode):
+            child_label = directory_label / name
+            child_descriptor = _open_directory_at(
+                directory_descriptor,
+                name,
+                label=child_label,
+            )
+            try:
+                child_identity = os.fstat(child_descriptor)
+                if (child_identity.st_dev, child_identity.st_ino) != (
+                    observed.st_dev,
+                    observed.st_ino,
+                ):
+                    raise RuntimeError(
+                        f"execution directory changed during cleanup: {child_label}"
+                    )
+                _remove_directory_contents_at(
+                    child_descriptor,
+                    directory_label=child_label,
+                )
+                current = os.stat(
+                    name,
+                    dir_fd=directory_descriptor,
+                    follow_symlinks=False,
+                )
+                if (current.st_dev, current.st_ino) != (
+                    child_identity.st_dev,
+                    child_identity.st_ino,
+                ):
+                    raise RuntimeError(
+                        f"execution directory changed during cleanup: {child_label}"
+                    )
+                os.rmdir(name, dir_fd=directory_descriptor)
+            finally:
+                os.close(child_descriptor)
+        else:
+            current = os.stat(
+                name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+            if (current.st_dev, current.st_ino) != (observed.st_dev, observed.st_ino):
+                raise RuntimeError(
+                    f"execution entry changed during cleanup: {directory_label / name}"
+                )
+            os.unlink(name, dir_fd=directory_descriptor)
+    os.fsync(directory_descriptor)
+
+
+_WINDOWS_DELETE = 0x00010000
+_WINDOWS_FILE_LIST_DIRECTORY = 0x00000001
+_WINDOWS_FILE_READ_ATTRIBUTES = 0x00000080
+_WINDOWS_FILE_SHARE_READ = 0x00000001
+_WINDOWS_FILE_SHARE_WRITE = 0x00000002
+_WINDOWS_OPEN_EXISTING = 3
+_WINDOWS_FILE_ATTRIBUTE_DIRECTORY = 0x00000010
+_WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+_WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
+_WINDOWS_FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
+_WINDOWS_FILE_DISPOSITION_INFO = 4
+
+
+def _open_windows_cleanup_entry(
+    path: Path,
+    *,
+    expected_inode: int,
+) -> tuple[int, int]:
+    """Open and validate one Windows entry without delete sharing."""
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    kernel32.CreateFileW.restype = wintypes.HANDLE
+    raw_handle = kernel32.CreateFileW(
+        str(path),
+        _WINDOWS_DELETE | _WINDOWS_FILE_LIST_DIRECTORY | _WINDOWS_FILE_READ_ATTRIBUTES,
+        _WINDOWS_FILE_SHARE_READ | _WINDOWS_FILE_SHARE_WRITE,
+        None,
+        _WINDOWS_OPEN_EXISTING,
+        _WINDOWS_FILE_FLAG_BACKUP_SEMANTICS | _WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT,
+        None,
+    )
+    invalid_handle = ctypes.c_void_p(-1).value
+    if raw_handle == invalid_handle:
+        error = ctypes.get_last_error()
+        raise OSError(error, os.strerror(error), path)
+    handle = int(raw_handle)
+    try:
+        attributes, inode = _windows_cleanup_handle_information(handle, path)
+        if expected_inode <= 0 or inode != expected_inode:
+            raise RuntimeError(f"Windows cleanup entry changed while opening: {path}")
+        return handle, attributes
+    except BaseException:
+        _close_windows_cleanup_handle(handle)
+        raise
+
+
+def _windows_cleanup_handle_information(handle: int, path: Path) -> tuple[int, int]:
+    """Return attributes and stable identity for one Windows cleanup handle."""
+    import ctypes
+    from ctypes import wintypes
+
+    class _ByHandleFileInformation(ctypes.Structure):
+        _fields_ = [
+            ("file_attributes", wintypes.DWORD),
+            ("creation_time", wintypes.FILETIME),
+            ("last_access_time", wintypes.FILETIME),
+            ("last_write_time", wintypes.FILETIME),
+            ("volume_serial_number", wintypes.DWORD),
+            ("file_size_high", wintypes.DWORD),
+            ("file_size_low", wintypes.DWORD),
+            ("number_of_links", wintypes.DWORD),
+            ("file_index_high", wintypes.DWORD),
+            ("file_index_low", wintypes.DWORD),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(_ByHandleFileInformation),
+    ]
+    kernel32.GetFileInformationByHandle.restype = wintypes.BOOL
+    information = _ByHandleFileInformation()
+    if not kernel32.GetFileInformationByHandle(handle, ctypes.byref(information)):
+        error = ctypes.get_last_error()
+        raise OSError(error, os.strerror(error), path)
+    inode = (int(information.file_index_high) << 32) | int(information.file_index_low)
+    return int(information.file_attributes), inode
+
+
+def _mark_windows_cleanup_handle_for_delete(handle: int, path: Path) -> None:
+    """Mark one exact, already-open Windows entry for deletion on close."""
+    import ctypes
+    from ctypes import wintypes
+
+    class _FileDispositionInformation(ctypes.Structure):
+        _fields_ = [("delete_file", wintypes.BOOL)]
+
+    disposition = _FileDispositionInformation(delete_file=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.SetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    kernel32.SetFileInformationByHandle.restype = wintypes.BOOL
+    if not kernel32.SetFileInformationByHandle(
+        handle,
+        _WINDOWS_FILE_DISPOSITION_INFO,
+        ctypes.byref(disposition),
+        ctypes.sizeof(disposition),
+    ):
+        error = ctypes.get_last_error()
+        raise OSError(error, os.strerror(error), path)
+
+
+def _close_windows_cleanup_handle(handle: int) -> None:
+    """Close one Windows cleanup handle."""
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    kernel32.CloseHandle(handle)
+
+
+def _remove_windows_directory_contents(path: Path) -> None:
+    """Delete children by exact Windows handles without following reparse points."""
+    with os.scandir(path) as entries:
+        snapshot = list(entries)
+    for entry in snapshot:
+        child_path = path / entry.name
+        observed = os.stat(child_path, follow_symlinks=False)
+        if observed.st_ino <= 0:
+            raise RuntimeError(
+                f"Windows cleanup entry has no stable identity: {child_path}"
+            )
+        child_handle, attributes = _open_windows_cleanup_entry(
+            child_path,
+            expected_inode=observed.st_ino,
+        )
+        try:
+            is_directory = bool(attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY)
+            is_reparse = bool(attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT)
+            if is_directory and not is_reparse:
+                _remove_windows_directory_contents(child_path)
+            _mark_windows_cleanup_handle_for_delete(child_handle, child_path)
+        finally:
+            _close_windows_cleanup_handle(child_handle)
+
+
+def _remove_execution_tree(
+    quarantine: Path,
+    *,
+    executions_descriptor: Optional[int],
+    root_descriptor: Optional[int],
+    windows_root_handle: Optional[int],
+    root_identity: tuple[int, int],
+) -> None:
+    """Remove only the execution root whose held identity was validated."""
+    if windows_root_handle is not None:
+        attributes, inode = _windows_cleanup_handle_information(
+            windows_root_handle,
+            quarantine,
+        )
+        if (
+            not attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY
+            or attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT
+            or inode != root_identity[1]
+        ):
+            raise RuntimeError(
+                f"cleanup tombstone changed before deletion: {quarantine}"
+            )
+        _remove_windows_directory_contents(quarantine)
+        _mark_windows_cleanup_handle_for_delete(windows_root_handle, quarantine)
+        return
+    if executions_descriptor is None or root_descriptor is None:
+        current = quarantine.lstat()
+        if (
+            not stat.S_ISDIR(current.st_mode)
+            or stat.S_ISLNK(current.st_mode)
+            or (current.st_dev, current.st_ino) != root_identity
+        ):
+            raise RuntimeError(
+                f"cleanup tombstone changed before deletion: {quarantine}"
+            )
+        shutil.rmtree(quarantine)
+        _fsync_directory(quarantine.parent)
+        return
+
+    _remove_directory_contents_at(
+        root_descriptor,
+        directory_label=quarantine,
+    )
+    current = os.stat(
+        quarantine.name,
+        dir_fd=executions_descriptor,
+        follow_symlinks=False,
+    )
+    if (
+        not stat.S_ISDIR(current.st_mode)
+        or (current.st_dev, current.st_ino) != root_identity
+    ):
+        raise RuntimeError(f"cleanup tombstone changed before deletion: {quarantine}")
+    os.rmdir(quarantine.name, dir_fd=executions_descriptor)
+    os.fsync(executions_descriptor)
 
 
 class Pipeline:
@@ -389,8 +1095,29 @@ class Pipeline:
         shared_dir = self.get_pipeline_shared_dir()
         shared_dir.mkdir(parents=True, exist_ok=True)
         resolved_execution_id = _validated_execution_id(execution_id)
-        execution_root = shared_dir / "executions" / resolved_execution_id
-        execution_root.parent.mkdir(parents=True, exist_ok=True)
+        executions_dir = shared_dir / "executions"
+        executions_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        executions_status = executions_dir.lstat()
+        if not stat.S_ISDIR(executions_status.st_mode) or stat.S_ISLNK(
+            executions_status.st_mode
+        ):
+            raise RuntimeError("pipeline executions path is not a real directory")
+        if os.name != "nt":
+            if executions_status.st_uid != _posix_effective_uid():
+                raise RuntimeError("pipeline executions path is not owner-controlled")
+            executions_descriptor = os.open(
+                executions_dir,
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_CLOEXEC", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+            )
+            try:
+                _posix_fchmod(executions_descriptor, 0o700)
+                os.fsync(executions_descriptor)
+            finally:
+                os.close(executions_descriptor)
+        execution_root = executions_dir / resolved_execution_id
         execution_root.mkdir(mode=0o700)
         if os.name != "nt":
             execution_root.chmod(0o700)
@@ -646,56 +1373,335 @@ class Pipeline:
         ):
             raise RuntimeError("pipeline executions path is not a real directory")
 
-        candidates: List[tuple[str, Path]] = []
-        for execution_id in normalized:
-            candidate = executions_dir / execution_id
-            try:
-                marker = _read_execution_marker(candidate)
-            except FileNotFoundError as exc:
-                raise RuntimeError(f"execution does not exist: {execution_id}") from exc
-            if marker["pipeline_name"] != self.name:
-                raise RuntimeError(
-                    f"execution marker pipeline mismatch: {execution_id}"
-                )
-            if not marker["terminal"] and execution_id not in verified and not force:
-                raise RuntimeError(
-                    f"execution is not terminal: {execution_id}; verify scheduler "
-                    "state and pass terminal_verified explicitly"
-                )
-            candidates.append((execution_id, candidate))
+        executions_descriptor: Optional[int] = None
+        if os.name != "nt":
+            no_follow = getattr(os, "O_NOFOLLOW", 0)
+            if no_follow == 0:
+                raise RuntimeError("secure directory-relative cleanup is unavailable")
+            executions_descriptor = os.open(
+                executions_dir,
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_CLOEXEC", 0)
+                | no_follow,
+            )
+            descriptor_status = os.fstat(executions_descriptor)
+            current_status = executions_dir.lstat()
+            if (
+                not stat.S_ISDIR(descriptor_status.st_mode)
+                or stat.S_ISLNK(current_status.st_mode)
+                or (descriptor_status.st_dev, descriptor_status.st_ino)
+                != (current_status.st_dev, current_status.st_ino)
+            ):
+                os.close(executions_descriptor)
+                raise RuntimeError("pipeline executions path changed during cleanup")
+            if descriptor_status.st_uid != _posix_effective_uid():
+                os.close(executions_descriptor)
+                raise RuntimeError("pipeline executions path is not owner-controlled")
+            _posix_fchmod(executions_descriptor, 0o700)
+            os.fsync(executions_descriptor)
 
+        candidates: List[
+            tuple[
+                str,
+                Path,
+                Path,
+                Optional[Path],
+                Optional[str],
+                str,
+                Dict[str, Any],
+                Optional[tuple[int, int]],
+            ]
+        ] = []
         removed: List[str] = []
-        for execution_id, candidate in candidates:
-            quarantine = executions_dir / f".remove-{execution_id}-{uuid4().hex}"
-            os.replace(candidate, quarantine)
-            sealed_input_mode: Optional[int] = None
-            try:
-                marker = _read_execution_marker(
-                    quarantine,
-                    expected_execution_id=execution_id,
+        try:
+            for execution_id in normalized:
+                candidate = executions_dir / execution_id
+                quarantine = executions_dir / f".remove-{execution_id}"
+                receipts = _find_cleanup_receipts(
+                    executions_dir,
+                    execution_id,
+                    executions_descriptor=executions_descriptor,
                 )
-                if marker["execution_id"] != execution_id:
-                    raise RuntimeError(
-                        f"execution changed before cleanup: {execution_id}"
+                candidate_exists = _entry_exists(
+                    candidate,
+                    parent_descriptor=executions_descriptor,
+                )
+                quarantine_exists = _entry_exists(
+                    quarantine,
+                    parent_descriptor=executions_descriptor,
+                )
+                if candidate_exists:
+                    if quarantine_exists or receipts:
+                        raise RuntimeError(
+                            f"execution and cleanup state both exist: {execution_id}"
+                        )
+                    cleanup_state = "live"
+                    marker, expected_identity = _inspect_execution_root(
+                        candidate,
+                        executions_descriptor=executions_descriptor,
+                        expected_execution_id=execution_id,
                     )
-                sealed_input_mode = _set_execution_input_mode(quarantine)
-                shutil.rmtree(quarantine)
-                _fsync_directory(executions_dir)
-            except BaseException:
-                if quarantine.exists() and not candidate.exists():
-                    if sealed_input_mode is not None:
+                    receipt = None
+                    receipt_nonce = None
+                elif quarantine_exists:
+                    cleanup_state = "tombstone"
+                    if receipts:
+                        receipt, receipt_nonce = receipts[0]
+                        marker = _read_cleanup_receipt_bound(
+                            receipt,
+                            receipt_nonce,
+                            executions_descriptor=executions_descriptor,
+                            expected_execution_id=execution_id,
+                        )
+                        expected_identity = _receipt_tombstone_identity(marker)
+                        current_identity = _execution_root_identity(
+                            quarantine,
+                            executions_descriptor=executions_descriptor,
+                        )
+                        if current_identity != expected_identity:
+                            raise RuntimeError(
+                                f"cleanup receipt tombstone mismatch: {execution_id}"
+                            )
+                    else:
+                        receipt = None
+                        receipt_nonce = None
+                        marker, expected_identity = _inspect_execution_root(
+                            quarantine,
+                            executions_descriptor=executions_descriptor,
+                            expected_execution_id=execution_id,
+                        )
+                elif receipts:
+                    cleanup_state = "receipt-only"
+                    receipt, receipt_nonce = receipts[0]
+                    marker = _read_cleanup_receipt_bound(
+                        receipt,
+                        receipt_nonce,
+                        executions_descriptor=executions_descriptor,
+                        expected_execution_id=execution_id,
+                    )
+                    expected_identity = None
+                else:
+                    raise RuntimeError(f"execution does not exist: {execution_id}")
+                if marker["pipeline_name"] != self.name:
+                    raise RuntimeError(
+                        f"execution marker pipeline mismatch: {execution_id}"
+                    )
+                if (
+                    not marker["terminal"]
+                    and execution_id not in verified
+                    and not force
+                ):
+                    raise RuntimeError(
+                        f"execution is not terminal: {execution_id}; verify scheduler "
+                        "state and pass terminal_verified explicitly"
+                    )
+                candidates.append(
+                    (
+                        execution_id,
+                        candidate,
+                        quarantine,
+                        receipt,
+                        receipt_nonce,
+                        cleanup_state,
+                        marker,
+                        expected_identity,
+                    )
+                )
+
+            for (
+                execution_id,
+                candidate,
+                quarantine,
+                receipt,
+                receipt_nonce,
+                cleanup_state,
+                marker,
+                expected_identity,
+            ) in candidates:
+                if cleanup_state == "live":
+                    if receipt is not None or receipt_nonce is not None:
+                        raise RuntimeError(
+                            f"live execution has a cleanup receipt: {execution_id}"
+                        )
+                    if executions_descriptor is None:
+                        os.replace(candidate, quarantine)
+                        _fsync_directory(executions_dir)
+                    else:
+                        os.replace(
+                            candidate.name,
+                            quarantine.name,
+                            src_dir_fd=executions_descriptor,
+                            dst_dir_fd=executions_descriptor,
+                        )
+                        os.fsync(executions_descriptor)
+                    cleanup_state = "tombstone"
+
+                if cleanup_state == "tombstone":
+                    root_descriptor: Optional[int] = None
+                    windows_root_handle: Optional[int] = None
+                    try:
+                        if executions_descriptor is None:
+                            quarantine_status = quarantine.lstat()
+                            if not stat.S_ISDIR(
+                                quarantine_status.st_mode
+                            ) or stat.S_ISLNK(quarantine_status.st_mode):
+                                raise RuntimeError(
+                                    f"cleanup tombstone is not a real directory: "
+                                    f"{execution_id}"
+                                )
+                            current_identity = (
+                                quarantine_status.st_dev,
+                                quarantine_status.st_ino,
+                            )
+                            if expected_identity is not None and (
+                                current_identity != expected_identity
+                            ):
+                                raise RuntimeError(
+                                    f"execution changed before cleanup: {execution_id}"
+                                )
+                            windows_root_handle, attributes = (
+                                _open_windows_cleanup_entry(
+                                    quarantine,
+                                    expected_inode=current_identity[1],
+                                )
+                            )
+                            if (
+                                not attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY
+                                or attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT
+                            ):
+                                raise RuntimeError(
+                                    f"cleanup tombstone is not a real directory: "
+                                    f"{execution_id}"
+                                )
+                            if receipt is None:
+                                marker = _read_execution_marker(
+                                    quarantine,
+                                    expected_execution_id=execution_id,
+                                )
+                        else:
+                            root_descriptor = _open_directory_at(
+                                executions_descriptor,
+                                quarantine.name,
+                                label=quarantine,
+                            )
+                            root_status = os.fstat(root_descriptor)
+                            current_identity = (
+                                root_status.st_dev,
+                                root_status.st_ino,
+                            )
+                            if expected_identity is not None and (
+                                current_identity != expected_identity
+                            ):
+                                raise RuntimeError(
+                                    f"execution changed before cleanup: {execution_id}"
+                                )
+                            if receipt is None:
+                                marker = _read_execution_marker_at(
+                                    root_descriptor,
+                                    execution_label=quarantine,
+                                    expected_execution_id=execution_id,
+                                )
+                        if marker["pipeline_name"] != self.name or (
+                            not marker["terminal"]
+                            and execution_id not in verified
+                            and not force
+                        ):
+                            raise RuntimeError(
+                                f"execution changed before cleanup: {execution_id}"
+                            )
+                        if receipt is None:
+                            receipt_nonce = uuid4().hex
+                            receipt = executions_dir / (
+                                f".remove-{execution_id}-{receipt_nonce}.json"
+                            )
+                            receipt_document = _cleanup_receipt_document(
+                                marker,
+                                tombstone_identity=current_identity,
+                                nonce=receipt_nonce,
+                            )
+                            if executions_descriptor is None:
+                                _atomic_json_dump(receipt, receipt_document)
+                            else:
+                                _write_execution_cleanup_receipt_at(
+                                    executions_descriptor,
+                                    receipt.name,
+                                    receipt_document,
+                                )
+                        assert receipt is not None
+                        assert receipt_nonce is not None
+                        marker = _read_cleanup_receipt_bound(
+                            receipt,
+                            receipt_nonce,
+                            executions_descriptor=executions_descriptor,
+                            expected_execution_id=execution_id,
+                        )
+                        if (
+                            marker["pipeline_name"] != self.name
+                            or _receipt_tombstone_identity(marker) != current_identity
+                        ):
+                            raise RuntimeError(
+                                f"execution cleanup receipt changed: {execution_id}"
+                            )
+                        _require_exact_cleanup_receipt(
+                            executions_dir,
+                            execution_id,
+                            executions_descriptor=executions_descriptor,
+                            expected_path=receipt,
+                            expected_nonce=receipt_nonce,
+                            expected_identity=current_identity,
+                        )
                         try:
-                            _set_execution_input_mode(
+                            _unlock_execution_input_for_cleanup(
                                 quarantine,
-                                mode=sealed_input_mode,
+                                root_descriptor=root_descriptor,
                             )
                         except FileNotFoundError:
                             pass
-                    os.replace(quarantine, candidate)
+                        _remove_execution_tree(
+                            quarantine,
+                            executions_descriptor=executions_descriptor,
+                            root_descriptor=root_descriptor,
+                            windows_root_handle=windows_root_handle,
+                            root_identity=current_identity,
+                        )
+                    finally:
+                        if root_descriptor is not None:
+                            os.close(root_descriptor)
+                        if windows_root_handle is not None:
+                            _close_windows_cleanup_handle(windows_root_handle)
+
+                assert receipt is not None
+                assert receipt_nonce is not None
+                _require_exact_cleanup_receipt(
+                    executions_dir,
+                    execution_id,
+                    executions_descriptor=executions_descriptor,
+                    expected_path=receipt,
+                    expected_nonce=receipt_nonce,
+                    expected_identity=_receipt_tombstone_identity(marker),
+                )
+                final_receipt = _read_cleanup_receipt_bound(
+                    receipt,
+                    receipt_nonce,
+                    executions_descriptor=executions_descriptor,
+                    expected_execution_id=execution_id,
+                )
+                if final_receipt["pipeline_name"] != self.name:
+                    raise RuntimeError(
+                        f"execution cleanup receipt changed: {execution_id}"
+                    )
+                if executions_descriptor is None:
+                    receipt.unlink()
                     _fsync_directory(executions_dir)
-                raise
-            removed.append(execution_id)
-        return removed
+                else:
+                    os.unlink(receipt.name, dir_fd=executions_descriptor)
+                    os.fsync(executions_descriptor)
+                removed.append(execution_id)
+            return removed
+        finally:
+            if executions_descriptor is not None:
+                os.close(executions_descriptor)
 
     def _write_execution_snapshot(
         self,

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -4,30 +4,204 @@ Provides the consolidated Pipeline class that combines pipeline creation, loadin
 """
 
 import os
+import hashlib
+import json
+import re
 import shlex
+import shutil
 import socket
+import stat
+import tempfile
 import yaml
-import copy
 from pathlib import Path
 from typing import Dict, Any, List, Optional
+from uuid import uuid4
 from jarvis_cd.core.config import load_class, Jarvis
 from jarvis_cd.util.logger import logger
 from jarvis_cd.util.hostfile import Hostfile
 
 
+_EXECUTION_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_SNAPSHOT_ENVIRONMENT = "JARVIS_PIPELINE_SNAPSHOT_DIR"
+_EXECUTION_MARKER = ".jarvis-execution.json"
+_EXECUTION_MARKER_SCHEMA = "jarvis.execution.v1"
+_MAX_EXPLICIT_EXECUTION_CLEANUP = 1024
+_WINDOWS_RESERVED_COMPONENTS = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    "CLOCK$",
+    *(f"COM{index}" for index in range(1, 10)),
+    *(f"LPT{index}" for index in range(1, 10)),
+}
+
+
 def _bounded_scheduler_stderr(result: Any, limit: int = 4096) -> Optional[str]:
     """Return a bounded scheduler diagnostic captured by the executor."""
-    stderr = getattr(result, 'stderr', {})
+    stderr = getattr(result, "stderr", {})
     if isinstance(stderr, dict):
-        value = stderr.get('localhost', '')
+        value = stderr.get("localhost", "")
     else:
         value = stderr
-    diagnostic = str(value or '').strip()
+    diagnostic = str(value or "").strip()
     if not diagnostic:
         return None
     if len(diagnostic) <= limit:
         return diagnostic
-    return '[truncated]\n' + diagnostic[-limit:]
+    return "[truncated]\n" + diagnostic[-limit:]
+
+
+def _atomic_yaml_dump(path: Path, value: Any) -> None:
+    """Durably replace one YAML document without exposing a truncated target."""
+    temporary_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            yaml.dump(value, temporary, default_flow_style=False)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.replace(temporary_path, path)
+        temporary_path = None
+        if os.name != "nt":
+            flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+            directory = os.open(path.parent, flags)
+            try:
+                os.fsync(directory)
+            finally:
+                os.close(directory)
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def _atomic_json_dump(path: Path, value: Dict[str, Any]) -> None:
+    """Durably replace one small JSON ownership document."""
+    temporary_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            json.dump(value, temporary, separators=(",", ":"), sort_keys=True)
+            temporary.write("\n")
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        if os.name != "nt":
+            temporary_path.chmod(0o600)
+        os.replace(temporary_path, path)
+        temporary_path = None
+        _fsync_directory(path.parent)
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist directory-entry changes on platforms that expose directory fsync."""
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _validated_execution_id(value: Optional[str]) -> str:
+    """Return a bounded path-safe scheduler execution identifier."""
+    execution_id = value or f"jarvis_{uuid4().hex}"
+    reserved_stem = execution_id.split(".", 1)[0].upper()
+    if (
+        _EXECUTION_ID_PATTERN.fullmatch(execution_id) is None
+        or execution_id.endswith(".")
+        or reserved_stem in _WINDOWS_RESERVED_COMPONENTS
+    ):
+        raise ValueError(
+            "execution_id must be 1-128 ASCII letters, digits, dots, underscores, "
+            "or hyphens, cannot begin with punctuation or end with a dot, and "
+            "cannot be a reserved Windows path alias"
+        )
+    return execution_id
+
+
+def _read_execution_marker(
+    execution_root: Path,
+    *,
+    expected_execution_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Read and validate an owned execution marker without following links."""
+    root_status = execution_root.lstat()
+    if not stat.S_ISDIR(root_status.st_mode) or stat.S_ISLNK(root_status.st_mode):
+        raise RuntimeError(f"execution root is not a real directory: {execution_root}")
+    marker_path = execution_root / _EXECUTION_MARKER
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(marker_path, flags)
+    try:
+        status = os.fstat(descriptor)
+        marker_status = marker_path.lstat()
+        if (
+            not stat.S_ISREG(status.st_mode)
+            or stat.S_ISLNK(marker_status.st_mode)
+            or (status.st_dev, status.st_ino)
+            != (marker_status.st_dev, marker_status.st_ino)
+            or status.st_nlink != 1
+            or status.st_size > 65_536
+        ):
+            raise RuntimeError(f"invalid execution ownership marker: {marker_path}")
+        payload = os.read(descriptor, 65_537)
+        if len(payload) > 65_536:
+            raise RuntimeError(
+                f"execution ownership marker is too large: {marker_path}"
+            )
+    finally:
+        os.close(descriptor)
+    try:
+        document = json.loads(payload.decode("utf-8", errors="strict"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"invalid execution ownership marker: {marker_path}"
+        ) from exc
+    if not isinstance(document, dict) or document.get("schema_version") != (
+        _EXECUTION_MARKER_SCHEMA
+    ):
+        raise RuntimeError(f"invalid execution ownership marker: {marker_path}")
+    execution_id = document.get("execution_id")
+    if (
+        not isinstance(execution_id, str)
+        or _validated_execution_id(execution_id) != execution_id
+    ):
+        raise RuntimeError(f"invalid execution ownership marker: {marker_path}")
+    expected_name = expected_execution_id or execution_root.name
+    if expected_name != execution_id:
+        raise RuntimeError(f"execution marker identity mismatch: {execution_root}")
+    if not isinstance(document.get("pipeline_name"), str):
+        raise RuntimeError(f"invalid execution ownership marker: {marker_path}")
+    if not isinstance(document.get("state"), str):
+        raise RuntimeError(f"invalid execution ownership marker: {marker_path}")
+    if not isinstance(document.get("submitted"), bool) or not isinstance(
+        document.get("terminal"), bool
+    ):
+        raise RuntimeError(f"invalid execution ownership marker: {marker_path}")
+    return document
 
 
 class Pipeline:
@@ -35,7 +209,7 @@ class Pipeline:
     Consolidated pipeline management class.
     Handles pipeline creation, loading, running, and lifecycle management.
     """
-    
+
     def __init__(self, name: str = None):
         """
         Initialize pipeline instance.
@@ -53,10 +227,17 @@ class Pipeline:
         # This is populated only by the scheduler provider boundary; it is
         # never inferred from package or application stdout.
         self.last_submission = None
+        # A scheduler execution may load a private working copy of the pipeline.
+        # Saves from that process must never mutate the operator's named pipeline.
+        self._execution_snapshot_dir = None
+        self._execution_root = None
+        self._execution_id = None
 
         # Container parameters
         self.container_image = ""  # Pre-built image to use
-        self.container_uri = ""  # Pre-built deploy image URI (skips build+deploy when set)
+        self.container_uri = (
+            ""  # Pre-built deploy image URI (skips build+deploy when set)
+        )
         self.container_engine = "podman"  # Default container engine
         self.container_base = "iowarp/iowarp-build:latest"  # Base image
         self.container_ssh_port = 2222  # Default SSH port for containers
@@ -110,11 +291,11 @@ class Pipeline:
         scheduler block does not name one explicitly. Environment
         variables in the user-supplied value are expanded.
         """
-        shared_dir = self.jarvis.get_pipeline_shared_dir(self.name)
-        spec_path = (self.scheduler or {}).get('hostfile')
+        shared_dir = self.get_pipeline_shared_dir()
+        spec_path = (self.scheduler or {}).get("hostfile")
         if spec_path:
             return os.path.expandvars(str(spec_path))
-        return str(Path(shared_dir) / 'hostfile.txt')
+        return str(Path(shared_dir) / "hostfile.txt")
 
     def _apply_scheduler_hostfile(self):
         """Bind ``self.hostfile`` to the scheduler-owned hostfile path.
@@ -128,15 +309,20 @@ class Pipeline:
         path = self._scheduler_hostfile_path()
         if not self.scheduler:
             return
-        self.scheduler['hostfile'] = path
+        self.scheduler["hostfile"] = path
         try:
-            self.hostfile = Hostfile(path=path, load_path=Path(path).exists(),
-                                     find_ips=False)
+            self.hostfile = Hostfile(
+                path=path, load_path=Path(path).exists(), find_ips=False
+            )
         except FileNotFoundError:
-            self.hostfile = Hostfile(path=path, load_path=False,
-                                     find_ips=False)
+            self.hostfile = Hostfile(path=path, load_path=False, find_ips=False)
 
-    def submit(self, submit: bool = True, wait: bool = False) -> Path:
+    def submit(
+        self,
+        submit: bool = True,
+        wait: bool = False,
+        execution_id: Optional[str] = None,
+    ) -> Path:
         """Write the scheduler job script and (optionally) submit it.
 
         :param submit: when True, exec the scheduler's submit command
@@ -145,71 +331,137 @@ class Pipeline:
         :param wait: when True (and submit is True), ask the scheduler
             to block until the job finishes. SLURM maps this to
             ``sbatch --wait``; backends without an equivalent ignore it.
+        :param execution_id: bounded caller-owned identity used to isolate the
+            submitted pipeline, environment, script, and hostfile.
         :return: Path to the generated job script.
         """
         if not self.scheduler:
             raise ValueError(
                 "Pipeline has no scheduler block. Add `scheduler:` to the "
-                "pipeline YAML before calling submit().")
+                "pipeline YAML before calling submit()."
+            )
         if not self.name:
             raise ValueError("Pipeline name not set; cannot submit job.")
 
         from jarvis_cd.core.scheduler import make_scheduler
-        shared_dir = self.jarvis.get_pipeline_shared_dir(self.name)
-        shared_dir.mkdir(parents=True, exist_ok=True)
 
-        # Prefer the YAML path the pipeline was loaded from so the job
-        # script re-loads exactly what the user submitted. Falls back to
-        # ``jarvis ppl run`` against the saved current pipeline.
-        pipeline_yaml = self.last_loaded_file
-        sched = make_scheduler(self.scheduler, shared_dir,
-                               pipeline_yaml=pipeline_yaml,
-                               pipeline_name=self.name)
-        script_path = sched.write_script()
+        shared_dir = self.get_pipeline_shared_dir()
+        shared_dir.mkdir(parents=True, exist_ok=True)
+        resolved_execution_id = _validated_execution_id(execution_id)
+        execution_root = shared_dir / "executions" / resolved_execution_id
+        execution_root.parent.mkdir(parents=True, exist_ok=True)
+        execution_root.mkdir(mode=0o700)
+        if os.name != "nt":
+            execution_root.chmod(0o700)
+        _fsync_directory(execution_root.parent)
+        _atomic_json_dump(
+            execution_root / _EXECUTION_MARKER,
+            {
+                "schema_version": _EXECUTION_MARKER_SCHEMA,
+                "pipeline_name": self.name,
+                "execution_id": resolved_execution_id,
+                "state": "preparing",
+                "submitted": False,
+                "terminal": False,
+            },
+        )
+
+        try:
+            # Save current in-memory state before sealing the submission input.
+            # The caller holds the per-pipeline MCP lock, so this cannot
+            # overwrite a cooperating writer with stale state.
+            self.save()
+            scheduler_spec = dict(self.scheduler)
+            scheduler_spec["hostfile"] = str(execution_root / "hostfile.txt")
+            snapshot_dir, input_dir, snapshot_sha256 = self._write_execution_snapshot(
+                execution_root,
+                scheduler_spec,
+            )
+            sched = make_scheduler(
+                scheduler_spec,
+                execution_root,
+                pipeline_name=self.name,
+                pipeline_snapshot_dir=snapshot_dir,
+            )
+            script_path = sched.write_script()
+        except BaseException as exc:
+            # No scheduler side effect has occurred yet, so this directory is
+            # solely ours and is safe to remove. Do not leave a partial input
+            # tree that an operator could mistake for a valid execution.
+            try:
+                shutil.rmtree(execution_root)
+                _fsync_directory(execution_root.parent)
+            except OSError as cleanup_error:
+                exc.add_note(
+                    "could not remove incomplete scheduler execution "
+                    f"{execution_root}: {cleanup_error}"
+                )
+            raise
         logger.pipeline(f"Wrote scheduler script: {script_path}")
         logger.pipeline(f"Hostfile (built at job start): {sched.hostfile}")
 
         self.last_submission = {
-            'schema_version': 'jarvis.scheduler.submission.v1',
-            'provider': sched.NAME,
-            'script_path': str(script_path),
-            'scheduler_job_id': None,
-            'scheduler_cluster': None,
-            'identity_source': None,
-            'state': 'scripted',
-            'submitted': False,
-            'wait': bool(wait),
-            'terminal': False,
-            'scheduler_stderr': None,
+            "schema_version": "jarvis.scheduler.submission.v1",
+            "execution_id": resolved_execution_id,
+            "provider": sched.NAME,
+            "script_path": str(script_path),
+            "hostfile_path": str(sched.hostfile),
+            "pipeline_snapshot_path": str(snapshot_dir),
+            "pipeline_input_path": str(input_dir),
+            "execution_root_path": str(execution_root),
+            "pipeline_snapshot_sha256": snapshot_sha256,
+            "scheduler_job_id": None,
+            "scheduler_cluster": None,
+            "identity_source": None,
+            "state": "scripted",
+            "submitted": False,
+            "wait": bool(wait),
+            "terminal": not submit,
+            "scheduler_stderr": None,
             # ``sbatch --wait`` reports the completed workload status through
             # the sbatch process.  Keep that raw value while separately
             # recording whether it is an observed terminal return code.
-            'submission_returncode': None,
-            'terminal_returncode': None,
+            "submission_returncode": None,
+            "terminal_returncode": None,
+            # A relay or site launcher may assign a provider-native job name
+            # before submit. Persist it before invoking the scheduler so an
+            # interrupted submit can be reconciled by an exact provider query.
+            "reconciliation_marker": (
+                self.scheduler.get("job_name")
+                if isinstance(self.scheduler.get("job_name"), str)
+                else None
+            ),
         }
+        self._update_execution_marker(execution_root)
+        # Save local JARVIS state before the external side effect. The relay's
+        # authenticated pre-submit intent remains the reconciliation authority;
+        # this record makes standalone JARVIS recovery and diagnosis possible.
+        self.save()
 
         if submit:
             from jarvis_cd.shell import Exec, LocalExecInfo
+
             argv = sched.submit_command(wait=wait)
-            cmd = ' '.join(shlex.quote(part) for part in argv)
+            cmd = " ".join(shlex.quote(part) for part in argv)
             logger.pipeline(f"Submitting: {cmd}")
             result = Exec(cmd, LocalExecInfo(hide_output=True)).run()
-            exit_code = result.exit_code.get('localhost', 1)
-            self.last_submission['submission_returncode'] = exit_code
+            exit_code = result.exit_code.get("localhost", 1)
+            self.last_submission["submission_returncode"] = exit_code
             scheduler_stderr = _bounded_scheduler_stderr(result)
-            self.last_submission['scheduler_stderr'] = scheduler_stderr
+            self.last_submission["scheduler_stderr"] = scheduler_stderr
             diagnostic = (
-                f"; scheduler stderr: {scheduler_stderr}"
-                if scheduler_stderr
-                else ''
+                f"; scheduler stderr: {scheduler_stderr}" if scheduler_stderr else ""
             )
-            stdout = result.stdout.get('localhost', '')
+            stdout = result.stdout.get("localhost", "")
             try:
                 provider_metadata = sched.parse_submission_output(stdout)
             except ValueError as exc:
-                self.last_submission['state'] = (
-                    'submission_failed' if exit_code != 0 else 'identity_failed'
+                self.last_submission["state"] = (
+                    "submission_failed" if exit_code != 0 else "identity_failed"
                 )
+                self.last_submission["submitted"] = exit_code == 0
+                self.last_submission["terminal"] = exit_code != 0
+                self._update_execution_marker(execution_root)
                 self.save()
                 if exit_code != 0:
                     raise RuntimeError(
@@ -221,19 +473,25 @@ class Pipeline:
                     f"structured job identity{diagnostic}"
                 ) from exc
             self.last_submission.update(provider_metadata)
-            self.last_submission.update({
-                'submitted': True,
-                'terminal': bool(wait),
-                'terminal_returncode': exit_code if wait else None,
-            })
+            self.last_submission.update(
+                {
+                    "submitted": True,
+                    "terminal": bool(wait),
+                    "terminal_returncode": exit_code if wait else None,
+                }
+            )
+            self._update_execution_marker(execution_root)
+            # Persist the provider-owned identity immediately after parsing;
+            # later logging or state decoration must not reopen the orphan gap.
+            self.save()
             logger.pipeline(
-                "Scheduler job identity: "
-                f"{self.last_submission['scheduler_job_id']}"
+                f"Scheduler job identity: {self.last_submission['scheduler_job_id']}"
             )
             if exit_code != 0:
-                self.last_submission['state'] = (
-                    'workload_failed' if wait else 'accepted_with_error'
+                self.last_submission["state"] = (
+                    "workload_failed" if wait else "accepted_with_error"
                 )
+                self._update_execution_marker(execution_root)
                 self.save()
                 if wait:
                     raise RuntimeError(
@@ -248,9 +506,202 @@ class Pipeline:
                     f"but the submission command returned exit {exit_code}: "
                     f"{cmd}{diagnostic}"
                 )
-            self.last_submission['state'] = 'completed' if wait else 'submitted'
+            self.last_submission["state"] = "completed" if wait else "submitted"
+        self._update_execution_marker(execution_root)
         self.save()
         return script_path
+
+    def _pipeline_storage_dir(self) -> Path:
+        """Return the directory this Pipeline instance is allowed to mutate."""
+        return self.get_pipeline_config_dir()
+
+    def get_pipeline_config_dir(self) -> Path:
+        """Return this invocation's pipeline configuration root."""
+        snapshot_dir = getattr(self, "_execution_snapshot_dir", None)
+        if snapshot_dir is not None:
+            return Path(snapshot_dir)
+        return self.jarvis.get_pipeline_dir(self.name)
+
+    def get_pipeline_shared_dir(self) -> Path:
+        """Return this invocation's isolated shared-data root."""
+        execution_root = getattr(self, "_execution_root", None)
+        if execution_root is not None:
+            return Path(execution_root) / "shared"
+        return self.jarvis.get_pipeline_shared_dir(self.name)
+
+    def get_pipeline_private_dir(self) -> Path:
+        """Return this invocation's isolated machine-private root."""
+        execution_root = getattr(self, "_execution_root", None)
+        if execution_root is not None:
+            return Path(execution_root) / "private"
+        return self.jarvis.get_pipeline_private_dir(self.name)
+
+    @property
+    def execution_container_name(self) -> str:
+        """Return a bounded container/instance name unique to this execution."""
+        execution_id = getattr(self, "_execution_id", None)
+        if execution_id is None:
+            return str(self.name)
+        prefix = re.sub(r"[^A-Za-z0-9_.-]", "-", str(self.name))[:40] or "jarvis"
+        digest = hashlib.sha256(str(execution_id).encode("ascii")).hexdigest()[:16]
+        return f"{prefix}-{digest}"
+
+    def _update_execution_marker(self, execution_root: Path) -> None:
+        """Persist cleanup eligibility alongside scheduler submission state."""
+        submission = self.last_submission or {}
+        _atomic_json_dump(
+            execution_root / _EXECUTION_MARKER,
+            {
+                "schema_version": _EXECUTION_MARKER_SCHEMA,
+                "pipeline_name": self.name,
+                "execution_id": submission.get("execution_id"),
+                "state": submission.get("state"),
+                "submitted": submission.get("submitted") is True,
+                "terminal": submission.get("terminal") is True,
+            },
+        )
+
+    def cleanup_executions(
+        self,
+        execution_ids: List[str],
+        *,
+        terminal_verified: Optional[List[str]] = None,
+        force: bool = False,
+    ) -> List[str]:
+        """Remove explicitly named owned execution roots.
+
+        Nonterminal submissions are refused unless their exact IDs appear in
+        ``terminal_verified`` (after an operator checks scheduler state), or
+        ``force`` is explicitly selected. There is deliberately no implicit
+        age/count retention because an older execution may still be queued.
+        """
+        if getattr(self, "_execution_root", None) is not None:
+            raise RuntimeError("cannot clean execution roots from a runtime snapshot")
+        if not self.name:
+            raise ValueError("Pipeline name not set")
+        if (
+            not isinstance(execution_ids, list)
+            or not execution_ids
+            or len(execution_ids) > _MAX_EXPLICIT_EXECUTION_CLEANUP
+        ):
+            raise ValueError(
+                "execution_ids must contain 1-1024 explicit execution identities"
+            )
+        normalized = [_validated_execution_id(value) for value in execution_ids]
+        if len(set(normalized)) != len(normalized):
+            raise ValueError("execution_ids cannot contain duplicates")
+        verified = {
+            _validated_execution_id(value) for value in (terminal_verified or [])
+        }
+        if not verified.issubset(normalized):
+            raise ValueError("terminal_verified must be a subset of execution_ids")
+
+        executions_dir = self.jarvis.get_pipeline_shared_dir(self.name) / "executions"
+        if not executions_dir.exists():
+            return []
+        executions_status = executions_dir.lstat()
+        if not stat.S_ISDIR(executions_status.st_mode) or stat.S_ISLNK(
+            executions_status.st_mode
+        ):
+            raise RuntimeError("pipeline executions path is not a real directory")
+
+        candidates: List[tuple[str, Path]] = []
+        for execution_id in normalized:
+            candidate = executions_dir / execution_id
+            try:
+                marker = _read_execution_marker(candidate)
+            except FileNotFoundError as exc:
+                raise RuntimeError(f"execution does not exist: {execution_id}") from exc
+            if marker["pipeline_name"] != self.name:
+                raise RuntimeError(
+                    f"execution marker pipeline mismatch: {execution_id}"
+                )
+            if not marker["terminal"] and execution_id not in verified and not force:
+                raise RuntimeError(
+                    f"execution is not terminal: {execution_id}; verify scheduler "
+                    "state and pass terminal_verified explicitly"
+                )
+            candidates.append((execution_id, candidate))
+
+        removed: List[str] = []
+        for execution_id, candidate in candidates:
+            quarantine = executions_dir / f".remove-{execution_id}-{uuid4().hex}"
+            os.replace(candidate, quarantine)
+            try:
+                marker = _read_execution_marker(
+                    quarantine,
+                    expected_execution_id=execution_id,
+                )
+                if marker["execution_id"] != execution_id:
+                    raise RuntimeError(
+                        f"execution changed before cleanup: {execution_id}"
+                    )
+                shutil.rmtree(quarantine)
+                _fsync_directory(executions_dir)
+            except BaseException:
+                if quarantine.exists() and not candidate.exists():
+                    os.replace(quarantine, candidate)
+                    _fsync_directory(executions_dir)
+                raise
+            removed.append(execution_id)
+        return removed
+
+    def _write_execution_snapshot(
+        self,
+        execution_root: Path,
+        scheduler_spec: Dict[str, Any],
+    ) -> tuple[Path, Path, str]:
+        """Seal immutable input and create an isolated scheduler working copy."""
+        source_dir = self._pipeline_storage_dir()
+        if getattr(self, "_execution_snapshot_dir", None) is not None:
+            raise RuntimeError(
+                "cannot submit a scheduler job from an execution snapshot"
+            )
+        source_config = source_dir / "pipeline.yaml"
+        try:
+            with source_config.open("r", encoding="utf-8") as stream:
+                pipeline_config = yaml.safe_load(stream)
+        except (OSError, yaml.YAMLError) as exc:
+            raise RuntimeError(
+                f"could not read saved pipeline for snapshot: {exc}"
+            ) from exc
+        if not isinstance(pipeline_config, dict):
+            raise RuntimeError("saved pipeline snapshot source is not a mapping")
+        pipeline_config = dict(pipeline_config)
+        pipeline_config["scheduler"] = dict(scheduler_spec)
+        pipeline_config.pop("last_loaded_file", None)
+        pipeline_config.pop("last_submission", None)
+
+        input_dir = execution_root / "input"
+        runtime_dir = execution_root / "runtime"
+        shared_dir = execution_root / "shared"
+        private_dir = execution_root / "private"
+        input_dir.mkdir(mode=0o700)
+        runtime_dir.mkdir(mode=0o700)
+        shared_dir.mkdir(mode=0o700)
+        private_dir.mkdir(mode=0o700)
+        for directory in (input_dir, runtime_dir):
+            _atomic_yaml_dump(directory / "pipeline.yaml", pipeline_config)
+            _atomic_yaml_dump(directory / "environment.yaml", dict(self.env))
+
+        digest = hashlib.sha256()
+        for path in (input_dir / "pipeline.yaml", input_dir / "environment.yaml"):
+            data = path.read_bytes()
+            digest.update(len(data).to_bytes(8, "big"))
+            digest.update(data)
+            if os.name != "nt":
+                path.chmod(0o400)
+        if os.name != "nt":
+            input_dir.chmod(0o500)
+            runtime_dir.chmod(0o700)
+            shared_dir.chmod(0o700)
+            private_dir.chmod(0o700)
+        _fsync_directory(input_dir)
+        _fsync_directory(runtime_dir)
+        _fsync_directory(shared_dir)
+        _fsync_directory(private_dir)
+        _fsync_directory(execution_root)
+        return runtime_dir, input_dir, digest.hexdigest()
 
     def _hostfile_is_local_only(self, hf) -> bool:
         """True when every host in the hostfile is this machine (or hostfile
@@ -259,7 +710,7 @@ class Pipeline:
         hostfiles contain remote hostnames and return False."""
         if not hf or len(hf) == 0:
             return True
-        local_names = {'localhost', '127.0.0.1', socket.gethostname()}
+        local_names = {"localhost", "127.0.0.1", socket.gethostname()}
         return all(h in local_names for h in hf.hosts)
 
     def is_containerized(self) -> bool:
@@ -277,7 +728,7 @@ class Pipeline:
         :return: True if at least one package uses container deployment
         """
         for pkg_def in self.packages:
-            if pkg_def.get('config', {}).get('deploy_mode') == 'container':
+            if pkg_def.get("config", {}).get("deploy_mode") == "container":
                 return True
         return False
 
@@ -294,6 +745,7 @@ class Pipeline:
         otherwise aborts with an OpenSSL version mismatch.
         """
         from ..shell.exec_info import ExecInfo
+
         ExecInfo.set_launcher_defaults(
             ssh_cmd=self.ssh_cmd,
             pssh_cmd=self.pssh_cmd,
@@ -307,17 +759,17 @@ class Pipeline:
         (e.g. a host-side FUSE/runtime alongside containerized workload
         pkgs).
         """
-        if self.base_deploy_mode == 'container':
-            deploy_mode = 'container'
+        if self.base_deploy_mode == "container":
+            deploy_mode = "container"
         else:
-            deploy_mode = 'default'
+            deploy_mode = "default"
 
         for pkg_def in self.packages:
-            cfg = pkg_def.setdefault('config', {})
-            cfg.setdefault('deploy_mode', deploy_mode)
+            cfg = pkg_def.setdefault("config", {})
+            cfg.setdefault("deploy_mode", deploy_mode)
         for idef in self.interceptors.values():
-            cfg = idef.setdefault('config', {})
-            cfg.setdefault('deploy_mode', deploy_mode)
+            cfg = idef.setdefault("config", {})
+            cfg.setdefault("deploy_mode", deploy_mode)
 
     def create(self, pipeline_name: str):
         """
@@ -354,11 +806,11 @@ class Pipeline:
         print(f"Config directory: {pipeline_config_dir}")
         print(f"Shared directory: {pipeline_shared_dir}")
         print(f"Private directory: {pipeline_private_dir}")
-        
+
     def load(self, load_type: str = None, pipeline_file: str = None):
         """
         Load pipeline from file or current configuration.
-        
+
         :param load_type: Type of pipeline file (e.g., 'yaml')
         :param pipeline_file: Path to pipeline file
         """
@@ -368,7 +820,7 @@ class Pipeline:
             self._load_from_config()
         else:
             raise ValueError("No pipeline name or file specified")
-    
+
     def save(self):
         """
         Save pipeline configuration and environment to separate files.
@@ -380,60 +832,59 @@ class Pipeline:
         if not self.name:
             raise ValueError("Pipeline name not set")
 
-        pipeline_dir = self.jarvis.get_pipeline_dir(self.name)
+        pipeline_dir = self._pipeline_storage_dir()
         pipeline_dir.mkdir(parents=True, exist_ok=True)
 
         # Create pipeline configuration in the SAME format as pipeline scripts
         # This allows code reuse by using the same parsing logic
-        pipeline_config = {
-            'name': self.name,
-            'pkgs': [],
-            'interceptors': []
-        }
+        pipeline_config = {"name": self.name, "pkgs": [], "interceptors": []}
 
         # Add metadata fields
         if self.created_at:
-            pipeline_config['created_at'] = self.created_at
+            pipeline_config["created_at"] = self.created_at
         if self.last_loaded_file:
-            pipeline_config['last_loaded_file'] = self.last_loaded_file
+            pipeline_config["last_loaded_file"] = self.last_loaded_file
         if self.last_submission:
-            pipeline_config['last_submission'] = self.last_submission
+            pipeline_config["last_submission"] = self.last_submission
         # Add container parameters (always save, even if empty/default)
-        pipeline_config['container_image'] = self.container_image
-        pipeline_config['container_uri'] = self.container_uri
-        pipeline_config['container_engine'] = self.container_engine
-        pipeline_config['container_base'] = self.container_base
-        pipeline_config['container_ssh_port'] = self.container_ssh_port
+        pipeline_config["container_image"] = self.container_image
+        pipeline_config["container_uri"] = self.container_uri
+        pipeline_config["container_engine"] = self.container_engine
+        pipeline_config["container_base"] = self.container_base
+        pipeline_config["container_ssh_port"] = self.container_ssh_port
         if self.container_extensions:
-            pipeline_config['container_extensions'] = self.container_extensions
+            pipeline_config["container_extensions"] = self.container_extensions
         if self.container_env:
-            pipeline_config['container_env'] = self.container_env
+            pipeline_config["container_env"] = self.container_env
         if self.container_host_path:
-            pipeline_config['container_host_path'] = self.container_host_path
+            pipeline_config["container_host_path"] = self.container_host_path
         if self.container_workspace:
-            pipeline_config['container_workspace'] = self.container_workspace
+            pipeline_config["container_workspace"] = self.container_workspace
         if self.container_caps:
-            pipeline_config['container_caps'] = self.container_caps
+            pipeline_config["container_caps"] = self.container_caps
         if self.container_binds:
-            pipeline_config['container_binds'] = self.container_binds
+            pipeline_config["container_binds"] = self.container_binds
+        pipeline_config["container_gpu"] = bool(self.container_gpu)
+        if self.tmp_bind_root:
+            pipeline_config["tmp_bind_root"] = self.tmp_bind_root
 
         # Add base_deploy_mode (default deploy_mode propagated to pkgs).
         if self.base_deploy_mode:
-            pipeline_config['base_deploy_mode'] = self.base_deploy_mode
+            pipeline_config["base_deploy_mode"] = self.base_deploy_mode
 
         # Persist launcher overrides so reloads round-trip and
         # downstream `ppl run` invocations see the same launcher even
         # without re-reading the original YAML.
         if self.ssh_cmd:
-            pipeline_config['ssh_cmd'] = self.ssh_cmd
+            pipeline_config["ssh_cmd"] = self.ssh_cmd
         if self.pssh_cmd:
-            pipeline_config['pssh_cmd'] = self.pssh_cmd
+            pipeline_config["pssh_cmd"] = self.pssh_cmd
         if self.mpi_cmd:
-            pipeline_config['mpi_cmd'] = self.mpi_cmd
+            pipeline_config["mpi_cmd"] = self.mpi_cmd
 
         # Persist scheduler block so reloads (and ``ppl print``) round-trip
         if self.scheduler:
-            pipeline_config['scheduler'] = self.scheduler
+            pipeline_config["scheduler"] = self.scheduler
 
         # Add hostfile parameter. The effective hostfile (pipeline override
         # if set, else the global jarvis hostfile) is always persisted to
@@ -444,89 +895,102 @@ class Pipeline:
         # hostfile from the allocation at run time; we must not preempt it
         # with a stub here. The scheduler block carries the path itself.
         if self.scheduler:
-            pipeline_config['hostfile'] = None
+            pipeline_config["hostfile"] = None
         else:
             effective_hostfile = self.hostfile or self.jarvis.hostfile
             if effective_hostfile and effective_hostfile.path:
-                shared_dir = self.jarvis.get_pipeline_shared_dir(self.name)
+                shared_dir = self.get_pipeline_shared_dir()
                 shared_dir.mkdir(parents=True, exist_ok=True)
-                hostfile_shared_path = str(shared_dir / 'hostfile')
+                hostfile_shared_path = str(shared_dir / "hostfile")
                 effective_hostfile.save(hostfile_shared_path)
-                pipeline_config['hostfile'] = hostfile_shared_path
+                pipeline_config["hostfile"] = hostfile_shared_path
             else:
-                pipeline_config['hostfile'] = None
+                pipeline_config["hostfile"] = None
 
         # Convert packages to script format (pkg_type + config parameters)
         for pkg in self.packages:
-            pkg_entry = {
-                'pkg_type': pkg['pkg_type']
-            }
+            pkg_entry = {"pkg_type": pkg["pkg_type"]}
             # Add pkg_name if different from pkg_type
-            if pkg['pkg_id'] != pkg['pkg_name']:
-                pkg_entry['pkg_name'] = pkg['pkg_id']
+            if pkg["pkg_id"] != pkg["pkg_name"]:
+                pkg_entry["pkg_name"] = pkg["pkg_id"]
 
             # Add all config parameters except internal ones
-            config = pkg.get('config', {})
+            config = pkg.get("config", {})
             for key, value in config.items():
                 pkg_entry[key] = value
 
-            pipeline_config['pkgs'].append(pkg_entry)
+            pipeline_config["pkgs"].append(pkg_entry)
 
         # Convert interceptors to script format
         for interceptor_id, interceptor_def in self.interceptors.items():
-            interceptor_entry = {
-                'pkg_type': interceptor_def['pkg_type']
-            }
+            interceptor_entry = {"pkg_type": interceptor_def["pkg_type"]}
             # Add pkg_name if different from pkg_type
-            if interceptor_id != interceptor_def['pkg_name']:
-                interceptor_entry['pkg_name'] = interceptor_id
+            if interceptor_id != interceptor_def["pkg_name"]:
+                interceptor_entry["pkg_name"] = interceptor_id
 
             # Add all config parameters
-            config = interceptor_def.get('config', {})
+            config = interceptor_def.get("config", {})
             for key, value in config.items():
                 interceptor_entry[key] = value
 
-            pipeline_config['interceptors'].append(interceptor_entry)
+            pipeline_config["interceptors"].append(interceptor_entry)
 
         # Save pipeline configuration (same format as pipeline scripts)
-        config_file = pipeline_dir / 'pipeline.yaml'
-        with open(config_file, 'w') as f:
-            yaml.dump(pipeline_config, f, default_flow_style=False)
+        config_file = pipeline_dir / "pipeline.yaml"
+        _atomic_yaml_dump(config_file, pipeline_config)
 
         # Save environment to separate file
-        env_file = pipeline_dir / 'environment.yaml'
-        with open(env_file, 'w') as f:
-            yaml.dump(self.env, f, default_flow_style=False)
-    
+        env_file = pipeline_dir / "environment.yaml"
+        _atomic_yaml_dump(env_file, self.env)
+
     def destroy(self, pipeline_name: str = None):
         """
         Destroy a pipeline by removing its directory and configuration.
         If no pipeline name is provided, destroy the current pipeline.
-        
+
         :param pipeline_name: Name of pipeline to destroy (optional)
         """
+        if getattr(self, "_execution_root", None) is not None:
+            raise RuntimeError(
+                "cannot destroy a named pipeline from a runtime snapshot"
+            )
+
         # Determine which pipeline to destroy
         if pipeline_name is None:
             if not self.name:
                 current_pipeline = self.jarvis.get_current_pipeline()
                 if not current_pipeline:
-                    print("No current pipeline to destroy. Specify a pipeline name or create/switch to one first.")
+                    print(
+                        "No current pipeline to destroy. Specify a pipeline name or create/switch to one first."
+                    )
                     return
                 pipeline_name = current_pipeline
             else:
                 pipeline_name = self.name
-                
+
         target_pipeline_dir = self.jarvis.get_pipeline_dir(pipeline_name)
+        executions_dir = (
+            self.jarvis.get_pipeline_shared_dir(pipeline_name) / "executions"
+        )
+        if executions_dir.exists():
+            status = executions_dir.lstat()
+            if not stat.S_ISDIR(status.st_mode) or stat.S_ISLNK(status.st_mode):
+                raise RuntimeError("pipeline executions path is not a real directory")
+            if any(executions_dir.iterdir()):
+                raise RuntimeError(
+                    f"Pipeline '{pipeline_name}' still owns execution snapshots; "
+                    "clean exact terminal execution IDs explicitly before destroy"
+                )
         current_pipeline = self.jarvis.get_current_pipeline()
-        is_current = (pipeline_name == current_pipeline)
-        
+        is_current = pipeline_name == current_pipeline
+
         # Check if pipeline exists
         if not target_pipeline_dir.exists():
             print(f"Pipeline '{pipeline_name}' not found.")
             return
-        
+
         # Try to clean packages first if pipeline is loadable
-        config_file = target_pipeline_dir / 'pipeline.yaml'
+        config_file = target_pipeline_dir / "pipeline.yaml"
         if config_file.exists():
             try:
                 # Load and clean pipeline
@@ -535,23 +999,24 @@ class Pipeline:
                 temp_pipeline.clean()
             except Exception as e:
                 print(f"Warning: Could not clean packages before destruction: {e}")
-        
+
         # Remove pipeline directory
         import shutil
+
         try:
             shutil.rmtree(target_pipeline_dir)
             print(f"Destroyed pipeline: {pipeline_name}")
-            
+
             # Clear current pipeline if we destroyed it
             if is_current:
                 config = self.jarvis.config.copy()
-                config['current_pipeline'] = None
+                config["current_pipeline"] = None
                 self.jarvis.save_config(config)
                 print("Cleared current pipeline (destroyed pipeline was active)")
-                
+
         except Exception as e:
             print(f"Error destroying pipeline directory: {e}")
-    
+
     def start(self):
         """Start all packages in the pipeline"""
         from jarvis_cd.util.logger import logger
@@ -577,10 +1042,12 @@ class Pipeline:
                     # Apply interceptors to this package before starting
                     self._apply_interceptors_to_package(pkg_instance, pkg_def)
 
-                    if hasattr(pkg_instance, 'start'):
+                    if hasattr(pkg_instance, "start"):
                         pkg_instance.start()
                     else:
-                        logger.warning(f"Package {pkg_def['pkg_id']} has no start method")
+                        logger.warning(
+                            f"Package {pkg_def['pkg_id']} has no start method"
+                        )
 
                     # Propagate environment changes to next packages
                     self.env.update(pkg_instance.env)
@@ -593,8 +1060,10 @@ class Pipeline:
 
                 except Exception as e:
                     logger.error(f"Error starting package {pkg_def['pkg_id']}: {e}")
-                    raise RuntimeError(f"Pipeline startup failed at package '{pkg_def['pkg_id']}': {e}") from e
-    
+                    raise RuntimeError(
+                        f"Pipeline startup failed at package '{pkg_def['pkg_id']}': {e}"
+                    ) from e
+
     def stop(self):
         """Stop all packages in the pipeline"""
         from jarvis_cd.util.logger import logger
@@ -614,17 +1083,19 @@ class Pipeline:
 
                     pkg_instance = self._load_package_instance(pkg_def, self.env)
 
-                    if hasattr(pkg_instance, 'stop'):
+                    if hasattr(pkg_instance, "stop"):
                         pkg_instance.stop()
                     else:
-                        logger.warning(f"Package {pkg_def['pkg_id']} has no stop method")
+                        logger.warning(
+                            f"Package {pkg_def['pkg_id']} has no stop method"
+                        )
 
                     # Print END message
                     logger.success(f"[{pkg_def['pkg_type']}] [STOP] END")
 
                 except Exception as e:
                     logger.error(f"Error stopping package {pkg_def['pkg_id']}: {e}")
-    
+
     def kill(self):
         """Force kill all packages in the pipeline"""
         from jarvis_cd.util.logger import logger
@@ -644,20 +1115,22 @@ class Pipeline:
 
                     pkg_instance = self._load_package_instance(pkg_def, self.env)
 
-                    if hasattr(pkg_instance, 'kill'):
+                    if hasattr(pkg_instance, "kill"):
                         pkg_instance.kill()
                     else:
-                        logger.warning(f"Package {pkg_def['pkg_id']} has no kill method")
+                        logger.warning(
+                            f"Package {pkg_def['pkg_id']} has no kill method"
+                        )
 
                     # Print END message
                     logger.success(f"[{pkg_def['pkg_type']}] [KILL] END")
 
                 except Exception as e:
                     logger.error(f"Error killing package {pkg_def['pkg_id']}: {e}")
-    
+
     def status(self) -> str:
         """Get status of the pipeline and its packages"""
-        from jarvis_cd.util.logger import logger, Color
+        from jarvis_cd.util.logger import logger
 
         if not self.name:
             return "No pipeline loaded"
@@ -673,7 +1146,7 @@ class Pipeline:
 
                 pkg_instance = self._load_package_instance(pkg_def, self.env)
 
-                if pkg_instance and hasattr(pkg_instance, 'status'):
+                if pkg_instance and hasattr(pkg_instance, "status"):
                     pkg_status = pkg_instance.status()
                     status_info.append(f"  {pkg_def['pkg_id']}: {pkg_status}")
                 else:
@@ -686,7 +1159,7 @@ class Pipeline:
                 status_info.append(f"  {pkg_def['pkg_id']}: error ({e})")
 
         return "\n".join(status_info)
-    
+
     def run(self, load_type: Optional[str] = None, pipeline_file: Optional[str] = None):
         """
         Run the pipeline (start all packages, then stop them).
@@ -754,22 +1227,22 @@ class Pipeline:
         :param pkg_def: Package definition dictionary
         :param pkg_type_label: Label for logging ("package" or "interceptor")
         """
-        from jarvis_cd.util.logger import logger, Color
+        from jarvis_cd.util.logger import logger
 
         try:
             # Print BEGIN message
             logger.success(f"[{pkg_def['pkg_type']}] [CONFIGURE] BEGIN")
 
             pkg_instance = self._load_package_instance(pkg_def, self.env)
-            if hasattr(pkg_instance, 'configure'):
+            if hasattr(pkg_instance, "configure"):
                 # Configure the package with its config
                 updated_config = pkg_instance.configure(**pkg_instance.config)
 
                 # Update pkg_def with the final config from the package
                 if updated_config:
-                    pkg_def['config'] = updated_config
+                    pkg_def["config"] = updated_config
                 else:
-                    pkg_def['config'] = pkg_instance.config.copy()
+                    pkg_def["config"] = pkg_instance.config.copy()
 
                 # Update the package environment in the pipeline's env
                 self.env.update(pkg_instance.env)
@@ -779,12 +1252,18 @@ class Pipeline:
 
         except Exception as e:
             import traceback
+
             logger.error(f"Error configuring {pkg_type_label} {pkg_def['pkg_id']}: {e}")
             logger.error("Full traceback:")
             traceback.print_exc()
             raise
-    
-    def append(self, package_spec: str, package_alias: Optional[str] = None, config_args: Optional[List[str]] = None):
+
+    def append(
+        self,
+        package_spec: str,
+        package_alias: Optional[str] = None,
+        config_args: Optional[List[str]] = None,
+    ):
         """
         Append a package to the pipeline.
 
@@ -794,10 +1273,10 @@ class Pipeline:
         """
         if not self.name:
             raise ValueError("No pipeline loaded. Create one with create() first")
-            
+
         # Parse package specification
-        if '.' in package_spec:
-            repo_name, pkg_name = package_spec.split('.', 1)
+        if "." in package_spec:
+            repo_name, pkg_name = package_spec.split(".", 1)
         else:
             # Try to find package in available repos
             pkg_name = package_spec
@@ -805,28 +1284,28 @@ class Pipeline:
             if not full_spec:
                 raise ValueError(f"Package not found: {pkg_name}")
             package_spec = full_spec
-            
+
         # Determine package ID
         if package_alias:
             pkg_id = package_alias
         else:
             pkg_id = pkg_name
-            
+
         # Check for duplicate package IDs
-        existing_ids = [pkg['pkg_id'] for pkg in self.packages]
+        existing_ids = [pkg["pkg_id"] for pkg in self.packages]
         if pkg_id in existing_ids:
             raise ValueError(f"Package ID already exists in pipeline: {pkg_id}")
-            
+
         # Get default configuration from package
         default_config = self._get_package_default_config(package_spec)
 
         # Build the package entry (needed for loading package instance)
         package_entry = {
-            'pkg_type': package_spec,
-            'pkg_id': pkg_id,
-            'pkg_name': pkg_name,
-            'global_id': f"{self.name}.{pkg_id}",
-            'config': default_config
+            "pkg_type": package_spec,
+            "pkg_id": pkg_id,
+            "pkg_name": pkg_name,
+            "global_id": f"{self.name}.{pkg_id}",
+            "config": default_config,
         }
 
         # Apply configuration arguments if provided (before validation)
@@ -838,19 +1317,19 @@ class Pipeline:
                 # Use PkgArgParse to parse and convert arguments
                 argparse = pkg_instance.get_argparse()
                 # Parse arguments - prepend 'configure' command
-                argparse.parse(['configure'] + config_args)
+                argparse.parse(["configure"] + config_args)
                 converted_args = argparse.kwargs
 
                 # Update package configuration with converted values
-                package_entry['config'].update(converted_args)
+                package_entry["config"].update(converted_args)
             except Exception as e:
                 print(f"Warning: Error parsing configuration arguments: {e}")
                 # Show available configuration options
                 argparse = pkg_instance.get_argparse()
-                argparse.print_help('configure')
+                argparse.print_help("configure")
 
         # Validate that all required parameters have values (after applying config_args)
-        self._validate_required_config(package_spec, package_entry['config'])
+        self._validate_required_config(package_spec, package_entry["config"])
 
         # Add package to pipeline
         self.packages.append(package_entry)
@@ -859,40 +1338,42 @@ class Pipeline:
         self.save()
 
         print(f"Added package {package_spec} as {pkg_id} to pipeline")
-    
+
     def rm(self, package_spec: str):
         """
         Remove a package from the pipeline.
-        
+
         :param package_spec: Package specification to remove (pkg_id)
         """
         # Find and remove the package
         package_found = False
-        
+
         for i, pkg_def in enumerate(self.packages):
-            if pkg_def['pkg_id'] == package_spec:
+            if pkg_def["pkg_id"] == package_spec:
                 removed_package = self.packages.pop(i)
                 package_found = True
                 break
-                
+
         if not package_found:
             # List available packages to help the user
-            available_ids = [pkg['pkg_id'] for pkg in self.packages]
+            available_ids = [pkg["pkg_id"] for pkg in self.packages]
             if available_ids:
                 print(f"Package '{package_spec}' not found in pipeline.")
                 print(f"Available packages: {', '.join(available_ids)}")
             else:
                 print("No packages in pipeline.")
             return
-            
+
         # Save updated configuration
         self.save()
-            
-        print(f"Removed package '{removed_package['pkg_id']}' ({removed_package['pkg_type']}) from pipeline '{self.name}'")
-    
+
+        print(
+            f"Removed package '{removed_package['pkg_id']}' ({removed_package['pkg_type']}) from pipeline '{self.name}'"
+        )
+
     def clean(self):
         """Clean all data for packages in the pipeline"""
-        from jarvis_cd.util.logger import logger, Color
+        from jarvis_cd.util.logger import logger
 
         logger.pipeline(f"Cleaning pipeline: {self.name}")
 
@@ -904,7 +1385,7 @@ class Pipeline:
 
                 pkg_instance = self._load_package_instance(pkg_def, self.env)
 
-                if hasattr(pkg_instance, 'clean'):
+                if hasattr(pkg_instance, "clean"):
                     pkg_instance.clean()
                 else:
                     logger.warning(f"Package {pkg_def['pkg_id']} has no clean method")
@@ -914,7 +1395,7 @@ class Pipeline:
 
             except Exception as e:
                 logger.error(f"Error cleaning package {pkg_def['pkg_id']}: {e}")
-    
+
     def configure_package(self, pkg_id: str, config_args: List[str]):
         """
         Configure a specific package in the pipeline.
@@ -925,7 +1406,7 @@ class Pipeline:
         # Find package in pipeline
         pkg_def = None
         for pkg in self.packages:
-            if pkg['pkg_id'] == pkg_id:
+            if pkg["pkg_id"] == pkg_id:
                 pkg_def = pkg
                 break
 
@@ -940,22 +1421,25 @@ class Pipeline:
             argparse = pkg_instance.get_argparse()
 
             # Get defaults by parsing with no user args
-            argparse.parse(['configure'])
+            argparse.parse(["configure"])
             defaults = argparse.kwargs.copy()
 
             # Parse with user args
-            argparse.parse(['configure'] + config_args)
+            argparse.parse(["configure"] + config_args)
             converted_args = argparse.kwargs
 
             # Only keep args the user explicitly provided (differ from defaults)
-            explicit_args = {k: v for k, v in converted_args.items()
-                            if k not in defaults or defaults[k] != v}
+            explicit_args = {
+                k: v
+                for k, v in converted_args.items()
+                if k not in defaults or defaults[k] != v
+            }
 
             # Update package configuration with only explicit values
-            pkg_def['config'].update(explicit_args)
+            pkg_def["config"].update(explicit_args)
 
             # Configure the package instance
-            if hasattr(pkg_instance, 'configure'):
+            if hasattr(pkg_instance, "configure"):
                 pkg_instance.configure(**explicit_args)
                 print(f"Configured package {pkg_id} successfully")
             else:
@@ -969,34 +1453,34 @@ class Pipeline:
             print(f"Error configuring package {pkg_id}: {e}")
             # Show available configuration options
             argparse = pkg_instance.get_argparse()
-            argparse.print_help('configure')
-    
+            argparse.print_help("configure")
+
     def show_package_readme(self, pkg_id: str):
         """
         Show README for a specific package in the pipeline.
-        
+
         :param pkg_id: Package ID to show README for
         """
         # Find package in pipeline
         pkg_def = None
         for pkg in self.packages:
-            if pkg['pkg_id'] == pkg_id:
+            if pkg["pkg_id"] == pkg_id:
                 pkg_def = pkg
                 break
-                
+
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
-        
+
         # Load package instance and delegate to it
         try:
             pkg_instance = self._load_package_instance(pkg_def, self.env)
             pkg_instance.show_readme()
         except Exception as e:
             print(f"Error showing README for package {pkg_id}: {e}")
-    
+
     def show_package_build_script(self, pkg_id: str):
         """Print the build.sh script for a package within this pipeline."""
-        pkg_def = next((p for p in self.packages if p['pkg_id'] == pkg_id), None)
+        pkg_def = next((p for p in self.packages if p["pkg_id"] == pkg_id), None)
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
         try:
@@ -1007,7 +1491,7 @@ class Pipeline:
 
     def show_package_deploy_dockerfile(self, pkg_id: str):
         """Print Dockerfile.deploy for a package within this pipeline."""
-        pkg_def = next((p for p in self.packages if p['pkg_id'] == pkg_id), None)
+        pkg_def = next((p for p in self.packages if p["pkg_id"] == pkg_id), None)
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
         try:
@@ -1019,27 +1503,27 @@ class Pipeline:
     def show_package_paths(self, pkg_id: str, path_flags: Dict[str, bool]):
         """
         Show directory paths for a specific package in the pipeline.
-        
+
         :param pkg_id: Package ID to show paths for
         :param path_flags: Dictionary of path flags to show
         """
         # Find package in pipeline
         pkg_def = None
         for pkg in self.packages:
-            if pkg['pkg_id'] == pkg_id:
+            if pkg["pkg_id"] == pkg_id:
                 pkg_def = pkg
                 break
-                
+
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
-        
+
         # Load package instance and delegate to it
         try:
             pkg_instance = self._load_package_instance(pkg_def, self.env)
             pkg_instance.show_paths(path_flags)
         except Exception as e:
             print(f"Error showing paths for package {pkg_id}: {e}")
-    
+
     def _load_from_config(self):
         """
         Load pipeline from its configuration files.
@@ -1049,50 +1533,60 @@ class Pipeline:
         - environment.yaml: Contains environment variables only
         """
         pipeline_dir = self.jarvis.get_pipeline_dir(self.name)
-        config_file = pipeline_dir / 'pipeline.yaml'
+        config_file = pipeline_dir / "pipeline.yaml"
 
         if not config_file.exists():
             raise FileNotFoundError(f"Pipeline configuration not found: {config_file}")
 
         # Load pipeline configuration (in script format)
-        with open(config_file, 'r') as f:
+        with open(config_file, "r") as f:
             pipeline_config = yaml.safe_load(f)
 
         # Extract metadata
-        self.created_at = pipeline_config.get('created_at')
-        self.last_loaded_file = pipeline_config.get('last_loaded_file')
-        self.last_submission = pipeline_config.get('last_submission')
+        self.created_at = pipeline_config.get("created_at")
+        self.last_loaded_file = pipeline_config.get("last_loaded_file")
+        self.last_submission = pipeline_config.get("last_submission")
 
         # Load container parameters
-        self.container_image = pipeline_config.get('container_image', '')
-        self.container_uri = pipeline_config.get('container_uri', '')
-        self.container_engine = pipeline_config.get('container_engine', 'podman')
-        self.container_base = pipeline_config.get('container_base', 'iowarp/iowarp-build:latest')
-        self.container_ssh_port = pipeline_config.get('container_ssh_port', 2222)
-        self.container_extensions = pipeline_config.get('container_extensions', {})
-        self.container_env = pipeline_config.get('container_env', {})
-        self.container_host_path = pipeline_config.get('container_host_path', '')
-        self.container_workspace = pipeline_config.get('container_workspace', '')
-        self.container_caps = pipeline_config.get('container_caps', [])
+        self.container_image = pipeline_config.get("container_image", "")
+        self.container_uri = pipeline_config.get("container_uri", "")
+        self.container_engine = pipeline_config.get("container_engine", "podman")
+        self.container_base = pipeline_config.get(
+            "container_base", "iowarp/iowarp-build:latest"
+        )
+        self.container_ssh_port = pipeline_config.get("container_ssh_port", 2222)
+        self.container_extensions = pipeline_config.get("container_extensions", {})
+        self.container_env = pipeline_config.get("container_env", {})
+        self.container_host_path = pipeline_config.get("container_host_path", "")
+        self.container_workspace = pipeline_config.get("container_workspace", "")
+        self.container_caps = pipeline_config.get("container_caps", [])
         self.container_binds = Pipeline._expand_env_in_config(
-            pipeline_config.get('container_binds', []) or [])
+            pipeline_config.get("container_binds", []) or []
+        )
+        self.container_gpu = bool(pipeline_config.get("container_gpu", False))
+        tmp_bind_root_raw = pipeline_config.get("tmp_bind_root")
+        self.tmp_bind_root = (
+            os.path.expandvars(tmp_bind_root_raw)
+            if isinstance(tmp_bind_root_raw, str) and tmp_bind_root_raw
+            else None
+        )
 
         # Launcher overrides (top-level YAML keys). None = use built-in
         # defaults (ssh / pssh / mpiexec). Typical override pattern:
         #   ssh_cmd: "env -u LD_LIBRARY_PATH ssh"
         # Wrapping ssh in env -u keeps a conda env's libcrypto out of
         # the host openssh, which otherwise dies on an ABI mismatch.
-        self.ssh_cmd = pipeline_config.get('ssh_cmd', None)
-        self.pssh_cmd = pipeline_config.get('pssh_cmd', None)
-        self.mpi_cmd = pipeline_config.get('mpi_cmd', None)
+        self.ssh_cmd = pipeline_config.get("ssh_cmd", None)
+        self.pssh_cmd = pipeline_config.get("pssh_cmd", None)
+        self.mpi_cmd = pipeline_config.get("mpi_cmd", None)
         self._apply_launcher_overrides()
 
         # Load base_deploy_mode. The legacy ``install_manager`` key is
         # still read once with a deprecation warning so saved pipelines
         # from before the rename keep loading.
-        self.base_deploy_mode = pipeline_config.get('base_deploy_mode', None)
-        if self.base_deploy_mode is None and 'install_manager' in pipeline_config:
-            self.base_deploy_mode = pipeline_config['install_manager']
+        self.base_deploy_mode = pipeline_config.get("base_deploy_mode", None)
+        if self.base_deploy_mode is None and "install_manager" in pipeline_config:
+            self.base_deploy_mode = pipeline_config["install_manager"]
             print(
                 "Warning: 'install_manager' is deprecated; "
                 "rename to 'base_deploy_mode' (per-package "
@@ -1100,7 +1594,7 @@ class Pipeline:
             )
 
         # Load hostfile parameter (None means use global jarvis hostfile)
-        hostfile_path = pipeline_config.get('hostfile')
+        hostfile_path = pipeline_config.get("hostfile")
         if hostfile_path:
             self.hostfile = Hostfile(path=os.path.expandvars(hostfile_path))
         else:
@@ -1109,7 +1603,7 @@ class Pipeline:
         # Load scheduler spec (mirrors _load_from_file). The hostfile
         # override is re-applied so reloading a saved pipeline keeps the
         # same scheduler-aware hostfile path.
-        scheduler_spec = pipeline_config.get('scheduler')
+        scheduler_spec = pipeline_config.get("scheduler")
         if scheduler_spec:
             self.scheduler = self._expand_env_in_config(dict(scheduler_spec))
             self._apply_scheduler_hostfile()
@@ -1121,22 +1615,26 @@ class Pipeline:
         self.interceptors = {}
 
         # Process interceptors from script format
-        interceptors_list = pipeline_config.get('interceptors', [])
+        interceptors_list = pipeline_config.get("interceptors", [])
         for interceptor_def in interceptors_list:
-            interceptor_id = interceptor_def.get('pkg_name', interceptor_def['pkg_type'].split('.')[-1])
-            interceptor_entry = self._process_package_definition(interceptor_def, interceptor_id)
+            interceptor_id = interceptor_def.get(
+                "pkg_name", interceptor_def["pkg_type"].split(".")[-1]
+            )
+            interceptor_entry = self._process_package_definition(
+                interceptor_def, interceptor_id
+            )
             self.interceptors[interceptor_id] = interceptor_entry
 
         # Process packages from script format
-        for pkg_def in pipeline_config.get('pkgs', []):
-            pkg_id = pkg_def.get('pkg_name', pkg_def['pkg_type'].split('.')[-1])
+        for pkg_def in pipeline_config.get("pkgs", []):
+            pkg_id = pkg_def.get("pkg_name", pkg_def["pkg_type"].split(".")[-1])
             package_entry = self._process_package_definition(pkg_def, pkg_id)
             self.packages.append(package_entry)
 
         # Load environment from separate file
-        env_file = pipeline_dir / 'environment.yaml'
+        env_file = pipeline_dir / "environment.yaml"
         if env_file.exists():
-            with open(env_file, 'r') as f:
+            with open(env_file, "r") as f:
                 env_config = yaml.safe_load(f)
                 if env_config:
                     self.env = env_config
@@ -1144,62 +1642,133 @@ class Pipeline:
                     self.env = {}
         else:
             self.env = {}
-    
+
     def _load_from_file(self, load_type: str, pipeline_file: str):
         """Load pipeline from a file"""
-        if load_type != 'yaml':
+        if load_type != "yaml":
             raise ValueError(f"Unsupported pipeline file type: {load_type}")
-            
+
         pipeline_file = Path(pipeline_file)
         if not pipeline_file.exists():
             raise FileNotFoundError(f"Pipeline file not found: {pipeline_file}")
-            
+
+        snapshot_environment = os.getenv(_SNAPSHOT_ENVIRONMENT)
+        snapshot_env_file = None
+        snapshot_marker = None
+        if snapshot_environment:
+            try:
+                snapshot_dir = Path(snapshot_environment).resolve(strict=True)
+                resolved_pipeline_file = pipeline_file.resolve(strict=True)
+            except (OSError, RuntimeError) as exc:
+                raise ValueError(f"invalid scheduler pipeline snapshot: {exc}") from exc
+            expected_pipeline_file = snapshot_dir / "pipeline.yaml"
+            if snapshot_dir.name != "runtime" or resolved_pipeline_file != (
+                expected_pipeline_file
+            ):
+                raise ValueError(
+                    "scheduler pipeline snapshot must contain the requested pipeline.yaml"
+                )
+            snapshot_env_file = snapshot_dir / "environment.yaml"
+            try:
+                resolved_env_file = snapshot_env_file.resolve(strict=True)
+            except OSError as exc:
+                raise ValueError(
+                    f"scheduler pipeline snapshot omitted environment.yaml: {exc}"
+                ) from exc
+            if (
+                resolved_env_file != snapshot_env_file
+                or not snapshot_env_file.is_file()
+            ):
+                raise ValueError("scheduler pipeline snapshot omitted environment.yaml")
+            try:
+                snapshot_marker = _read_execution_marker(snapshot_dir.parent)
+            except (OSError, RuntimeError, ValueError) as exc:
+                raise ValueError(f"invalid scheduler execution root: {exc}") from exc
+            self._execution_snapshot_dir = snapshot_dir
+            self._execution_root = snapshot_dir.parent
+            self._execution_id = snapshot_marker["execution_id"]
+
         # Load pipeline definition
-        with open(pipeline_file, 'r') as f:
+        with open(pipeline_file, "r") as f:
             pipeline_def = yaml.safe_load(f)
-            
-        self.name = pipeline_def.get('name', pipeline_file.stem)
-        
+
+        self.name = pipeline_def.get("name", pipeline_file.stem)
+        if (
+            snapshot_marker is not None
+            and snapshot_marker["pipeline_name"] != self.name
+        ):
+            raise ValueError("scheduler execution marker did not match pipeline name")
+
         # Handle environment - can be a string (named env) or missing (auto-build)
         # Inline dictionaries are NOT supported
-        env_field = pipeline_def.get('env')
+        env_field = pipeline_def.get("env")
 
-        if env_field is None:
+        if snapshot_env_file is not None:
+            try:
+                with snapshot_env_file.open("r", encoding="utf-8") as stream:
+                    snapshot_env = yaml.safe_load(stream)
+            except (OSError, yaml.YAMLError) as exc:
+                raise ValueError(
+                    f"could not read scheduler environment snapshot: {exc}"
+                ) from exc
+            if not isinstance(snapshot_env, dict) or not all(
+                isinstance(name, str) and isinstance(value, str)
+                for name, value in snapshot_env.items()
+            ):
+                raise ValueError(
+                    "scheduler environment snapshot is not a string mapping"
+                )
+            self.env = dict(snapshot_env)
+        elif env_field is None:
             # No env field defined - automatically build environment
             try:
                 from jarvis_cd.core.environment import EnvironmentManager
+
                 env_manager = EnvironmentManager(self.jarvis)
                 self.env = env_manager._capture_current_environment()
-                print(f"Auto-built environment with {len(self.env)} variables (no 'env' field in pipeline)")
+                print(
+                    f"Auto-built environment with {len(self.env)} variables (no 'env' field in pipeline)"
+                )
             except Exception as e:
                 print(f"Warning: Could not auto-build environment: {e}")
                 self.env = {}
         elif isinstance(env_field, str):
             # Reference to named environment (deprecated)
-            print(f"Warning: String env references are deprecated. Use inline dict overrides instead.")
+            print(
+                "Warning: String env references are deprecated. Use inline dict overrides instead."
+            )
             env_name = env_field
             try:
                 from jarvis_cd.core.environment import EnvironmentManager
+
                 env_manager = EnvironmentManager(self.jarvis)
                 self.env = env_manager.load_named_environment(env_name)
-            except Exception as e:
+            except Exception:
                 # Named environment doesn't exist - build it automatically
-                print(f"Named environment '{env_name}' does not exist. Building it now...")
+                print(
+                    f"Named environment '{env_name}' does not exist. Building it now..."
+                )
                 try:
                     from jarvis_cd.core.environment import EnvironmentManager
+
                     env_manager = EnvironmentManager(self.jarvis)
                     # Build the named environment from current environment (no additional args)
                     env_manager.build_named_environment(env_name, [])
                     # Now load the newly created environment
                     self.env = env_manager.load_named_environment(env_name)
-                    print(f"Built named environment '{env_name}' with {len(self.env)} variables")
+                    print(
+                        f"Built named environment '{env_name}' with {len(self.env)} variables"
+                    )
                 except Exception as build_error:
-                    print(f"Warning: Could not build named environment '{env_name}': {build_error}")
+                    print(
+                        f"Warning: Could not build named environment '{env_name}': {build_error}"
+                    )
                     self.env = {}
         elif isinstance(env_field, dict):
             # Inline dict: auto-capture environment, then overlay user overrides
             try:
                 from jarvis_cd.core.environment import EnvironmentManager
+
                 env_manager = EnvironmentManager(self.jarvis)
                 self.env = env_manager._capture_current_environment()
             except Exception as e:
@@ -1207,13 +1776,15 @@ class Pipeline:
                 self.env = {}
             # Apply user overrides from YAML
             self.env.update(env_field)
-            print(f"Built environment with {len(self.env)} variables ({len(env_field)} overrides from pipeline YAML)")
+            print(
+                f"Built environment with {len(self.env)} variables ({len(env_field)} overrides from pipeline YAML)"
+            )
         else:
             raise ValueError(
                 f"Invalid 'env' field type: {type(env_field).__name__}. "
                 "The 'env' field must be either a string (named environment) or omitted (auto-build)."
             )
-        
+
         # Initialize other attributes
         self.created_at = str(Path().cwd())
         self.last_loaded_file = str(pipeline_file.absolute())
@@ -1221,24 +1792,27 @@ class Pipeline:
         self.interceptors = {}  # Store pipeline-level interceptors by name
 
         # Load container parameters
-        self.container_image = pipeline_def.get('container_image', '')
-        self.container_uri = pipeline_def.get('container_uri', '')
-        self.container_engine = pipeline_def.get('container_engine', 'podman')
-        self.container_base = pipeline_def.get('container_base', 'iowarp/iowarp-build:latest')
-        self.container_ssh_port = pipeline_def.get('container_ssh_port', 2222)
-        self.container_extensions = pipeline_def.get('container_extensions', {})
-        self.container_env = pipeline_def.get('container_env', {})
-        self.container_host_path = pipeline_def.get('container_host_path', '')
-        self.container_workspace = pipeline_def.get('container_workspace', '')
-        self.container_gpu = pipeline_def.get('container_gpu', False)
+        self.container_image = pipeline_def.get("container_image", "")
+        self.container_uri = pipeline_def.get("container_uri", "")
+        self.container_engine = pipeline_def.get("container_engine", "podman")
+        self.container_base = pipeline_def.get(
+            "container_base", "iowarp/iowarp-build:latest"
+        )
+        self.container_ssh_port = pipeline_def.get("container_ssh_port", 2222)
+        self.container_extensions = pipeline_def.get("container_extensions", {})
+        self.container_env = pipeline_def.get("container_env", {})
+        self.container_host_path = pipeline_def.get("container_host_path", "")
+        self.container_workspace = pipeline_def.get("container_workspace", "")
+        self.container_gpu = pipeline_def.get("container_gpu", False)
         # Apptainer-only: capabilities and extra bind mounts that must be
         # baked into `apptainer instance start`. Per-exec --cap-add and
         # --bind are silently ignored on a running instance, so anything
         # the workload needs (e.g., SYS_ADMIN + /dev/fuse for FUSE mounts)
         # has to be declared at the pipeline level here.
-        self.container_caps = pipeline_def.get('container_caps', [])
+        self.container_caps = pipeline_def.get("container_caps", [])
         self.container_binds = Pipeline._expand_env_in_config(
-            pipeline_def.get('container_binds', []) or [])
+            pipeline_def.get("container_binds", []) or []
+        )
 
         # Optional per-host /tmp redirect for the apptainer instance.
         # When a pipeline workload hardcodes scratch dirs under /tmp
@@ -1252,25 +1826,24 @@ class Pipeline:
         # caller must mkdir <root>/<pipeline_name>/tmp on every host
         # (use a pre_cmd, since the path is per-host and may not exist
         # yet on first run).
-        tmp_bind_root_raw = pipeline_def.get('tmp_bind_root', None)
+        tmp_bind_root_raw = pipeline_def.get("tmp_bind_root", None)
         self.tmp_bind_root = (
-            os.path.expandvars(tmp_bind_root_raw)
-            if tmp_bind_root_raw else None
+            os.path.expandvars(tmp_bind_root_raw) if tmp_bind_root_raw else None
         )
 
         # Launcher overrides (top-level YAML keys). None = use built-in
         # defaults (ssh / pssh / mpiexec). See _apply_launcher_overrides.
-        self.ssh_cmd = pipeline_def.get('ssh_cmd', None)
-        self.pssh_cmd = pipeline_def.get('pssh_cmd', None)
-        self.mpi_cmd = pipeline_def.get('mpi_cmd', None)
+        self.ssh_cmd = pipeline_def.get("ssh_cmd", None)
+        self.pssh_cmd = pipeline_def.get("pssh_cmd", None)
+        self.mpi_cmd = pipeline_def.get("mpi_cmd", None)
         self._apply_launcher_overrides()
 
         # Load base_deploy_mode. The legacy ``install_manager`` key is
         # still read once with a deprecation warning so existing YAMLs
         # keep loading after the rename.
-        self.base_deploy_mode = pipeline_def.get('base_deploy_mode', None)
-        if self.base_deploy_mode is None and 'install_manager' in pipeline_def:
-            self.base_deploy_mode = pipeline_def['install_manager']
+        self.base_deploy_mode = pipeline_def.get("base_deploy_mode", None)
+        if self.base_deploy_mode is None and "install_manager" in pipeline_def:
+            self.base_deploy_mode = pipeline_def["install_manager"]
             print(
                 "Warning: 'install_manager' is deprecated; "
                 "rename to 'base_deploy_mode' (per-package "
@@ -1278,7 +1851,7 @@ class Pipeline:
             )
 
         # Load hostfile parameter (None means use global jarvis hostfile)
-        hostfile_path = pipeline_def.get('hostfile')
+        hostfile_path = pipeline_def.get("hostfile")
         if hostfile_path:
             self.hostfile = Hostfile(path=os.path.expandvars(hostfile_path))
         else:
@@ -1288,7 +1861,7 @@ class Pipeline:
         # hostfile path — point self.hostfile at the file the generated
         # job script will write so every package in the pipeline sees
         # the same allocation-derived hosts.
-        scheduler_spec = pipeline_def.get('scheduler')
+        scheduler_spec = pipeline_def.get("scheduler")
         if scheduler_spec:
             self.scheduler = self._expand_env_in_config(dict(scheduler_spec))
             self._apply_scheduler_hostfile()
@@ -1296,18 +1869,22 @@ class Pipeline:
             self.scheduler = None
 
         # Process interceptors
-        interceptors_list = pipeline_def.get('interceptors', [])
+        interceptors_list = pipeline_def.get("interceptors", [])
         for interceptor_def in interceptors_list:
-            interceptor_id = interceptor_def.get('pkg_name', interceptor_def['pkg_type'].split('.')[-1])
-            interceptor_entry = self._process_package_definition(interceptor_def, interceptor_id)
+            interceptor_id = interceptor_def.get(
+                "pkg_name", interceptor_def["pkg_type"].split(".")[-1]
+            )
+            interceptor_entry = self._process_package_definition(
+                interceptor_def, interceptor_id
+            )
             self.interceptors[interceptor_id] = interceptor_entry
 
         # Process packages
-        for pkg_def in pipeline_def.get('pkgs', []):
-            pkg_id = pkg_def.get('pkg_name', pkg_def['pkg_type'])
+        for pkg_def in pipeline_def.get("pkgs", []):
+            pkg_id = pkg_def.get("pkg_name", pkg_def["pkg_type"].split(".")[-1])
             package_entry = self._process_package_definition(pkg_def, pkg_id)
             self.packages.append(package_entry)
-        
+
         # Validate that interceptor and package IDs are unique
         self._validate_unique_ids()
 
@@ -1318,33 +1895,37 @@ class Pipeline:
         # package's install_method (falling back to base_deploy_mode for
         # YAMLs that don't set install_method explicitly).
         from jarvis_cd.core.installer import Installer
+
         Installer.install_all(self)
 
         # Save pipeline configuration and environment
         self.save()
 
-        # Set as current pipeline
-        self.jarvis.set_current_pipeline(self.name)
+        # A scheduler snapshot is an isolated execution copy, not an operator
+        # navigation event. Never let concurrent queued jobs race on the
+        # process-global current-pipeline record.
+        if snapshot_marker is None:
+            self.jarvis.set_current_pipeline(self.name)
 
         print(f"Loaded pipeline: {self.name}")
         print(f"Packages: {[pkg['pkg_id'] for pkg in self.packages]}")
-    
-    def _load_package_instance(self, pkg_def: Dict[str, Any], pipeline_env: Optional[Dict[str, str]] = None):
+
+    def _load_package_instance(
+        self, pkg_def: Dict[str, Any], pipeline_env: Optional[Dict[str, str]] = None
+    ):
         """
         Load a package instance from package definition.
-        
+
         :param pkg_def: Package definition dictionary
         :param pipeline_env: Pipeline environment variables
         :return: Package instance
         """
-        from jarvis_cd.core.pkg import Pkg
-        
-        pkg_type = pkg_def['pkg_type']
-        
+        pkg_type = pkg_def["pkg_type"]
+
         # Find package class
-        if '.' in pkg_type:
+        if "." in pkg_type:
             # Full specification like "builtin.ior"
-            import_parts = pkg_type.split('.')
+            import_parts = pkg_type.split(".")
             repo_name = import_parts[0]
             pkg_name = import_parts[1]
         else:
@@ -1352,33 +1933,35 @@ class Pipeline:
             full_spec = self.jarvis.find_package(pkg_type)
             if not full_spec:
                 raise ValueError(f"Package not found: {pkg_type}")
-            import_parts = full_spec.split('.')
+            import_parts = full_spec.split(".")
             repo_name = import_parts[0]
             pkg_name = import_parts[1]
-            
+
         # Determine class name (convert snake_case and kebab-case to PascalCase)
         import re
-        class_name = ''.join(word.capitalize() for word in re.split(r'[_-]', pkg_name))
-        
+
+        class_name = "".join(word.capitalize() for word in re.split(r"[_-]", pkg_name))
+
         # Load class
-        if repo_name == 'builtin':
+        if repo_name == "builtin":
             repo_path = str(self.jarvis.get_builtin_repo_path())
         else:
             # Find repo path in registered repos
             repo_path = None
-            for registered_repo in self.jarvis.repos['repos']:
+            for registered_repo in self.jarvis.repos["repos"]:
                 if Path(registered_repo).name == repo_name:
                     repo_path = registered_repo
                     break
-                    
+
             if not repo_path:
                 raise ValueError(f"Repository not found: {repo_name}")
-                
+
         import_str = f"{repo_name}.{pkg_name}.pkg"
         try:
             pkg_class = load_class(import_str, repo_path, class_name)
         except Exception as e:
             import traceback
+
             error_details = traceback.format_exc()
             raise ValueError(
                 f"Failed to load package '{pkg_type}':\n"
@@ -1399,6 +1982,7 @@ class Pipeline:
             pkg_instance = pkg_class(pipeline=self)
         except Exception as e:
             import traceback
+
             error_details = traceback.format_exc()
             raise ValueError(
                 f"Failed to instantiate package '{pkg_type}':\n"
@@ -1408,34 +1992,36 @@ class Pipeline:
             )
 
         # Set basic attributes
-        pkg_instance.pkg_type = pkg_def['pkg_type']
-        pkg_instance.pkg_id = pkg_def['pkg_id']
-        pkg_instance.global_id = pkg_def['global_id']
+        pkg_instance.pkg_type = pkg_def["pkg_type"]
+        pkg_instance.pkg_id = pkg_def["pkg_id"]
+        pkg_instance.global_id = pkg_def["global_id"]
 
         # Initialize directories now that pkg_id is set
         pkg_instance._ensure_directories()
 
         # Set configuration
-        base_config = pkg_def.get('config', {})
-        base_config.setdefault('do_dbg', False)
-        base_config.setdefault('dbg_port', 50000)
+        base_config = pkg_def.get("config", {})
+        base_config.setdefault("do_dbg", False)
+        base_config.setdefault("dbg_port", 50000)
         pkg_instance.config = base_config
-            
+
         # Set up environment variables - mod_env is exact replica of env plus LD_PRELOAD
         if pipeline_env is None:
             pipeline_env = {}
 
         # env contains everything except LD_PRELOAD
-        pkg_instance.env = {k: v for k, v in pipeline_env.items() if k != 'LD_PRELOAD'}
+        pkg_instance.env = {k: v for k, v in pipeline_env.items() if k != "LD_PRELOAD"}
 
         # mod_env is exact replica of env plus LD_PRELOAD (if it exists)
         pkg_instance.mod_env = pkg_instance.env.copy()
-        if 'LD_PRELOAD' in pipeline_env:
-            pkg_instance.mod_env['LD_PRELOAD'] = pipeline_env['LD_PRELOAD']
+        if "LD_PRELOAD" in pipeline_env:
+            pkg_instance.mod_env["LD_PRELOAD"] = pipeline_env["LD_PRELOAD"]
 
         return pkg_instance
-    
-    def _process_package_definition(self, pkg_def: Dict[str, Any], pkg_id: str) -> Dict[str, Any]:
+
+    def _process_package_definition(
+        self, pkg_def: Dict[str, Any], pkg_id: str
+    ) -> Dict[str, Any]:
         """
         Process a package definition from YAML, merging YAML config with defaults.
 
@@ -1443,10 +2029,10 @@ class Pipeline:
         :param pkg_id: Package ID to use
         :return: Complete package entry with merged configuration
         """
-        pkg_type = pkg_def['pkg_type']
+        pkg_type = pkg_def["pkg_type"]
 
         # Resolve pkg_type to full specification (repo.package) if not already specified
-        if '.' not in pkg_type:
+        if "." not in pkg_type:
             resolved_type = self.jarvis.find_package(pkg_type)
             if resolved_type:
                 pkg_type = resolved_type
@@ -1456,8 +2042,9 @@ class Pipeline:
         default_config = self._get_package_default_config(pkg_type)
 
         # Extract config from YAML
-        yaml_config = {k: v for k, v in pkg_def.items()
-                      if k not in ['pkg_type', 'pkg_name']}
+        yaml_config = {
+            k: v for k, v in pkg_def.items() if k not in ["pkg_type", "pkg_name"]
+        }
 
         # Merge YAML config on top of defaults
         merged_config = default_config.copy()
@@ -1469,11 +2056,11 @@ class Pipeline:
         merged_config = self._expand_env_in_config(merged_config)
 
         return {
-            'pkg_type': pkg_type,
-            'pkg_id': pkg_id,
-            'pkg_name': pkg_type.split('.')[-1],
-            'global_id': f"{self.name}.{pkg_id}",
-            'config': merged_config
+            "pkg_type": pkg_type,
+            "pkg_id": pkg_id,
+            "pkg_name": pkg_type.split(".")[-1],
+            "global_id": f"{self.name}.{pkg_id}",
+            "config": merged_config,
         }
 
     @staticmethod
@@ -1501,11 +2088,11 @@ class Pipeline:
         try:
             # Create a temporary package definition to load the package
             temp_pkg_def = {
-                'pkg_type': package_spec,
-                'pkg_id': 'temp',
-                'pkg_name': package_spec.split('.')[-1],
-                'global_id': 'temp.temp',
-                'config': {}
+                "pkg_type": package_spec,
+                "pkg_id": "temp",
+                "pkg_name": package_spec.split(".")[-1],
+                "global_id": "temp.temp",
+                "config": {},
             }
 
             # Load package instance
@@ -1513,7 +2100,7 @@ class Pipeline:
 
             # Use PkgArgParse to get defaults by parsing 'configure' with no args
             argparse = pkg_instance.get_argparse()
-            argparse.parse(['configure'])
+            argparse.parse(["configure"])
             default_config = argparse.kwargs
 
             return default_config
@@ -1523,67 +2110,75 @@ class Pipeline:
             raise ValueError(f"Failed to load package '{package_spec}': {e}")
 
         return {}
-    
+
     def _validate_unique_ids(self):
         """
         Validate that interceptor IDs and package IDs are unique within the pipeline.
         """
         # Get all package IDs
-        package_ids = {pkg['pkg_id'] for pkg in self.packages}
-        
+        package_ids = {pkg["pkg_id"] for pkg in self.packages}
+
         # Get all interceptor IDs
         interceptor_ids = set(self.interceptors.keys())
-        
+
         # Check for conflicts
         conflicts = package_ids & interceptor_ids
         if conflicts:
-            conflict_list = ', '.join(conflicts)
-            raise ValueError(f"ID conflicts between packages and interceptors: {conflict_list}. "
-                           f"Package and interceptor IDs must be unique within the pipeline.")
-    
+            conflict_list = ", ".join(conflicts)
+            raise ValueError(
+                f"ID conflicts between packages and interceptors: {conflict_list}. "
+                f"Package and interceptor IDs must be unique within the pipeline."
+            )
+
     def _validate_required_config(self, package_spec: str, config: Dict[str, Any]):
         """
         Validate that all required configuration parameters have values.
-        
-        :param package_spec: Package specification 
+
+        :param package_spec: Package specification
         :param config: Configuration dictionary
         :raises ValueError: If required parameters are missing or None
         """
         try:
             # Create a temporary package definition to load the package
             temp_pkg_def = {
-                'pkg_type': package_spec,
-                'pkg_id': 'temp',
-                'pkg_name': package_spec.split('.')[-1],
-                'global_id': 'temp.temp',
-                'config': {}
+                "pkg_type": package_spec,
+                "pkg_id": "temp",
+                "pkg_name": package_spec.split(".")[-1],
+                "global_id": "temp.temp",
+                "config": {},
             }
-            
+
             # Load package instance
             pkg_instance = self._load_package_instance(temp_pkg_def)
-            
+
             # Get configuration menu to check for required parameters
-            if hasattr(pkg_instance, 'configure_menu'):
+            if hasattr(pkg_instance, "configure_menu"):
                 config_menu = pkg_instance.configure_menu()
                 if config_menu:
                     missing_required = []
                     for menu_item in config_menu:
-                        name = menu_item.get('name')
-                        default_value = menu_item.get('default')
-                        
+                        name = menu_item.get("name")
+                        default_value = menu_item.get("default")
+
                         # If parameter has no default and is not provided in config, it's required
-                        if name and default_value is None and (name not in config or config[name] is None):
+                        if (
+                            name
+                            and default_value is None
+                            and (name not in config or config[name] is None)
+                        ):
                             missing_required.append(name)
-                    
+
                     if missing_required:
-                        raise ValueError(f"Missing required configuration parameters for {package_spec}: {', '.join(missing_required)}")
-                        
+                        raise ValueError(
+                            f"Missing required configuration parameters for {package_spec}: {', '.join(missing_required)}"
+                        )
+
         except Exception as e:
             if "Missing required configuration parameters" in str(e):
                 raise  # Re-raise our validation error
             # Other errors during validation are not fatal
             print(f"Warning: Could not validate configuration for {package_spec}: {e}")
-    
+
     def _apply_interceptors_to_package(self, pkg_instance, pkg_def):
         """
         Apply interceptors to a package instance during pipeline start.
@@ -1591,21 +2186,25 @@ class Pipeline:
         :param pkg_instance: The package instance to apply interceptors to
         :param pkg_def: The package definition from pipeline configuration
         """
-        from jarvis_cd.util.logger import logger, Color
+        from jarvis_cd.util.logger import logger
 
         # Get interceptors list from package configuration
-        interceptors_list = pkg_def.get('config', {}).get('interceptors', [])
+        interceptors_list = pkg_def.get("config", {}).get("interceptors", [])
 
         if not interceptors_list:
             return
 
-        logger.warning(f"Applying {len(interceptors_list)} interceptors to {pkg_def['pkg_id']}")
+        logger.warning(
+            f"Applying {len(interceptors_list)} interceptors to {pkg_def['pkg_id']}"
+        )
 
         for interceptor_name in interceptors_list:
             try:
                 # Find interceptor in pipeline-level interceptors
                 if interceptor_name not in self.interceptors:
-                    logger.error(f"Warning: Interceptor '{interceptor_name}' not found in pipeline interceptors")
+                    logger.error(
+                        f"Warning: Interceptor '{interceptor_name}' not found in pipeline interceptors"
+                    )
                     continue
 
                 interceptor_def = self.interceptors[interceptor_name]
@@ -1614,11 +2213,15 @@ class Pipeline:
                 logger.success(f"[{interceptor_def['pkg_type']}] [MODIFY_ENV] BEGIN")
 
                 # Load interceptor instance
-                interceptor_instance = self._load_package_instance(interceptor_def, self.env)
+                interceptor_instance = self._load_package_instance(
+                    interceptor_def, self.env
+                )
 
                 # Verify it's an interceptor and has modify_env method
-                if not hasattr(interceptor_instance, 'modify_env'):
-                    logger.error(f"Warning: Package '{interceptor_name}' does not have modify_env() method")
+                if not hasattr(interceptor_instance, "modify_env"):
+                    logger.error(
+                        f"Warning: Package '{interceptor_name}' does not have modify_env() method"
+                    )
                     continue
 
                 # Share the same mod_env reference between interceptor and package
@@ -1644,36 +2247,35 @@ class Pipeline:
         :return: Path to generated YAML file
         """
         import yaml
-        from pathlib import Path
 
         # Create pipeline configuration with all packages
         pipeline_config = {
-            'name': f'{self.name}_container',
-            'pkgs': []
+            "name": f"{self.execution_container_name}_container",
+            "pkgs": [],
         }
 
         # Add all packages (excluding 'deploy' config)
         for pkg_def in self.packages:
-            pkg_entry = {'pkg_type': pkg_def['pkg_type']}
-            for key, value in pkg_def['config'].items():
-                if key not in ['deploy', 'deploy_mode', 'deploy_ssh_port']:
+            pkg_entry = {"pkg_type": pkg_def["pkg_type"]}
+            for key, value in pkg_def["config"].items():
+                if key not in ["deploy", "deploy_mode", "deploy_ssh_port"]:
                     pkg_entry[key] = value
-            pipeline_config['pkgs'].append(pkg_entry)
+            pipeline_config["pkgs"].append(pkg_entry)
 
         # Add interceptors if any
         if self.interceptors:
-            pipeline_config['interceptors'] = []
+            pipeline_config["interceptors"] = []
             for interceptor_name, interceptor_def in self.interceptors.items():
-                interceptor_entry = {'pkg_type': interceptor_def['pkg_type']}
-                for key, value in interceptor_def.get('config', {}).items():
-                    if key not in ['deploy', 'deploy_mode', 'deploy_ssh_port']:
+                interceptor_entry = {"pkg_type": interceptor_def["pkg_type"]}
+                for key, value in interceptor_def.get("config", {}).items():
+                    if key not in ["deploy", "deploy_mode", "deploy_ssh_port"]:
                         interceptor_entry[key] = value
-                pipeline_config['interceptors'].append(interceptor_entry)
+                pipeline_config["interceptors"].append(interceptor_entry)
 
         # Write to shared directory
-        shared_dir = self.jarvis.get_pipeline_shared_dir(self.name)
-        yaml_path = shared_dir / 'pipeline.yaml'
-        with open(yaml_path, 'w') as f:
+        shared_dir = self.get_pipeline_shared_dir()
+        yaml_path = shared_dir / "pipeline.yaml"
+        with open(yaml_path, "w") as f:
             yaml.dump(pipeline_config, f, default_flow_style=False)
 
         print(f"Generated pipeline YAML: {yaml_path}")
@@ -1689,10 +2291,10 @@ class Pipeline:
         import yaml
         import os
 
-        shared_dir = self.jarvis.get_pipeline_shared_dir(self.name)
-        compose_path = shared_dir / 'docker-compose.yaml'
+        shared_dir = self.get_pipeline_shared_dir()
+        compose_path = shared_dir / "docker-compose.yaml"
 
-        container_name = f"{self.name}_container"
+        container_name = f"{self.execution_container_name}_container"
 
         # Use pipeline-level SSH port configuration
         ssh_port = self.container_ssh_port
@@ -1704,12 +2306,14 @@ class Pipeline:
         docker_host_prefix = self.container_host_path
         workspace_root = self.container_workspace
         if docker_host_prefix and workspace_root and os.path.isdir(workspace_root):
+
             def to_host_path(path_str):
                 """Remap a workspace path to the Docker host path."""
                 if path_str.startswith(workspace_root):
-                    return docker_host_prefix + path_str[len(workspace_root):]
+                    return docker_host_prefix + path_str[len(workspace_root) :]
                 return path_str
         else:
+
             def to_host_path(path_str):
                 return path_str
 
@@ -1719,44 +2323,49 @@ class Pipeline:
         # In DinD environments, the home directory is on the overlay
         # filesystem — copy SSH keys to the workspace so sibling
         # containers can access them.
-        ssh_dir = os.path.expanduser('~/.ssh')
-        if docker_host_prefix and workspace_root and os.path.isdir(workspace_root) \
-                and not ssh_dir.startswith(workspace_root):
-            docker_ssh_dir = os.path.join(workspace_root, '.ssh-host')
+        ssh_dir = os.path.expanduser("~/.ssh")
+        if (
+            docker_host_prefix
+            and workspace_root
+            and os.path.isdir(workspace_root)
+            and not ssh_dir.startswith(workspace_root)
+        ):
+            docker_ssh_dir = os.path.join(workspace_root, ".ssh-host")
             if os.path.exists(ssh_dir):
                 import shutil
+
                 if os.path.exists(docker_ssh_dir):
                     shutil.rmtree(docker_ssh_dir)
                 shutil.copytree(ssh_dir, docker_ssh_dir)
             ssh_dir = docker_ssh_dir
         container_cmd = (
-            f'set -e && '
-            f'cp -r /root/.ssh_host /root/.ssh && '
-            f'chmod 700 /root/.ssh && '
-            f'chmod 600 /root/.ssh/* 2>/dev/null || true && '
-            f'cat /root/.ssh/*.pub > /root/.ssh/authorized_keys 2>/dev/null && '
-            f'chmod 600 /root/.ssh/authorized_keys 2>/dev/null || true && '
+            f"set -e && "
+            f"cp -r /root/.ssh_host /root/.ssh && "
+            f"chmod 700 /root/.ssh && "
+            f"chmod 600 /root/.ssh/* 2>/dev/null || true && "
+            f"cat /root/.ssh/*.pub > /root/.ssh/authorized_keys 2>/dev/null && "
+            f"chmod 600 /root/.ssh/authorized_keys 2>/dev/null || true && "
             f'echo "Host *" > /root/.ssh/config && '
             f'echo "    Port {ssh_port}" >> /root/.ssh/config && '
             f'echo "    StrictHostKeyChecking no" >> /root/.ssh/config && '
-            f'chmod 600 /root/.ssh/config && '
+            f"chmod 600 /root/.ssh/config && "
             f'sed -i "s/^#*Port .*/Port {ssh_port}/" /etc/ssh/sshd_config && '
-            f'/usr/sbin/sshd && '
-            f'sleep infinity'
+            f"/usr/sbin/sshd && "
+            f"sleep infinity"
         )
 
         # Create compose configuration using the global container image.
         # Shared and private directories are mounted at the SAME path
         # inside the container so that all configuration paths (hostfile,
         # pipeline YAML, package data) are identical on host and container.
-        private_dir = self.jarvis.get_pipeline_private_dir(self.name)
+        private_dir = self.get_pipeline_private_dir()
 
         # Prepare volume mounts — identical host:container paths
         # (use to_host_path for Docker-in-Docker remapping)
         volumes = [
             f"{to_host_path(str(private_dir))}:{private_dir}",
             f"{to_host_path(str(shared_dir))}:{shared_dir}",
-            f"{to_host_path(ssh_dir)}:/root/.ssh_host:ro"
+            f"{to_host_path(ssh_dir)}:/root/.ssh_host:ro",
         ]
 
         # Workload-specific bind mounts from `container_binds` in the
@@ -1764,27 +2373,26 @@ class Pipeline:
         # The apptainer path applies these in _start_containerized_pipeline;
         # for docker/podman compose we have to bake them into the
         # service's volume list.
-        for bind in (self.container_binds or []):
-            if ':' in bind:
-                host, _, rest = bind.partition(':')
+        for bind in self.container_binds or []:
+            if ":" in bind:
+                host, _, rest = bind.partition(":")
                 volumes.append(f"{to_host_path(host)}:{rest}")
             else:
                 volumes.append(f"{to_host_path(bind)}:{bind}")
 
-
         service_config = {
-            'container_name': container_name,
-            'image': self.container_image,
-            'entrypoint': ['/bin/bash', '-c'],
-            'command': [container_cmd],
-            'network_mode': 'host',
-            'ipc': 'host',  # Share IPC namespace with host (removes shm limits)
-            'volumes': volumes
+            "container_name": container_name,
+            "image": self.container_image,
+            "entrypoint": ["/bin/bash", "-c"],
+            "command": [container_cmd],
+            "network_mode": "host",
+            "ipc": "host",  # Share IPC namespace with host (removes shm limits)
+            "volumes": volumes,
         }
 
         # Inject container environment variables into the compose service
         if self.container_env:
-            service_config['environment'] = {
+            service_config["environment"] = {
                 str(k): os.path.expandvars(str(v))
                 for k, v in self.container_env.items()
             }
@@ -1798,14 +2406,10 @@ class Pipeline:
             # Deep merge container_extensions into service_config
             self._merge_dict(service_config, self.container_extensions)
 
-        compose_config = {
-            'services': {
-                self.name: service_config
-            }
-        }
+        compose_config = {"services": {self.name: service_config}}
 
         # Write compose file
-        with open(compose_path, 'w') as f:
+        with open(compose_path, "w") as f:
             yaml.dump(compose_config, f, default_flow_style=False)
 
         print(f"Generated docker-compose file: {compose_path}")
@@ -1847,11 +2451,11 @@ class Pipeline:
 
         engine = self.container_engine.lower()
 
-        if engine == 'apptainer':
+        if engine == "apptainer":
             # Apptainer: start persistent instances with sshd on every node
             # (mirrors docker compose up -d).
-            shared_dir = self.jarvis.get_pipeline_shared_dir(self.name)
-            private_dir = self.jarvis.get_pipeline_private_dir(self.name)
+            shared_dir = self.get_pipeline_shared_dir()
+            private_dir = self.get_pipeline_private_dir()
             # Resolve the SIF: when YAML supplies `container_image`, treat
             # it as the SIF basename (or absolute path) so a pipeline can
             # reuse another pipeline's prebuilt SIF instead of building
@@ -1862,11 +2466,11 @@ class Pipeline:
             if sif_candidate.is_absolute() and sif_candidate.exists():
                 sif_path = sif_candidate
             else:
-                sif_path = self.jarvis.get_containers_dir() / f'{sif_ref}.sif'
-            instance_name = self.name
+                sif_path = self.jarvis.get_containers_dir() / f"{sif_ref}.sif"
+            instance_name = self.execution_container_name
             ssh_port = self.container_ssh_port
 
-            nv_flag = '--nv ' if getattr(self, 'container_gpu', False) else ''
+            nv_flag = "--nv " if getattr(self, "container_gpu", False) else ""
 
             # Bake bind mounts into the instance: per-exec --bind is
             # silently ignored on a running instance, so anything packages
@@ -1874,14 +2478,13 @@ class Pipeline:
             # private dirs cover all per-package shared/private subdirs;
             # container_binds adds workload-specific extras (e.g.,
             # /dev/fuse for FUSE mounts).
-            binds = [f'{shared_dir}:{shared_dir}',
-                     f'{private_dir}:{private_dir}']
+            binds = [f"{shared_dir}:{shared_dir}", f"{private_dir}:{private_dir}"]
             binds.extend(self.container_binds or [])
-            bind_flags = ''.join(f'--bind {b} ' for b in binds)
+            bind_flags = "".join(f"--bind {b} " for b in binds)
 
-            cap_flag = ''
+            cap_flag = ""
             if self.container_caps:
-                cap_flag = f'--add-caps {",".join(self.container_caps)} '
+                cap_flag = f"--add-caps {','.join(self.container_caps)} "
 
             # Per-pipeline writable layer backed by NFS, not RAM.
             # `--writable-tmpfs` is RAM-only (capped at ~50% of system
@@ -1894,20 +2497,22 @@ class Pipeline:
             #
             # `--no-mount tmp` keeps the host's small /tmp out of the
             # picture; in-container /tmp lands in the overlay (NFS).
-            overlay_dir = shared_dir / 'overlay'
+            overlay_dir = shared_dir / "overlay"
             overlay_dir.mkdir(parents=True, exist_ok=True)
-            overlay_flag = f'--overlay {overlay_dir} '
-            no_mount_flag = '--no-mount tmp '
+            overlay_flag = f"--overlay {overlay_dir} "
+            no_mount_flag = "--no-mount tmp "
 
             # When tmp_bind_root is set in the pipeline YAML, replace the
             # overlay-backed /tmp with a per-host bind mount so workloads
             # that hardcode /tmp scratch dirs don't collide across hosts.
             # See pipeline-load comment for rationale.
-            tmp_bind_flag = ''
+            tmp_bind_flag = ""
             if self.tmp_bind_root:
-                tmp_bind_path = f"{self.tmp_bind_root}/{self.name}/tmp"
-                tmp_bind_flag = f'--bind {tmp_bind_path}:/tmp '
-                no_mount_flag = ''
+                tmp_bind_path = (
+                    f"{self.tmp_bind_root}/{self.execution_container_name}/tmp"
+                )
+                tmp_bind_flag = f"--bind {tmp_bind_path}:/tmp "
+                no_mount_flag = ""
 
             start_cmd = (
                 f"apptainer instance start {nv_flag}{cap_flag}{bind_flags}"
@@ -1937,7 +2542,8 @@ class Pipeline:
             else:
                 logger.info(
                     f"Hostfile has {len(hostfile)} hosts; starting "
-                    "apptainer instance on every host via PsshExecInfo")
+                    "apptainer instance on every host via PsshExecInfo"
+                )
                 exec_info = PsshExecInfo(hostfile=hostfile)
 
             # Per-host bind source for tmp_bind_root must exist on every
@@ -1945,23 +2551,28 @@ class Pipeline:
             # otherwise apptainer aborts with "mount source X doesn't
             # exist". Fan a mkdir to all hosts via the same exec_info.
             if self.tmp_bind_root:
-                tmp_mkdir = f"mkdir -p {self.tmp_bind_root}/{self.name}/tmp"
+                tmp_mkdir = (
+                    f"mkdir -p {self.tmp_bind_root}/{self.execution_container_name}/tmp"
+                )
                 logger.info(
                     f"tmp_bind_root set; ensuring {self.tmp_bind_root}/"
-                    f"{self.name}/tmp exists on every host")
+                    f"{self.execution_container_name}/tmp exists on every host"
+                )
                 Exec(tmp_mkdir, exec_info).run()
 
             Exec(start_cmd, exec_info).run()
             logger.success("Apptainer instances started (SSH ready)")
         else:
             # Docker/Podman: start containers via compose
-            shared_dir = self.jarvis.get_pipeline_shared_dir(self.name)
-            compose_path = shared_dir / 'docker-compose.yaml'
+            shared_dir = self.get_pipeline_shared_dir()
+            compose_path = shared_dir / "docker-compose.yaml"
 
             if not compose_path.exists():
-                raise FileNotFoundError(f"Compose file not found: {compose_path}. Did you load the pipeline?")
+                raise FileNotFoundError(
+                    f"Compose file not found: {compose_path}. Did you load the pipeline?"
+                )
 
-            if engine == 'podman':
+            if engine == "podman":
                 up_cmd = f"podman-compose -f {compose_path} up -d"
             else:
                 up_cmd = f"docker compose -f {compose_path} up -d"
@@ -1987,7 +2598,7 @@ class Pipeline:
                 pkg_instance = self._load_package_instance(pkg_def, self.env)
                 self._apply_interceptors_to_package(pkg_instance, pkg_def)
 
-                if hasattr(pkg_instance, 'start'):
+                if hasattr(pkg_instance, "start"):
                     pkg_instance.start()
                 else:
                     logger.warning(f"Package {pkg_def['pkg_id']} has no start method")
@@ -2014,12 +2625,12 @@ class Pipeline:
         from jarvis_cd.util.hostfile import Hostfile
 
         engine = self.container_engine.lower()
-        if engine == 'apptainer':
+        if engine == "apptainer":
             return
 
         image = self.name
         local_host = socket.gethostname()
-        skip = ('localhost', '127.0.0.1', local_host)
+        skip = ("localhost", "127.0.0.1", local_host)
 
         # Probe each remote host; only transfer to those missing the image
         needs_transfer = []
@@ -2030,7 +2641,12 @@ class Pipeline:
                 f"ssh -o BatchMode=yes -o StrictHostKeyChecking=no "
                 f"{host} '{engine} image inspect {image} >/dev/null 2>&1'"
             )
-            if Exec(check_cmd, LocalExecInfo(hide_output=True)).run().exit_code.get('localhost', 1) == 0:
+            if (
+                Exec(check_cmd, LocalExecInfo(hide_output=True))
+                .run()
+                .exit_code.get("localhost", 1)
+                == 0
+            ):
                 logger.info(f"Image '{image}' already on {host}, skipping transfer")
             else:
                 needs_transfer.append(host)
@@ -2039,18 +2655,18 @@ class Pipeline:
             return
 
         # Save image once to the pipeline's shared dir (visible from every node)
-        shared_dir = self.jarvis.get_pipeline_shared_dir(self.name)
+        shared_dir = self.get_pipeline_shared_dir()
         tar_path = shared_dir / f"{image}.tar"
         logger.info(f"Saving image '{image}' to {tar_path}...")
         save = Exec(f"{engine} save -o {tar_path} {image}", LocalExecInfo()).run()
-        if save.exit_code.get('localhost', 1) != 0:
+        if save.exit_code.get("localhost", 1) != 0:
             raise RuntimeError(f"Failed to save image '{image}' to {tar_path}")
 
         # PSSH-load on every host that needs it (parallel)
         logger.info(f"Loading image '{image}' on {needs_transfer} in parallel...")
         load = Exec(
             f"{engine} load -i {tar_path}",
-            PsshExecInfo(hostfile=Hostfile(hosts=needs_transfer))
+            PsshExecInfo(hostfile=Hostfile(hosts=needs_transfer)),
         ).run()
         for host, code in load.exit_code.items():
             if code != 0:
@@ -2078,7 +2694,7 @@ class Pipeline:
             try:
                 logger.success(f"[{pkg_def['pkg_type']}] [STOP] BEGIN")
                 pkg_instance = self._load_package_instance(pkg_def, self.env)
-                if hasattr(pkg_instance, 'stop'):
+                if hasattr(pkg_instance, "stop"):
                     pkg_instance.stop()
                 logger.success(f"[{pkg_def['pkg_type']}] [STOP] END")
             except Exception as e:
@@ -2086,13 +2702,13 @@ class Pipeline:
 
         # Bring down the containers
         engine = self.container_engine.lower()
-        if engine == 'apptainer':
-            stop_cmd = f"apptainer instance stop {self.name}"
-        elif engine == 'podman':
-            compose_path = self.jarvis.get_pipeline_shared_dir(self.name) / 'docker-compose.yaml'
+        if engine == "apptainer":
+            stop_cmd = f"apptainer instance stop {self.execution_container_name}"
+        elif engine == "podman":
+            compose_path = self.get_pipeline_shared_dir() / "docker-compose.yaml"
             stop_cmd = f"podman-compose -f {compose_path} down"
         else:
-            compose_path = self.jarvis.get_pipeline_shared_dir(self.name) / 'docker-compose.yaml'
+            compose_path = self.get_pipeline_shared_dir() / "docker-compose.yaml"
             stop_cmd = f"docker compose -f {compose_path} down"
 
         hostfile = self.get_hostfile()
@@ -2120,7 +2736,7 @@ class Pipeline:
             try:
                 logger.success(f"[{pkg_def['pkg_type']}] [KILL] BEGIN")
                 pkg_instance = self._load_package_instance(pkg_def, self.env)
-                if hasattr(pkg_instance, 'kill'):
+                if hasattr(pkg_instance, "kill"):
                     pkg_instance.kill()
                 logger.success(f"[{pkg_def['pkg_type']}] [KILL] END")
             except Exception as e:
@@ -2128,13 +2744,13 @@ class Pipeline:
 
         # Force-remove containers
         engine = self.container_engine.lower()
-        if engine == 'apptainer':
-            kill_cmd = f"apptainer instance stop {self.name}"
-        elif engine == 'podman':
-            compose_path = self.jarvis.get_pipeline_shared_dir(self.name) / 'docker-compose.yaml'
+        if engine == "apptainer":
+            kill_cmd = f"apptainer instance stop {self.execution_container_name}"
+        elif engine == "podman":
+            compose_path = self.get_pipeline_shared_dir() / "docker-compose.yaml"
             kill_cmd = f"podman-compose -f {compose_path} kill && podman-compose -f {compose_path} down"
         else:
-            compose_path = self.jarvis.get_pipeline_shared_dir(self.name) / 'docker-compose.yaml'
+            compose_path = self.get_pipeline_shared_dir() / "docker-compose.yaml"
             kill_cmd = f"docker compose -f {compose_path} kill && docker compose -f {compose_path} down"
 
         hostfile = self.get_hostfile()

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -4,6 +4,7 @@ Provides the consolidated Pipeline class that combines pipeline creation, loadin
 """
 
 import os
+import shlex
 import socket
 import yaml
 import copy
@@ -33,6 +34,10 @@ class Pipeline:
         self.env = {}
         self.created_at = None
         self.last_loaded_file = None
+        # Structured metadata from the most recent scheduler submission.
+        # This is populated only by the scheduler provider boundary; it is
+        # never inferred from package or application stdout.
+        self.last_submission = None
 
         # Container parameters
         self.container_image = ""  # Pre-built image to use
@@ -149,15 +154,76 @@ class Pipeline:
         logger.pipeline(f"Wrote scheduler script: {script_path}")
         logger.pipeline(f"Hostfile (built at job start): {sched.hostfile}")
 
+        self.last_submission = {
+            'schema_version': 'jarvis.scheduler.submission.v1',
+            'provider': sched.NAME,
+            'script_path': str(script_path),
+            'scheduler_job_id': None,
+            'scheduler_cluster': None,
+            'identity_source': None,
+            'state': 'scripted',
+            'submitted': False,
+            'wait': bool(wait),
+            'terminal': False,
+            # ``sbatch --wait`` reports the completed workload status through
+            # the sbatch process.  Keep that raw value while separately
+            # recording whether it is an observed terminal return code.
+            'submission_returncode': None,
+            'terminal_returncode': None,
+        }
+
         if submit:
             from jarvis_cd.shell import Exec, LocalExecInfo
-            cmd = ' '.join(sched.submit_command(wait=wait))
+            argv = sched.submit_command(wait=wait)
+            cmd = ' '.join(shlex.quote(part) for part in argv)
             logger.pipeline(f"Submitting: {cmd}")
-            result = Exec(cmd, LocalExecInfo()).run()
+            result = Exec(cmd, LocalExecInfo(hide_output=True)).run()
             exit_code = result.exit_code.get('localhost', 1)
-            if exit_code != 0:
+            self.last_submission['submission_returncode'] = exit_code
+            stdout = result.stdout.get('localhost', '')
+            try:
+                provider_metadata = sched.parse_submission_output(stdout)
+            except ValueError as exc:
+                self.last_submission['state'] = (
+                    'submission_failed' if exit_code != 0 else 'identity_failed'
+                )
+                self.save()
+                if exit_code != 0:
+                    raise RuntimeError(
+                        f"Scheduler submission failed (exit {exit_code}): {cmd}"
+                    ) from exc
                 raise RuntimeError(
-                    f"Scheduler submission failed (exit {exit_code}): {cmd}")
+                    "Scheduler accepted the submission but did not return a "
+                    "structured job identity"
+                ) from exc
+            self.last_submission.update(provider_metadata)
+            self.last_submission.update({
+                'submitted': True,
+                'terminal': bool(wait),
+                'terminal_returncode': exit_code if wait else None,
+            })
+            logger.pipeline(
+                "Scheduler job identity: "
+                f"{self.last_submission['scheduler_job_id']}"
+            )
+            if exit_code != 0:
+                self.last_submission['state'] = (
+                    'workload_failed' if wait else 'accepted_with_error'
+                )
+                self.save()
+                if wait:
+                    raise RuntimeError(
+                        "Scheduler job "
+                        f"{self.last_submission['scheduler_job_id']} was accepted, "
+                        f"but the workload failed (exit {exit_code}): {cmd}"
+                    )
+                raise RuntimeError(
+                    "Scheduler job "
+                    f"{self.last_submission['scheduler_job_id']} was accepted, "
+                    f"but the submission command returned exit {exit_code}: {cmd}"
+                )
+            self.last_submission['state'] = 'completed' if wait else 'submitted'
+        self.save()
         return script_path
 
     def _hostfile_is_local_only(self, hf) -> bool:
@@ -250,6 +316,7 @@ class Pipeline:
         self.env = {}
         self.created_at = str(Path().cwd())
         self.last_loaded_file = None
+        self.last_submission = None
 
         # Save pipeline configuration and environment
         self.save()
@@ -303,6 +370,8 @@ class Pipeline:
             pipeline_config['created_at'] = self.created_at
         if self.last_loaded_file:
             pipeline_config['last_loaded_file'] = self.last_loaded_file
+        if self.last_submission:
+            pipeline_config['last_submission'] = self.last_submission
         # Add container parameters (always save, even if empty/default)
         pipeline_config['container_image'] = self.container_image
         pipeline_config['container_uri'] = self.container_uri
@@ -966,6 +1035,7 @@ class Pipeline:
         # Extract metadata
         self.created_at = pipeline_config.get('created_at')
         self.last_loaded_file = pipeline_config.get('last_loaded_file')
+        self.last_submission = pipeline_config.get('last_submission')
 
         # Load container parameters
         self.container_image = pipeline_config.get('container_image', '')

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -15,6 +15,21 @@ from jarvis_cd.util.logger import logger
 from jarvis_cd.util.hostfile import Hostfile
 
 
+def _bounded_scheduler_stderr(result: Any, limit: int = 4096) -> Optional[str]:
+    """Return a bounded scheduler diagnostic captured by the executor."""
+    stderr = getattr(result, 'stderr', {})
+    if isinstance(stderr, dict):
+        value = stderr.get('localhost', '')
+    else:
+        value = stderr
+    diagnostic = str(value or '').strip()
+    if not diagnostic:
+        return None
+    if len(diagnostic) <= limit:
+        return diagnostic
+    return '[truncated]\n' + diagnostic[-limit:]
+
+
 class Pipeline:
     """
     Consolidated pipeline management class.
@@ -165,6 +180,7 @@ class Pipeline:
             'submitted': False,
             'wait': bool(wait),
             'terminal': False,
+            'scheduler_stderr': None,
             # ``sbatch --wait`` reports the completed workload status through
             # the sbatch process.  Keep that raw value while separately
             # recording whether it is an observed terminal return code.
@@ -180,6 +196,13 @@ class Pipeline:
             result = Exec(cmd, LocalExecInfo(hide_output=True)).run()
             exit_code = result.exit_code.get('localhost', 1)
             self.last_submission['submission_returncode'] = exit_code
+            scheduler_stderr = _bounded_scheduler_stderr(result)
+            self.last_submission['scheduler_stderr'] = scheduler_stderr
+            diagnostic = (
+                f"; scheduler stderr: {scheduler_stderr}"
+                if scheduler_stderr
+                else ''
+            )
             stdout = result.stdout.get('localhost', '')
             try:
                 provider_metadata = sched.parse_submission_output(stdout)
@@ -190,11 +213,12 @@ class Pipeline:
                 self.save()
                 if exit_code != 0:
                     raise RuntimeError(
-                        f"Scheduler submission failed (exit {exit_code}): {cmd}"
+                        f"Scheduler submission failed (exit {exit_code}): "
+                        f"{cmd}{diagnostic}"
                     ) from exc
                 raise RuntimeError(
                     "Scheduler accepted the submission but did not return a "
-                    "structured job identity"
+                    f"structured job identity{diagnostic}"
                 ) from exc
             self.last_submission.update(provider_metadata)
             self.last_submission.update({
@@ -215,12 +239,14 @@ class Pipeline:
                     raise RuntimeError(
                         "Scheduler job "
                         f"{self.last_submission['scheduler_job_id']} was accepted, "
-                        f"but the workload failed (exit {exit_code}): {cmd}"
+                        f"but the workload failed (exit {exit_code}): "
+                        f"{cmd}{diagnostic}"
                     )
                 raise RuntimeError(
                     "Scheduler job "
                     f"{self.last_submission['scheduler_job_id']} was accepted, "
-                    f"but the submission command returned exit {exit_code}: {cmd}"
+                    f"but the submission command returned exit {exit_code}: "
+                    f"{cmd}{diagnostic}"
                 )
             self.last_submission['state'] = 'completed' if wait else 'submitted'
         self.save()

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -11,31 +11,48 @@ import shlex
 import shutil
 import socket
 import stat
+import subprocess
+import sys
 import tempfile
 import yaml
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 from uuid import uuid4
 from jarvis_cd.core.config import load_class, Jarvis
+from jarvis_cd.core.execution import (
+    LEGACY_RECORD_SCHEMA,
+    RECORD_NAME,
+    RECORD_SCHEMA,
+    ExecutionHandle,
+    ExecutionProgressSnapshot,
+    ExecutionRecord,
+    ExecutionStore,
+    is_execution_transaction_lock,
+    execution_transaction_lock,
+    prepare_direct_execution_lease,
+    validate_execution_id,
+    validate_pipeline_id,
+)
 from jarvis_cd.util.logger import logger
 from jarvis_cd.util.hostfile import Hostfile
 
 
-_EXECUTION_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _SNAPSHOT_ENVIRONMENT = "JARVIS_PIPELINE_SNAPSHOT_DIR"
-_EXECUTION_MARKER = ".jarvis-execution.json"
-_EXECUTION_MARKER_SCHEMA = "jarvis.execution.v1"
+_EXECUTION_MARKER = RECORD_NAME
+_EXECUTION_MARKER_SCHEMA = LEGACY_RECORD_SCHEMA
 _EXECUTION_CLEANUP_SCHEMA = "jarvis.execution-cleanup.v1"
 _MAX_EXPLICIT_EXECUTION_CLEANUP = 1024
-_WINDOWS_RESERVED_COMPONENTS = {
-    "CON",
-    "PRN",
-    "AUX",
-    "NUL",
-    "CLOCK$",
-    *(f"COM{index}" for index in range(1, 10)),
-    *(f"LPT{index}" for index in range(1, 10)),
-}
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> Dict[str, Any]:
+    """Build a JSON object while rejecting duplicate security fields."""
+    document: Dict[str, Any] = {}
+    for key, value in pairs:
+        if key in document:
+            raise ValueError(f"duplicate JSON key: {key}")
+        document[key] = value
+    return document
 
 
 def _bounded_scheduler_stderr(result: Any, limit: int = 4096) -> Optional[str]:
@@ -51,6 +68,17 @@ def _bounded_scheduler_stderr(result: Any, limit: int = 4096) -> Optional[str]:
     if len(diagnostic) <= limit:
         return diagnostic
     return "[truncated]\n" + diagnostic[-limit:]
+
+
+def _bounded_execution_error(error: BaseException, limit: int = 16_384) -> str:
+    """Return a bounded UTF-8 diagnostic without masking the original error."""
+    diagnostic = str(error) or type(error).__name__
+    encoded = diagnostic.encode("utf-8")
+    if len(encoded) <= limit:
+        return diagnostic
+    prefix = b"[truncated]\n"
+    suffix = encoded[-(limit - len(prefix)) :].decode("utf-8", errors="ignore")
+    return f"[truncated]\n{suffix}"
 
 
 def _atomic_yaml_dump(path: Path, value: Any) -> None:
@@ -144,20 +172,8 @@ def _posix_fchmod(descriptor: int, mode: int) -> None:
 
 
 def _validated_execution_id(value: Optional[str]) -> str:
-    """Return a bounded path-safe scheduler execution identifier."""
-    execution_id = value or f"jarvis_{uuid4().hex}"
-    reserved_stem = execution_id.split(".", 1)[0].upper()
-    if (
-        _EXECUTION_ID_PATTERN.fullmatch(execution_id) is None
-        or execution_id.endswith(".")
-        or reserved_stem in _WINDOWS_RESERVED_COMPONENTS
-    ):
-        raise ValueError(
-            "execution_id must be 1-128 ASCII letters, digits, dots, underscores, "
-            "or hyphens, cannot begin with punctuation or end with a dot, and "
-            "cannot be a reserved Windows path alias"
-        )
-    return execution_id
+    """Return a bounded path-safe execution identifier."""
+    return validate_execution_id(value)
 
 
 def _read_execution_marker(
@@ -206,15 +222,27 @@ def _validate_execution_marker_payload(
 ) -> Dict[str, Any]:
     """Decode and validate a bounded execution marker payload."""
     try:
-        document = json.loads(payload.decode("utf-8", errors="strict"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        document = json.loads(
+            payload.decode("utf-8", errors="strict"),
+            object_pairs_hook=_reject_duplicate_json_keys,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
         raise RuntimeError(
             f"invalid execution ownership marker: {marker_label}"
         ) from exc
-    if not isinstance(document, dict) or document.get("schema_version") != (
-        _EXECUTION_MARKER_SCHEMA
-    ):
+    if not isinstance(document, dict) or document.get("schema_version") not in {
+        _EXECUTION_MARKER_SCHEMA,
+        RECORD_SCHEMA,
+    }:
         raise RuntimeError(f"invalid execution ownership marker: {marker_label}")
+    if document.get("schema_version") == RECORD_SCHEMA:
+        try:
+            record = ExecutionRecord.from_dict(document)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"invalid execution ownership marker: {marker_label}"
+            ) from exc
+        document = record.to_dict()
     execution_id = document.get("execution_id")
     if (
         not isinstance(execution_id, str)
@@ -223,8 +251,15 @@ def _validate_execution_marker_payload(
         raise RuntimeError(f"invalid execution ownership marker: {marker_label}")
     if expected_name != execution_id:
         raise RuntimeError(f"execution marker identity mismatch: {marker_label}")
-    if not isinstance(document.get("pipeline_name"), str):
+    pipeline_name = document.get("pipeline_name")
+    if not isinstance(pipeline_name, str):
         raise RuntimeError(f"invalid execution ownership marker: {marker_label}")
+    try:
+        validate_pipeline_id(pipeline_name)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"invalid execution ownership marker: {marker_label}"
+        ) from exc
     if not isinstance(document.get("state"), str):
         raise RuntimeError(f"invalid execution ownership marker: {marker_label}")
     if not isinstance(document.get("submitted"), bool) or not isinstance(
@@ -313,17 +348,23 @@ def _validate_execution_cleanup_receipt(
 ) -> Dict[str, Any]:
     """Decode one cleanup receipt and validate identity-bound fields."""
     try:
-        document = json.loads(payload.decode("utf-8", errors="strict"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        document = json.loads(
+            payload.decode("utf-8", errors="strict"),
+            object_pairs_hook=_reject_duplicate_json_keys,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
         raise RuntimeError(
             f"invalid execution cleanup receipt: {receipt_label}"
         ) from exc
+    pipeline_name = (
+        document.get("pipeline_name") if isinstance(document, dict) else None
+    )
     if (
         not isinstance(document, dict)
         or document.get("schema_version") != _EXECUTION_CLEANUP_SCHEMA
         or document.get("execution_id") != expected_execution_id
         or document.get("cleanup_nonce") != expected_nonce
-        or not isinstance(document.get("pipeline_name"), str)
+        or not isinstance(pipeline_name, str)
         or not isinstance(document.get("state"), str)
         or not isinstance(document.get("submitted"), bool)
         or not isinstance(document.get("terminal"), bool)
@@ -333,6 +374,12 @@ def _validate_execution_cleanup_receipt(
         or document["tombstone_inode"] <= 0
     ):
         raise RuntimeError(f"invalid execution cleanup receipt: {receipt_label}")
+    try:
+        validate_pipeline_id(pipeline_name)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"invalid execution cleanup receipt: {receipt_label}"
+        ) from exc
     return document
 
 
@@ -963,8 +1010,9 @@ class Pipeline:
 
         :param name: Pipeline name (optional for new pipelines)
         """
+        validated_name = validate_pipeline_id(name) if name is not None else None
         self.jarvis = Jarvis.get_instance()
-        self.name = name
+        self.name = validated_name
         self.packages = []
         self.interceptors = {}  # Store pipeline-level interceptors by name
         self.env = {}
@@ -1017,7 +1065,7 @@ class Pipeline:
         self.scheduler = None
 
         # Load existing pipeline if name is provided
-        if name:
+        if validated_name:
             self.load()
 
     def get_hostfile(self) -> Hostfile:
@@ -1069,7 +1117,7 @@ class Pipeline:
         submit: bool = True,
         wait: bool = False,
         execution_id: Optional[str] = None,
-    ) -> Path:
+    ) -> ExecutionHandle:
         """Write the scheduler job script and (optionally) submit it.
 
         :param submit: when True, exec the scheduler's submit command
@@ -1080,7 +1128,8 @@ class Pipeline:
             ``sbatch --wait``; backends without an equivalent ignore it.
         :param execution_id: bounded caller-owned identity used to isolate the
             submitted pipeline, environment, script, and hostfile.
-        :return: Path to the generated job script.
+        :return: Queryable JARVIS execution handle. The generated script remains
+            available as ``handle.script_path`` and in ``last_submission``.
         """
         if not self.scheduler:
             raise ValueError(
@@ -1095,44 +1144,68 @@ class Pipeline:
         shared_dir = self.get_pipeline_shared_dir()
         shared_dir.mkdir(parents=True, exist_ok=True)
         resolved_execution_id = _validated_execution_id(execution_id)
-        executions_dir = shared_dir / "executions"
-        executions_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-        executions_status = executions_dir.lstat()
-        if not stat.S_ISDIR(executions_status.st_mode) or stat.S_ISLNK(
-            executions_status.st_mode
-        ):
-            raise RuntimeError("pipeline executions path is not a real directory")
-        if os.name != "nt":
-            if executions_status.st_uid != _posix_effective_uid():
-                raise RuntimeError("pipeline executions path is not owner-controlled")
-            executions_descriptor = os.open(
-                executions_dir,
-                os.O_RDONLY
-                | getattr(os, "O_DIRECTORY", 0)
-                | getattr(os, "O_CLOEXEC", 0)
-                | getattr(os, "O_NOFOLLOW", 0),
-            )
-            try:
-                _posix_fchmod(executions_descriptor, 0o700)
-                os.fsync(executions_descriptor)
-            finally:
-                os.close(executions_descriptor)
-        execution_root = executions_dir / resolved_execution_id
-        execution_root.mkdir(mode=0o700)
-        if os.name != "nt":
-            execution_root.chmod(0o700)
-        _fsync_directory(execution_root.parent)
-        _atomic_json_dump(
-            execution_root / _EXECUTION_MARKER,
-            {
-                "schema_version": _EXECUTION_MARKER_SCHEMA,
-                "pipeline_name": self.name,
-                "execution_id": resolved_execution_id,
-                "state": "preparing",
-                "submitted": False,
-                "terminal": False,
-            },
+        scheduler_provider = self.scheduler.get("name")
+        if not isinstance(scheduler_provider, str) or not scheduler_provider.strip():
+            raise ValueError("scheduler.name is required (e.g. 'slurm')")
+        store = self._execution_store()
+        store.create(
+            resolved_execution_id,
+            mode="scheduler",
+            scheduler_provider=scheduler_provider.strip().lower(),
         )
+        execution_root = store.executions_dir / resolved_execution_id
+
+        def persist_stage_exception(
+            error: BaseException,
+            stage: str,
+            *,
+            ambiguous: bool,
+            accepted: bool = False,
+            return_code: int = 1,
+        ) -> None:
+            """Best-effort durable state for one failed submission stage."""
+            diagnostic = _bounded_execution_error(error)
+            try:
+                current = store.get(resolved_execution_id)
+                metadata = {
+                    "failure_stage": stage,
+                    "submission_diagnostic": diagnostic,
+                }
+                if current.terminal and current.state != "scripted":
+                    store.update(resolved_execution_id, metadata=metadata)
+                elif ambiguous:
+                    uncertain_state = (
+                        "unknown"
+                        if current.state in {"preparing", "submitting", "submitted"}
+                        else None
+                    )
+                    store.update(
+                        resolved_execution_id,
+                        state=uncertain_state,
+                        submitted=current.submitted or accepted,
+                        terminal=None,
+                        metadata=metadata,
+                    )
+                else:
+                    store.update(
+                        resolved_execution_id,
+                        state="failed",
+                        submitted=current.submitted or accepted,
+                        terminal=True,
+                        return_code=return_code if return_code != 0 else 1,
+                        error=diagnostic,
+                        metadata=metadata,
+                    )
+            except Exception as record_error:
+                error.add_note(
+                    f"could not persist scheduler stage {stage!r}: {record_error}"
+                )
+            try:
+                self.save()
+            except Exception as save_error:
+                error.add_note(
+                    f"could not save scheduler stage {stage!r}: {save_error}"
+                )
 
         try:
             # Save current in-memory state before sealing the submission input.
@@ -1153,16 +1226,19 @@ class Pipeline:
             )
             script_path = sched.write_script()
         except BaseException as exc:
-            # No scheduler side effect has occurred yet, so this directory is
-            # solely ours and is safe to remove. Do not leave a partial input
-            # tree that an operator could mistake for a valid execution.
             try:
-                shutil.rmtree(execution_root)
-                _fsync_directory(execution_root.parent)
-            except OSError as cleanup_error:
+                store.update(
+                    resolved_execution_id,
+                    state="failed",
+                    terminal=True,
+                    return_code=1,
+                    error=_bounded_execution_error(exc),
+                    metadata={"failure_stage": "scheduler_preparation"},
+                )
+            except Exception as record_error:
                 exc.add_note(
-                    "could not remove incomplete scheduler execution "
-                    f"{execution_root}: {cleanup_error}"
+                    "could not persist failed scheduler preparation state: "
+                    f"{record_error}"
                 )
             raise
         logger.pipeline(f"Wrote scheduler script: {script_path}")
@@ -1200,84 +1276,191 @@ class Pipeline:
                 else None
             ),
         }
-        self._update_execution_marker(execution_root)
-        # Save local JARVIS state before the external side effect. The relay's
-        # authenticated pre-submit intent remains the reconciliation authority;
-        # this record makes standalone JARVIS recovery and diagnosis possible.
-        self.save()
-
-        if submit:
-            from jarvis_cd.shell import Exec, LocalExecInfo
-
-            argv = sched.submit_command(wait=wait)
-            cmd = " ".join(shlex.quote(part) for part in argv)
-            logger.pipeline(f"Submitting: {cmd}")
-            result = Exec(cmd, LocalExecInfo(hide_output=True)).run()
-            exit_code = result.exit_code.get("localhost", 1)
-            self.last_submission["submission_returncode"] = exit_code
-            scheduler_stderr = _bounded_scheduler_stderr(result)
-            self.last_submission["scheduler_stderr"] = scheduler_stderr
-            diagnostic = (
-                f"; scheduler stderr: {scheduler_stderr}" if scheduler_stderr else ""
+        try:
+            self._update_execution_marker(execution_root)
+            # Save local JARVIS state before the external side effect. The
+            # relay's authenticated intent remains the reconciliation authority;
+            # this record makes standalone recovery and diagnosis possible.
+            self.save()
+        except BaseException as exc:
+            self.last_submission["state"] = "pre_submit_failed"
+            self.last_submission["terminal"] = True
+            persist_stage_exception(
+                exc,
+                "scheduler_pre_submit_persistence",
+                ambiguous=False,
             )
-            stdout = result.stdout.get("localhost", "")
-            try:
-                provider_metadata = sched.parse_submission_output(stdout)
-            except ValueError as exc:
-                self.last_submission["state"] = (
-                    "submission_failed" if exit_code != 0 else "identity_failed"
+            raise
+
+        if not submit:
+            return store.get(resolved_execution_id).handle
+
+        from jarvis_cd.shell import Exec, LocalExecInfo
+
+        argv = sched.submit_command(wait=wait)
+        cmd = " ".join(shlex.quote(part) for part in argv)
+        logger.pipeline(f"Submitting: {cmd}")
+        try:
+            result = Exec(cmd, LocalExecInfo(hide_output=True)).run()
+        except BaseException as exc:
+            self.last_submission["state"] = "submit_ambiguous"
+            self.last_submission["terminal"] = False
+            persist_stage_exception(
+                exc,
+                "scheduler_submit_side_effect",
+                ambiguous=True,
+            )
+            raise
+        exit_code = result.exit_code.get("localhost", 1)
+        self.last_submission["submission_returncode"] = exit_code
+        scheduler_stderr = _bounded_scheduler_stderr(result)
+        self.last_submission["scheduler_stderr"] = scheduler_stderr
+        diagnostic = (
+            f"; scheduler stderr: {scheduler_stderr}" if scheduler_stderr else ""
+        )
+        stdout = result.stdout.get("localhost", "")
+        try:
+            provider_metadata = sched.parse_submission_output(stdout)
+        except ValueError as parse_error:
+            self.last_submission["state"] = (
+                "submission_failed" if exit_code != 0 else "identity_failed"
+            )
+            self.last_submission["submitted"] = exit_code == 0
+            self.last_submission["terminal"] = exit_code != 0
+            if exit_code != 0:
+                outcome_error = RuntimeError(
+                    f"Scheduler submission failed (exit {exit_code}): {cmd}{diagnostic}"
                 )
-                self.last_submission["submitted"] = exit_code == 0
-                self.last_submission["terminal"] = exit_code != 0
-                self._update_execution_marker(execution_root)
-                self.save()
-                if exit_code != 0:
-                    raise RuntimeError(
-                        f"Scheduler submission failed (exit {exit_code}): "
-                        f"{cmd}{diagnostic}"
-                    ) from exc
-                raise RuntimeError(
+            else:
+                outcome_error = RuntimeError(
                     "Scheduler accepted the submission but did not return a "
                     f"structured job identity{diagnostic}"
-                ) from exc
-            self.last_submission.update(provider_metadata)
-            self.last_submission.update(
-                {
-                    "submitted": True,
-                    "terminal": bool(wait),
-                    "terminal_returncode": exit_code if wait else None,
-                }
-            )
+                )
+            try:
+                self._update_execution_marker(execution_root)
+                self.save()
+            except BaseException as persist_error:
+                outcome_error.add_note(
+                    f"could not persist scheduler parse outcome: {persist_error}"
+                )
+                persist_stage_exception(
+                    outcome_error,
+                    "scheduler_submission_identity_parse",
+                    ambiguous=exit_code == 0,
+                    accepted=exit_code == 0,
+                    return_code=exit_code,
+                )
+            raise outcome_error from parse_error
+
+        self.last_submission.update(provider_metadata)
+        self.last_submission.update(
+            {
+                "submitted": True,
+                "terminal": bool(wait),
+                "terminal_returncode": exit_code if wait else None,
+            }
+        )
+        try:
             self._update_execution_marker(execution_root)
             # Persist the provider-owned identity immediately after parsing;
             # later logging or state decoration must not reopen the orphan gap.
             self.save()
-            logger.pipeline(
-                f"Scheduler job identity: {self.last_submission['scheduler_job_id']}"
+        except BaseException as exc:
+            self.last_submission["state"] = "identity_persistence_failed"
+            self.last_submission["terminal"] = False
+            persist_stage_exception(
+                exc,
+                "scheduler_identity_persistence",
+                ambiguous=True,
+                accepted=True,
             )
-            if exit_code != 0:
-                self.last_submission["state"] = (
-                    "workload_failed" if wait else "accepted_with_error"
+            raise RuntimeError(
+                "Scheduler accepted job "
+                f"{self.last_submission['scheduler_job_id']}, but JARVIS could not "
+                "persist its complete submission identity"
+            ) from exc
+        logger.pipeline(
+            f"Scheduler job identity: {self.last_submission['scheduler_job_id']}"
+        )
+        if exit_code != 0:
+            self.last_submission["state"] = (
+                "workload_failed" if wait else "accepted_with_error"
+            )
+            if wait:
+                outcome_error = RuntimeError(
+                    "Scheduler job "
+                    f"{self.last_submission['scheduler_job_id']} was accepted, "
+                    f"but the workload failed (exit {exit_code}): "
+                    f"{cmd}{diagnostic}"
                 )
-                self._update_execution_marker(execution_root)
-                self.save()
-                if wait:
-                    raise RuntimeError(
-                        "Scheduler job "
-                        f"{self.last_submission['scheduler_job_id']} was accepted, "
-                        f"but the workload failed (exit {exit_code}): "
-                        f"{cmd}{diagnostic}"
-                    )
-                raise RuntimeError(
+            else:
+                outcome_error = RuntimeError(
                     "Scheduler job "
                     f"{self.last_submission['scheduler_job_id']} was accepted, "
                     f"but the submission command returned exit {exit_code}: "
                     f"{cmd}{diagnostic}"
                 )
-            self.last_submission["state"] = "completed" if wait else "submitted"
-        self._update_execution_marker(execution_root)
-        self.save()
-        return script_path
+            try:
+                self._update_execution_marker(execution_root)
+                self.save()
+            except BaseException as persist_error:
+                outcome_error.add_note(
+                    f"could not persist scheduler terminal outcome: {persist_error}"
+                )
+                persist_stage_exception(
+                    outcome_error,
+                    "scheduler_terminal_outcome_persistence",
+                    ambiguous=not wait,
+                    accepted=True,
+                    return_code=exit_code,
+                )
+            raise outcome_error
+
+        self.last_submission["state"] = "completed" if wait else "submitted"
+        try:
+            self._update_execution_marker(execution_root)
+            self.save()
+        except BaseException as exc:
+            persist_stage_exception(
+                exc,
+                "scheduler_final_state_persistence",
+                ambiguous=True,
+                accepted=True,
+            )
+            raise RuntimeError(
+                "Scheduler accepted job "
+                f"{self.last_submission['scheduler_job_id']}, but JARVIS could not "
+                "persist its final submission state"
+            ) from exc
+        return store.get(resolved_execution_id).handle
+
+    def _execution_store(self) -> ExecutionStore:
+        """Return the durable execution store for this pipeline identity."""
+        if not self.name:
+            raise ValueError("Pipeline name not set")
+        execution_root = getattr(self, "_execution_root", None)
+        if execution_root is not None:
+            executions_dir = Path(execution_root).parent
+        else:
+            executions_dir = (
+                self.jarvis.get_pipeline_shared_dir(self.name) / "executions"
+            )
+        return ExecutionStore(executions_dir, self.name)
+
+    def get_execution(self, execution_id: str) -> ExecutionRecord:
+        """Return the latest durable state for one exact execution identity."""
+        return self._execution_store().get(execution_id)
+
+    def list_executions(self) -> List[ExecutionRecord]:
+        """Return all durable executions owned by this pipeline."""
+        return self._execution_store().list()
+
+    def get_execution_progress(
+        self,
+        execution_id: str,
+    ) -> ExecutionProgressSnapshot:
+        """Return validated package progress for one exact execution."""
+        return self._execution_store().progress(execution_id)
 
     def _pipeline_storage_dir(self) -> Path:
         """Return the directory this Pipeline instance is allowed to mutate."""
@@ -1315,17 +1498,98 @@ class Pipeline:
         return f"{prefix}-{digest}"
 
     def _update_execution_marker(self, execution_root: Path) -> None:
-        """Persist cleanup eligibility alongside scheduler submission state."""
+        """Project scheduler compatibility metadata into its durable record."""
         submission = self.last_submission or {}
-        _atomic_json_dump(
-            execution_root / _EXECUTION_MARKER,
-            {
-                "schema_version": _EXECUTION_MARKER_SCHEMA,
-                "pipeline_name": self.name,
-                "execution_id": submission.get("execution_id"),
-                "state": submission.get("state"),
-                "submitted": submission.get("submitted") is True,
-                "terminal": submission.get("terminal") is True,
+        execution_id = submission.get("execution_id")
+        if not isinstance(execution_id, str) or execution_root.name != execution_id:
+            raise RuntimeError("scheduler submission lost its execution identity")
+        store = ExecutionStore(execution_root.parent, str(self.name))
+        current = store.get(execution_id)
+        scheduler_state = submission.get("state")
+        if scheduler_state == "scripted":
+            if submission.get("submitted") is True:
+                if submission.get("wait") is True:
+                    canonical_state = (
+                        "completed"
+                        if submission.get("terminal_returncode") == 0
+                        else "failed"
+                    )
+                else:
+                    canonical_state = "submitted"
+            else:
+                canonical_state = (
+                    "scripted" if submission.get("terminal") else ("submitting")
+                )
+        else:
+            canonical_state = {
+                "submitted": "submitted",
+                "completed": "completed",
+                "submission_failed": "failed",
+                "identity_failed": "unknown",
+                "pre_submit_failed": "failed",
+                "submit_ambiguous": "unknown",
+                "identity_persistence_failed": "unknown",
+                "workload_failed": "failed",
+                "accepted_with_error": "submitted",
+            }.get(scheduler_state)
+        # A fast scheduler job may advance the record before the submitting
+        # process has parsed the provider-native identity. Never regress that
+        # independently persisted runtime state back to submitted. A terminal
+        # runtime result is authoritative over sbatch's process status.
+        runtime_terminal = current.terminal and current.state in {
+            "completed",
+            "failed",
+            "canceled",
+        }
+        if runtime_terminal or (
+            current.state == "running"
+            and canonical_state in {None, "scripted", "submitting", "submitted"}
+        ):
+            canonical_state = None
+        terminal = submission.get("terminal") is True
+        if canonical_state is None:
+            terminal_value = None
+        else:
+            terminal_value = terminal
+        return_code = submission.get("terminal_returncode")
+        if canonical_state == "failed" and not isinstance(return_code, int):
+            submission_return_code = submission.get("submission_returncode")
+            return_code = (
+                submission_return_code
+                if isinstance(submission_return_code, int)
+                and not isinstance(submission_return_code, bool)
+                and submission_return_code != 0
+                else 1
+            )
+        if runtime_terminal or not isinstance(return_code, int):
+            return_code = current.return_code
+        scheduler_error = submission.get("scheduler_stderr")
+        if (
+            runtime_terminal
+            or not isinstance(scheduler_error, str)
+            or not scheduler_error
+        ):
+            scheduler_error = current.error
+        provider = submission.get("provider")
+        native_id = submission.get("scheduler_job_id")
+        cluster = submission.get("scheduler_cluster")
+        store.update(
+            execution_id,
+            state=canonical_state,
+            submitted=current.submitted or submission.get("submitted") is True,
+            terminal=terminal_value,
+            scheduler_provider=(
+                provider if provider is not None else current.scheduler_provider
+            ),
+            native_id=(
+                native_id if native_id is not None else current.scheduler_native_id
+            ),
+            cluster=cluster if cluster is not None else current.cluster,
+            return_code=return_code,
+            error=scheduler_error,
+            metadata={
+                "submission": dict(submission),
+                "script_path": submission.get("script_path"),
             },
         )
 
@@ -1414,7 +1678,15 @@ class Pipeline:
             ]
         ] = []
         removed: List[str] = []
+        execution_locks = ExitStack()
         try:
+            # Acquire locks in stable order so overlapping multi-ID cleanups do
+            # not deadlock. Hold them through ownership validation, tombstone
+            # deletion, and cleanup-receipt removal.
+            for execution_id in sorted(normalized):
+                execution_locks.enter_context(
+                    execution_transaction_lock(executions_dir, execution_id)
+                )
             for execution_id in normalized:
                 candidate = executions_dir / execution_id
                 quarantine = executions_dir / f".remove-{execution_id}"
@@ -1700,6 +1972,7 @@ class Pipeline:
                 removed.append(execution_id)
             return removed
         finally:
+            execution_locks.close()
             if executions_descriptor is not None:
                 os.close(executions_descriptor)
 
@@ -1834,6 +2107,7 @@ class Pipeline:
 
         :param pipeline_name: Name of the pipeline to create
         """
+        pipeline_name = validate_pipeline_id(pipeline_name)
         self.name = pipeline_name
 
         # Create all three directories for the pipeline
@@ -2025,6 +2299,7 @@ class Pipeline:
             else:
                 pipeline_name = self.name
 
+        pipeline_name = validate_pipeline_id(pipeline_name)
         target_pipeline_dir = self.jarvis.get_pipeline_dir(pipeline_name)
         executions_dir = (
             self.jarvis.get_pipeline_shared_dir(pipeline_name) / "executions"
@@ -2033,7 +2308,10 @@ class Pipeline:
             status = executions_dir.lstat()
             if not stat.S_ISDIR(status.st_mode) or stat.S_ISLNK(status.st_mode):
                 raise RuntimeError("pipeline executions path is not a real directory")
-            if any(executions_dir.iterdir()):
+            if any(
+                not is_execution_transaction_lock(entry)
+                for entry in executions_dir.iterdir()
+            ):
                 raise RuntimeError(
                     f"Pipeline '{pipeline_name}' still owns execution snapshots; "
                     "clean exact terminal execution IDs explicitly before destroy"
@@ -2094,6 +2372,7 @@ class Pipeline:
                     # Print BEGIN message
                     logger.success(f"[{pkg_def['pkg_type']}] [START] BEGIN")
 
+                    self._bind_package_execution_environment(pkg_def)
                     pkg_instance = self._load_package_instance(pkg_def, self.env)
 
                     # Apply interceptors to this package before starting
@@ -2121,6 +2400,50 @@ class Pipeline:
                         f"Pipeline startup failed at package '{pkg_def['pkg_id']}': {e}"
                     ) from e
 
+    def _bind_package_execution_environment(self, pkg_def: Dict[str, Any]) -> None:
+        """Bind authoritative per-package progress paths to the active execution."""
+        execution_root = getattr(self, "_execution_root", None)
+        execution_id = getattr(self, "_execution_id", None)
+        if execution_root is None or not isinstance(execution_id, str):
+            return
+        package_id = str(pkg_def.get("pkg_id") or pkg_def.get("pkg_type") or "package")
+        package_name = str(pkg_def.get("pkg_type") or package_id)
+        prefix = re.sub(r"[^A-Za-z0-9_-]", "-", package_id).strip("-")[:48]
+        if not prefix:
+            prefix = "package"
+        digest = hashlib.sha256(package_id.encode("utf-8")).hexdigest()[:12]
+        progress_dir = Path(execution_root) / "progress"
+        progress_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if os.name != "nt":
+            progress_dir.chmod(0o700)
+        progress_path = progress_dir / f"{prefix}-{digest}.jsonl"
+        package_config = pkg_def.get("config", {})
+        package_containerized = isinstance(package_config, dict) and (
+            package_config.get("deploy_mode") == "container"
+        )
+        progress_transport = (
+            "stdout" if self.is_containerized() or package_containerized else "sidecar"
+        )
+        self.env.update(
+            {
+                "JARVIS_EXECUTION_ID": execution_id,
+                "JARVIS_PACKAGE_ID": package_id,
+                "JARVIS_PACKAGE_NAME": package_name,
+                "JARVIS_PROGRESS_PATH": str(progress_path),
+                "JARVIS_PROGRESS_TRANSPORT": progress_transport,
+            }
+        )
+        record = self._execution_store().get(execution_id)
+        progress_files = dict(record.metadata.get("progress_files", {}))
+        progress_files[package_id] = {
+            "filename": progress_path.name,
+            "package_name": package_name,
+        }
+        self._execution_store().update(
+            execution_id,
+            metadata={"progress_files": progress_files},
+        )
+
     def stop(self):
         """Stop all packages in the pipeline"""
         from jarvis_cd.util.logger import logger
@@ -2138,6 +2461,7 @@ class Pipeline:
                     # Print BEGIN message
                     logger.success(f"[{pkg_def['pkg_type']}] [STOP] BEGIN")
 
+                    self._bind_package_execution_environment(pkg_def)
                     pkg_instance = self._load_package_instance(pkg_def, self.env)
 
                     if hasattr(pkg_instance, "stop"):
@@ -2170,6 +2494,7 @@ class Pipeline:
                     # Print BEGIN message
                     logger.success(f"[{pkg_def['pkg_type']}] [KILL] BEGIN")
 
+                    self._bind_package_execution_environment(pkg_def)
                     pkg_instance = self._load_package_instance(pkg_def, self.env)
 
                     if hasattr(pkg_instance, "kill"):
@@ -2217,19 +2542,82 @@ class Pipeline:
 
         return "\n".join(status_info)
 
-    def run(self, load_type: Optional[str] = None, pipeline_file: Optional[str] = None):
+    def run(
+        self,
+        load_type: Optional[str] = None,
+        pipeline_file: Optional[str] = None,
+        execution_id: Optional[str] = None,
+        wait: bool = True,
+    ) -> ExecutionHandle:
         """
         Run the pipeline (start all packages, then stop them).
         Optionally load a pipeline file first.
 
         :param load_type: Type of pipeline file to load (e.g., 'yaml')
         :param pipeline_file: Path to pipeline file to load and run
+        :param execution_id: Optional caller-selected JARVIS execution identity.
+        :param wait: When false, launch an owned local execution process and
+            return its queryable handle immediately.
+        :return: Queryable handle for the live or completed execution.
         """
+        if load_type and pipeline_file:
+            self.load(load_type, pipeline_file)
+        if not wait:
+            return self._launch_direct_execution(execution_id)
+        store = self._execution_store()
+        original_execution_root = getattr(self, "_execution_root", None)
+        original_execution_id = getattr(self, "_execution_id", None)
+        original_execution_env = {
+            name: self.env.get(name)
+            for name in (
+                "JARVIS_EXECUTION_ID",
+                "JARVIS_PACKAGE_ID",
+                "JARVIS_PACKAGE_NAME",
+                "JARVIS_PROGRESS_PATH",
+                "JARVIS_PROGRESS_TRANSPORT",
+            )
+        }
+        snapshot_execution_id = getattr(self, "_execution_id", None)
+        if getattr(self, "_execution_root", None) is not None:
+            if execution_id is not None and execution_id != snapshot_execution_id:
+                raise ValueError("scheduler snapshot execution_id cannot be overridden")
+            if not isinstance(snapshot_execution_id, str):
+                raise RuntimeError("scheduler snapshot has no execution identity")
+            resolved_execution_id = snapshot_execution_id
+            record = store.get(resolved_execution_id)
+            if record.mode == "scheduler":
+                store.update(
+                    resolved_execution_id,
+                    state="running",
+                    submitted=True,
+                    terminal=False,
+                )
+            elif record.mode == "direct":
+                store.update(
+                    resolved_execution_id,
+                    state="running",
+                    submitted=False,
+                    terminal=False,
+                )
+            else:
+                raise RuntimeError("execution snapshot record has the wrong mode")
+        else:
+            resolved_execution_id = _validated_execution_id(execution_id)
+            record = store.create(resolved_execution_id, mode="direct")
+            self._execution_root = store.executions_dir / resolved_execution_id
+            self._execution_id = resolved_execution_id
+            try:
+                store.update(
+                    resolved_execution_id,
+                    state="running",
+                    submitted=False,
+                    terminal=False,
+                )
+            except BaseException:
+                self._execution_root = original_execution_root
+                self._execution_id = original_execution_id
+                raise
         try:
-            # Load pipeline file if specified
-            if load_type and pipeline_file:
-                self.load(load_type, pipeline_file)
-
             # Configure all packages before starting.
             # This runs _configure() on each package, which sets up
             # environment variables (e.g., CHI_SERVER_CONF) needed by start().
@@ -2238,15 +2626,176 @@ class Pipeline:
             self.start()
             logger.pipeline("Pipeline started successfully. Stopping packages...")
             self.stop()
-        except Exception as e:
-            logger.error(f"Error during pipeline run: {e}")
+            if record.mode == "scheduler":
+                # The generated scheduler script owns the final transition so
+                # failures in post-run hooks are included in the execution.
+                return store.get(resolved_execution_id).handle
+            return store.update(
+                resolved_execution_id,
+                state="completed",
+                terminal=True,
+                return_code=0,
+                error=None,
+            ).handle
+        except BaseException as error:
+            logger.error(f"Error during pipeline run: {error}")
             logger.info("Attempting to stop packages...")
             try:
                 self.stop()
-            except Exception as stop_error:
+            except BaseException as stop_error:
                 logger.error(f"Error during cleanup: {stop_error}")
+                error.add_note(f"pipeline cleanup also failed: {stop_error}")
+            try:
+                store.update(
+                    resolved_execution_id,
+                    state="failed",
+                    terminal=True,
+                    return_code=1,
+                    error=_bounded_execution_error(error),
+                )
+            except Exception as record_error:
+                error.add_note(
+                    f"could not persist failed execution state: {record_error}"
+                )
             # Re-raise the original error after cleanup
             raise
+        finally:
+            if record.mode == "direct":
+                self._execution_root = original_execution_root
+                self._execution_id = original_execution_id
+                for name, value in original_execution_env.items():
+                    if value is None:
+                        self.env.pop(name, None)
+                    else:
+                        self.env[name] = value
+
+    def _launch_direct_execution(
+        self,
+        execution_id: Optional[str],
+    ) -> ExecutionHandle:
+        """Launch an isolated local execution and return before it completes."""
+        if getattr(self, "_execution_root", None) is not None:
+            raise RuntimeError("cannot background an execution snapshot")
+        if not self.name:
+            raise ValueError("Pipeline name not set")
+        self.name = validate_pipeline_id(self.name)
+        resolved_execution_id = _validated_execution_id(execution_id)
+        self.save()
+        store = self._execution_store()
+        direct_launch = {
+            "schema_version": "jarvis.direct-launch.v1",
+            "phase": "launching",
+            "launcher_pid": os.getpid(),
+            "child_pid": None,
+        }
+        store.create(
+            resolved_execution_id,
+            mode="direct",
+            metadata={"direct_launch": direct_launch},
+        )
+        execution_root = store.executions_dir / resolved_execution_id
+        process: Optional[subprocess.Popen[Any]] = None
+        try:
+            runtime_dir, input_dir, snapshot_sha256 = self._write_execution_snapshot(
+                execution_root,
+                {},
+            )
+            prepare_direct_execution_lease(execution_root)
+            stdout_path = execution_root / "stdout.log"
+            stderr_path = execution_root / "stderr.log"
+            direct_launch = {**direct_launch, "phase": "prepared"}
+            store.update(
+                resolved_execution_id,
+                metadata={
+                    "direct_launch": direct_launch,
+                    "pipeline_snapshot_path": str(runtime_dir),
+                    "pipeline_input_path": str(input_dir),
+                    "pipeline_snapshot_sha256": snapshot_sha256,
+                    "stdout_file": stdout_path.name,
+                    "stderr_file": stderr_path.name,
+                },
+            )
+            stdout_stream = stdout_path.open("ab", buffering=0)
+            try:
+                stderr_stream = stderr_path.open("ab", buffering=0)
+            except BaseException:
+                stdout_stream.close()
+                raise
+            try:
+                if os.name != "nt":
+                    stdout_path.chmod(0o600)
+                    stderr_path.chmod(0o600)
+                command = [
+                    sys.executable,
+                    "-m",
+                    "jarvis_cd.core.execution",
+                    "run-snapshot",
+                    "--execution-root",
+                    str(execution_root),
+                    "--execution-id",
+                    resolved_execution_id,
+                    "--snapshot-dir",
+                    str(runtime_dir),
+                ]
+                options: Dict[str, Any] = {
+                    "stdin": subprocess.DEVNULL,
+                    "stdout": stdout_stream,
+                    "stderr": stderr_stream,
+                    "close_fds": True,
+                }
+                if os.name == "nt":
+                    options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+                else:
+                    options["start_new_session"] = True
+                launched_process = subprocess.Popen(command, **options)
+                process = launched_process
+            finally:
+                stdout_stream.close()
+                stderr_stream.close()
+            direct_launch = {
+                **direct_launch,
+                "phase": "spawned",
+                "child_pid": launched_process.pid,
+            }
+            try:
+                store.update(
+                    resolved_execution_id,
+                    metadata={
+                        "direct_launch": direct_launch,
+                        "direct_process_id": launched_process.pid,
+                    },
+                )
+            except BaseException:
+                if launched_process.poll() is None:
+                    launched_process.terminate()
+                    try:
+                        launched_process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        launched_process.kill()
+                        launched_process.wait(timeout=5)
+                raise
+        except BaseException as error:
+            failed_launch = dict(direct_launch)
+            failed_launch["phase"] = "failed"
+            try:
+                store.update(
+                    resolved_execution_id,
+                    state="failed",
+                    terminal=True,
+                    return_code=1,
+                    error=_bounded_execution_error(error),
+                    metadata={
+                        "direct_launch": failed_launch,
+                        "failure_stage": "direct_launch",
+                    },
+                )
+            except Exception as record_error:
+                error.add_note(
+                    f"could not persist failed direct launch state: {record_error}"
+                )
+            raise
+        assert process is not None
+        return store.get(resolved_execution_id).handle
 
     def configure_all_packages(self):
         """
@@ -2598,6 +3147,11 @@ class Pipeline:
         # Load pipeline configuration (in script format)
         with open(config_file, "r") as f:
             pipeline_config = yaml.safe_load(f)
+        if not isinstance(pipeline_config, dict):
+            raise ValueError("pipeline configuration must be a mapping")
+        stored_name = validate_pipeline_id(pipeline_config.get("name"))
+        if stored_name != self.name:
+            raise ValueError("pipeline configuration identity mismatch")
 
         # Extract metadata
         self.created_at = pipeline_config.get("created_at")
@@ -2748,8 +3302,10 @@ class Pipeline:
         # Load pipeline definition
         with open(pipeline_file, "r") as f:
             pipeline_def = yaml.safe_load(f)
+        if not isinstance(pipeline_def, dict):
+            raise ValueError("pipeline YAML must be a mapping")
 
-        self.name = pipeline_def.get("name", pipeline_file.stem)
+        self.name = validate_pipeline_id(pipeline_def.get("name", pipeline_file.stem))
         if (
             snapshot_marker is not None
             and snapshot_marker["pipeline_name"] != self.name
@@ -3652,6 +4208,7 @@ class Pipeline:
         for pkg_def in self.packages:
             try:
                 logger.success(f"[{pkg_def['pkg_type']}] [START] BEGIN")
+                self._bind_package_execution_environment(pkg_def)
                 pkg_instance = self._load_package_instance(pkg_def, self.env)
                 self._apply_interceptors_to_package(pkg_instance, pkg_def)
 
@@ -3661,6 +4218,7 @@ class Pipeline:
                     logger.warning(f"Package {pkg_def['pkg_id']} has no start method")
 
                 self.env.update(pkg_instance.env)
+                self._started_instances.append(pkg_instance)
                 logger.success(f"[{pkg_def['pkg_type']}] [START] END")
             except Exception as e:
                 logger.error(f"Error starting package {pkg_def['pkg_id']}: {e}")
@@ -3750,6 +4308,7 @@ class Pipeline:
         for pkg_def in reversed(self.packages):
             try:
                 logger.success(f"[{pkg_def['pkg_type']}] [STOP] BEGIN")
+                self._bind_package_execution_environment(pkg_def)
                 pkg_instance = self._load_package_instance(pkg_def, self.env)
                 if hasattr(pkg_instance, "stop"):
                     pkg_instance.stop()
@@ -3792,6 +4351,7 @@ class Pipeline:
         for pkg_def in self.packages:
             try:
                 logger.success(f"[{pkg_def['pkg_type']}] [KILL] BEGIN")
+                self._bind_package_execution_environment(pkg_def)
                 pkg_instance = self._load_package_instance(pkg_def, self.env)
                 if hasattr(pkg_instance, "kill"):
                     pkg_instance.kill()

--- a/jarvis_cd/core/pkg.py
+++ b/jarvis_cd/core/pkg.py
@@ -4,12 +4,12 @@ Provides the consolidated Pkg class and its subclasses for Services, Application
 """
 
 import os
-import yaml
+import sys
 import time
 import inspect
 from pathlib import Path
 from typing import Dict, Any, List, Optional
-from jarvis_cd.core.config import Jarvis, load_class
+from jarvis_cd.core.config import Jarvis
 from jarvis_cd.util.hostfile import Hostfile
 
 
@@ -18,7 +18,7 @@ class Pkg:
     Consolidated base class for all Jarvis packages.
     Provides common functionality and interface for services, applications, and interceptors.
     """
-    
+
     @classmethod
     def load_standalone(cls, package_spec: str):
         """
@@ -33,9 +33,9 @@ class Pkg:
         jarvis = Jarvis.get_instance()
 
         # Parse package specification
-        if '.' in package_spec:
+        if "." in package_spec:
             # Full specification like "builtin.ior"
-            import_parts = package_spec.split('.')
+            import_parts = package_spec.split(".")
             repo_name = import_parts[0]
             pkg_name = import_parts[1]
         else:
@@ -43,21 +43,22 @@ class Pkg:
             full_spec = jarvis.find_package(package_spec)
             if not full_spec:
                 raise ValueError(f"Package not found: {package_spec}")
-            import_parts = full_spec.split('.')
+            import_parts = full_spec.split(".")
             repo_name = import_parts[0]
             pkg_name = import_parts[1]
 
         # Determine class name (convert snake_case to PascalCase)
         import re
-        class_name = ''.join(word.capitalize() for word in re.split(r'[_-]', pkg_name))
+
+        class_name = "".join(word.capitalize() for word in re.split(r"[_-]", pkg_name))
 
         # Load class
-        if repo_name == 'builtin':
+        if repo_name == "builtin":
             repo_path = str(jarvis.get_builtin_repo_path())
         else:
             # Find repo path in registered repos
             repo_path = None
-            for registered_repo in jarvis.repos['repos']:
+            for registered_repo in jarvis.repos["repos"]:
                 if Path(registered_repo).name == repo_name:
                     repo_path = registered_repo
                     break
@@ -69,7 +70,9 @@ class Pkg:
         try:
             pkg_class = load_class(import_str, repo_path, class_name)
         except Exception as e:
-            raise ValueError(f"Failed to load package '{package_spec}': Error loading class {class_name} from {import_str}: {e}")
+            raise ValueError(
+                f"Failed to load package '{package_spec}': Error loading class {class_name} from {import_str}: {e}"
+            )
 
         if not pkg_class:
             raise ValueError(f"Package class not found: {class_name} in {import_str}")
@@ -92,7 +95,7 @@ class Pkg:
         pkg_instance._ensure_directories()
 
         return pkg_instance
-    
+
     def __init__(self, pipeline):
         """
         Initialize package with default values.
@@ -101,13 +104,13 @@ class Pkg:
         """
         self.jarvis = Jarvis.get_instance()
         self.pipeline = pipeline
-        self.pkg_dir = None          # Directory containing the package source (pkg.py file)
-        self.config_dir = None       # Directory for saving package configuration files
+        self.pkg_dir = None  # Directory containing the package source (pkg.py file)
+        self.config_dir = None  # Directory for saving package configuration files
         self.shared_dir = None
         self.private_dir = None
-        self.env = {}                # Base environment (everything except LD_PRELOAD)
-        self.mod_env = {}           # Modified environment (exact replica of env + LD_PRELOAD)
-        self.config = {'interceptors': {}}
+        self.env = {}  # Base environment (everything except LD_PRELOAD)
+        self.mod_env = {}  # Modified environment (exact replica of env + LD_PRELOAD)
+        self.config = {"interceptors": {}}
         self.pkg_type = None
         self.global_id = None
         self.pkg_id = None
@@ -136,12 +139,12 @@ class Pkg:
         :return: Hostfile object
         """
         # Check if package has a hostfile configured
-        hostfile_path = self.config.get('hostfile', '')
+        hostfile_path = self.config.get("hostfile", "")
         if hostfile_path:
             return Hostfile(path=hostfile_path)
 
         # Fall back to pipeline's hostfile
-        if hasattr(self.pipeline, 'get_hostfile'):
+        if hasattr(self.pipeline, "get_hostfile"):
             return self.pipeline.get_hostfile()
 
         # Fall back to global jarvis hostfile
@@ -155,15 +158,15 @@ class Pkg:
         Default values should almost always be None.
         """
         pass
-        
+
     def _configure_menu(self) -> List[Dict[str, Any]]:
         """
         Override this method to define configuration options.
-        
+
         :return: List of configuration option dictionaries
         """
         return []
-        
+
     def _configure(self, **kwargs):
         """
         Override this method to handle package configuration.
@@ -173,102 +176,101 @@ class Pkg:
         :param kwargs: Configuration parameters
         """
         self.update_config(kwargs, rebuild=False)
-        
+
     def configure_menu(self):
         """
         Get the complete configuration menu including common parameters.
         Returns the menu in argument dictionary format so parameters can be set from command line.
-        
+
         :return: List of configuration option dictionaries
         """
         # Get package-specific menu
         package_menu = self._configure_menu()
-        
+
         # Add common parameters that all packages should have
         common_menu = [
             {
-                'name': 'install_method',
-                'msg': "Installer to use for this package "
-                       "('pip', 'conda', 'spack', 'container'). Empty "
-                       "string defers to the pipeline's base_deploy_mode.",
-                'type': str,
-                'default': '',
+                "name": "install_method",
+                "msg": "Installer to use for this package "
+                "('pip', 'conda', 'spack', 'container'). Empty "
+                "string defers to the pipeline's base_deploy_mode.",
+                "type": str,
+                "default": "",
             },
             {
-                'name': 'install_query',
-                'msg': 'Package spec consumed by the installer (e.g. spack '
-                       'spec, pip requirement, conda package name).',
-                'type': str,
-                'default': '',
+                "name": "install_query",
+                "msg": "Package spec consumed by the installer (e.g. spack "
+                "spec, pip requirement, conda package name).",
+                "type": str,
+                "default": "",
             },
             {
-                'name': 'install',
-                'msg': 'Deprecated alias for install_query. Prefer '
-                       'install_query.',
-                'type': str,
-                'default': '',
+                "name": "install",
+                "msg": "Deprecated alias for install_query. Prefer install_query.",
+                "type": str,
+                "default": "",
             },
             {
-                'name': 'container_cache',
-                'msg': 'Use Docker layer cache when building containers (set false to force rebuild)',
-                'type': bool,
-                'default': True,
+                "name": "container_cache",
+                "msg": "Use Docker layer cache when building containers (set false to force rebuild)",
+                "type": bool,
+                "default": True,
             },
             {
-                'name': 'interceptors',
-                'msg': 'List of interceptor package names to apply',
-                'type': list,
-                'default': [],
-                'args': [
+                "name": "interceptors",
+                "msg": "List of interceptor package names to apply",
+                "type": list,
+                "default": [],
+                "args": [
                     {
-                        'name': 'interceptor_name',
-                        'msg': 'Name of an interceptor package',
-                        'type': str,
+                        "name": "interceptor_name",
+                        "msg": "Name of an interceptor package",
+                        "type": str,
                     }
-                ]
+                ],
             },
             {
-                'name': 'sleep',
-                'msg': 'Sleep time in seconds',
-                'type': int,
-                'default': 0,
+                "name": "sleep",
+                "msg": "Sleep time in seconds",
+                "type": int,
+                "default": 0,
             },
             {
-                'name': 'do_dbg',
-                'msg': 'Enable debug mode',
-                'type': bool,
-                'default': False,
+                "name": "do_dbg",
+                "msg": "Enable debug mode",
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'dbg_port',
-                'msg': 'Debug port number',
-                'type': int,
-                'default': 1234,
+                "name": "dbg_port",
+                "msg": "Debug port number",
+                "type": int,
+                "default": 1234,
             },
             {
-                'name': 'timeout',
-                'msg': 'Operation timeout in seconds',
-                'type': int,
-                'default': 300,
+                "name": "timeout",
+                "msg": "Operation timeout in seconds",
+                "type": int,
+                "default": 300,
             },
             {
-                'name': 'retry_count',
-                'msg': 'Number of retry attempts',
-                'type': int,
-                'default': 3,
+                "name": "retry_count",
+                "msg": "Number of retry attempts",
+                "type": int,
+                "default": 3,
             },
             {
-                'name': 'hide_output',
-                'msg': 'Hide command output',
-                'type': bool,
-                'default': False,
+                "name": "hide_output",
+                "msg": "Hide command output",
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'hostfile',
-                'msg': 'Path to hostfile (empty string means use pipeline hostfile)',
-                'type': str,
-                'default': '',
-            }
+                "name": "hostfile",
+                "msg": "Path to hostfile (empty string means use pipeline hostfile)",
+                "type": str,
+                "default": "",
+            },
         ]
 
         # Combine package-specific and common menus
@@ -282,7 +284,8 @@ class Pkg:
         :return: PkgArgParse instance
         """
         from jarvis_cd.util import PkgArgParse
-        pkg_name = getattr(self, 'pkg_id', None) or self.__class__.__name__
+
+        pkg_name = getattr(self, "pkg_id", None) or self.__class__.__name__
         return PkgArgParse(pkg_name, self.configure_menu())
 
     def configure(self, **kwargs):
@@ -329,7 +332,7 @@ class Pkg:
         :return: Delegate instance
         """
         # Check if we already have a delegate for this mode
-        delegate_key = f'_delegate_{deploy_mode}'
+        delegate_key = f"_delegate_{deploy_mode}"
         if hasattr(self, delegate_key) and getattr(self, delegate_key) is not None:
             return getattr(self, delegate_key)
 
@@ -338,14 +341,17 @@ class Pkg:
 
         # Build delegate class name: {BaseClassName}{DeployModeCapitalized}
         # e.g., 'Ior' + 'Container' = 'IorContainer'
-        deploy_mode_capitalized = ''.join(word.capitalize() for word in deploy_mode.split('_'))
+        deploy_mode_capitalized = "".join(
+            word.capitalize() for word in deploy_mode.split("_")
+        )
         delegate_class_name = f"{base_class_name}{deploy_mode_capitalized}"
 
         # Import the module dynamically relative to current package
         # e.g., if we're in builtin.ior.pkg, import builtin.ior.{deploy_mode}
         import importlib
+
         current_module = self.__class__.__module__  # e.g., 'builtin.ior.pkg'
-        package_path = current_module.rsplit('.', 1)[0]  # e.g., 'builtin.ior'
+        package_path = current_module.rsplit(".", 1)[0]  # e.g., 'builtin.ior'
         module_path = f"{package_path}.{deploy_mode}"
 
         try:
@@ -397,15 +403,39 @@ class Pkg:
         - private_dir: pipeline_name/pkg_id
         """
         if not self.config_dir or not self.shared_dir or not self.private_dir:
-            pkg_id = getattr(self, 'pkg_id', None) or self.__class__.__name__.lower()
+            pkg_id = getattr(self, "pkg_id", None) or self.__class__.__name__.lower()
 
             # Get directories from pipeline
-            pipeline_config_dir = self.jarvis.get_pipeline_dir(self.pipeline.name)
-            pipeline_shared_dir = self.jarvis.get_pipeline_shared_dir(self.pipeline.name)
-            pipeline_private_dir = self.jarvis.get_pipeline_private_dir(self.pipeline.name)
+            getters = [
+                getattr(self.pipeline, method, None)
+                for method in (
+                    "get_pipeline_config_dir",
+                    "get_pipeline_shared_dir",
+                    "get_pipeline_private_dir",
+                )
+            ]
+            scoped_roots = (
+                [getter() for getter in getters]
+                if all(callable(getter) for getter in getters)
+                else []
+            )
+            if len(scoped_roots) == 3 and all(
+                isinstance(root, (str, os.PathLike)) for root in scoped_roots
+            ):
+                pipeline_config_dir, pipeline_shared_dir, pipeline_private_dir = (
+                    Path(root) for root in scoped_roots
+                )
+            else:
+                pipeline_config_dir = self.jarvis.get_pipeline_dir(self.pipeline.name)
+                pipeline_shared_dir = self.jarvis.get_pipeline_shared_dir(
+                    self.pipeline.name
+                )
+                pipeline_private_dir = self.jarvis.get_pipeline_private_dir(
+                    self.pipeline.name
+                )
 
             if not self.config_dir:
-                self.config_dir = str(pipeline_config_dir / 'packages' / pkg_id)
+                self.config_dir = str(pipeline_config_dir / "packages" / pkg_id)
             if not self.shared_dir:
                 self.shared_dir = str(pipeline_shared_dir / pkg_id)
             if not self.private_dir:
@@ -415,10 +445,10 @@ class Pkg:
             for dir_path in [self.config_dir, self.shared_dir, self.private_dir]:
                 if dir_path and not Path(dir_path).exists():
                     Path(dir_path).mkdir(parents=True, exist_ok=True)
-            
+
             # Call user-defined initialization
             self._init()
-    
+
     def _detect_pkg_dir(self):
         """
         Detect the directory containing this package's source code (where pkg.py is located).
@@ -428,33 +458,37 @@ class Pkg:
             class_file = inspect.getfile(self.__class__)
             # Get the directory containing the package file
             self.pkg_dir = str(Path(class_file).parent)
-        except Exception as e:
+        except Exception:
             # Fallback: leave pkg_dir as None if detection fails
             pass
-            
+
     def _apply_menu_defaults(self):
         """
         Apply default values from the configuration menu to ensure all parameters have values.
         """
         menu = self.configure_menu()
         for item in menu:
-            param_name = item.get('name')
-            default_value = item.get('default')
-            if param_name and param_name not in self.config and default_value is not None:
+            param_name = item.get("name")
+            default_value = item.get("default")
+            if (
+                param_name
+                and param_name not in self.config
+                and default_value is not None
+            ):
                 self.config[param_name] = default_value
-        
+
     def update_config(self, new_config: Dict[str, Any], rebuild: bool = True):
         """
         Update package configuration.
-        
+
         :param new_config: New configuration values
         :param rebuild: Whether to rebuild configuration files
         """
         self.config.update(new_config)
-        
-        if rebuild and hasattr(self, '_configure'):
+
+        if rebuild and hasattr(self, "_configure"):
             self._configure(**self.config)
-            
+
     def start(self):
         """
         Start the package.
@@ -462,7 +496,7 @@ class Pkg:
         Override this method in package implementations.
         """
         pass
-        
+
     def stop(self):
         """
         Stop the package.
@@ -470,7 +504,7 @@ class Pkg:
         Override this method in package implementations.
         """
         pass
-        
+
     def kill(self):
         """
         Kill the package.
@@ -478,7 +512,7 @@ class Pkg:
         Override this method in package implementations.
         """
         pass
-        
+
     def clean(self):
         """
         Clean package data.
@@ -487,141 +521,143 @@ class Pkg:
         Override this method in package implementations.
         """
         pass
-        
+
     def status(self) -> str:
         """
         Override this method to return package status.
         Called during pipeline status operations.
-        
+
         :return: Status string
         """
         return "unknown"
-        
+
     def track_env(self, env_track_dict: Dict[str, str]):
         """
         Track environment variables.
-        
+
         :param env_track_dict: Dictionary of environment variables to track
         """
         # Add to env (but not LD_PRELOAD)
         for key, value in env_track_dict.items():
-            if key != 'LD_PRELOAD':
+            if key != "LD_PRELOAD":
                 self.env[key] = value
-        
+
         # mod_env is exact replica of env plus LD_PRELOAD
         self.mod_env = self.env.copy()
-        if 'LD_PRELOAD' in env_track_dict:
-            self.mod_env['LD_PRELOAD'] = env_track_dict['LD_PRELOAD']
-        
+        if "LD_PRELOAD" in env_track_dict:
+            self.mod_env["LD_PRELOAD"] = env_track_dict["LD_PRELOAD"]
+
     def prepend_env(self, env_name: str, val: str):
         """
         Prepend a value to an environment variable.
-        
+
         :param env_name: Environment variable name
         :param val: Value to prepend
         """
         # For LD_PRELOAD, only update mod_env
-        if env_name == 'LD_PRELOAD':
-            current_val = self.mod_env.get(env_name, '')
+        if env_name == "LD_PRELOAD":
+            current_val = self.mod_env.get(env_name, "")
             if current_val:
                 self.mod_env[env_name] = f"{val}:{current_val}"
             else:
                 self.mod_env[env_name] = val
         else:
             # For other variables, update env
-            current_val = self.env.get(env_name, '')
+            current_val = self.env.get(env_name, "")
             if current_val:
                 self.env[env_name] = f"{val}:{current_val}"
             else:
                 self.env[env_name] = val
-            
+
             # Keep mod_env in sync (exact replica of env + LD_PRELOAD)
             self.mod_env[env_name] = self.env[env_name]
-            
+
     def setenv(self, env_name: str, val: str):
         """
         Set an environment variable.
-        
+
         :param env_name: Environment variable name
         :param val: Value to set
         """
         # For LD_PRELOAD, only update mod_env
-        if env_name == 'LD_PRELOAD':
+        if env_name == "LD_PRELOAD":
             self.mod_env[env_name] = val
         else:
             # For other variables, update env
             self.env[env_name] = val
-            
+
             # Keep mod_env in sync (exact replica of env + LD_PRELOAD)
             self.mod_env[env_name] = val
 
     def find_library(self, library_name: str) -> Optional[str]:
         """
         Find a shared library by searching LD_LIBRARY_PATH and system paths.
-        
+
         :param library_name: Name of the library to find
         :return: Path to library if found, None otherwise
         """
         import shutil
-        
+
         # Generate possible library filenames
         lib_filenames = [
-            f"lib{library_name}.so",     # Standard shared library
-            f"{library_name}.so",        # Library name as-is with .so
-            f"lib{library_name}.a",      # Static library
-            library_name                 # Exact name as provided
+            f"lib{library_name}.so",  # Standard shared library
+            f"{library_name}.so",  # Library name as-is with .so
+            f"lib{library_name}.a",  # Static library
+            library_name,  # Exact name as provided
         ]
-        
+
         # Collect all library search paths in priority order
         search_paths = []
-        
+
         # 1. Package-specific environment (mod_env takes precedence over env)
-        mod_ld_path = self.mod_env.get('LD_LIBRARY_PATH')
+        mod_ld_path = self.mod_env.get("LD_LIBRARY_PATH")
         if mod_ld_path:
-            search_paths.extend(mod_ld_path.split(':'))
-        
-        env_ld_path = self.env.get('LD_LIBRARY_PATH')
+            search_paths.extend(mod_ld_path.split(os.pathsep))
+
+        env_ld_path = self.env.get("LD_LIBRARY_PATH")
         if env_ld_path:
-            search_paths.extend(env_ld_path.split(':'))
-            
+            search_paths.extend(env_ld_path.split(os.pathsep))
+
         # 2. System LD_LIBRARY_PATH
-        system_ld_path = os.environ.get('LD_LIBRARY_PATH')
+        system_ld_path = os.environ.get("LD_LIBRARY_PATH")
         if system_ld_path:
-            search_paths.extend(system_ld_path.split(':'))
-        
+            search_paths.extend(system_ld_path.split(os.pathsep))
+
         # 3. Common system library directories
-        search_paths.extend([
-            "/usr/lib",
-            "/usr/local/lib", 
-            "/usr/lib64",
-            "/usr/local/lib64",
-            "/lib",
-            "/lib64"
-        ])
-        
+        search_paths.extend(
+            [
+                "/usr/lib",
+                "/usr/local/lib",
+                "/usr/lib64",
+                "/usr/local/lib64",
+                "/lib",
+                "/lib64",
+            ]
+        )
+
         # Search for the library in all paths
         for search_path in search_paths:
             if not search_path:  # Skip empty paths
                 continue
-                
+
             search_dir = Path(search_path)
             if not search_dir.exists():
                 continue
-                
+
             for lib_filename in lib_filenames:
                 lib_path = search_dir / lib_filename
                 print(lib_path)
                 if lib_path.exists():
                     return str(lib_path)
-        
+
         # Fallback: try using shutil.which for executable-style lookup
         for lib_filename in lib_filenames:
             lib_path = shutil.which(lib_filename)
             if lib_path:
                 return lib_path
-                
+
         return None
-    
+
     def log(self, message, color=None):
         """
         Log a message with package context and optional color.
@@ -629,7 +665,7 @@ class Pkg:
         :param message: Message to log
         :param color: Color to use (from jarvis_cd.util.logger.Color enum), defaults to YELLOW for info messages
         """
-        from jarvis_cd.util.logger import logger, Color
+        from jarvis_cd.util.logger import logger
 
         formatted_message = f"[{self.__class__.__name__}] {message}"
 
@@ -638,31 +674,31 @@ class Pkg:
         else:
             # Default to yellow for info messages
             logger.warning(formatted_message)
-        
+
     def sleep(self, time_sec=None):
         """
         Sleep for a specified amount of time.
-        
+
         :param time_sec: Time to sleep in seconds. If not provided, uses self.config['sleep']
         """
         if time_sec is None:
-            time_sec = self.config.get('sleep', 0)
-            
+            time_sec = self.config.get("sleep", 0)
+
         self.log(f"Sleeping for {time_sec} seconds")
         if time_sec > 0:
             time.sleep(time_sec)
-            
+
     def copy_template_file(self, source_path, dest_path, replacements=None):
         """
         Copy a template file from source to destination, replacing template constants.
-        
+
         Template constants have the format ##CONSTANT_NAME## and are replaced with
         values from the replacements dictionary.
-        
+
         :param source_path: Path to the source template file
         :param dest_path: Path where the processed file should be saved
         :param replacements: Dictionary of replacements {CONSTANT_NAME: value}
-        
+
         Example:
             self.copy_template_file(f'{self.pkg_dir}/config/hermes.xml',
                                    self.adios2_xml_path,
@@ -671,35 +707,35 @@ class Pkg:
         try:
             if replacements is None:
                 replacements = {}
-                
+
             # Read the template file
-            with open(source_path, 'r') as f:
+            with open(source_path, "r") as f:
                 content = f.read()
-            
+
             # Replace template constants
             for key, value in replacements.items():
                 template_token = f"##{key}##"
                 content = content.replace(template_token, str(value))
-            
+
             # Ensure destination directory exists
             dest_dir = Path(dest_path).parent
             dest_dir.mkdir(parents=True, exist_ok=True)
-            
+
             # Write the processed content to destination
-            with open(dest_path, 'w') as f:
+            with open(dest_path, "w") as f:
                 f.write(content)
-                
-            self.log(f"Copied template file {source_path} -> {dest_path} with {len(replacements)} replacements")
-            
+
+            self.log(
+                f"Copied template file {source_path} -> {dest_path} with {len(replacements)} replacements"
+            )
+
         except FileNotFoundError:
             self.log(f"Error: Template file not found: {source_path}")
             raise
         except Exception as e:
             self.log(f"Error copying template file {source_path} -> {dest_path}: {e}")
             raise
-            
-        
-    
+
     # ------------------------------------------------------------------
     # Container support — properties
     # ------------------------------------------------------------------
@@ -712,11 +748,11 @@ class Pkg:
                        When None, uses self._build_suffix (set by build_phase).
         :return: e.g. 'jarvis-build-lammps-kokkos-a100'
         """
-        pkg_name = self.pkg_type.split('.')[-1].replace('_', '-')
-        s = suffix if suffix is not None else getattr(self, '_build_suffix', '')
+        pkg_name = self.pkg_type.split(".")[-1].replace("_", "-")
+        s = suffix if suffix is not None else getattr(self, "_build_suffix", "")
         if s:
-            return f'jarvis-build-{pkg_name}-{s}'
-        return f'jarvis-build-{pkg_name}'
+            return f"jarvis-build-{pkg_name}-{s}"
+        return f"jarvis-build-{pkg_name}"
 
     def deploy_image_name(self, suffix=None) -> str:
         """
@@ -725,10 +761,19 @@ class Pkg:
         :param suffix: Image suffix identifying this configuration.
                        When None, uses self._deploy_suffix (set by build_deploy_phase).
         """
-        base = self.pipeline.name if hasattr(self, 'pipeline') and self.pipeline else 'jarvis-deploy'
-        s = suffix if suffix is not None else getattr(self, '_deploy_suffix', '')
+        pipeline = getattr(self, "pipeline", None)
+        base = (
+            getattr(
+                pipeline,
+                "execution_container_name",
+                getattr(pipeline, "name", "jarvis-deploy"),
+            )
+            if pipeline
+            else "jarvis-deploy"
+        )
+        s = suffix if suffix is not None else getattr(self, "_deploy_suffix", "")
         if s:
-            return f'{base}-{s}'
+            return f"{base}-{s}"
         return base
 
     @property
@@ -739,9 +784,9 @@ class Pkg:
         """
         mounts = []
         if self.shared_dir:
-            mounts.append(f'{self.shared_dir}:{self.shared_dir}')
+            mounts.append(f"{self.shared_dir}:{self.shared_dir}")
         if self.private_dir:
-            mounts.append(f'{self.private_dir}:{self.private_dir}')
+            mounts.append(f"{self.private_dir}:{self.private_dir}")
         return mounts
 
     @property
@@ -749,9 +794,9 @@ class Pkg:
         """SSH port for reaching container nodes.
         Returns the pipeline's container_ssh_port when the pipeline is
         containerized, otherwise the default SSH port (22)."""
-        if hasattr(self, 'pipeline') and self.pipeline:
+        if hasattr(self, "pipeline") and self.pipeline:
             if self.pipeline._has_containerized_packages():
-                return getattr(self.pipeline, 'container_ssh_port', 22)
+                return getattr(self.pipeline, "container_ssh_port", 22)
         return 22
 
     @property
@@ -763,21 +808,22 @@ class Pkg:
         wrp_cte_libfuse running on the host while the workload runs in
         the SIF).
         """
-        if hasattr(self, 'pipeline') and self.pipeline:
-            if self.config.get('deploy_mode') == 'container':
-                return getattr(self.pipeline, 'container_engine', 'none')
-        return 'none'
+        if hasattr(self, "pipeline") and self.pipeline:
+            if self.config.get("deploy_mode") == "container":
+                return getattr(self.pipeline, "container_engine", "none")
+        return "none"
 
     @property
     def _build_engine(self) -> str:
         """Get the engine to use for building (apptainer needs docker/podman as intermediate)."""
         engine = self._container_engine
-        if engine == 'apptainer':
+        if engine == "apptainer":
             import shutil
-            if shutil.which('docker'):
-                return 'docker'
-            elif shutil.which('podman'):
-                return 'podman'
+
+            if shutil.which("docker"):
+                return "docker"
+            elif shutil.which("podman"):
+                return "podman"
             else:
                 raise RuntimeError(
                     "Apptainer requires docker or podman for the build phase. "
@@ -800,12 +846,13 @@ class Pkg:
         :return: File content with substitutions applied
         """
         import os
+
         path = os.path.join(self.pkg_dir, filename)
-        with open(path, 'r') as f:
+        with open(path, "r") as f:
             content = f.read()
         if replacements:
             for key, value in replacements.items():
-                content = content.replace(f'##{key}##', str(value))
+                content = content.replace(f"##{key}##", str(value))
         return content
 
     # Keep old name as alias for backwards compatibility
@@ -868,20 +915,21 @@ class Pkg:
                            callers are migrated.
         :return: True if the image exists
         """
-        if engine == 'apptainer':
+        if engine == "apptainer":
             from pathlib import Path
+
             sif_root = sif_dir or shared_dir
             if not sif_root:
                 return False
-            sif = Path(sif_root) / f'{image_name}.sif'
+            sif = Path(sif_root) / f"{image_name}.sif"
             return sif.exists()
         # docker / podman
         from jarvis_cd.shell import Exec, LocalExecInfo
+
         result = Exec(
-            f'{engine} image inspect {image_name}',
-            LocalExecInfo(hide_output=True)
+            f"{engine} image inspect {image_name}", LocalExecInfo(hide_output=True)
         ).run()
-        return result.exit_code.get('localhost', 1) == 0
+        return result.exit_code.get("localhost", 1) == 0
 
     def show_build_script(self):
         """
@@ -891,7 +939,7 @@ class Pkg:
         packages that gate generation on deploy_mode).
         """
         # Most _build_phase implementations require deploy_mode='container'
-        self.config.setdefault('deploy_mode', 'container')
+        self.config.setdefault("deploy_mode", "container")
 
         try:
             result = self._build_phase()
@@ -901,20 +949,20 @@ class Pkg:
         else:
             err = None
 
-        content = ''
-        suffix = ''
+        content = ""
+        suffix = ""
         if result and isinstance(result, tuple):
-            content, suffix = (result + ('',))[:2]
+            content, suffix = (result + ("",))[:2]
 
         if not content and self.pkg_dir:
-            raw = Path(self.pkg_dir) / 'build.sh'
+            raw = Path(self.pkg_dir) / "build.sh"
             if raw.exists():
                 print(f"=== build.sh for {self.__class__.__name__} (raw template) ===")
                 print(f"Location: {raw}")
                 if err:
                     print(f"Note: _build_phase() raised {type(err).__name__}: {err}")
                 print()
-                print(raw.read_text(encoding='utf-8'))
+                print(raw.read_text(encoding="utf-8"))
                 return
 
         if content:
@@ -936,7 +984,7 @@ class Pkg:
         deploy image for this package. Falls back to the raw Dockerfile.deploy
         on disk when _build_deploy_phase() returns None or empty.
         """
-        self.config.setdefault('deploy_mode', 'container')
+        self.config.setdefault("deploy_mode", "container")
 
         try:
             result = self._build_deploy_phase()
@@ -946,20 +994,24 @@ class Pkg:
         else:
             err = None
 
-        content = ''
-        suffix = ''
+        content = ""
+        suffix = ""
         if result and isinstance(result, tuple):
-            content, suffix = (result + ('',))[:2]
+            content, suffix = (result + ("",))[:2]
 
         if not content and self.pkg_dir:
-            raw = Path(self.pkg_dir) / 'Dockerfile.deploy'
+            raw = Path(self.pkg_dir) / "Dockerfile.deploy"
             if raw.exists():
-                print(f"=== Dockerfile.deploy for {self.__class__.__name__} (raw template) ===")
+                print(
+                    f"=== Dockerfile.deploy for {self.__class__.__name__} (raw template) ==="
+                )
                 print(f"Location: {raw}")
                 if err:
-                    print(f"Note: _build_deploy_phase() raised {type(err).__name__}: {err}")
+                    print(
+                        f"Note: _build_deploy_phase() raised {type(err).__name__}: {err}"
+                    )
                 print()
-                print(raw.read_text(encoding='utf-8'))
+                print(raw.read_text(encoding="utf-8"))
                 return
 
         if content:
@@ -982,15 +1034,15 @@ class Pkg:
         if not self.pkg_dir:
             print("Package directory not set - cannot locate README")
             return
-            
-        readme_path = Path(self.pkg_dir) / 'README.md'
-        
+
+        readme_path = Path(self.pkg_dir) / "README.md"
+
         if readme_path.exists():
             print(f"=== README for {self.__class__.__name__} ===")
             print(f"Location: {readme_path}")
             print()
             try:
-                with open(readme_path, 'r', encoding='utf-8') as f:
+                with open(readme_path, "r", encoding="utf-8") as f:
                     content = f.read()
                 print(content)
             except Exception as e:
@@ -998,53 +1050,53 @@ class Pkg:
         else:
             print(f"No README found for package {self.__class__.__name__}")
             print(f"Expected location: {readme_path}")
-    
+
     def show_paths(self, path_flags: Dict[str, bool]):
         """
         Show directory paths based on flags.
-        
+
         :param path_flags: Dictionary of path flags to show
         """
         try:
             # Ensure directories are set
             self._ensure_directories()
-            
+
             paths_to_show = []
-            
+
             # Check each flag and add corresponding paths
-            if path_flags.get('conf'):
+            if path_flags.get("conf"):
                 if self.config_dir:
                     paths_to_show.append(f"{self.config_dir}/config.yaml")
-                    
-            if path_flags.get('env'):
+
+            if path_flags.get("env"):
                 if self.config_dir:
                     paths_to_show.append(f"{self.config_dir}/env.yaml")
-                    
-            if path_flags.get('mod_env'):
+
+            if path_flags.get("mod_env"):
                 if self.config_dir:
                     paths_to_show.append(f"{self.config_dir}/mod_env.yaml")
-                    
-            if path_flags.get('conf_dir'):
+
+            if path_flags.get("conf_dir"):
                 if self.config_dir:
                     paths_to_show.append(self.config_dir)
-                    
-            if path_flags.get('shared_dir'):
+
+            if path_flags.get("shared_dir"):
                 if self.shared_dir:
                     paths_to_show.append(self.shared_dir)
-                    
-            if path_flags.get('priv_dir'):
+
+            if path_flags.get("priv_dir"):
                 if self.private_dir:
                     paths_to_show.append(self.private_dir)
-                    
-            if path_flags.get('pkg_dir'):
+
+            if path_flags.get("pkg_dir"):
                 if self.pkg_dir:
                     paths_to_show.append(self.pkg_dir)
-            
+
             # Print only the paths, one per line (for shell usage)
             for path in paths_to_show:
                 if path:  # Only print non-None paths
                     print(path)
-                    
+
         except Exception as e:
             print(f"Error getting package paths: {e}", file=sys.stderr)
 
@@ -1057,7 +1109,7 @@ class Service(Pkg):
 
     def __init__(self, pipeline):
         super().__init__(pipeline=pipeline)
-        
+
     def _init(self):
         """
         Initialize service-specific variables.
@@ -1121,14 +1173,14 @@ class Interceptor(Pkg):
 
     def __init__(self, pipeline):
         super().__init__(pipeline=pipeline)
-        
+
     def _init(self):
         """
         Initialize interceptor-specific variables.
         Override in subclasses.
         """
         pass
-        
+
     def modify_env(self):
         """
         Override this method to modify the environment for interception.

--- a/jarvis_cd/core/pkg.py
+++ b/jarvis_cd/core/pkg.py
@@ -7,10 +7,103 @@ import os
 import sys
 import time
 import inspect
+import threading
 from pathlib import Path
-from typing import Dict, Any, List, Optional
+from typing import TYPE_CHECKING, Dict, Any, Callable, List, Optional, cast
 from jarvis_cd.core.config import Jarvis
 from jarvis_cd.util.hostfile import Hostfile
+
+if TYPE_CHECKING:
+    from jarvis_cd.progress import (
+        PackageProgressProvider,
+        ProgressObservation,
+        ProgressReporter,
+    )
+
+
+class _PackageProgressLineCallback:
+    """Serialize one provider stream and finalize it exactly once at EOF."""
+
+    def __init__(
+        self,
+        provider: Optional["PackageProgressProvider"],
+        reporter: "ProgressReporter",
+        *,
+        progress_path: Path,
+        execution_id: str,
+        package_name: str,
+        package_id: str,
+    ) -> None:
+        self._provider = provider
+        self._reporter = reporter
+        self._progress_path = progress_path
+        self._expected_identity = (execution_id, package_name, package_id)
+        self._lock = threading.Lock()
+        self._finalized = False
+        self._source: Optional[str] = None
+
+    def __call__(self, stream_name: str, line: str) -> None:
+        """Interpret one stdout line and persist validated observations."""
+        if stream_name != "stdout":
+            return
+        with self._lock:
+            if self._finalized:
+                raise RuntimeError("package progress callback is already finalized")
+            from jarvis_cd.progress import (
+                PROGRESS_LINE_PREFIX,
+                ProgressStore,
+                event_from_progress_line,
+            )
+
+            if line.strip().startswith(PROGRESS_LINE_PREFIX):
+                if self._source == "provider":
+                    raise ValueError(
+                        "package progress cannot mix provider and structured sources"
+                    )
+                event = event_from_progress_line(line)
+                if event is None:
+                    raise ValueError("structured package progress line was empty")
+                identity = (
+                    event.execution_id,
+                    event.package_name,
+                    event.package_id,
+                )
+                if identity != self._expected_identity:
+                    raise ValueError("structured package progress identity mismatch")
+                ProgressStore(self._progress_path).append(event)
+                self._source = "structured_stdout"
+                return
+            if self._source == "structured_stdout" or self._provider is None:
+                return
+            observations = self._provider.observe_progress(line)
+            if observations:
+                self._source = "provider"
+                self._persist(observations)
+
+    def finalize(self) -> None:
+        """Flush the provider's final fragment once after output capture closes."""
+        with self._lock:
+            if self._finalized:
+                return
+            if self._source != "structured_stdout" and self._provider is not None:
+                observations = self._provider.finalize_progress()
+                if observations:
+                    self._source = "provider"
+                    self._persist(observations)
+            self._finalized = True
+
+    def _persist(self, observations: list["ProgressObservation"]) -> None:
+        """Persist typed observations with JARVIS-owned identity and sequence."""
+        for observation in observations:
+            self._reporter.emit(
+                label=observation.label,
+                state=observation.state,
+                current=observation.current,
+                total=observation.total,
+                unit=observation.unit,
+                message=observation.message,
+                metadata=dict(observation.metadata),
+            )
 
 
 class Pkg:
@@ -149,6 +242,91 @@ class Pkg:
 
         # Fall back to global jarvis hostfile
         return self.jarvis.hostfile
+
+    def get_progress_provider(self) -> Optional["PackageProgressProvider"]:
+        """Load this package's optional sibling ``progress.py`` provider.
+
+        The convention works for packages loaded from a registered filesystem
+        repository as well as packages bundled in the JARVIS distribution.
+
+        :return: A package progress provider, or ``None`` when not implemented.
+        """
+        from jarvis_cd.progress import provider_from_package
+
+        return provider_from_package(self)
+
+    def bind_execution_progress(
+        self,
+        execution_id: str,
+        path: str | os.PathLike[str],
+    ) -> None:
+        """Bind package reporters to a JARVIS-owned execution sidecar.
+
+        Pipeline execution code must call this after assigning the execution ID
+        and before invoking package lifecycle methods. Package configuration is
+        deliberately not allowed to select the authoritative sidecar.
+
+        :param execution_id: Stable JARVIS execution identifier.
+        :param path: Absolute JSONL path inside the owned execution root.
+        """
+        if not isinstance(execution_id, str) or not execution_id.strip():
+            raise ValueError("execution progress requires a non-empty execution ID")
+        progress_path = Path(path)
+        if not progress_path.is_absolute():
+            raise ValueError("execution progress path must be absolute")
+        values = {
+            "JARVIS_EXECUTION_ID": execution_id,
+            "JARVIS_PROGRESS_PATH": str(progress_path),
+            "JARVIS_PACKAGE_NAME": str(self.pkg_type),
+            "JARVIS_PACKAGE_ID": str(self.pkg_id),
+            "JARVIS_PROGRESS_TRANSPORT": "sidecar",
+        }
+        self.env.update(values)
+        self.mod_env.update(values)
+
+    def progress_line_callback(self) -> Optional[Callable[[str, str], None]]:
+        """Build a generic stdout-to-sidecar callback for this package.
+
+        Package-local providers interpret application output. Already
+        structured ``JARVIS_PROGRESS`` lines are accepted without a provider.
+        This helper owns event identity, sequencing, validation, persistence,
+        and EOF finalization.
+
+        :return: A line callback bound to this execution, or ``None``.
+        """
+        execution_id = self.mod_env.get("JARVIS_EXECUTION_ID")
+        progress_path = self.mod_env.get("JARVIS_PROGRESS_PATH")
+        package_name = self.mod_env.get("JARVIS_PACKAGE_NAME")
+        package_id = self.mod_env.get("JARVIS_PACKAGE_ID")
+        transport = self.mod_env.get("JARVIS_PROGRESS_TRANSPORT", "sidecar")
+        if not all(
+            isinstance(value, str) and value
+            for value in (execution_id, progress_path, package_name, package_id)
+        ):
+            return None
+        if transport not in {"sidecar", "stdout"}:
+            raise ValueError("package progress transport must be sidecar or stdout")
+        provider = self.get_progress_provider()
+        if provider is None and transport != "stdout":
+            return None
+
+        from jarvis_cd.progress import ProgressReporter
+
+        reporter = ProgressReporter(
+            package_name=cast(str, package_name),
+            package_id=cast(str, package_id),
+            execution_id=cast(str, execution_id),
+            path=cast(str, progress_path),
+        )
+
+        return _PackageProgressLineCallback(
+            provider,
+            reporter,
+            progress_path=Path(cast(str, progress_path)),
+            execution_id=cast(str, execution_id),
+            package_name=cast(str, package_name),
+            package_id=cast(str, package_id),
+        )
 
     def _init(self):
         """

--- a/jarvis_cd/core/scheduler.py
+++ b/jarvis_cd/core/scheduler.py
@@ -18,6 +18,7 @@ populate.
 from __future__ import annotations
 
 import os
+import re
 import shlex
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -98,6 +99,15 @@ class Scheduler:
         """
         raise NotImplementedError
 
+    def parse_submission_output(self, stdout: str) -> Dict[str, Any]:
+        """Parse provider-owned submission output into stable metadata.
+
+        Scheduler implementations must reject output that cannot be tied to a
+        submission made by their own command.  Callers must never infer job
+        identities from arbitrary application stdout.
+        """
+        raise NotImplementedError
+
     def _pipeline_invocation(self) -> str:
         """Shell snippet that runs the pipeline once the hostfile is in
         place. Always points jarvis at the persisted YAML when one was
@@ -151,6 +161,10 @@ class SlurmScheduler(Scheduler):
         'mail_user':       '--mail-user',
         'mail_type':       '--mail-type',
     }
+
+    _PARSABLE_SUBMISSION = re.compile(
+        r"^(?P<job_id>[0-9]+)(?:;(?P<cluster>[A-Za-z0-9_.-]+))?$"
+    )
 
     def _directives(self) -> List[str]:
         lines: List[str] = []
@@ -217,11 +231,29 @@ class SlurmScheduler(Scheduler):
         return script
 
     def submit_command(self, wait: bool = False) -> List[str]:
-        cmd = ["sbatch"]
+        # ``--parsable`` is the provider boundary: stdout is a stable
+        # ``job_id[;cluster]`` record rather than human-oriented text.
+        cmd = ["sbatch", "--parsable"]
         if wait:
             cmd.append("--wait")
         cmd.append(str(self.script_path))
         return cmd
+
+    def parse_submission_output(self, stdout: str) -> Dict[str, Any]:
+        """Parse the exact record produced by ``sbatch --parsable``."""
+        value = stdout.strip()
+        match = self._PARSABLE_SUBMISSION.fullmatch(value)
+        if match is None:
+            raise ValueError(
+                "SLURM submission did not return a valid "
+                "`sbatch --parsable` job identity"
+            )
+        return {
+            'provider': self.NAME,
+            'scheduler_job_id': match.group('job_id'),
+            'scheduler_cluster': match.group('cluster'),
+            'identity_source': 'scheduler_submit_api',
+        }
 
 
 _SCHEDULERS: Dict[str, type] = {

--- a/jarvis_cd/core/scheduler.py
+++ b/jarvis_cd/core/scheduler.py
@@ -6,9 +6,10 @@ that turn a pipeline's ``scheduler:`` YAML block into a submittable job
 script. The generated script is responsible for:
 
   1. Constructing a hostfile from the scheduler's allocation
-     (e.g. ``$SLURM_JOB_NODELIST``) and writing it to the location the
-     pipeline expects (defaults to ``${SHARED_DIR}/hostfile.txt``).
-  2. Running the pipeline once the hostfile is in place.
+     (e.g. ``$SLURM_JOB_NODELIST``) and writing it to the execution-scoped
+     location the pipeline expects.
+  2. Running the pipeline's isolated execution snapshot once the hostfile is
+     in place.
 
 The hostfile path is exported back onto the pipeline so every package
 that resolves ``self.hostfile`` sees the same file the job script will
@@ -20,13 +21,32 @@ from __future__ import annotations
 import os
 import re
 import shlex
+import sys
+import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
-def make_scheduler(spec: Dict[str, Any], pipeline_shared_dir: Path,
-                   pipeline_yaml: Optional[str] = None,
-                   pipeline_name: Optional[str] = None) -> "Scheduler":
+_DIRECTIVE_KEY = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+_HOST_SUFFIX = re.compile(r"^[A-Za-z0-9_.:-]{1,64}$")
+
+
+def _validated_single_line(value: Any, *, field: str, limit: int = 4096) -> str:
+    """Return one bounded printable scheduler value."""
+    if not isinstance(value, str) or not value or len(value.encode("utf-8")) > limit:
+        raise ValueError(f"scheduler.{field} must be a non-empty bounded string")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise ValueError(f"scheduler.{field} cannot contain control characters")
+    return value
+
+
+def make_scheduler(
+    spec: Dict[str, Any],
+    pipeline_shared_dir: Path,
+    pipeline_yaml: Optional[str] = None,
+    pipeline_name: Optional[str] = None,
+    pipeline_snapshot_dir: Optional[Path] = None,
+) -> "Scheduler":
     """Factory: build a Scheduler from a parsed YAML dict.
 
     :param spec: ``scheduler:`` block from the pipeline YAML
@@ -36,20 +56,26 @@ def make_scheduler(spec: Dict[str, Any], pipeline_shared_dir: Path,
         (None when invoked from a pre-loaded current pipeline)
     :param pipeline_name: pipeline name (used for ``jarvis ppl run`` when
         no YAML path is supplied)
+    :param pipeline_snapshot_dir: immutable execution-scoped pipeline input
+        directory. When provided, the scheduler runs that snapshot rather than
+        reloading mutable named-pipeline state.
     """
-    name = (spec or {}).get('name')
+    name = (spec or {}).get("name")
     if not name:
         raise ValueError("scheduler.name is required (e.g. 'slurm')")
 
     name = str(name).strip().lower()
     cls = _SCHEDULERS.get(name)
     if cls is None:
-        supported = ', '.join(sorted(_SCHEDULERS))
-        raise ValueError(
-            f"Unsupported scheduler '{name}'. Supported: {supported}")
-    return cls(spec, pipeline_shared_dir,
-               pipeline_yaml=pipeline_yaml,
-               pipeline_name=pipeline_name)
+        supported = ", ".join(sorted(_SCHEDULERS))
+        raise ValueError(f"Unsupported scheduler '{name}'. Supported: {supported}")
+    return cls(
+        spec,
+        pipeline_shared_dir,
+        pipeline_yaml=pipeline_yaml,
+        pipeline_name=pipeline_name,
+        pipeline_snapshot_dir=pipeline_snapshot_dir,
+    )
 
 
 class Scheduler:
@@ -62,17 +88,30 @@ class Scheduler:
     #: shared directory
     SCRIPT_NAME: str = "submit.sh"
 
-    def __init__(self, spec: Dict[str, Any], pipeline_shared_dir: Path,
-                 pipeline_yaml: Optional[str] = None,
-                 pipeline_name: Optional[str] = None):
+    def __init__(
+        self,
+        spec: Dict[str, Any],
+        pipeline_shared_dir: Path,
+        pipeline_yaml: Optional[str] = None,
+        pipeline_name: Optional[str] = None,
+        pipeline_snapshot_dir: Optional[Path] = None,
+    ):
         self.spec = dict(spec or {})
         self.shared_dir = Path(pipeline_shared_dir)
         self.pipeline_yaml = pipeline_yaml
         self.pipeline_name = pipeline_name
+        self.pipeline_snapshot_dir = (
+            Path(pipeline_snapshot_dir) if pipeline_snapshot_dir is not None else None
+        )
 
-        default_hostfile = str(self.shared_dir / 'hostfile.txt')
-        hostfile = self.spec.get('hostfile') or default_hostfile
-        self.hostfile = os.path.expandvars(hostfile)
+        default_hostfile = str(self.shared_dir / "hostfile.txt")
+        hostfile = self.spec.get("hostfile") or default_hostfile
+        validated_hostfile = _validated_single_line(
+            hostfile,
+            field="hostfile",
+        )
+        self.hostfile = os.path.expandvars(validated_hostfile)
+        _validated_single_line(self.hostfile, field="hostfile")
 
     @property
     def script_path(self) -> Path:
@@ -83,11 +122,49 @@ class Scheduler:
         raise NotImplementedError
 
     def write_script(self) -> Path:
-        """Render the submission script and write it to the shared dir."""
+        """Durably write the execution-scoped submission script."""
         self.shared_dir.mkdir(parents=True, exist_ok=True)
         path = self.script_path
-        path.write_text(self.render())
-        path.chmod(0o755)
+        descriptor, temporary_name = tempfile.mkstemp(
+            dir=self.shared_dir,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            text=True,
+        )
+        temporary_path = Path(temporary_name)
+        descriptor_owned = True
+        try:
+            try:
+                stream = os.fdopen(
+                    descriptor,
+                    "w",
+                    encoding="utf-8",
+                    newline="\n",
+                )
+            except BaseException:
+                os.close(descriptor)
+                descriptor_owned = False
+                raise
+            descriptor_owned = False
+            with stream:
+                stream.write(self.render())
+                stream.flush()
+                os.fsync(stream.fileno())
+            temporary_path.chmod(0o700)
+            os.replace(temporary_path, path)
+            if os.name != "nt":
+                directory = os.open(
+                    self.shared_dir,
+                    os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+                )
+                try:
+                    os.fsync(directory)
+                finally:
+                    os.close(directory)
+        finally:
+            if descriptor_owned:
+                os.close(descriptor)
+            temporary_path.unlink(missing_ok=True)
         return path
 
     def submit_command(self, wait: bool = False) -> List[str]:
@@ -114,11 +191,18 @@ class Scheduler:
         supplied, falling back to ``jarvis ppl run`` against the
         currently-loaded pipeline otherwise.
         """
+        if self.pipeline_snapshot_dir is not None:
+            snapshot = self.pipeline_snapshot_dir
+            snapshot_yaml = snapshot / "pipeline.yaml"
+            return (
+                "env JARVIS_PIPELINE_SNAPSHOT_DIR="
+                f"{shlex.quote(str(snapshot))} "
+                f"jarvis ppl run yaml {shlex.quote(str(snapshot_yaml))}"
+            )
         if self.pipeline_yaml:
             return f"jarvis ppl run yaml {shlex.quote(self.pipeline_yaml)}"
         if self.pipeline_name:
-            return (f"jarvis cd {shlex.quote(self.pipeline_name)} && "
-                    f"jarvis ppl run")
+            return f"jarvis cd {shlex.quote(self.pipeline_name)} && jarvis ppl run"
         return "jarvis ppl run"
 
 
@@ -133,38 +217,85 @@ class SlurmScheduler(Scheduler):
     #: can pass arbitrary SBATCH flags from YAML without us hard-coding
     #: every one.
     _STRUCTURAL_KEYS = {
-        'name', 'hostfile', 'suffix', 'sbatch_args', 'pre_cmds', 'post_cmds',
+        "name",
+        "hostfile",
+        "suffix",
+        "sbatch_args",
+        "pre_cmds",
+        "post_cmds",
     }
 
     #: explicit short-key -> SBATCH long-flag map. Anything not in here
     #: that isn't structural is passed as ``--<key>=<value>`` with
     #: underscores rewritten to dashes.
     _EXPLICIT_DIRECTIVES = {
-        'job_name':        '--job-name',
-        'nodes':           '--nodes',
-        'ntasks':          '--ntasks',
-        'ntasks_per_node': '--ntasks-per-node',
-        'cpus_per_task':   '--cpus-per-task',
-        'mem':             '--mem',
-        'time':            '--time',
-        'partition':       '--partition',
-        'account':         '--account',
-        'qos':             '--qos',
-        'output':          '--output',
-        'error':           '--error',
-        'gres':            '--gres',
-        'gpus':            '--gpus',
-        'gpus_per_node':   '--gpus-per-node',
-        'constraint':      '--constraint',
-        'reservation':     '--reservation',
-        'exclusive':       '--exclusive',
-        'mail_user':       '--mail-user',
-        'mail_type':       '--mail-type',
+        "job_name": "--job-name",
+        "nodes": "--nodes",
+        "ntasks": "--ntasks",
+        "ntasks_per_node": "--ntasks-per-node",
+        "cpus_per_task": "--cpus-per-task",
+        "mem": "--mem",
+        "time": "--time",
+        "partition": "--partition",
+        "account": "--account",
+        "qos": "--qos",
+        "output": "--output",
+        "error": "--error",
+        "gres": "--gres",
+        "gpus": "--gpus",
+        "gpus_per_node": "--gpus-per-node",
+        "constraint": "--constraint",
+        "reservation": "--reservation",
+        "exclusive": "--exclusive",
+        "mail_user": "--mail-user",
+        "mail_type": "--mail-type",
     }
 
     _PARSABLE_SUBMISSION = re.compile(
         r"^(?P<job_id>[0-9]+)(?:;(?P<cluster>[A-Za-z0-9_.-]+))?$"
     )
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._validate_spec()
+
+    def _validate_spec(self) -> None:
+        """Reject directive and hook text that can alter script structure."""
+        if len(self.spec) > 128:
+            raise ValueError("scheduler contains too many fields")
+        for key, value in self.spec.items():
+            if not isinstance(key, str) or _DIRECTIVE_KEY.fullmatch(key) is None:
+                raise ValueError(f"invalid scheduler directive key: {key!r}")
+            if key in {"sbatch_args", "pre_cmds", "post_cmds"}:
+                if not isinstance(value, list) or len(value) > 64:
+                    raise ValueError(f"scheduler.{key} must be a bounded list")
+                for entry in value:
+                    rendered = _validated_single_line(entry, field=key)
+                    if key == "sbatch_args" and (
+                        not rendered.startswith("--")
+                        or any(character.isspace() for character in rendered)
+                        or "#" in rendered
+                    ):
+                        raise ValueError(
+                            "scheduler.sbatch_args entries must be single --flag tokens"
+                        )
+                continue
+            if value is None or isinstance(value, bool):
+                continue
+            if isinstance(value, int):
+                if value < 0:
+                    raise ValueError(f"scheduler.{key} cannot be negative")
+                continue
+            rendered = _validated_single_line(value, field=key)
+            if key != "hostfile" and (
+                any(character.isspace() for character in rendered) or "#" in rendered
+            ):
+                raise ValueError(
+                    f"scheduler.{key} must be one printable directive token"
+                )
+        suffix = self.spec.get("suffix")
+        if suffix is not None and _HOST_SUFFIX.fullmatch(str(suffix)) is None:
+            raise ValueError("scheduler.suffix is not a valid hostname suffix")
 
     def _directives(self) -> List[str]:
         lines: List[str] = []
@@ -173,21 +304,21 @@ class SlurmScheduler(Scheduler):
                 continue
             if value is None or value is False:
                 continue
-            flag = self._EXPLICIT_DIRECTIVES.get(
-                key, f"--{key.replace('_', '-')}")
+            flag = self._EXPLICIT_DIRECTIVES.get(key, f"--{key.replace('_', '-')}")
             if value is True:
                 lines.append(f"#SBATCH {flag}")
             else:
                 lines.append(f"#SBATCH {flag}={value}")
-        for raw in self.spec.get('sbatch_args', []) or []:
+        for raw in self.spec.get("sbatch_args", []) or []:
             lines.append(f"#SBATCH {raw}")
         return lines
 
     def render(self) -> str:
         directives = "\n".join(self._directives())
-        pre = "\n".join(self.spec.get('pre_cmds', []) or [])
-        post = "\n".join(self.spec.get('post_cmds', []) or [])
+        pre = "\n".join(self.spec.get("pre_cmds", []) or [])
+        post = "\n".join(self.spec.get("post_cmds", []) or [])
         hostfile = shlex.quote(self.hostfile)
+        python_executable = shlex.quote(sys.executable)
         invocation = self._pipeline_invocation()
 
         # Build hostfile from the allocation. scontrol expands the
@@ -196,18 +327,72 @@ class SlurmScheduler(Scheduler):
         # append it to each hostname — used to redirect traffic onto a
         # secondary NIC (e.g. `ares-comp-1` -> `ares-comp-1-40g` for the
         # 40GbE interface).
-        suffix = self.spec.get('suffix')
+        suffix = self.spec.get("suffix")
         if suffix:
             hostnames_cmd = (
-                f"scontrol show hostnames \"$SLURM_JOB_NODELIST\" "
-                f"| awk -v s={shlex.quote(str(suffix))} '{{print $0 s}}'")
+                f'scontrol show hostnames "$SLURM_JOB_NODELIST" '
+                f"| awk -v s={shlex.quote(str(suffix))} '{{print $0 s}}'"
+            )
         else:
             hostnames_cmd = 'scontrol show hostnames "$SLURM_JOB_NODELIST"'
         hostfile_block = (
-            f'mkdir -p "$(dirname {hostfile})"\n'
-            f'{hostnames_cmd} > {hostfile}\n'
-            f'echo "Wrote hostfile: {hostfile}"\n'
-            f'cat {hostfile}\n'
+            f"jarvis_hostfile={hostfile}\n"
+            'jarvis_hostfile_dir=$(dirname -- "$jarvis_hostfile")\n'
+            "jarvis_hostfile_name=${jarvis_hostfile##*/}\n"
+            'mkdir -p -- "$jarvis_hostfile_dir"\n'
+            "jarvis_hostfile_tmp=$(mktemp -- "
+            '"$jarvis_hostfile_dir/.${jarvis_hostfile_name}.jarvis.$$.XXXXXX")\n'
+            "jarvis_cleanup_hostfile_tmp() {\n"
+            '    if [ -n "${jarvis_hostfile_tmp:-}" ]; then\n'
+            '        rm -f -- "$jarvis_hostfile_tmp"\n'
+            "    fi\n"
+            "}\n"
+            "trap jarvis_cleanup_hostfile_tmp EXIT\n"
+            f'if ! {{ {hostnames_cmd}; }} > "$jarvis_hostfile_tmp"; then\n'
+            '    echo "Could not expand the SLURM allocation hostfile" >&2\n'
+            "    exit 1\n"
+            "fi\n"
+            'if [ ! -s "$jarvis_hostfile_tmp" ]; then\n'
+            '    echo "SLURM allocation produced an empty hostfile" >&2\n'
+            "    exit 1\n"
+            "fi\n"
+            f'{python_executable} - "$jarvis_hostfile_tmp" '
+            "\"$jarvis_hostfile\" <<'PY'\n"
+            "import errno\n"
+            "import os\n"
+            "import sys\n"
+            "\n"
+            "temporary_path, final_path = sys.argv[1:]\n"
+            "with open(temporary_path, 'rb') as stream:\n"
+            "    os.fsync(stream.fileno())\n"
+            "os.replace(temporary_path, final_path)\n"
+            "directory_path = os.path.dirname(final_path) or '.'\n"
+            "unsupported = {errno.EBADF, errno.EINVAL}\n"
+            "for name in ('ENOTSUP', 'EOPNOTSUPP'):\n"
+            "    value = getattr(errno, name, None)\n"
+            "    if value is not None:\n"
+            "        unsupported.add(value)\n"
+            "try:\n"
+            "    directory = os.open(\n"
+            "        directory_path,\n"
+            "        os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0),\n"
+            "    )\n"
+            "except OSError as error:\n"
+            "    if error.errno not in unsupported:\n"
+            "        raise\n"
+            "else:\n"
+            "    try:\n"
+            "        os.fsync(directory)\n"
+            "    except OSError as error:\n"
+            "        if error.errno not in unsupported:\n"
+            "            raise\n"
+            "    finally:\n"
+            "        os.close(directory)\n"
+            "PY\n"
+            "jarvis_hostfile_tmp=\n"
+            "trap - EXIT\n"
+            'echo "Wrote hostfile: $jarvis_hostfile"\n'
+            'cat -- "$jarvis_hostfile"\n'
         )
 
         script = (
@@ -249,10 +434,10 @@ class SlurmScheduler(Scheduler):
                 "`sbatch --parsable` job identity"
             )
         return {
-            'provider': self.NAME,
-            'scheduler_job_id': match.group('job_id'),
-            'scheduler_cluster': match.group('cluster'),
-            'identity_source': 'scheduler_submit_api',
+            "provider": self.NAME,
+            "scheduler_job_id": match.group("job_id"),
+            "scheduler_cluster": match.group("cluster"),
+            "identity_source": "scheduler_submit_api",
         }
 
 

--- a/jarvis_cd/core/scheduler.py
+++ b/jarvis_cd/core/scheduler.py
@@ -205,6 +205,47 @@ class Scheduler:
             return f"jarvis cd {shlex.quote(self.pipeline_name)} && jarvis ppl run"
         return "jarvis ppl run"
 
+    def _execution_lifecycle_block(self) -> str:
+        """Render an EXIT trap that durably finalizes scheduler script state."""
+        finalizer = ""
+        if self.pipeline_snapshot_dir is not None:
+            execution_root = self.pipeline_snapshot_dir.parent
+            execution_id = execution_root.name
+            python_executable = shlex.quote(sys.executable)
+            finalizer = (
+                f"    if ! {python_executable} -m jarvis_cd.core.execution finalize "
+                f"--execution-root {shlex.quote(str(execution_root))} "
+                f"--execution-id {shlex.quote(execution_id)} "
+                '--return-code "$jarvis_exit_code"; then\n'
+                '        echo "Could not persist JARVIS execution state" >&2\n'
+                '        if [ "$jarvis_exit_code" -eq 0 ]; then\n'
+                "            jarvis_exit_code=1\n"
+                "        fi\n"
+                "    fi\n"
+            )
+        return (
+            "jarvis_hostfile_tmp=\n"
+            "jarvis_finalize_execution() {\n"
+            "    jarvis_exit_code=$?\n"
+            "    trap - EXIT\n"
+            '    if [ -n "${jarvis_hostfile_tmp:-}" ]; then\n'
+            '        if ! rm -f -- "$jarvis_hostfile_tmp"; then\n'
+            '            echo "Could not remove temporary JARVIS hostfile" >&2\n'
+            '            if [ "$jarvis_exit_code" -eq 0 ]; then\n'
+            "                jarvis_exit_code=1\n"
+            "            fi\n"
+            "        fi\n"
+            "    fi\n"
+            f"{finalizer}"
+            '    exit "$jarvis_exit_code"\n'
+            "}\n"
+            "trap jarvis_finalize_execution EXIT\n"
+        )
+
+    def _execution_activation_block(self) -> str:
+        """Render provider-specific runtime identity activation when available."""
+        return ""
+
 
 class SlurmScheduler(Scheduler):
     """SLURM (sbatch) backend."""
@@ -320,6 +361,8 @@ class SlurmScheduler(Scheduler):
         hostfile = shlex.quote(self.hostfile)
         python_executable = shlex.quote(sys.executable)
         invocation = self._pipeline_invocation()
+        lifecycle = self._execution_lifecycle_block()
+        activation = self._execution_activation_block()
 
         # Build hostfile from the allocation. scontrol expands the
         # compact nodelist into one host per line; that's exactly what
@@ -342,12 +385,6 @@ class SlurmScheduler(Scheduler):
             'mkdir -p -- "$jarvis_hostfile_dir"\n'
             "jarvis_hostfile_tmp=$(mktemp -- "
             '"$jarvis_hostfile_dir/.${jarvis_hostfile_name}.jarvis.$$.XXXXXX")\n'
-            "jarvis_cleanup_hostfile_tmp() {\n"
-            '    if [ -n "${jarvis_hostfile_tmp:-}" ]; then\n'
-            '        rm -f -- "$jarvis_hostfile_tmp"\n'
-            "    fi\n"
-            "}\n"
-            "trap jarvis_cleanup_hostfile_tmp EXIT\n"
             f'if ! {{ {hostnames_cmd}; }} > "$jarvis_hostfile_tmp"; then\n'
             '    echo "Could not expand the SLURM allocation hostfile" >&2\n'
             "    exit 1\n"
@@ -390,7 +427,6 @@ class SlurmScheduler(Scheduler):
             "        os.close(directory)\n"
             "PY\n"
             "jarvis_hostfile_tmp=\n"
-            "trap - EXIT\n"
             'echo "Wrote hostfile: $jarvis_hostfile"\n'
             'cat -- "$jarvis_hostfile"\n'
         )
@@ -400,6 +436,9 @@ class SlurmScheduler(Scheduler):
             f"{directives}\n"
             "\n"
             "set -euo pipefail\n"
+            "\n"
+            f"{lifecycle}"
+            f"{activation}"
             "\n"
             "# --- Pre-run hooks ---\n"
             f"{pre}\n"
@@ -414,6 +453,25 @@ class SlurmScheduler(Scheduler):
             f"{post}\n"
         )
         return script
+
+    def _execution_activation_block(self) -> str:
+        """Bind the allocation's trusted SLURM identity before user hooks."""
+        if self.pipeline_snapshot_dir is None:
+            return ""
+        execution_root = self.pipeline_snapshot_dir.parent
+        execution_id = execution_root.name
+        python_executable = shlex.quote(sys.executable)
+        return (
+            "jarvis_scheduler_cluster_args=()\n"
+            'if [ -n "${SLURM_CLUSTER_NAME:-}" ]; then\n'
+            '    jarvis_scheduler_cluster_args=(--cluster "$SLURM_CLUSTER_NAME")\n'
+            "fi\n"
+            f"{python_executable} -m jarvis_cd.core.execution activate "
+            f"--execution-root {shlex.quote(str(execution_root))} "
+            f"--execution-id {shlex.quote(execution_id)} "
+            f"--provider {shlex.quote(self.NAME)} "
+            '--native-id "$SLURM_JOB_ID" "${jarvis_scheduler_cluster_args[@]}"\n'
+        )
 
     def submit_command(self, wait: bool = False) -> List[str]:
         # ``--parsable`` is the provider boundary: stdout is a stable

--- a/jarvis_cd/progress/__init__.py
+++ b/jarvis_cd/progress/__init__.py
@@ -1,1 +1,53 @@
-"""Package-owned progress providers for JARVIS builtin applications."""
+"""Generic progress semantics for JARVIS executions and package providers."""
+
+from .discovery import (
+    load_progress_module,
+    package_progress_context,
+    provider_from_package,
+)
+from .provider import (
+    LineBuffer,
+    PackageProgressProvider,
+    PackageScopeFilter,
+    ProgressObservation,
+    ProgressProviderFactory,
+    RelayProgressAdapter,
+    RelayProgressAdapterFactory,
+)
+from .reporter import (
+    EXECUTION_ID_ENV,
+    PACKAGE_ID_ENV,
+    PACKAGE_NAME_ENV,
+    PROGRESS_LINE_PREFIX,
+    PROGRESS_PATH_ENV,
+    PROGRESS_TRANSPORT_ENV,
+    ProgressReporter,
+    event_from_progress_line,
+)
+from .schema import PROGRESS_SCHEMA_VERSION, ProgressEvent, ProgressState
+from .store import ProgressStore
+
+__all__ = [
+    "EXECUTION_ID_ENV",
+    "LineBuffer",
+    "PACKAGE_ID_ENV",
+    "PACKAGE_NAME_ENV",
+    "PROGRESS_LINE_PREFIX",
+    "PROGRESS_PATH_ENV",
+    "PROGRESS_SCHEMA_VERSION",
+    "PROGRESS_TRANSPORT_ENV",
+    "PackageProgressProvider",
+    "PackageScopeFilter",
+    "ProgressEvent",
+    "ProgressObservation",
+    "ProgressProviderFactory",
+    "ProgressReporter",
+    "ProgressState",
+    "ProgressStore",
+    "RelayProgressAdapter",
+    "RelayProgressAdapterFactory",
+    "event_from_progress_line",
+    "load_progress_module",
+    "package_progress_context",
+    "provider_from_package",
+]

--- a/jarvis_cd/progress/__init__.py
+++ b/jarvis_cd/progress/__init__.py
@@ -1,0 +1,1 @@
+"""Package-owned progress providers for JARVIS builtin applications."""

--- a/jarvis_cd/progress/discovery.py
+++ b/jarvis_cd/progress/discovery.py
@@ -1,0 +1,146 @@
+"""Package-local progress discovery for installed and filesystem repositories."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import sys
+import threading
+from types import ModuleType
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from .provider import PackageProgressProvider, ProgressProviderFactory
+
+_MODULE_LOAD_LOCK = threading.RLock()
+
+if TYPE_CHECKING:
+    from jarvis_cd.core.pkg import Pkg
+
+
+def provider_from_package(package: "Pkg") -> PackageProgressProvider | None:
+    """Load the optional sibling ``progress.py`` for a package instance.
+
+    JARVIS repository packages are imported from their registered filesystem
+    roots. Resolving relative to the already-loaded ``pkg.py`` module therefore
+    works without requiring the repository to publish a Python distribution or
+    an entry point.
+    """
+    progress_path = _package_directory(package) / "progress.py"
+    if not progress_path.is_file():
+        return None
+    progress_module = load_progress_module(progress_path)
+    progress_module_name = progress_module.__name__
+    factory = getattr(progress_module, "adapter_from_package", None)
+    if factory is None:
+        raise TypeError(
+            f"package progress module must export adapter_from_package: "
+            f"{progress_module_name}"
+        )
+    if not callable(factory):
+        raise TypeError(
+            f"package progress adapter_from_package is not callable: "
+            f"{progress_module_name}"
+        )
+    context = package_progress_context(package)
+    provider = cast(ProgressProviderFactory, factory)(context)
+    if provider is not None and not isinstance(provider, PackageProgressProvider):
+        raise TypeError(
+            f"package progress provider is incomplete: {progress_module_name}"
+        )
+    return provider
+
+
+def load_progress_module(path: str | Path) -> ModuleType:
+    """Load one package-local progress module in an isolated namespace.
+
+    JARVIS repositories deliberately reuse short top-level names such as
+    ``builtin``. Importing progress providers through those names can collide
+    with the distribution's own package cache. A path-derived private package
+    preserves sibling relative imports without mutating repository namespaces.
+
+    :param path: Absolute or relative path to a package's ``progress.py``.
+    :return: The loaded progress module.
+    """
+    progress_path = Path(path).resolve()
+    if not progress_path.is_file():
+        raise FileNotFoundError(
+            f"package progress module does not exist: {progress_path}"
+        )
+    with _MODULE_LOAD_LOCK:
+        return _load_progress_module_locked(progress_path)
+
+
+def _load_progress_module_locked(progress_path: Path) -> ModuleType:
+    """Load one resolved provider path while holding the module-cache lock."""
+    digest = hashlib.sha256(str(progress_path).encode("utf-8")).hexdigest()[:24]
+    package_name = f"_jarvis_cd_package_progress_{digest}"
+    module_name = f"{package_name}.progress"
+    cached = sys.modules.get(module_name)
+    if cached is not None:
+        cached_path = Path(str(getattr(cached, "__file__", ""))).resolve()
+        if cached_path != progress_path:
+            raise ImportError(
+                f"package progress module cache collision: {progress_path}"
+            )
+        return cached
+
+    package_module = ModuleType(package_name)
+    package_module.__file__ = str(progress_path.parent / "__init__.py")
+    package_module.__package__ = package_name
+    package_module.__path__ = [str(progress_path.parent)]
+    spec = importlib.util.spec_from_file_location(module_name, progress_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load package progress module: {progress_path}")
+    progress_module = importlib.util.module_from_spec(spec)
+    sys.modules[package_name] = package_module
+    sys.modules[module_name] = progress_module
+    try:
+        spec.loader.exec_module(progress_module)
+    except BaseException:
+        sys.modules.pop(module_name, None)
+        sys.modules.pop(package_name, None)
+        raise
+    return progress_module
+
+
+def _package_directory(package: "Pkg") -> Path:
+    """Resolve the source directory for a loaded JARVIS package instance."""
+    configured = getattr(package, "pkg_dir", None)
+    if configured:
+        return Path(str(configured)).resolve()
+    module_name = package.__class__.__module__
+    module = sys.modules.get(module_name)
+    module_path = getattr(module, "__file__", None)
+    if not module_path:
+        raise ValueError(
+            f"cannot locate package source directory for {package.pkg_type}"
+        )
+    return Path(str(module_path)).resolve().parent
+
+
+def package_progress_context(package: "Pkg") -> dict[str, Any]:
+    """Build the generic, non-secret context supplied to a provider factory."""
+    context: dict[str, Any] = dict(package.config)
+    identities: dict[str, object] = {
+        "pkg_type": package.pkg_type,
+        "pkg_id": package.pkg_id,
+        "global_id": package.global_id,
+    }
+    for field_name, value in identities.items():
+        if not isinstance(value, str) or not value:
+            raise ValueError(
+                f"package progress requires a non-empty {field_name} identity"
+            )
+        context[field_name] = value
+    pipeline = package.pipeline
+    for field_name in ("base_deploy_mode", "install_manager"):
+        value = getattr(pipeline, field_name, None)
+        if value is not None:
+            context[field_name] = value
+    package_mode = context.get("deploy_mode") or context.get("install_method")
+    base_mode = context.get("base_deploy_mode") or context.get("install_manager")
+    effective_mode = package_mode or base_mode
+    if effective_mode:
+        context["effective_deploy_mode"] = effective_mode
+    return context

--- a/jarvis_cd/progress/lammps.py
+++ b/jarvis_cd/progress/lammps.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import math
 import os
 import statistics
 from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any, cast
 
@@ -17,7 +19,8 @@ class LammpsThermoProgressAdapter:
     package_version: str = "builtin"
     run_id: str = ""
     adapter_name: str = "lammps"
-    application_profile: str | None = None
+    application_profile: str | None = "jarvis-cd.builtin.lammps"
+    log_visibility: str = "scoped_stdout"
     total_steps: float | None = None
     output_dir: Path | None = None
     warmup_samples: int = 2
@@ -32,14 +35,54 @@ class LammpsThermoProgressAdapter:
     active_run_steps: float | None = None
     active_run_start_step: float | None = None
     active_package_stdout: bool = False
-    emitted_keys: set[tuple[float, float, float, float | None]] = field(
-        default_factory=set
-    )
+    authoritative_source: str | None = None
+    stdout_fragment: str = ""
+    jarvis_stdout_fragment: str = ""
+    last_emitted_key: tuple[float, float, float, float | None] | None = None
 
     def observe_stdout(self, text: str) -> list[dict[str, object]]:
         """Extract progress from an already trusted package-owned log."""
+        return self._observe_stdout(text, finalize=False)
+
+    def finalize_stdout(self) -> list[dict[str, object]]:
+        """Flush the final package-log fragment at end of stream."""
+        return self._observe_stdout("", finalize=True)
+
+    def reset_stdout(self) -> None:
+        """Reset package-log parser state after file replacement or truncation."""
+        if self.authoritative_source not in (None, "package_log"):
+            return
+        self.authoritative_source = None
+        self.stdout_fragment = ""
+        self.active_columns = []
+        self.active_step_column = None
+        self.active_time_column = None
+        self.active_time_column_name = None
+        self.samples = []
+        self.last_step = None
+        self.completed_steps = 0.0
+        self.active_run_steps = None
+        self.active_run_start_step = None
+        self.last_emitted_key = None
+
+    def _observe_stdout(
+        self,
+        text: str,
+        *,
+        finalize: bool,
+    ) -> list[dict[str, object]]:
+        if self.authoritative_source == "jarvis_stdout":
+            if finalize:
+                self.stdout_fragment = ""
+            return []
+        if text and self.authoritative_source is None:
+            self.authoritative_source = "package_log"
         records: list[dict[str, object]] = []
-        for line in text.splitlines():
+        for line in self._complete_lines(
+            text,
+            fragment_name="stdout_fragment",
+            finalize=finalize,
+        ):
             record = self.observe_line(line)
             if record is not None:
                 records.append(record)
@@ -47,10 +90,33 @@ class LammpsThermoProgressAdapter:
 
     def observe_jarvis_stdout(self, text: str) -> list[dict[str, object]]:
         """Extract records only while JARVIS identifies ``builtin.lammps``."""
+        return self._observe_jarvis_stdout(text, finalize=False)
+
+    def finalize_jarvis_stdout(self) -> list[dict[str, object]]:
+        """Flush the final JARVIS-scoped fragment at end of stream."""
+        return self._observe_jarvis_stdout("", finalize=True)
+
+    def _observe_jarvis_stdout(
+        self,
+        text: str,
+        *,
+        finalize: bool,
+    ) -> list[dict[str, object]]:
+        if self.authoritative_source == "package_log":
+            if finalize:
+                self.jarvis_stdout_fragment = ""
+                self.active_package_stdout = False
+            return []
         records: list[dict[str, object]] = []
-        for line in text.splitlines():
+        for line in self._complete_lines(
+            text,
+            fragment_name="jarvis_stdout_fragment",
+            finalize=finalize,
+        ):
             stripped = line.strip()
             if stripped == f"[{self.package_name}] [START] BEGIN":
+                if self.authoritative_source is None:
+                    self.authoritative_source = "jarvis_stdout"
                 self.active_package_stdout = True
                 continue
             if stripped == f"[{self.package_name}] [START] END":
@@ -61,7 +127,24 @@ class LammpsThermoProgressAdapter:
             record = self.observe_line(line)
             if record is not None:
                 records.append(record)
+        if finalize:
+            self.active_package_stdout = False
         return records
+
+    def _complete_lines(
+        self,
+        text: str,
+        *,
+        fragment_name: str,
+        finalize: bool,
+    ) -> list[str]:
+        fragment = cast(str, getattr(self, fragment_name))
+        lines = (fragment + text).splitlines(keepends=True)
+        if not finalize and lines and not lines[-1].endswith(("\n", "\r")):
+            setattr(self, fragment_name, lines.pop())
+        else:
+            setattr(self, fragment_name, "")
+        return [line.rstrip("\r\n") for line in lines]
 
     def progress_log_paths(self) -> list[Path]:
         """Return the LAMMPS thermo log owned by this package execution."""
@@ -85,16 +168,16 @@ class LammpsThermoProgressAdapter:
         """Require observed LAMMPS timing rather than a claimed percentage."""
         eta = metadata.get("eta_seconds")
         absolute_step = metadata.get("absolute_step")
+        eta_value = _finite_number(eta)
+        absolute_step_value = _finite_number(absolute_step)
         return (
             metadata.get("adapter") == self.adapter_name
             and metadata.get("prediction_status") == "observed_lammps_timing"
             and metadata.get("timing_source") == "lammps_thermo_cpu"
-            and isinstance(eta, int | float)
-            and not isinstance(eta, bool)
-            and float(eta) >= 0
-            and isinstance(absolute_step, int | float)
-            and not isinstance(absolute_step, bool)
-            and float(absolute_step) >= 0
+            and eta_value is not None
+            and eta_value >= 0
+            and absolute_step_value is not None
+            and absolute_step_value >= 0
         )
 
     def observe_line(self, line: str) -> dict[str, object] | None:
@@ -107,9 +190,10 @@ class LammpsThermoProgressAdapter:
             self.active_run_start_step = reset_step
             self.last_step = reset_step
             return None
-        run_steps = _parse_run_steps(stripped)
-        if run_steps is not None:
-            self.active_run_steps = run_steps
+        run_command = _parse_run_command(stripped)
+        if run_command is not None:
+            run_steps, run_upto = run_command
+            self.active_run_steps = None if run_upto else run_steps
             self.active_run_start_step = None
             return None
         if _looks_like_thermo_header(stripped):
@@ -124,12 +208,13 @@ class LammpsThermoProgressAdapter:
                     break
             return None
         if stripped.startswith("Loop time of "):
+            completed_steps = self.completed_steps
             if self.active_run_steps is not None:
-                self.completed_steps += self.active_run_steps
+                completed_steps += self.active_run_steps
             elif self.active_run_start_step is not None and self.last_step is not None:
-                self.completed_steps += max(
-                    0.0, self.last_step - self.active_run_start_step
-                )
+                completed_steps += max(0.0, self.last_step - self.active_run_start_step)
+            if math.isfinite(completed_steps):
+                self.completed_steps = completed_steps
             self.active_run_steps = None
             self.active_run_start_step = None
             self.active_columns = []
@@ -148,9 +233,8 @@ class LammpsThermoProgressAdapter:
         parts = stripped.split()
         if len(parts) != len(self.active_columns):
             return None
-        try:
-            step = float(parts[self.active_step_column])
-        except ValueError:
+        step = _optional_float(parts[self.active_step_column])
+        if step is None:
             return None
         if step < 0:
             return None
@@ -165,10 +249,12 @@ class LammpsThermoProgressAdapter:
         current = self.completed_steps + max(0.0, step - self.active_run_start_step)
         if self.active_run_steps is not None:
             current = min(self.completed_steps + self.active_run_steps, current)
-        progress_key = (self.completed_steps, current, step, elapsed_seconds)
-        if progress_key in self.emitted_keys:
+        if not math.isfinite(current):
             return None
-        self.emitted_keys.add(progress_key)
+        progress_key = (self.completed_steps, current, step, elapsed_seconds)
+        if progress_key == self.last_emitted_key:
+            return None
+        self.last_emitted_key = progress_key
         if elapsed_seconds is not None:
             self.samples.append((current, elapsed_seconds))
             self.samples = self.samples[-self.sample_window :]
@@ -191,6 +277,8 @@ class LammpsThermoProgressAdapter:
                     "timing_column": self.active_time_column_name,
                     **prediction,
                     "source": "jarvis_package",
+                    "progress_source": self.authoritative_source,
+                    "log_visibility": self.log_visibility,
                     "package_name": self.package_name,
                     "package_version": self.package_version,
                     "run_id": self.run_id,
@@ -222,13 +310,14 @@ class LammpsThermoProgressAdapter:
         for (previous_step, previous_time), (step, timestamp) in zip(
             self.samples,
             self.samples[1:],
-            strict=False,
         ):
             step_delta = step - previous_step
             time_delta = timestamp - previous_time
-            if step_delta <= 0 or time_delta < 0:
+            if step_delta <= 0 or time_delta <= 0:
                 continue
-            rates.append(time_delta / step_delta)
+            rate = time_delta / step_delta
+            if math.isfinite(rate):
+                rates.append(rate)
         if not rates:
             return {
                 "confidence": "warming_up",
@@ -238,8 +327,19 @@ class LammpsThermoProgressAdapter:
             }
         ordered = sorted(rates)
         trimmed = ordered[1:-1] if len(ordered) > 2 else ordered
-        seconds_per_step = statistics.fmean(trimmed)
+        seconds_per_step = statistics.mean(trimmed)
         remaining_steps = max(0.0, self.total_steps - current_step)
+        eta_seconds = remaining_steps * seconds_per_step
+        if not all(
+            math.isfinite(value)
+            for value in (seconds_per_step, remaining_steps, eta_seconds)
+        ):
+            return {
+                "confidence": "timing_unavailable",
+                "samples": len(self.samples),
+                "prediction_status": "nonfinite_prediction_rejected",
+                "elapsed_seconds": elapsed_seconds,
+            }
         return {
             "prediction_method": "trimmed_mean_step_time_after_warmup",
             "rate_samples": len(rates),
@@ -247,7 +347,7 @@ class LammpsThermoProgressAdapter:
             "min_seconds_per_step": min(trimmed),
             "max_seconds_per_step": max(trimmed),
             "seconds_per_step": seconds_per_step,
-            "eta_seconds": remaining_steps * seconds_per_step,
+            "eta_seconds": eta_seconds,
             "elapsed_seconds": elapsed_seconds,
             "remaining_steps": remaining_steps,
             "samples": len(self.samples),
@@ -265,46 +365,72 @@ def adapter_from_package(
     if package_type != "builtin.lammps":
         return None
     output = package.get("out")
+    deploy_mode = package.get("effective_deploy_mode") or package.get("deploy_mode")
+    progress = package.get("progress")
+    shared_log = _nested_progress_value(progress, "log_visibility") == "shared"
     output_dir = (
         Path(os.path.expandvars(output))
-        if isinstance(output, str) and output.strip()
+        if deploy_mode != "container"
+        and shared_log
+        and isinstance(output, str)
+        and output.strip()
         else None
     )
     return LammpsThermoProgressAdapter(
         package_name=str(package_type),
-        package_version=str(
-            package.get("pkg_version")
-            or package.get("version")
-            or package.get("package_version")
-            or "builtin"
-        ),
+        package_version=_distribution_version(),
+        log_visibility="shared" if output_dir is not None else "scoped_stdout",
         total_steps=_optional_float(
             package.get("total_steps")
             or package.get("steps")
-            or _nested_progress_total(package.get("progress"))
+            or _nested_progress_total(progress)
         ),
         output_dir=output_dir,
     )
 
 
 def _nested_progress_total(value: object) -> object:
+    return _nested_progress_value(value, "total_steps") or _nested_progress_value(
+        value, "total"
+    )
+
+
+def _nested_progress_value(value: object, key: str) -> object:
     if not isinstance(value, dict):
         return None
-    typed = cast(dict[str, object], value)
-    return typed.get("total_steps") or typed.get("total")
+    typed = cast("dict[str, object]", value)
+    return typed.get(key)
+
+
+def _distribution_version() -> str:
+    try:
+        return version("jarvis_cd")
+    except PackageNotFoundError:
+        return "source-checkout"
 
 
 def _optional_float(value: object) -> float | None:
     if value is None or isinstance(value, bool):
         return None
-    if isinstance(value, int | float):
-        return float(value)
+    if isinstance(value, (int, float)):
+        return _finite_number(value)
     if isinstance(value, str) and value != "":
         try:
-            return float(value)
-        except ValueError:
+            parsed = float(value)
+        except (TypeError, ValueError, OverflowError):
             return None
+        return parsed if math.isfinite(parsed) else None
     return None
+
+
+def _finite_number(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return parsed if math.isfinite(parsed) else None
 
 
 def _looks_like_thermo_header(line: str) -> bool:
@@ -312,11 +438,14 @@ def _looks_like_thermo_header(line: str) -> bool:
     return "Step" in columns and len(columns) >= 2
 
 
-def _parse_run_steps(line: str) -> float | None:
+def _parse_run_command(line: str) -> tuple[float, bool] | None:
     parts = line.split()
     if len(parts) < 2 or parts[0] != "run":
         return None
-    return _optional_float(parts[1])
+    run_value = _optional_float(parts[1])
+    if run_value is None or run_value < 0:
+        return None
+    return run_value, "upto" in parts[2:]
 
 
 def _parse_reset_timestep(line: str) -> float | None:

--- a/jarvis_cd/progress/lammps.py
+++ b/jarvis_cd/progress/lammps.py
@@ -1,0 +1,336 @@
+"""Package-owned LAMMPS progress provider for ``builtin.lammps``."""
+
+from __future__ import annotations
+
+import os
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+
+@dataclass
+class LammpsThermoProgressAdapter:
+    """Parse live LAMMPS thermo records under the JARVIS package boundary."""
+
+    package_name: str = "builtin.lammps"
+    package_version: str = "builtin"
+    run_id: str = ""
+    adapter_name: str = "lammps"
+    application_profile: str | None = None
+    total_steps: float | None = None
+    output_dir: Path | None = None
+    warmup_samples: int = 2
+    sample_window: int = 8
+    active_columns: list[str] = field(default_factory=list)
+    active_step_column: int | None = None
+    active_time_column: int | None = None
+    active_time_column_name: str | None = None
+    samples: list[tuple[float, float]] = field(default_factory=list)
+    last_step: float | None = None
+    completed_steps: float = 0.0
+    active_run_steps: float | None = None
+    active_run_start_step: float | None = None
+    active_package_stdout: bool = False
+    emitted_keys: set[tuple[float, float, float, float | None]] = field(
+        default_factory=set
+    )
+
+    def observe_stdout(self, text: str) -> list[dict[str, object]]:
+        """Extract progress from an already trusted package-owned log."""
+        records: list[dict[str, object]] = []
+        for line in text.splitlines():
+            record = self.observe_line(line)
+            if record is not None:
+                records.append(record)
+        return records
+
+    def observe_jarvis_stdout(self, text: str) -> list[dict[str, object]]:
+        """Extract records only while JARVIS identifies ``builtin.lammps``."""
+        records: list[dict[str, object]] = []
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped == f"[{self.package_name}] [START] BEGIN":
+                self.active_package_stdout = True
+                continue
+            if stripped == f"[{self.package_name}] [START] END":
+                self.active_package_stdout = False
+                continue
+            if not self.active_package_stdout:
+                continue
+            record = self.observe_line(line)
+            if record is not None:
+                records.append(record)
+        return records
+
+    def progress_log_paths(self) -> list[Path]:
+        """Return the LAMMPS thermo log owned by this package execution."""
+        if self.output_dir is None:
+            return []
+        return [self.output_dir / "log.lammps"]
+
+    def package_load_probe_python(self) -> str:
+        """Return a probe that locates the installed builtin LAMMPS package."""
+        return (
+            "from pathlib import Path\n"
+            "import jarvis_cd\n"
+            "root = Path(jarvis_cd.__file__).resolve().parent.parent\n"
+            "path = root / 'builtin' / 'builtin' / 'lammps' / 'pkg.py'\n"
+            "if not path.is_file():\n"
+            "    raise SystemExit(f'JARVIS builtin LAMMPS package missing: {path}')\n"
+            "print(path)"
+        )
+
+    def acceptance_progress_valid(self, metadata: dict[str, Any]) -> bool:
+        """Require observed LAMMPS timing rather than a claimed percentage."""
+        eta = metadata.get("eta_seconds")
+        absolute_step = metadata.get("absolute_step")
+        return (
+            metadata.get("adapter") == self.adapter_name
+            and metadata.get("prediction_status") == "observed_lammps_timing"
+            and metadata.get("timing_source") == "lammps_thermo_cpu"
+            and isinstance(eta, int | float)
+            and not isinstance(eta, bool)
+            and float(eta) >= 0
+            and isinstance(absolute_step, int | float)
+            and not isinstance(absolute_step, bool)
+            and float(absolute_step) >= 0
+        )
+
+    def observe_line(self, line: str) -> dict[str, object] | None:
+        """Extract one progress observation from a LAMMPS output line."""
+        stripped = line.strip()
+        if stripped == "":
+            return None
+        reset_step = _parse_reset_timestep(stripped)
+        if reset_step is not None:
+            self.active_run_start_step = reset_step
+            self.last_step = reset_step
+            return None
+        run_steps = _parse_run_steps(stripped)
+        if run_steps is not None:
+            self.active_run_steps = run_steps
+            self.active_run_start_step = None
+            return None
+        if _looks_like_thermo_header(stripped):
+            self.active_columns = stripped.split()
+            self.active_step_column = self.active_columns.index("Step")
+            self.active_time_column = None
+            self.active_time_column_name = None
+            for candidate in ("CPU", "Cpu", "cpu"):
+                if candidate in self.active_columns:
+                    self.active_time_column = self.active_columns.index(candidate)
+                    self.active_time_column_name = candidate
+                    break
+            return None
+        if stripped.startswith("Loop time of "):
+            if self.active_run_steps is not None:
+                self.completed_steps += self.active_run_steps
+            elif self.active_run_start_step is not None and self.last_step is not None:
+                self.completed_steps += max(
+                    0.0, self.last_step - self.active_run_start_step
+                )
+            self.active_run_steps = None
+            self.active_run_start_step = None
+            self.active_columns = []
+            self.active_step_column = None
+            self.active_time_column = None
+            self.active_time_column_name = None
+            return None
+        if self.active_step_column is None:
+            return None
+        if (
+            self.total_steps is not None
+            and self.completed_steps >= self.total_steps
+            and self.active_run_steps is None
+        ):
+            return None
+        parts = stripped.split()
+        if len(parts) != len(self.active_columns):
+            return None
+        try:
+            step = float(parts[self.active_step_column])
+        except ValueError:
+            return None
+        if step < 0:
+            return None
+        elapsed_seconds = None
+        if self.active_time_column is not None:
+            elapsed_seconds = _optional_float(parts[self.active_time_column])
+            if elapsed_seconds is not None and elapsed_seconds < 0:
+                elapsed_seconds = None
+        if self.active_run_start_step is None:
+            self.active_run_start_step = step
+        self.last_step = step
+        current = self.completed_steps + max(0.0, step - self.active_run_start_step)
+        if self.active_run_steps is not None:
+            current = min(self.completed_steps + self.active_run_steps, current)
+        progress_key = (self.completed_steps, current, step, elapsed_seconds)
+        if progress_key in self.emitted_keys:
+            return None
+        self.emitted_keys.add(progress_key)
+        if elapsed_seconds is not None:
+            self.samples.append((current, elapsed_seconds))
+            self.samples = self.samples[-self.sample_window :]
+        prediction = self._prediction(current, elapsed_seconds=elapsed_seconds)
+        return _drop_none(
+            {
+                "label": "timestep",
+                "current": current,
+                "total": self.total_steps,
+                "unit": "step",
+                "message": _lammps_message(current, self.total_steps),
+                "metadata": {
+                    "adapter": self.adapter_name,
+                    "columns": self.active_columns,
+                    "step_column": "Step",
+                    "absolute_step": step,
+                    "run_start_step": self.active_run_start_step,
+                    "run_steps": self.active_run_steps,
+                    "completed_prior_runs": self.completed_steps,
+                    "timing_column": self.active_time_column_name,
+                    **prediction,
+                    "source": "jarvis_package",
+                    "package_name": self.package_name,
+                    "package_version": self.package_version,
+                    "run_id": self.run_id,
+                    "execution_id": self.run_id,
+                },
+            }
+        )
+
+    def _prediction(
+        self,
+        current_step: float,
+        *,
+        elapsed_seconds: float | None,
+    ) -> dict[str, object]:
+        if elapsed_seconds is None:
+            return {
+                "confidence": "timing_unavailable",
+                "samples": len(self.samples),
+                "prediction_status": "no_lammps_timing_column",
+            }
+        if self.total_steps is None or len(self.samples) <= self.warmup_samples:
+            return {
+                "confidence": "warming_up",
+                "samples": len(self.samples),
+                "prediction_status": "warming_up",
+                "elapsed_seconds": elapsed_seconds,
+            }
+        rates: list[float] = []
+        for (previous_step, previous_time), (step, timestamp) in zip(
+            self.samples,
+            self.samples[1:],
+            strict=False,
+        ):
+            step_delta = step - previous_step
+            time_delta = timestamp - previous_time
+            if step_delta <= 0 or time_delta < 0:
+                continue
+            rates.append(time_delta / step_delta)
+        if not rates:
+            return {
+                "confidence": "warming_up",
+                "samples": len(self.samples),
+                "prediction_status": "warming_up",
+                "elapsed_seconds": elapsed_seconds,
+            }
+        ordered = sorted(rates)
+        trimmed = ordered[1:-1] if len(ordered) > 2 else ordered
+        seconds_per_step = statistics.fmean(trimmed)
+        remaining_steps = max(0.0, self.total_steps - current_step)
+        return {
+            "prediction_method": "trimmed_mean_step_time_after_warmup",
+            "rate_samples": len(rates),
+            "trimmed_rate_samples": len(trimmed),
+            "min_seconds_per_step": min(trimmed),
+            "max_seconds_per_step": max(trimmed),
+            "seconds_per_step": seconds_per_step,
+            "eta_seconds": remaining_steps * seconds_per_step,
+            "elapsed_seconds": elapsed_seconds,
+            "remaining_steps": remaining_steps,
+            "samples": len(self.samples),
+            "prediction_status": "observed_lammps_timing",
+            "timing_source": "lammps_thermo_cpu",
+            "confidence": "observed" if len(rates) >= 2 else "low_sample",
+        }
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> LammpsThermoProgressAdapter | None:
+    """Create the provider only for the builtin JARVIS LAMMPS package."""
+    package_type = package.get("pkg_type")
+    if package_type != "builtin.lammps":
+        return None
+    output = package.get("out")
+    output_dir = (
+        Path(os.path.expandvars(output))
+        if isinstance(output, str) and output.strip()
+        else None
+    )
+    return LammpsThermoProgressAdapter(
+        package_name=str(package_type),
+        package_version=str(
+            package.get("pkg_version")
+            or package.get("version")
+            or package.get("package_version")
+            or "builtin"
+        ),
+        total_steps=_optional_float(
+            package.get("total_steps")
+            or package.get("steps")
+            or _nested_progress_total(package.get("progress"))
+        ),
+        output_dir=output_dir,
+    )
+
+
+def _nested_progress_total(value: object) -> object:
+    if not isinstance(value, dict):
+        return None
+    typed = cast(dict[str, object], value)
+    return typed.get("total_steps") or typed.get("total")
+
+
+def _optional_float(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str) and value != "":
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _looks_like_thermo_header(line: str) -> bool:
+    columns = line.split()
+    return "Step" in columns and len(columns) >= 2
+
+
+def _parse_run_steps(line: str) -> float | None:
+    parts = line.split()
+    if len(parts) < 2 or parts[0] != "run":
+        return None
+    return _optional_float(parts[1])
+
+
+def _parse_reset_timestep(line: str) -> float | None:
+    parts = line.split()
+    if len(parts) < 2 or parts[0] != "reset_timestep":
+        return None
+    return _optional_float(parts[1])
+
+
+def _lammps_message(step: float, total_steps: float | None) -> str:
+    if total_steps is None:
+        return f"LAMMPS step {int(step)}"
+    return f"LAMMPS step {int(step)} of {int(total_steps)}"
+
+
+def _drop_none(value: dict[str, object | None]) -> dict[str, object]:
+    return {key: item for key, item in value.items() if item is not None}

--- a/jarvis_cd/progress/paraview.py
+++ b/jarvis_cd/progress/paraview.py
@@ -1,8 +1,4 @@
-"""Compatibility bridge to the package-local builtin LAMMPS provider.
-
-New integrations should use package-local JARVIS discovery. This module keeps
-the historical relay entry point without importing JARVIS repository names.
-"""
+"""Compatibility bridge to the package-local builtin ParaView provider."""
 
 from pathlib import Path
 from typing import Any, cast
@@ -14,17 +10,22 @@ _MODULE = load_progress_module(
     Path(__file__).resolve().parents[2]
     / "builtin"
     / "builtin"
-    / "lammps"
+    / "paraview"
     / "progress.py"
 )
 
-LammpsThermoProgressAdapter = _MODULE.LammpsThermoProgressAdapter
+ParaViewProgressAdapter = _MODULE.ParaViewProgressAdapter
+ParaViewProgressReporter = _MODULE.ParaViewProgressReporter
 _FACTORY = cast(RelayProgressAdapterFactory, _MODULE.adapter_from_package)
 
 
 def adapter_from_package(package: dict[str, Any]) -> RelayProgressAdapter | None:
-    """Create the package-local LAMMPS provider through the legacy entry point."""
+    """Create the package-local ParaView provider through a stable entry point."""
     return _FACTORY(package)
 
 
-__all__ = ["LammpsThermoProgressAdapter", "adapter_from_package"]
+__all__ = [
+    "ParaViewProgressAdapter",
+    "ParaViewProgressReporter",
+    "adapter_from_package",
+]

--- a/jarvis_cd/progress/provider.py
+++ b/jarvis_cd/progress/provider.py
@@ -1,0 +1,152 @@
+"""Generic package progress provider protocol and stream utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+from .schema import JsonValue, ProgressEvent, ProgressState
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressObservation:
+    """Application-specific progress interpreted without execution identity.
+
+    JARVIS core supplies package and execution identity when it persists an
+    observation. Providers therefore cannot select an authoritative sidecar or
+    impersonate another package through this object.
+    """
+
+    label: str
+    state: ProgressState = ProgressState.RUNNING
+    current: float | None = None
+    total: float | None = None
+    unit: str | None = None
+    message: str | None = None
+    metadata: Mapping[str, JsonValue] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validate the observation with the same rules as persisted events."""
+        ProgressEvent(
+            package_name="provider",
+            package_id="provider",
+            execution_id="provider",
+            label=self.label,
+            state=self.state,
+            current=self.current,
+            total=self.total,
+            unit=self.unit,
+            message=self.message,
+            sequence=0,
+            metadata=self.metadata,
+        ).to_json()
+
+
+@runtime_checkable
+class PackageProgressProvider(Protocol):
+    """Minimal JARVIS-owned progress contract implemented beside a package."""
+
+    def observe_progress(self, text: str) -> list[ProgressObservation]:
+        """Interpret application stdout and return typed observations."""
+        ...
+
+    def finalize_progress(self) -> list[ProgressObservation]:
+        """Flush a final unterminated application-output fragment."""
+        ...
+
+    def reset_progress(self) -> None:
+        """Reset parsing after the underlying application stream is replaced."""
+        ...
+
+
+@runtime_checkable
+class RelayProgressAdapter(Protocol):
+    """Legacy clio-relay adapter contract kept outside the JARVIS core SPI."""
+
+    package_name: str
+    package_id: str
+    package_version: str
+    run_id: str
+    adapter_name: str
+    application_profile: str | None
+
+    def observe_jarvis_stdout(self, text: str) -> list[dict[str, object]]:
+        """Observe text framed by JARVIS package lifecycle markers."""
+        ...
+
+    def observe_stdout(self, text: str) -> list[dict[str, object]]:
+        """Observe text from a trusted package-owned stream or sidecar."""
+        ...
+
+    def finalize_jarvis_stdout(self) -> list[dict[str, object]]:
+        """Flush an incomplete final JARVIS stdout line."""
+        ...
+
+    def finalize_stdout(self) -> list[dict[str, object]]:
+        """Flush an incomplete final package-owned stream line."""
+        ...
+
+    def reset_stdout(self) -> None:
+        """Reset parsing after a package-owned sidecar is replaced."""
+        ...
+
+    def progress_log_paths(self) -> list[Path]:
+        """Return explicitly shared package-owned progress sidecars."""
+        ...
+
+    def package_load_probe_python(self) -> str | None:
+        """Return an optional Python probe for the provider implementation."""
+        ...
+
+    def acceptance_progress_valid(self, metadata: dict[str, Any]) -> bool:
+        """Validate package-specific evidence in an observed record."""
+        ...
+
+
+ProgressProviderFactory = Callable[[dict[str, Any]], PackageProgressProvider | None]
+RelayProgressAdapterFactory = Callable[[dict[str, Any]], RelayProgressAdapter | None]
+
+
+class LineBuffer:
+    """Turn arbitrary text chunks into complete lines without losing fragments."""
+
+    def __init__(self) -> None:
+        self.fragment = ""
+
+    def feed(self, text: str, *, finalize: bool = False) -> list[str]:
+        """Return complete lines and retain any incomplete final fragment."""
+        lines = (self.fragment + text).splitlines(keepends=True)
+        if not finalize and lines and not lines[-1].endswith(("\n", "\r")):
+            self.fragment = lines.pop()
+        else:
+            self.fragment = ""
+        return [line.rstrip("\r\n") for line in lines]
+
+    def reset(self) -> None:
+        """Discard a buffered fragment."""
+        self.fragment = ""
+
+
+class PackageScopeFilter:
+    """Expose lines only while JARVIS identifies the owning package as active."""
+
+    def __init__(self, package_name: str) -> None:
+        self.package_name = package_name
+        self.active = False
+
+    def observe(self, line: str) -> str | None:
+        """Return an in-scope line, or ``None`` for markers/unrelated output."""
+        stripped = line.strip()
+        if stripped == f"[{self.package_name}] [START] BEGIN":
+            self.active = True
+            return None
+        if stripped == f"[{self.package_name}] [START] END":
+            self.active = False
+            return None
+        return line if self.active else None
+
+    def reset(self) -> None:
+        """Close the active package scope."""
+        self.active = False

--- a/jarvis_cd/progress/reporter.py
+++ b/jarvis_cd/progress/reporter.py
@@ -1,0 +1,113 @@
+"""Dependency-free reporter for package scripts and ParaView ``pvbatch``."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import TextIO
+
+from .schema import JsonValue, ProgressEvent, ProgressState
+from .store import ProgressStore
+
+PROGRESS_LINE_PREFIX = "JARVIS_PROGRESS "
+PROGRESS_PATH_ENV = "JARVIS_PROGRESS_PATH"
+PROGRESS_TRANSPORT_ENV = "JARVIS_PROGRESS_TRANSPORT"
+EXECUTION_ID_ENV = "JARVIS_EXECUTION_ID"
+PACKAGE_NAME_ENV = "JARVIS_PACKAGE_NAME"
+PACKAGE_ID_ENV = "JARVIS_PACKAGE_ID"
+
+
+class ProgressReporter:
+    """Emit structured progress to stdout or a durable JSONL sidecar.
+
+    This JARVIS-side module uses only the Python standard library. Applications
+    with an older embedded Python may emit the same line schema independently.
+    """
+
+    def __init__(
+        self,
+        *,
+        package_name: str | None = None,
+        package_id: str | None = None,
+        execution_id: str | None = None,
+        path: str | os.PathLike[str] | None = None,
+        stream: TextIO | None = None,
+    ) -> None:
+        self.package_name = package_name or os.environ.get(PACKAGE_NAME_ENV, "")
+        self.package_id = package_id or os.environ.get(PACKAGE_ID_ENV, "")
+        self.execution_id = execution_id or os.environ.get(EXECUTION_ID_ENV, "")
+        configured_path = (
+            path if path is not None else os.environ.get(PROGRESS_PATH_ENV)
+        )
+        configured_transport = (
+            None if path is not None else os.environ.get(PROGRESS_TRANSPORT_ENV)
+        )
+        if configured_transport not in {None, "sidecar", "stdout"}:
+            raise ValueError("JARVIS_PROGRESS_TRANSPORT must be 'sidecar' or 'stdout'")
+        if configured_transport == "sidecar" and not configured_path:
+            raise ValueError("sidecar progress transport requires JARVIS_PROGRESS_PATH")
+        self.transport = configured_transport or (
+            "sidecar" if configured_path else "stdout"
+        )
+        self.path = (
+            Path(configured_path)
+            if configured_path and self.transport == "sidecar"
+            else None
+        )
+        self.stream = stream or sys.stdout
+        latest = ProgressStore(self.path).latest() if self.path is not None else None
+        if latest is not None and (
+            latest.execution_id,
+            latest.package_name,
+            latest.package_id,
+        ) != (self.execution_id, self.package_name, self.package_id):
+            raise ValueError(
+                "existing progress store identity does not match this reporter"
+            )
+        self.sequence = latest.sequence if latest is not None else 0
+
+    def emit(
+        self,
+        *,
+        label: str,
+        state: ProgressState = ProgressState.RUNNING,
+        current: float | None = None,
+        total: float | None = None,
+        unit: str | None = None,
+        message: str | None = None,
+        metadata: dict[str, JsonValue] | None = None,
+    ) -> ProgressEvent:
+        """Validate and emit one progress event, returning the exact event."""
+        self.sequence += 1
+        event = ProgressEvent(
+            package_name=self.package_name,
+            package_id=self.package_id,
+            execution_id=self.execution_id,
+            label=label,
+            state=state,
+            current=current,
+            total=total,
+            unit=unit,
+            message=message,
+            sequence=self.sequence,
+            metadata=metadata or {},
+        )
+        if self.path is not None:
+            ProgressStore(self.path).append(event)
+        else:
+            self.stream.write(f"{PROGRESS_LINE_PREFIX}{event.to_json()}\n")
+            self.stream.flush()
+        return event
+
+
+def event_from_progress_line(line: str) -> ProgressEvent | None:
+    """Parse one structured stdout or raw JSONL sidecar line."""
+    stripped = line.strip()
+    if not stripped:
+        return None
+    if stripped.startswith(PROGRESS_LINE_PREFIX):
+        stripped = stripped[len(PROGRESS_LINE_PREFIX) :]
+    elif not stripped.startswith("{"):
+        return None
+    return ProgressEvent.from_json(stripped)

--- a/jarvis_cd/progress/schema.py
+++ b/jarvis_cd/progress/schema.py
@@ -1,0 +1,303 @@
+"""Typed, application-independent progress records for JARVIS executions."""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Final, Mapping, cast
+
+PROGRESS_SCHEMA_VERSION: Final = "jarvis.progress.v1"
+MAX_PROGRESS_EVENT_BYTES: Final = 64 * 1024
+MAX_IDENTITY_TEXT: Final = 256
+MAX_MESSAGE_TEXT: Final = 4096
+_EVENT_FIELDS: Final = frozenset(
+    {
+        "schema_version",
+        "package_name",
+        "package_id",
+        "execution_id",
+        "label",
+        "state",
+        "current",
+        "total",
+        "unit",
+        "message",
+        "sequence",
+        "observed_at_epoch",
+        "determinate",
+        "metadata",
+    }
+)
+
+
+class ProgressState(StrEnum):
+    """Lifecycle state represented by a package progress observation."""
+
+    PENDING = "pending"
+    STARTING = "starting"
+    RUNNING = "running"
+    READY = "ready"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELED = "canceled"
+
+
+JsonScalar = str | int | float | bool | None
+JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressEvent:
+    """One durable package progress observation.
+
+    ``total`` is optional by design. An event is determinate only when its
+    producer has supplied a real, positive total; JARVIS never invents one.
+    """
+
+    package_name: str
+    package_id: str
+    execution_id: str
+    label: str
+    state: ProgressState = ProgressState.RUNNING
+    current: float | None = None
+    total: float | None = None
+    unit: str | None = None
+    message: str | None = None
+    sequence: int = 0
+    observed_at_epoch: float = field(default_factory=time.time)
+    metadata: Mapping[str, JsonValue] = field(default_factory=dict)
+    schema_version: str = PROGRESS_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        """Reject ambiguous, non-finite, or non-JSON progress at creation."""
+        if self.schema_version != PROGRESS_SCHEMA_VERSION:
+            raise ValueError(f"unsupported progress schema: {self.schema_version!r}")
+        if not isinstance(self.state, ProgressState):
+            raise ValueError("progress state must be a ProgressState")
+        for field_name, value in (
+            ("package_name", self.package_name),
+            ("package_id", self.package_id),
+            ("execution_id", self.execution_id),
+            ("label", self.label),
+        ):
+            if not value or not value.strip():
+                raise ValueError(f"progress {field_name} must be non-empty")
+            if len(value) > MAX_IDENTITY_TEXT:
+                raise ValueError(f"progress {field_name} exceeds maximum length")
+        if (
+            isinstance(self.sequence, bool)
+            or not isinstance(self.sequence, int)
+            or self.sequence < 0
+        ):
+            raise ValueError("progress sequence must be a non-negative integer")
+        _validate_finite("observed_at_epoch", self.observed_at_epoch)
+        if self.observed_at_epoch < 0:
+            raise ValueError("progress observed_at_epoch cannot be negative")
+        if self.current is not None:
+            _validate_finite("current", self.current)
+            if self.current < 0:
+                raise ValueError("progress current cannot be negative")
+        if self.total is not None:
+            _validate_finite("total", self.total)
+            if self.total <= 0:
+                raise ValueError("progress total must be positive")
+            if self.current is None:
+                raise ValueError("determinate progress requires current")
+            if self.current > self.total:
+                raise ValueError("progress current cannot exceed total")
+        if self.unit is not None and not self.unit.strip():
+            raise ValueError("progress unit must be non-empty when supplied")
+        if self.unit is not None and len(self.unit) > MAX_IDENTITY_TEXT:
+            raise ValueError("progress unit exceeds maximum length")
+        if self.message is not None and not self.message.strip():
+            raise ValueError("progress message must be non-empty when supplied")
+        if self.message is not None and len(self.message) > MAX_MESSAGE_TEXT:
+            raise ValueError("progress message exceeds maximum length")
+        _canonical_json(dict(self.metadata))
+
+    @property
+    def determinate(self) -> bool:
+        """Return whether the producer supplied a real quantitative total."""
+        return self.current is not None and self.total is not None
+
+    def as_dict(self) -> dict[str, JsonValue]:
+        """Serialize this event to the stable JARVIS progress schema."""
+        value: dict[str, JsonValue] = {
+            "schema_version": self.schema_version,
+            "package_name": self.package_name,
+            "package_id": self.package_id,
+            "execution_id": self.execution_id,
+            "label": self.label,
+            "state": self.state.value,
+            "sequence": self.sequence,
+            "observed_at_epoch": self.observed_at_epoch,
+            "determinate": self.determinate,
+            "metadata": dict(self.metadata),
+        }
+        for key, item in (
+            ("current", self.current),
+            ("total", self.total),
+            ("unit", self.unit),
+            ("message", self.message),
+        ):
+            if item is not None:
+                value[key] = item
+        return value
+
+    def as_adapter_record(self) -> dict[str, object]:
+        """Project the event into the existing relay adapter record shape."""
+        metadata: dict[str, object] = {
+            **dict(self.metadata),
+            "schema_version": self.schema_version,
+            "package_name": self.package_name,
+            "package_id": self.package_id,
+            "execution_id": self.execution_id,
+            "run_id": self.execution_id,
+            "progress_state": self.state.value,
+            "sequence": self.sequence,
+            "observed_at_epoch": self.observed_at_epoch,
+            "determinate": self.determinate,
+        }
+        record: dict[str, object] = {
+            "label": self.label,
+            "message": self.message or self.label,
+            "metadata": metadata,
+        }
+        if self.current is not None:
+            record["current"] = self.current
+        if self.total is not None:
+            record["total"] = self.total
+        if self.unit is not None:
+            record["unit"] = self.unit
+        return record
+
+    def to_json(self) -> str:
+        """Return one canonical JSON representation suitable for JSONL."""
+        encoded = _canonical_json(self.as_dict())
+        if len(encoded.encode("utf-8")) > MAX_PROGRESS_EVENT_BYTES:
+            raise ValueError("progress event exceeds maximum encoded size")
+        return encoded
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "ProgressEvent":
+        """Parse and validate a mapping using the stable progress schema."""
+        unknown = set(value) - _EVENT_FIELDS
+        if unknown:
+            raise ValueError(f"unknown progress event fields: {sorted(unknown)}")
+        metadata = value.get("metadata", {})
+        if not isinstance(metadata, dict):
+            raise ValueError("progress metadata must be an object")
+        state = _required_str(value, "state")
+        try:
+            typed_state = ProgressState(state)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"invalid progress state: {state!r}") from exc
+        event = cls(
+            schema_version=_required_str(value, "schema_version"),
+            package_name=_required_str(value, "package_name"),
+            package_id=_required_str(value, "package_id"),
+            execution_id=_required_str(value, "execution_id"),
+            label=_required_str(value, "label"),
+            state=typed_state,
+            current=_optional_number(value, "current"),
+            total=_optional_number(value, "total"),
+            unit=_optional_str(value, "unit"),
+            message=_optional_str(value, "message"),
+            sequence=_required_int(value, "sequence"),
+            observed_at_epoch=_required_number(value, "observed_at_epoch"),
+            metadata=cast(dict[str, JsonValue], metadata),
+        )
+        claimed_determinate = value.get("determinate")
+        if not isinstance(claimed_determinate, bool):
+            raise ValueError("progress determinate must be boolean")
+        if claimed_determinate is not event.determinate:
+            raise ValueError("progress determinate does not match current and total")
+        return event
+
+    @classmethod
+    def from_json(cls, payload: str) -> "ProgressEvent":
+        """Parse one bounded JSON event."""
+        if len(payload.encode("utf-8")) > MAX_PROGRESS_EVENT_BYTES:
+            raise ValueError("progress event exceeds maximum encoded size")
+        try:
+            value = json.loads(payload, object_pairs_hook=_reject_duplicate_keys)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ValueError("progress event is not valid JSON") from exc
+        if not isinstance(value, dict):
+            raise ValueError("progress event must be a JSON object")
+        return cls.from_dict(cast(dict[str, Any], value))
+
+
+def _canonical_json(value: object) -> str:
+    try:
+        return json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("progress event must contain finite JSON values") from exc
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON key: {key}")
+        value[key] = item
+    return value
+
+
+def _validate_finite(field_name: str, value: float) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"progress {field_name} must be numeric")
+    try:
+        finite = math.isfinite(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"progress {field_name} must be finite") from exc
+    if not finite:
+        raise ValueError(f"progress {field_name} must be finite")
+
+
+def _required_str(value: Mapping[str, Any], key: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str):
+        raise ValueError(f"progress {key} must be a string")
+    return item
+
+
+def _optional_str(value: Mapping[str, Any], key: str) -> str | None:
+    item = value.get(key)
+    if item is None:
+        return None
+    if not isinstance(item, str):
+        raise ValueError(f"progress {key} must be a string")
+    return item
+
+
+def _required_int(value: Mapping[str, Any], key: str) -> int:
+    item = value.get(key)
+    if isinstance(item, bool) or not isinstance(item, int):
+        raise ValueError(f"progress {key} must be an integer")
+    return item
+
+
+def _required_number(value: Mapping[str, Any], key: str) -> float:
+    item = value.get(key)
+    if isinstance(item, bool) or not isinstance(item, (int, float)):
+        raise ValueError(f"progress {key} must be numeric")
+    return float(item)
+
+
+def _optional_number(value: Mapping[str, Any], key: str) -> float | None:
+    item = value.get(key)
+    if item is None:
+        return None
+    if isinstance(item, bool) or not isinstance(item, (int, float)):
+        raise ValueError(f"progress {key} must be numeric")
+    return float(item)

--- a/jarvis_cd/progress/store.py
+++ b/jarvis_cd/progress/store.py
@@ -1,0 +1,291 @@
+"""Durable append-only storage for structured JARVIS progress events."""
+
+from __future__ import annotations
+
+import os
+import stat
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Final, Iterator
+
+from .schema import MAX_PROGRESS_EVENT_BYTES, ProgressEvent
+from jarvis_cd.util.private_path import (
+    ensure_private_descriptor,
+    ensure_private_path,
+    reject_private_path_redirection,
+)
+
+MAX_PROGRESS_STORE_BYTES: Final = 64 * 1024 * 1024
+
+
+class ProgressStore:
+    """Append and query a bounded JSONL progress sidecar."""
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        self.path = Path(path)
+
+    def append(self, event: ProgressEvent) -> None:
+        """Durably append one event without following a sidecar symlink."""
+        payload = (event.to_json() + "\n").encode("utf-8")
+        _reject_symlink_tree(self.path.parent)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_private_path(self.path.parent, directory=True)
+        _reject_symlink_tree(self.path.parent)
+        with _exclusive_store_lock(self.path):
+            descriptor = _open_store(self.path, write=True)
+            try:
+                info = _validate_descriptor(self.path, descriptor)
+                projected_size = info.st_size + len(payload)
+                if projected_size > MAX_PROGRESS_STORE_BYTES:
+                    raise ValueError("progress store would exceed maximum size")
+                previous_event = _latest_event(descriptor, info.st_size)
+                if previous_event is not None and (
+                    _stream_identity(event) != _stream_identity(previous_event)
+                ):
+                    raise ValueError(
+                        "progress event identity must remain stable within a store"
+                    )
+                previous_sequence = (
+                    previous_event.sequence if previous_event is not None else -1
+                )
+                if event.sequence <= previous_sequence:
+                    raise ValueError("progress event sequences must increase strictly")
+                offset = 0
+                while offset < len(payload):
+                    written = os.write(descriptor, payload[offset:])
+                    if written <= 0:
+                        raise OSError("short write while appending progress event")
+                    offset += written
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+
+    def read_all(self) -> list[ProgressEvent]:
+        """Read and validate every complete event in sequence order."""
+        _reject_symlink_tree(self.path)
+        if not self.path.exists():
+            return []
+        _reject_symlink_tree(self.path.parent)
+        with _exclusive_store_lock(self.path):
+            descriptor = _open_store(self.path, write=False)
+            try:
+                info = _validate_descriptor(self.path, descriptor)
+                if info.st_size > MAX_PROGRESS_STORE_BYTES:
+                    raise ValueError("progress store exceeds maximum size")
+                _require_complete_framing(descriptor, info.st_size)
+                os.lseek(descriptor, 0, os.SEEK_SET)
+            except Exception:
+                os.close(descriptor)
+                raise
+            events: list[ProgressEvent] = []
+            previous_sequence = -1
+            stream_identity: tuple[str, str, str] | None = None
+            with os.fdopen(descriptor, "r", encoding="utf-8", newline="") as stream:
+                for line_number, line in enumerate(stream, start=1):
+                    if len(line.encode("utf-8")) > MAX_PROGRESS_EVENT_BYTES + 1:
+                        raise ValueError(
+                            f"progress line {line_number} exceeds maximum size"
+                        )
+                    payload = line.rstrip("\r\n")
+                    if not payload:
+                        continue
+                    event = ProgressEvent.from_json(payload)
+                    event_identity = _stream_identity(event)
+                    if stream_identity is None:
+                        stream_identity = event_identity
+                    elif event_identity != stream_identity:
+                        raise ValueError(
+                            "progress event identity must remain stable within a store"
+                        )
+                    if event.sequence <= previous_sequence:
+                        raise ValueError(
+                            "progress event sequences must increase strictly"
+                        )
+                    previous_sequence = event.sequence
+                    events.append(event)
+            return events
+
+    def latest(self) -> ProgressEvent | None:
+        """Return the most recent valid event, if one exists."""
+        events = self.read_all()
+        return events[-1] if events else None
+
+
+def _reject_symlink(path: Path, *, label: str) -> None:
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError:
+        return
+    attributes = getattr(path.lstat(), "st_file_attributes", 0)
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    if stat.S_ISLNK(mode) or attributes & reparse_flag:
+        raise ValueError(f"{label} cannot be a symlink or reparse point: {path}")
+
+
+def _reject_symlink_tree(path: Path) -> None:
+    try:
+        reject_private_path_redirection(path)
+    except RuntimeError as exc:
+        raise ValueError(
+            f"progress path cannot be redirected by a symlink or reparse point: {path}"
+        ) from exc
+    absolute = Path(os.path.abspath(path))
+    existing: list[Path] = []
+    current = absolute
+    while True:
+        if current.exists() or current.is_symlink():
+            existing.append(current)
+        if current == current.parent:
+            break
+        current = current.parent
+    for component in reversed(existing):
+        _reject_symlink(component, label="progress path component")
+
+
+def _open_store(path: Path, *, write: bool) -> int:
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if not write:
+        descriptor = os.open(path, os.O_RDONLY | nofollow)
+        try:
+            ensure_private_descriptor(path, descriptor, directory=False)
+        except BaseException:
+            os.close(descriptor)
+            raise
+        return descriptor
+    try:
+        descriptor = os.open(
+            path,
+            os.O_APPEND | os.O_CREAT | os.O_EXCL | os.O_RDWR | nofollow,
+            0o600,
+        )
+    except FileExistsError:
+        descriptor = os.open(path, os.O_APPEND | os.O_RDWR | nofollow)
+    else:
+        if os.name != "nt":
+            os.fchmod(descriptor, 0o600)  # type: ignore[attr-defined]
+    try:
+        ensure_private_descriptor(path, descriptor, directory=False)
+    except BaseException:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
+def _latest_event(descriptor: int, size: int) -> ProgressEvent | None:
+    if size == 0:
+        return None
+    _require_complete_framing(descriptor, size)
+    tail_size = min(size, (MAX_PROGRESS_EVENT_BYTES + 1) * 2)
+    os.lseek(descriptor, size - tail_size, os.SEEK_SET)
+    remaining = tail_size
+    chunks: list[bytes] = []
+    while remaining:
+        chunk = os.read(descriptor, remaining)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    lines = b"".join(chunks).splitlines()
+    if size > tail_size and lines:
+        lines.pop(0)
+    for line in reversed(lines):
+        if line.strip():
+            try:
+                payload = line.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ValueError("progress store contains invalid UTF-8") from exc
+            return ProgressEvent.from_json(payload)
+    return None
+
+
+def _require_complete_framing(descriptor: int, size: int) -> None:
+    """Reject a non-empty JSONL store whose final record is unterminated."""
+    if size == 0:
+        return
+    os.lseek(descriptor, size - 1, os.SEEK_SET)
+    if os.read(descriptor, 1) != b"\n":
+        raise ValueError("progress store has an incomplete final JSONL record")
+
+
+def _stream_identity(event: ProgressEvent) -> tuple[str, str, str]:
+    """Return the immutable identity shared by every event in one sidecar."""
+    return (event.execution_id, event.package_name, event.package_id)
+
+
+def _validate_descriptor(path: Path, descriptor: int) -> os.stat_result:
+    info = os.fstat(descriptor)
+    if not stat.S_ISREG(info.st_mode):
+        raise ValueError(f"progress store must be a regular file: {path}")
+    path_info = path.lstat()
+    if stat.S_ISLNK(path_info.st_mode) or (
+        path_info.st_dev,
+        path_info.st_ino,
+    ) != (info.st_dev, info.st_ino):
+        raise ValueError(f"progress store changed during secure open: {path}")
+    if os.name != "nt":
+        getuid = getattr(os, "getuid", None)
+        if getuid is not None and info.st_uid != getuid():
+            raise PermissionError(
+                f"progress store is not owned by current user: {path}"
+            )
+        if stat.S_IMODE(info.st_mode) & 0o077:
+            raise PermissionError(f"progress store permissions are not private: {path}")
+    return info
+
+
+@contextmanager
+def _exclusive_store_lock(path: Path) -> Iterator[None]:
+    lock_path = path.with_name(path.name + ".lock")
+    _reject_symlink(lock_path, label="progress lock")
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(
+            lock_path,
+            os.O_CREAT | os.O_EXCL | os.O_RDWR | nofollow,
+            0o600,
+        )
+    except FileExistsError:
+        descriptor = os.open(lock_path, os.O_RDWR | nofollow)
+    try:
+        ensure_private_descriptor(lock_path, descriptor, directory=False)
+        _validate_descriptor(lock_path, descriptor)
+        if os.fstat(descriptor).st_size == 0:
+            os.write(descriptor, b"0")
+            os.fsync(descriptor)
+        _lock_descriptor(descriptor)
+        try:
+            yield
+        finally:
+            _unlock_descriptor(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _lock_descriptor(descriptor: int) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(  # type: ignore[attr-defined]
+            descriptor,
+            fcntl.LOCK_EX,  # type: ignore[attr-defined]
+        )
+
+
+def _unlock_descriptor(descriptor: int) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(  # type: ignore[attr-defined]
+            descriptor,
+            fcntl.LOCK_UN,  # type: ignore[attr-defined]
+        )

--- a/jarvis_cd/shell/core_exec.py
+++ b/jarvis_cd/shell/core_exec.py
@@ -28,6 +28,10 @@ class CoreExec(ABC):
         self.process_groups = {}  # hostname -> process-group leader pid
         self.windows_jobs: Dict[str, WindowsJob] = {}
         self.output_threads = {}  # hostname -> (stdout_thread, stderr_thread)
+        self.output_callback_errors = []
+        self._output_callback_failure = threading.Event()
+        self._output_callback_lock = threading.Lock()
+        self._output_callback_finalized = False
 
     @abstractmethod
     def run(self):
@@ -59,6 +63,18 @@ class CoreExec(ABC):
             self.exit_code[hostname] = exit_code
 
             self._join_output_threads(hostname)
+            self._finalize_output_callback()
+
+            if self.output_callback_errors:
+                existing = self.stderr.get(hostname, "")
+                separator = "" if not existing or existing.endswith("\n") else "\n"
+                self.stderr[hostname] = (
+                    f"{existing}{separator}{''.join(self.output_callback_errors)}"
+                )
+                self.output_callback_errors.clear()
+                if exit_code == 0:
+                    exit_code = 1
+                    self.exit_code[hostname] = exit_code
 
             windows_job = self.windows_jobs.get(hostname)
             if windows_job is not None:
@@ -103,6 +119,57 @@ class CoreExec(ABC):
         if any(thread.is_alive() for thread in threads):
             diagnostic = "Output capture did not close after process-tree termination\n"
             self.stderr[hostname] = self.stderr.get(hostname, "") + diagnostic
+
+    def _record_output_callback_failure(
+        self,
+        output_type: str,
+        exc: Exception,
+        *,
+        terminate: bool,
+    ) -> None:
+        """Latch one bounded callback failure and terminate the owned process."""
+        should_terminate = False
+        with self._output_callback_lock:
+            if self._output_callback_failure.is_set():
+                return
+            self._output_callback_failure.set()
+            detail = str(exc)
+            if len(detail) > 4096:
+                detail = detail[:4093] + "..."
+            self.output_callback_errors.append(
+                f"Output line callback failed for {output_type}: {detail}\n"
+            )
+            should_terminate = terminate
+        if should_terminate:
+            hostname = getattr(self, "hostname", "localhost")
+            try:
+                self.kill(hostname)
+            except Exception as kill_error:
+                detail = str(kill_error)
+                if len(detail) > 1024:
+                    detail = detail[:1021] + "..."
+                with self._output_callback_lock:
+                    self.output_callback_errors.append(
+                        f"Could not terminate process after callback failure: {detail}\n"
+                    )
+
+    def _finalize_output_callback(self) -> None:
+        """Finalize a stateful output callback once after both streams close."""
+        callback = getattr(getattr(self, "exec_info", None), "line_callback", None)
+        finalizer = getattr(callback, "finalize", None)
+        if finalizer is None or not callable(finalizer):
+            return
+        with self._output_callback_lock:
+            if (
+                self._output_callback_finalized
+                or self._output_callback_failure.is_set()
+            ):
+                return
+            self._output_callback_finalized = True
+        try:
+            finalizer()
+        except Exception as exc:
+            self._record_output_callback_failure("finalization", exc, terminate=False)
 
     def wait_all(self) -> Dict[str, int]:
         """
@@ -257,7 +324,11 @@ class LocalExec(CoreExec):
             self.process_groups[self.hostname] = process.pid
 
             # Start output monitoring threads
-            if self.exec_info.collect_output or not self.exec_info.hide_output:
+            if (
+                self.exec_info.collect_output
+                or not self.exec_info.hide_output
+                or self.exec_info.line_callback is not None
+            ):
                 stdout_thread = threading.Thread(
                     target=self._monitor_output, args=(process.stdout, "stdout")
                 )
@@ -299,6 +370,17 @@ class LocalExec(CoreExec):
             for line in iter(pipe.readline, ""):
                 if not line:
                     break
+
+                callback = self.exec_info.line_callback
+                if callback is not None and not self._output_callback_failure.is_set():
+                    try:
+                        callback(output_type, line)
+                    except Exception as exc:
+                        self._record_output_callback_failure(
+                            output_type,
+                            exc,
+                            terminate=True,
+                        )
 
                 # Store in buffer if collecting output
                 if self.exec_info.collect_output:

--- a/jarvis_cd/shell/core_exec.py
+++ b/jarvis_cd/shell/core_exec.py
@@ -1,17 +1,17 @@
 """
 Core execution classes for Jarvis shell execution.
 """
+
 import subprocess
 import threading
 import time
 import os
 import signal
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Optional, List
-from pathlib import Path
+from typing import Dict
 
 from .exec_info import ExecInfo, ExecType
-from ..util.hostfile import Hostfile
+from .windows_job import WindowsJob, spawn_windows_job_process
 
 
 class CoreExec(ABC):
@@ -22,11 +22,13 @@ class CoreExec(ABC):
 
     def __init__(self):
         self.exit_code = {}  # hostname -> exit_code
-        self.stdout = {}     # hostname -> stdout 
-        self.stderr = {}     # hostname -> stderr
+        self.stdout = {}  # hostname -> stdout
+        self.stderr = {}  # hostname -> stderr
         self.processes = {}  # hostname -> process
+        self.process_groups = {}  # hostname -> process-group leader pid
+        self.windows_jobs: Dict[str, WindowsJob] = {}
         self.output_threads = {}  # hostname -> (stdout_thread, stderr_thread)
-        
+
     @abstractmethod
     def run(self):
         """Execute the command"""
@@ -36,59 +38,127 @@ class CoreExec(ABC):
     def get_cmd(self) -> str:
         """Get the command string"""
         pass
-        
-    def wait(self, hostname: str = 'localhost') -> int:
+
+    def wait(self, hostname: str = "localhost") -> int:
         """
         Wait for execution to complete.
-        
+
         :param hostname: Hostname to wait for
         :return: Exit code
         """
         if hostname in self.processes:
             process = self.processes[hostname]
-            exit_code = process.wait()
+            timeout = getattr(getattr(self, "exec_info", None), "timeout", None)
+            timed_out = False
+            try:
+                exit_code = process.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                self.kill(hostname)
+                exit_code = 124
             self.exit_code[hostname] = exit_code
-            
-            # Wait for output threads to complete
-            if hostname in self.output_threads:
-                stdout_thread, stderr_thread = self.output_threads[hostname]
-                if stdout_thread:
-                    stdout_thread.join()
-                if stderr_thread:
-                    stderr_thread.join()
-                    
+
+            self._join_output_threads(hostname)
+
+            windows_job = self.windows_jobs.get(hostname)
+            if windows_job is not None:
+                try:
+                    windows_job.ensure_empty(process)
+                finally:
+                    windows_job.close(process)
+                    self.windows_jobs.pop(hostname, None)
+
+            if timed_out:
+                diagnostic = f"Command timed out after {timeout} seconds"
+                existing = self.stderr.get(hostname, "")
+                separator = "" if not existing or existing.endswith("\n") else "\n"
+                self.stderr[hostname] = f"{existing}{separator}{diagnostic}\n"
+
             return exit_code
         return 0
-        
+
+    def _join_output_threads(self, hostname: str) -> None:
+        """Bound output-drain joins and terminate descendants retaining pipes."""
+        if hostname not in self.output_threads:
+            return
+        threads = [
+            thread for thread in self.output_threads[hostname] if thread is not None
+        ]
+        deadline = time.monotonic() + 5
+        for thread in threads:
+            thread.join(timeout=max(0, deadline - time.monotonic()))
+        if not any(thread.is_alive() for thread in threads):
+            return
+        self.kill(hostname)
+        process = self.processes.get(hostname)
+        if process is not None:
+            for pipe in (process.stdout, process.stderr):
+                if pipe is not None:
+                    try:
+                        pipe.close()
+                    except (OSError, ValueError):
+                        pass
+        for thread in threads:
+            thread.join(timeout=1)
+        if any(thread.is_alive() for thread in threads):
+            diagnostic = "Output capture did not close after process-tree termination\n"
+            self.stderr[hostname] = self.stderr.get(hostname, "") + diagnostic
+
     def wait_all(self) -> Dict[str, int]:
         """
         Wait for all processes to complete.
-        
+
         :return: Dictionary of hostname -> exit_code
         """
         for hostname in list(self.processes.keys()):
             self.wait(hostname)
         return self.exit_code.copy()
-        
-    def kill(self, hostname: str = 'localhost'):
+
+    def kill(self, hostname: str = "localhost"):
         """
         Kill the process.
-        
+
         :param hostname: Hostname to kill process on
         """
         if hostname in self.processes:
             process = self.processes[hostname]
             try:
-                if process.poll() is None:  # Process is still running
-                    process.terminate()
-                    # Give it a moment to terminate gracefully
-                    time.sleep(0.1)
-                    if process.poll() is None:
+                if os.name == "nt":
+                    windows_job = self.windows_jobs.get(hostname)
+                    if windows_job is None:
+                        raise RuntimeError(
+                            "Windows subprocess has no identity-pinned Job Object"
+                        )
+                    windows_job.terminate(process)
+                else:
+                    process_group = self.process_groups.get(hostname, process.pid)
+                    try:
+                        os.killpg(process_group, signal.SIGTERM)
+                    except ProcessLookupError:
+                        process_group = None
+                    if process_group is not None:
+                        deadline = time.monotonic() + 1
+                        while time.monotonic() < deadline:
+                            try:
+                                os.killpg(process_group, 0)
+                            except ProcessLookupError:
+                                break
+                            time.sleep(0.02)
+                        try:
+                            os.killpg(process_group, 0)
+                        except ProcessLookupError:
+                            pass
+                        else:
+                            os.killpg(process_group, signal.SIGKILL)
+                    try:
+                        process.wait(timeout=1)
+                    except subprocess.TimeoutExpired:
                         process.kill()
+                        process.wait()
             except ProcessLookupError:
                 # Process already terminated
                 pass
-                
+
     def kill_all(self):
         """Kill all processes"""
         for hostname in list(self.processes.keys()):
@@ -99,24 +169,24 @@ class LocalExec(CoreExec):
     """
     Execute commands locally using subprocess.
     """
-    
+
     def __init__(self, cmd: str, exec_info: ExecInfo):
         """
         Initialize local execution.
-        
+
         :param cmd: Command to execute
         :param exec_info: Execution information
         """
         super().__init__()
         self.cmd = cmd
         self.exec_info = exec_info
-        self.hostname = 'localhost'
-        
+        self.hostname = "localhost"
+
         # Initialize output storage
         self.stdout[self.hostname] = ""
         self.stderr[self.hostname] = ""
         self.exit_code[self.hostname] = 0
-        
+
         # Skip execution in dry_run mode (used to build command strings)
         if exec_info.dry_run:
             return
@@ -127,11 +197,11 @@ class LocalExec(CoreExec):
         # If not async, wait for completion
         if not exec_info.exec_async:
             self.wait(self.hostname)
-            
+
     def get_cmd(self) -> str:
         """Get the command string"""
         return self.cmd
-        
+
     def run(self):
         """Execute the command locally"""
         # Set up environment
@@ -145,111 +215,135 @@ class LocalExec(CoreExec):
 
         # Prepare stdin
         stdin_pipe = subprocess.PIPE if self.exec_info.stdin else None
-        
+
         # Start process
         try:
-            process = subprocess.Popen(
-                self.cmd,
-                shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                stdin=stdin_pipe,
-                env=env,
-                cwd=self.exec_info.cwd,
-                text=True,
-                bufsize=1,  # Line buffered
-                universal_newlines=True
-            )
-            
+            popen_options = {}
+            if os.name == "nt":
+                popen_options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+            else:
+                popen_options["start_new_session"] = True
+            if os.name == "nt":
+                process, windows_job = spawn_windows_job_process(
+                    self.cmd,
+                    shell=True,
+                    stdin_payload=self.exec_info.stdin,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    env=env,
+                    cwd=self.exec_info.cwd,
+                    text=True,
+                    bufsize=1,
+                    universal_newlines=True,
+                    **popen_options,
+                )
+                self.windows_jobs[self.hostname] = windows_job
+            else:
+                process = subprocess.Popen(
+                    self.cmd,
+                    shell=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    stdin=stdin_pipe,
+                    env=env,
+                    cwd=self.exec_info.cwd,
+                    text=True,
+                    bufsize=1,  # Line buffered
+                    universal_newlines=True,
+                    **popen_options,
+                )
+
             self.processes[self.hostname] = process
-            
+            self.process_groups[self.hostname] = process.pid
+
             # Start output monitoring threads
             if self.exec_info.collect_output or not self.exec_info.hide_output:
                 stdout_thread = threading.Thread(
-                    target=self._monitor_output,
-                    args=(process.stdout, 'stdout')
+                    target=self._monitor_output, args=(process.stdout, "stdout")
                 )
                 stderr_thread = threading.Thread(
-                    target=self._monitor_output,
-                    args=(process.stderr, 'stderr')
+                    target=self._monitor_output, args=(process.stderr, "stderr")
                 )
-                
+
                 stdout_thread.daemon = True
                 stderr_thread.daemon = True
-                
+
                 stdout_thread.start()
                 stderr_thread.start()
-                
+
                 self.output_threads[self.hostname] = (stdout_thread, stderr_thread)
-            
+
             # Send stdin if provided
-            if self.exec_info.stdin:
+            if self.exec_info.stdin and os.name != "nt":
                 try:
                     process.stdin.write(self.exec_info.stdin)
                     process.stdin.close()
                 except BrokenPipeError:
                     # Process may have terminated before we could write
                     pass
-                    
+
         except Exception as e:
             print(f"Error starting process: {e}")
             self.exit_code[self.hostname] = 1
-            
+
     def _monitor_output(self, pipe, output_type: str):
         """
         Monitor stdout or stderr in a separate thread.
-        
+
         :param pipe: The pipe to monitor
         :param output_type: 'stdout' or 'stderr'
         """
         output_buffer = []
-        
+
         try:
-            for line in iter(pipe.readline, ''):
+            for line in iter(pipe.readline, ""):
                 if not line:
                     break
-                    
+
                 # Store in buffer if collecting output
                 if self.exec_info.collect_output:
                     output_buffer.append(line)
-                    
+
                 # Print to console if not hidden
                 if not self.exec_info.hide_output:
-                    if output_type == 'stdout':
-                        print(line, end='')
+                    if output_type == "stdout":
+                        print(line, end="")
                     else:
-                        print(line, end='', file=subprocess.sys.stderr)
-                        
+                        print(line, end="", file=subprocess.sys.stderr)
+
                 # Write to file if specified
-                pipe_file = (self.exec_info.pipe_stdout if output_type == 'stdout' 
-                           else self.exec_info.pipe_stderr)
+                pipe_file = (
+                    self.exec_info.pipe_stdout
+                    if output_type == "stdout"
+                    else self.exec_info.pipe_stderr
+                )
                 if pipe_file:
                     try:
-                        with open(pipe_file, 'a') as f:
+                        with open(pipe_file, "a") as f:
                             f.write(line)
                     except Exception as e:
                         print(f"Error writing to {pipe_file}: {e}")
-                        
+
         except Exception as e:
             print(f"Error monitoring {output_type}: {e}")
         finally:
             pipe.close()
-            
+
         # Store collected output
         if self.exec_info.collect_output:
-            if output_type == 'stdout':
-                self.stdout[self.hostname] = ''.join(output_buffer)
+            if output_type == "stdout":
+                self.stdout[self.hostname] = "".join(output_buffer)
             else:
-                self.stderr[self.hostname] = ''.join(output_buffer)
-                
-    def wait(self, hostname: str = 'localhost') -> int:
+                self.stderr[self.hostname] = "".join(output_buffer)
+
+    def wait(self, hostname: str = "localhost") -> int:
         """Wait for completion and handle sleep"""
         exit_code = super().wait(hostname)
-        
+
         # Sleep if specified
         if self.exec_info.sleep_ms > 0:
             time.sleep(self.exec_info.sleep_ms / 1000.0)
-            
+
         return exit_code
 
 
@@ -260,20 +354,20 @@ class MpiVersion(LocalExec):
     """
 
     def __init__(self, exec_info: ExecInfo):
-        self.cmd = 'mpiexec --version'
+        self.cmd = "mpiexec --version"
 
         # When running in a container, detect MPI inside the container
         c = exec_info.container
-        if c and c not in ('none',):
-            img = exec_info.container_image or ''
-            if c == 'apptainer':
+        if c and c not in ("none",):
+            img = exec_info.container_image or ""
+            if c == "apptainer":
                 # Enter the long-running pipeline instance, not a fresh
                 # SIF exec — keeps detection in the same namespace as
                 # the rest of the pipeline.
-                self.cmd = f'apptainer exec instance://{img} mpiexec --version'
+                self.cmd = f"apptainer exec instance://{img} mpiexec --version"
             else:
-                container_name = f'{img}_container' if img else ''
-                self.cmd = f'{c} exec {container_name} mpiexec --version'
+                container_name = f"{img}_container" if img else ""
+                self.cmd = f"{c} exec {container_name} mpiexec --version"
 
         # Create modified exec_info for introspection
         # CRITICAL: Must set exec_async=False to ensure we wait for output
@@ -284,7 +378,7 @@ class MpiVersion(LocalExec):
             hide_output=True,
             exec_async=False,
             dry_run=False,
-            container='none',
+            container="none",
         )
 
         # If the hostfile points to remote nodes, run via SSH on the
@@ -292,11 +386,15 @@ class MpiVersion(LocalExec):
         hostfile = introspect_info.hostfile
         if hostfile and not hostfile.is_local():
             from .ssh_exec import SshExec
-            probe = SshExec(self.cmd, introspect_info.mod(
-                exec_type=ExecType.SSH,
-                hostfile=hostfile.subset(1),
-                port=22,
-            ))
+
+            probe = SshExec(
+                self.cmd,
+                introspect_info.mod(
+                    exec_type=ExecType.SSH,
+                    hostfile=hostfile.subset(1),
+                    port=22,
+                ),
+            )
         else:
             probe = LocalExec(self.cmd, introspect_info)
         self.exit_code = probe.exit_code
@@ -304,21 +402,21 @@ class MpiVersion(LocalExec):
         self.stderr = probe.stderr
         self.processes = probe.processes
         self.output_threads = probe.output_threads
-        
+
         # Determine MPI version from output (key may be hostname, not 'localhost')
-        vinfo = ''
+        vinfo = ""
         for v in self.stdout.values():
             if v:
                 vinfo = v
                 break
-        
-        if 'mpich' in vinfo.lower():
+
+        if "mpich" in vinfo.lower():
             self.version = ExecType.MPICH
-        elif 'Open MPI' in vinfo or 'OpenRTE' in vinfo:
+        elif "Open MPI" in vinfo or "OpenRTE" in vinfo:
             self.version = ExecType.OPENMPI
-        elif 'Intel(R) MPI Library' in vinfo:
+        elif "Intel(R) MPI Library" in vinfo:
             self.version = ExecType.INTEL_MPI
-        elif 'mpiexec version' in vinfo:
+        elif "mpiexec version" in vinfo:
             self.version = ExecType.CRAY_MPICH
         else:
             # Default to MPICH if we can't determine

--- a/jarvis_cd/shell/exec_info.py
+++ b/jarvis_cd/shell/exec_info.py
@@ -2,13 +2,14 @@
 Execution information classes for Jarvis shell execution.
 Contains ExecType enums and ExecInfo data structures.
 """
+
 from enum import Enum
-from typing import Dict, Any, Optional, List, Union
-from pathlib import Path
+from typing import Callable, Optional
 
 
 class ExecType(Enum):
     """Execution types supported by Jarvis"""
+
     LOCAL = "local"
     SSH = "ssh"
     PSSH = "pssh"
@@ -50,18 +51,41 @@ class ExecInfo:
         if mpi_cmd is not None:
             cls._default_mpi_cmd = mpi_cmd or None
 
-    def __init__(self, exec_type=ExecType.LOCAL, nprocs=None, ppn=None,
-                 user=None, pkey=None, port=None,
-                 hostfile=None, env=None,
-                 sleep_ms=0, sudo=False, sudoenv=True, cwd=None,
-                 collect_output=None, pipe_stdout=None, pipe_stderr=None,
-                 hide_output=None, exec_async=False, stdin=None,
-                 strict_ssh=False, timeout=None,
-                 container='none', gpu=False, container_image=None,
-                 shared_dir=None, private_dir=None, bind_mounts=None,
-                 dry_run=False,
-                 ssh_cmd=None, pssh_cmd=None, mpi_cmd=None,
-                 **kwargs):
+    def __init__(
+        self,
+        exec_type=ExecType.LOCAL,
+        nprocs=None,
+        ppn=None,
+        user=None,
+        pkey=None,
+        port=None,
+        hostfile=None,
+        env=None,
+        sleep_ms=0,
+        sudo=False,
+        sudoenv=True,
+        cwd=None,
+        collect_output=None,
+        pipe_stdout=None,
+        pipe_stderr=None,
+        hide_output=None,
+        exec_async=False,
+        stdin=None,
+        strict_ssh=False,
+        timeout=None,
+        container="none",
+        gpu=False,
+        container_image=None,
+        shared_dir=None,
+        private_dir=None,
+        bind_mounts=None,
+        dry_run=False,
+        ssh_cmd=None,
+        pssh_cmd=None,
+        mpi_cmd=None,
+        line_callback: Optional[Callable[[str, str], None]] = None,
+        **kwargs,
+    ):
         """
         Initialize execution information.
 
@@ -100,6 +124,10 @@ class ExecInfo:
             bind-mount into the container (docker/podman: -v, apptainer: --bind).
         :param dry_run: If True, build the command string but do not execute it.
             Used by Exec to obtain the MPI command string for container wrapping.
+        :param line_callback: Optional callback receiving ``(stream_name, line)``
+            for each stdout/stderr line as it is observed. If the callback
+            exposes ``finalize()``, execution invokes it once after both output
+            streams close. Callback failures terminate the owned process.
         :param kwargs: Additional unknown parameters (silently ignored)
         """
         self.exec_type = exec_type
@@ -129,25 +157,23 @@ class ExecInfo:
         self.private_dir = private_dir
         self.bind_mounts = bind_mounts or []
         self.dry_run = dry_run
+        self.line_callback = line_callback
 
         # Launcher overrides. None means "use the built-in default"
         # (``ssh`` / ``pssh`` / ``mpiexec``). Set per-instance via kwargs
         # or globally via ``ExecInfo.set_launcher_defaults`` (the pipeline
         # loader calls that after reading top-level ssh_cmd/pssh_cmd/
         # mpi_cmd from YAML).
-        self.ssh_cmd = (ssh_cmd if ssh_cmd is not None
-                        else ExecInfo._default_ssh_cmd)
-        self.pssh_cmd = (pssh_cmd if pssh_cmd is not None
-                         else ExecInfo._default_pssh_cmd)
-        self.mpi_cmd = (mpi_cmd if mpi_cmd is not None
-                        else ExecInfo._default_mpi_cmd)
+        self.ssh_cmd = ssh_cmd if ssh_cmd is not None else ExecInfo._default_ssh_cmd
+        self.pssh_cmd = pssh_cmd if pssh_cmd is not None else ExecInfo._default_pssh_cmd
+        self.mpi_cmd = mpi_cmd if mpi_cmd is not None else ExecInfo._default_mpi_cmd
 
         # Basic environment for process execution (without LD_PRELOAD)
         # This is used for launching MPI itself, not the MPI processes
         self.basic_env = self.env.copy()
-        if 'LD_PRELOAD' in self.basic_env:
-            del self.basic_env['LD_PRELOAD']
-        
+        if "LD_PRELOAD" in self.basic_env:
+            del self.basic_env["LD_PRELOAD"]
+
     def mod(self, **kwargs):
         """
         Create a modified copy of this ExecInfo with updated parameters.
@@ -157,14 +183,39 @@ class ExecInfo:
         """
         # Create a copy of current attributes
         current_attrs = {}
-        for attr in ['exec_type', 'nprocs', 'ppn', 'user', 'pkey', 'port',
-                     'hostfile', 'env', 'sleep_ms', 'sudo', 'sudoenv', 'cwd',
-                     'collect_output', 'pipe_stdout', 'pipe_stderr', 'hide_output',
-                     'exec_async', 'stdin', 'strict_ssh', 'timeout',
-                     'container', 'gpu', 'container_image',
-                     'shared_dir', 'private_dir', 'bind_mounts',
-                     'dry_run',
-                     'ssh_cmd', 'pssh_cmd', 'mpi_cmd']:
+        for attr in [
+            "exec_type",
+            "nprocs",
+            "ppn",
+            "user",
+            "pkey",
+            "port",
+            "hostfile",
+            "env",
+            "sleep_ms",
+            "sudo",
+            "sudoenv",
+            "cwd",
+            "collect_output",
+            "pipe_stdout",
+            "pipe_stderr",
+            "hide_output",
+            "exec_async",
+            "stdin",
+            "strict_ssh",
+            "timeout",
+            "container",
+            "gpu",
+            "container_image",
+            "shared_dir",
+            "private_dir",
+            "bind_mounts",
+            "dry_run",
+            "ssh_cmd",
+            "pssh_cmd",
+            "mpi_cmd",
+            "line_callback",
+        ]:
             current_attrs[attr] = getattr(self, attr)
 
         # Update with new values
@@ -175,41 +226,41 @@ class ExecInfo:
 
 class SshExecInfo(ExecInfo):
     """SSH-specific execution information"""
-    
+
     def __init__(self, **kwargs):
         super().__init__(exec_type=ExecType.SSH, **kwargs)
 
 
 class PsshExecInfo(ExecInfo):
     """PSSH-specific execution information"""
-    
+
     def __init__(self, **kwargs):
         super().__init__(exec_type=ExecType.PSSH, **kwargs)
 
 
 class MpiExecInfo(ExecInfo):
     """MPI-specific execution information"""
-    
+
     def __init__(self, **kwargs):
         super().__init__(exec_type=ExecType.MPI, **kwargs)
 
 
 class LocalExecInfo(ExecInfo):
     """Local execution information"""
-    
+
     def __init__(self, **kwargs):
         super().__init__(exec_type=ExecType.LOCAL, **kwargs)
 
 
 class ScpExecInfo(ExecInfo):
     """SCP-specific execution information"""
-    
+
     def __init__(self, **kwargs):
         super().__init__(exec_type=ExecType.SCP, **kwargs)
 
 
 class PscpExecInfo(ExecInfo):
     """PSCP-specific execution information"""
-    
+
     def __init__(self, **kwargs):
         super().__init__(exec_type=ExecType.PSCP, **kwargs)

--- a/jarvis_cd/shell/process.py
+++ b/jarvis_cd/shell/process.py
@@ -1,9 +1,26 @@
 """
 Process utility classes for Jarvis shell execution.
 """
+
+import os
+import subprocess
+import sys
 from typing import Union, List
 from .exec_factory import Exec
-from .exec_info import ExecInfo, LocalExecInfo
+from .exec_info import ExecInfo, ExecType, LocalExecInfo
+
+
+def _is_local_windows(exec_info: ExecInfo) -> bool:
+    """Return whether a utility should use the native Windows implementation."""
+    return os.name == "nt" and exec_info.exec_type == ExecType.LOCAL
+
+
+def _python_command(source: str, *args: str) -> str:
+    """Build a Windows-safe command for one standard-library operation."""
+    # Literal newlines inside a ``cmd.exe`` argument are treated as command
+    # separators even when ``list2cmdline`` quotes the argument. Keep the
+    # command line single-line and let Python decode the source representation.
+    return subprocess.list2cmdline([sys.executable, "-c", f"exec({source!r})", *args])
 
 
 class Kill(Exec):
@@ -32,16 +49,16 @@ class KillAll(Exec):
     """
     Kill all processes owned by the current user.
     """
-    
+
     def __init__(self, exec_info: ExecInfo = None):
         """
         Kill all processes owned by current user.
-        
+
         :param exec_info: Info needed to execute the command
         """
         if exec_info is None:
             exec_info = LocalExecInfo()
-            
+
         kill_cmd = "pkill -9 -u $(whoami)"
         super().__init__(kill_cmd, exec_info)
 
@@ -50,48 +67,62 @@ class Which(Exec):
     """
     Find the location of an executable.
     """
-    
+
     def __init__(self, executable: str, exec_info: ExecInfo = None):
         """
         Find executable location.
-        
+
         :param executable: Name of executable to find
         :param exec_info: Execution information
         """
         if exec_info is None:
             exec_info = LocalExecInfo()
-            
-        which_cmd = f"which {executable}"
+
+        if _is_local_windows(exec_info):
+            which_cmd = _python_command(
+                "import shutil, sys\n"
+                "path = shutil.which(sys.argv[1])\n"
+                'print(path or "")\n'
+                "raise SystemExit(0 if path else 1)",
+                executable,
+            )
+        else:
+            which_cmd = f"which {executable}"
         super().__init__(which_cmd, exec_info)
         self.executable = executable
-        
+
     def get_path(self) -> str:
         """
         Get the path to the executable.
-        
+
         :return: Path to executable or empty string if not found
         """
-        return self.stdout.get('localhost', '').strip()
-        
+        return self.stdout.get("localhost", "").strip()
+
     def exists(self) -> bool:
         """
         Check if executable exists.
-        
+
         :return: True if executable was found
         """
-        return self.exit_code.get('localhost', 1) == 0 and bool(self.get_path())
+        return self.exit_code.get("localhost", 1) == 0 and bool(self.get_path())
 
 
 class Mkdir(Exec):
     """
     Create directories.
     """
-    
-    def __init__(self, paths: Union[str, List[str]], exec_info: ExecInfo = None, 
-                 parents: bool = True, exist_ok: bool = True):
+
+    def __init__(
+        self,
+        paths: Union[str, List[str]],
+        exec_info: ExecInfo = None,
+        parents: bool = True,
+        exist_ok: bool = True,
+    ):
         """
         Create directories.
-        
+
         :param paths: Directory path(s) to create
         :param exec_info: Execution information
         :param parents: Create parent directories if needed
@@ -99,19 +130,28 @@ class Mkdir(Exec):
         """
         if exec_info is None:
             exec_info = LocalExecInfo()
-            
+
         if isinstance(paths, str):
             paths = [paths]
-            
-        flags = []
-        if parents:
-            flags.append('-p')
-            
-        # Build command with properly escaped paths
-        flag_str = ' '.join(flags)
-        path_str = ' '.join([f'"{path}"' for path in paths])
-        mkdir_cmd = f"mkdir {flag_str} {path_str}".strip()
-            
+
+        if _is_local_windows(exec_info):
+            mkdir_cmd = _python_command(
+                "from pathlib import Path\n"
+                "import sys\n"
+                "for value in sys.argv[1:]:\n"
+                f"    Path(value).mkdir(parents={parents!r}, exist_ok={exist_ok!r})",
+                *paths,
+            )
+        else:
+            flags = []
+            if parents:
+                flags.append("-p")
+
+            # Build command with properly escaped paths
+            flag_str = " ".join(flags)
+            path_str = " ".join([f'"{path}"' for path in paths])
+            mkdir_cmd = f"mkdir {flag_str} {path_str}".strip()
+
         super().__init__(mkdir_cmd, exec_info)
 
 
@@ -119,12 +159,17 @@ class Rm(Exec):
     """
     Remove files and directories.
     """
-    
-    def __init__(self, paths: Union[str, List[str]], exec_info: ExecInfo = None,
-                 recursive: bool = False, force: bool = True):
+
+    def __init__(
+        self,
+        paths: Union[str, List[str]],
+        exec_info: ExecInfo = None,
+        recursive: bool = False,
+        force: bool = True,
+    ):
         """
         Remove files and directories.
-        
+
         :param paths: File/directory path(s) to remove
         :param exec_info: Execution information
         :param recursive: Remove directories recursively
@@ -132,21 +177,40 @@ class Rm(Exec):
         """
         if exec_info is None:
             exec_info = LocalExecInfo()
-            
+
         if isinstance(paths, str):
             paths = [paths]
-            
-        flags = []
-        if recursive:
-            flags.append('-r')
-        if force:
-            flags.append('-f')
-            
-        # Build command with properly escaped paths
-        flag_str = ' '.join(flags)
-        path_str = ' '.join([f'"{path}"' for path in paths])
-        rm_cmd = f"rm {flag_str} {path_str}".strip()
-            
+
+        if _is_local_windows(exec_info):
+            rm_cmd = _python_command(
+                "from pathlib import Path\n"
+                "import shutil, sys\n"
+                f"recursive = {recursive!r}\n"
+                f"force = {force!r}\n"
+                "for value in sys.argv[1:]:\n"
+                "    path = Path(value)\n"
+                "    if not path.exists() and not path.is_symlink():\n"
+                "        if force:\n"
+                "            continue\n"
+                "        raise FileNotFoundError(value)\n"
+                "    if path.is_dir() and not path.is_symlink():\n"
+                "        shutil.rmtree(path) if recursive else path.rmdir()\n"
+                "    else:\n"
+                "        path.unlink()",
+                *paths,
+            )
+        else:
+            flags = []
+            if recursive:
+                flags.append("-r")
+            if force:
+                flags.append("-f")
+
+            # Build command with properly escaped paths
+            flag_str = " ".join(flags)
+            path_str = " ".join([f'"{path}"' for path in paths])
+            rm_cmd = f"rm {flag_str} {path_str}".strip()
+
         super().__init__(rm_cmd, exec_info)
 
 
@@ -154,12 +218,17 @@ class Chmod(Exec):
     """
     Change file permissions.
     """
-    
-    def __init__(self, paths: Union[str, List[str]], mode: str, exec_info: ExecInfo = None,
-                 recursive: bool = False):
+
+    def __init__(
+        self,
+        paths: Union[str, List[str]],
+        mode: str,
+        exec_info: ExecInfo = None,
+        recursive: bool = False,
+    ):
         """
         Change file permissions.
-        
+
         :param paths: File/directory path(s) to modify
         :param mode: Permission mode (e.g., '755', '+x', 'u+w')
         :param exec_info: Execution information
@@ -167,19 +236,40 @@ class Chmod(Exec):
         """
         if exec_info is None:
             exec_info = LocalExecInfo()
-            
+
         if isinstance(paths, str):
             paths = [paths]
-            
-        flags = []
-        if recursive:
-            flags.append('-R')
-            
-        # Build command with properly escaped paths
-        flag_str = ' '.join(flags)
-        path_str = ' '.join([f'"{path}"' for path in paths])
-        chmod_cmd = f"chmod {flag_str} {mode} {path_str}".strip()
-            
+
+        if _is_local_windows(exec_info):
+            chmod_cmd = _python_command(
+                "from pathlib import Path\n"
+                "import os, stat, sys\n"
+                "mode = sys.argv[1]\n"
+                f"recursive = {recursive!r}\n"
+                "def apply(path):\n"
+                "    current = stat.S_IMODE(path.stat().st_mode)\n"
+                "    target = (int(mode, 8) if mode.isdigit() else "
+                "current | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)\n"
+                "    os.chmod(path, target)\n"
+                "for value in sys.argv[2:]:\n"
+                "    root = Path(value)\n"
+                "    apply(root)\n"
+                "    if recursive and root.is_dir():\n"
+                '        for child in root.rglob("*"):\n'
+                "            apply(child)",
+                mode,
+                *paths,
+            )
+        else:
+            flags = []
+            if recursive:
+                flags.append("-R")
+
+            # Build command with properly escaped paths
+            flag_str = " ".join(flags)
+            path_str = " ".join([f'"{path}"' for path in paths])
+            chmod_cmd = f"chmod {flag_str} {mode} {path_str}".strip()
+
         super().__init__(chmod_cmd, exec_info)
 
 
@@ -187,18 +277,24 @@ class Sleep(Exec):
     """
     Sleep for a specified duration.
     """
-    
+
     def __init__(self, duration: Union[int, float], exec_info: ExecInfo = None):
         """
         Sleep for specified duration.
-        
+
         :param duration: Sleep duration in seconds
         :param exec_info: Execution information
         """
         if exec_info is None:
             exec_info = LocalExecInfo()
-            
-        sleep_cmd = f"sleep {duration}"
+
+        if _is_local_windows(exec_info):
+            sleep_cmd = _python_command(
+                "import sys, time; time.sleep(float(sys.argv[1]))",
+                str(duration),
+            )
+        else:
+            sleep_cmd = f"sleep {duration}"
         super().__init__(sleep_cmd, exec_info)
 
 

--- a/jarvis_cd/shell/ssh_exec.py
+++ b/jarvis_cd/shell/ssh_exec.py
@@ -1,11 +1,10 @@
 """
 SSH execution classes for Jarvis shell execution.
 """
+
 import threading
-from typing import List, Dict, Any
 from .core_exec import CoreExec, LocalExec
-from .exec_info import ExecInfo, SshExecInfo, PsshExecInfo
-from ..util.hostfile import Hostfile
+from .exec_info import SshExecInfo, PsshExecInfo
 
 
 class SshExec(LocalExec):
@@ -13,41 +12,47 @@ class SshExec(LocalExec):
     Execute commands on remote hosts using SSH.
     Inherits from LocalExec to reuse subprocess management.
     """
-    
+
     def __init__(self, cmd: str, exec_info: SshExecInfo, hostname: str = None):
         """
         Initialize SSH execution.
-        
+
         :param cmd: Command to execute remotely
         :param exec_info: SSH execution information
         :param hostname: Target hostname (if None, uses first host from hostfile)
         """
         self.original_cmd = cmd
-        self.target_hostname = hostname or (exec_info.hostfile.hosts[0] if exec_info.hostfile else 'localhost')
-        
+        self.target_hostname = hostname or (
+            exec_info.hostfile.hosts[0] if exec_info.hostfile else "localhost"
+        )
+
         # Build SSH command
         ssh_cmd = self._build_ssh_command(cmd, exec_info)
-        
+
         # Initialize with SSH command
         super().__init__(ssh_cmd, exec_info)
-        
+
         # Override hostname for output tracking
         self.hostname = self.target_hostname
-        if 'localhost' in self.stdout:
-            self.stdout[self.hostname] = self.stdout.pop('localhost')
-        if 'localhost' in self.stderr:
-            self.stderr[self.hostname] = self.stderr.pop('localhost')
-        if 'localhost' in self.exit_code:
-            self.exit_code[self.hostname] = self.exit_code.pop('localhost')
-        if 'localhost' in self.processes:
-            self.processes[self.hostname] = self.processes.pop('localhost')
-        if 'localhost' in self.output_threads:
-            self.output_threads[self.hostname] = self.output_threads.pop('localhost')
-            
+        if "localhost" in self.stdout:
+            self.stdout[self.hostname] = self.stdout.pop("localhost")
+        if "localhost" in self.stderr:
+            self.stderr[self.hostname] = self.stderr.pop("localhost")
+        if "localhost" in self.exit_code:
+            self.exit_code[self.hostname] = self.exit_code.pop("localhost")
+        if "localhost" in self.processes:
+            self.processes[self.hostname] = self.processes.pop("localhost")
+        if "localhost" in self.process_groups:
+            self.process_groups[self.hostname] = self.process_groups.pop("localhost")
+        if "localhost" in self.windows_jobs:
+            self.windows_jobs[self.hostname] = self.windows_jobs.pop("localhost")
+        if "localhost" in self.output_threads:
+            self.output_threads[self.hostname] = self.output_threads.pop("localhost")
+
     def _build_ssh_command(self, cmd: str, exec_info: SshExecInfo) -> str:
         """
         Build SSH command with all necessary parameters.
-        
+
         :param cmd: Original command to execute
         :param exec_info: SSH execution information
         :return: Complete SSH command string
@@ -59,33 +64,44 @@ class SshExec(LocalExec):
         if exec_info.ssh_cmd:
             ssh_parts = exec_info.ssh_cmd.split()
         else:
-            ssh_parts = ['ssh']
+            ssh_parts = ["ssh"]
+
+        # Agent and scheduler launches are non-interactive. Never let a
+        # password or keyboard-interactive prompt retain the process tree, and
+        # avoid multiplying connection retries behind the caller's timeout.
+        ssh_parts.extend(
+            [
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectionAttempts=1",
+            ]
+        )
 
         # SSH options
         if not exec_info.strict_ssh:
-            ssh_parts.extend([
-                '-o', 'StrictHostKeyChecking=no',
-                '-o', 'UserKnownHostsFile=/dev/null'
-            ])
-            
+            ssh_parts.extend(
+                ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null"]
+            )
+
         # Port
         if exec_info.port and exec_info.port != 22:
-            ssh_parts.extend(['-p', str(exec_info.port)])
-            
+            ssh_parts.extend(["-p", str(exec_info.port)])
+
         # Private key
         if exec_info.pkey:
-            ssh_parts.extend(['-i', exec_info.pkey])
-            
+            ssh_parts.extend(["-i", exec_info.pkey])
+
         # Connection timeout
         if exec_info.timeout:
-            ssh_parts.extend(['-o', f'ConnectTimeout={exec_info.timeout}'])
-            
+            ssh_parts.extend(["-o", f"ConnectTimeout={exec_info.timeout}"])
+
         # Target host
         if exec_info.user:
-            ssh_parts.append(f'{exec_info.user}@{self.target_hostname}')
+            ssh_parts.append(f"{exec_info.user}@{self.target_hostname}")
         else:
             ssh_parts.append(self.target_hostname)
-            
+
         # Build remote command. The cmd may already contain single-quoted
         # substrings (e.g. `docker exec <c> bash -c 'inner'` from
         # _prepare_container); escape any inner single quotes before
@@ -94,9 +110,9 @@ class SshExec(LocalExec):
         remote_cmd = self._build_remote_command(cmd, exec_info)
         escaped = remote_cmd.replace("'", "'\\''")
         ssh_parts.append(f"'{escaped}'")
-        
-        return ' '.join(ssh_parts)
-        
+
+        return " ".join(ssh_parts)
+
     def _build_remote_command(self, cmd: str, exec_info: SshExecInfo) -> str:
         """
         Build the command to execute on the remote host.
@@ -110,7 +126,7 @@ class SshExec(LocalExec):
 
         # Change directory if specified (must use && since it's a separate command)
         if exec_info.cwd:
-            cmd_parts.append(f'cd {exec_info.cwd}')
+            cmd_parts.append(f"cd {exec_info.cwd}")
 
         # Set environment variables (these go before the command on same line)
         if exec_info.env:
@@ -125,26 +141,26 @@ class SshExec(LocalExec):
 
         # Add environment variables
         if env_prefix:
-            final_cmd_parts.append(' '.join(env_prefix))
+            final_cmd_parts.append(" ".join(env_prefix))
 
         # Add sudo if requested
         if exec_info.sudo:
             if exec_info.sudoenv and exec_info.env:
                 # Preserve environment with sudo
-                final_cmd_parts.append('sudo -E')
+                final_cmd_parts.append("sudo -E")
             else:
-                final_cmd_parts.append('sudo')
+                final_cmd_parts.append("sudo")
 
         # Add the actual command
         final_cmd_parts.append(cmd)
 
         # Join env vars, sudo, and command with spaces (they run together)
-        final_cmd = ' '.join(final_cmd_parts)
+        final_cmd = " ".join(final_cmd_parts)
 
         # Add cd command if needed (joined with &&)
         if cmd_parts:
             cmd_parts.append(final_cmd)
-            return ' && '.join(cmd_parts)
+            return " && ".join(cmd_parts)
         else:
             return final_cmd
 
@@ -153,11 +169,11 @@ class PsshExec(CoreExec):
     """
     Execute commands on multiple hosts using parallel SSH.
     """
-    
+
     def __init__(self, cmd: str, exec_info: PsshExecInfo):
         """
         Initialize parallel SSH execution.
-        
+
         :param cmd: Command to execute on all hosts
         :param exec_info: PSSH execution information
         """
@@ -165,21 +181,21 @@ class PsshExec(CoreExec):
         self.cmd = cmd
         self.exec_info = exec_info
         self.ssh_executors = {}
-        
+
         if not exec_info.hostfile or len(exec_info.hostfile) == 0:
             raise ValueError("PSSH requires a hostfile with at least one host")
-            
+
         # Start SSH execution on each host
         self.run()
-        
+
         # If not async, wait for all to complete
         if not exec_info.exec_async:
             self.wait_all()
-            
+
     def run(self):
         """Execute command on all hosts in parallel"""
         threads = []
-        
+
         for hostname in self.exec_info.hostfile.hosts:
             # Create SSH exec info for this host
             ssh_info = SshExecInfo(
@@ -197,64 +213,69 @@ class PsshExec(CoreExec):
                 exec_async=True,  # Always async for parallel execution
                 strict_ssh=self.exec_info.strict_ssh,
                 timeout=self.exec_info.timeout,
+                dry_run=self.exec_info.dry_run,
                 # Forward the pipeline-level ssh launcher override down
                 # to each per-host SshExec.
                 ssh_cmd=self.exec_info.ssh_cmd,
             )
-            
+
             # Start SSH execution in a thread
             thread = threading.Thread(
-                target=self._execute_on_host,
-                args=(hostname, ssh_info)
+                target=self._execute_on_host, args=(hostname, ssh_info)
             )
             thread.daemon = True
             thread.start()
             threads.append(thread)
-            
+
         # Wait for all threads to start their SSH processes
         for thread in threads:
             thread.join()
-            
+
     def _execute_on_host(self, hostname: str, ssh_info: SshExecInfo):
         """
         Execute command on a specific host.
-        
+
         :param hostname: Target hostname
         :param ssh_info: SSH execution information
         """
         try:
             ssh_exec = SshExec(self.cmd, ssh_info, hostname)
             self.ssh_executors[hostname] = ssh_exec
-            
+
             # Copy process reference for management
             if hostname in ssh_exec.processes:
                 self.processes[hostname] = ssh_exec.processes[hostname]
-                
+            if hostname in ssh_exec.process_groups:
+                self.process_groups[hostname] = ssh_exec.process_groups[hostname]
+            if hostname in ssh_exec.windows_jobs:
+                self.windows_jobs[hostname] = ssh_exec.windows_jobs[hostname]
+
         except Exception as e:
             print(f"Error executing on {hostname}: {e}")
             self.exit_code[hostname] = 1
             self.stdout[hostname] = ""
             self.stderr[hostname] = str(e)
-            
+
     def wait(self, hostname: str) -> int:
         """
         Wait for execution on a specific host to complete.
-        
+
         :param hostname: Hostname to wait for
         :return: Exit code
         """
         if hostname in self.ssh_executors:
             ssh_exec = self.ssh_executors[hostname]
             exit_code = ssh_exec.wait(hostname)
-            
+
             # Copy outputs
             self.stdout[hostname] = ssh_exec.stdout.get(hostname, "")
             self.stderr[hostname] = ssh_exec.stderr.get(hostname, "")
             self.exit_code[hostname] = exit_code
-            
+            self.windows_jobs.pop(hostname, None)
+
             return exit_code
         return 0
-        
+
     def get_cmd(self) -> str:
         """Get the original command"""
         return self.cmd

--- a/jarvis_cd/shell/windows_job.py
+++ b/jarvis_cd/shell/windows_job.py
@@ -1,0 +1,409 @@
+"""Identity-pinned Windows Job Object ownership for subprocess trees."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+_JOB_EMPTY_TIMEOUT_SECONDS = 10.0
+_NATURAL_EXIT_GRACE_SECONDS = 1.0
+_WRITER_TIMEOUT_SECONDS = 5.0
+_POLL_SECONDS = 0.02
+_MAX_BROKER_MESSAGE_BYTES = 1024 * 1024
+
+_BROKER_SCRIPT = r"""
+import json
+import os
+import subprocess
+import sys
+
+
+def read_exact(descriptor, size):
+    chunks = []
+    remaining = size
+    while remaining:
+        chunk = os.read(descriptor, remaining)
+        if not chunk:
+            raise SystemExit(125)
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+descriptor = sys.stdin.fileno()
+message_size = int.from_bytes(read_exact(descriptor, 4), "big")
+if message_size < 1 or message_size > 1024 * 1024:
+    raise SystemExit(125)
+try:
+    message = json.loads(read_exact(descriptor, message_size))
+except (UnicodeDecodeError, json.JSONDecodeError):
+    raise SystemExit(125)
+if not isinstance(message, dict) or not isinstance(message.get("shell"), bool):
+    raise SystemExit(125)
+command = message.get("command")
+if not isinstance(command, (str, list)):
+    raise SystemExit(125)
+if isinstance(command, list) and not all(isinstance(item, str) for item in command):
+    raise SystemExit(125)
+child = subprocess.Popen(command, shell=message["shell"], stdin=descriptor)
+raise SystemExit(child.wait())
+"""
+
+
+@dataclass(slots=True)
+class WindowsJob:
+    """Own one process tree through a retained kernel Job Object handle."""
+
+    handle: int
+    writer: threading.Thread
+    writer_errors: list[BaseException]
+    closed: bool = False
+    terminated_for_capture: bool = False
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def terminate(
+        self,
+        process: subprocess.Popen[Any],
+        *,
+        timeout_seconds: float = _JOB_EMPTY_TIMEOUT_SECONDS,
+    ) -> None:
+        """Terminate the pinned job and prove that it became empty."""
+        with self._lock:
+            if self.closed:
+                return
+            if _active_processes(self.handle):
+                _terminate_job(self.handle)
+        if process.poll() is None:
+            try:
+                process.wait(timeout=timeout_seconds)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=timeout_seconds)
+        self._finish_writer(process, timeout_seconds=timeout_seconds)
+        _wait_until_empty(self.handle, timeout_seconds=timeout_seconds)
+
+    def ensure_empty(
+        self,
+        process: subprocess.Popen[Any],
+        *,
+        timeout_seconds: float = _JOB_EMPTY_TIMEOUT_SECONDS,
+    ) -> None:
+        """Reject and clean descendants left behind by a completed root."""
+        self._finish_writer(process, timeout_seconds=timeout_seconds)
+        residual = _active_after_wait(
+            self.handle,
+            timeout_seconds=_NATURAL_EXIT_GRACE_SECONDS,
+        )
+        if residual == 0:
+            return
+        self.terminated_for_capture = True
+        self.terminate(process, timeout_seconds=timeout_seconds)
+        raise RuntimeError(
+            f"completed subprocess left {residual} Windows Job Object descendants"
+        )
+
+    def close(
+        self,
+        process: subprocess.Popen[Any],
+        *,
+        timeout_seconds: float = _JOB_EMPTY_TIMEOUT_SECONDS,
+    ) -> None:
+        """Close the retained handle only after bounded tree cleanup."""
+        with self._lock:
+            if self.closed:
+                return
+        try:
+            if _active_processes(self.handle):
+                self.terminate(process, timeout_seconds=timeout_seconds)
+        finally:
+            with self._lock:
+                if not self.closed:
+                    _close_handle(self.handle)
+                    self.closed = True
+
+    def _finish_writer(
+        self,
+        process: subprocess.Popen[Any],
+        *,
+        timeout_seconds: float,
+    ) -> None:
+        self.writer.join(timeout=min(timeout_seconds, _WRITER_TIMEOUT_SECONDS))
+        if self.writer.is_alive():
+            with self._lock:
+                if not self.closed and _active_processes(self.handle):
+                    _terminate_job(self.handle)
+            if process.stdin is not None:
+                try:
+                    process.stdin.close()
+                except (OSError, ValueError):
+                    pass
+            self.writer.join(timeout=1)
+            if self.writer.is_alive():
+                raise RuntimeError("Windows broker stdin writer did not stop")
+        if self.writer_errors:
+            raise RuntimeError(
+                f"Windows broker input failed: {self.writer_errors[0]}"
+            ) from self.writer_errors[0]
+
+
+def spawn_windows_job_process(
+    command: str | list[str],
+    *,
+    shell: bool,
+    stdin_payload: bytes | str | None,
+    **popen_kwargs: Any,
+) -> tuple[subprocess.Popen[Any], WindowsJob]:
+    """Spawn only after pinning a blocked broker to a kill-on-close job."""
+    if os.name != "nt":
+        raise RuntimeError("Windows Job Objects are unavailable on this platform")
+    if "stdin" in popen_kwargs:
+        raise ValueError("spawn_windows_job_process owns broker stdin")
+    message = json.dumps(
+        {"command": command, "shell": shell},
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if not message or len(message) > _MAX_BROKER_MESSAGE_BYTES:
+        raise ValueError("Windows broker command exceeded its message bound")
+    payload = (
+        b""
+        if stdin_payload is None
+        else stdin_payload.encode("utf-8")
+        if isinstance(stdin_payload, str)
+        else stdin_payload
+    )
+    frame = len(message).to_bytes(4, "big") + message + payload
+
+    handle = _create_job()
+    creationflags = int(popen_kwargs.pop("creationflags", 0))
+    creationflags |= int(getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0))
+    process: subprocess.Popen[Any] | None = None
+    try:
+        process = subprocess.Popen(
+            [sys.executable, "-I", "-S", "-c", _BROKER_SCRIPT],
+            stdin=subprocess.PIPE,
+            creationflags=creationflags,
+            **popen_kwargs,
+        )
+        _assign_process(handle, process)
+    except BaseException:
+        if process is not None:
+            process.kill()
+            process.wait(timeout=5)
+        _close_handle(handle)
+        raise
+
+    writer_errors: list[BaseException] = []
+
+    def write_frame() -> None:
+        try:
+            if process.stdin is None:
+                raise RuntimeError("Windows broker stdin pipe was not created")
+            stream = getattr(process.stdin, "buffer", process.stdin)
+            stream.write(frame)
+            stream.flush()
+        except BaseException as exc:
+            writer_errors.append(exc)
+        finally:
+            if process.stdin is not None:
+                try:
+                    process.stdin.close()
+                except (OSError, ValueError):
+                    pass
+
+    writer = threading.Thread(target=write_frame, daemon=True)
+    writer.start()
+    return process, WindowsJob(
+        handle=handle,
+        writer=writer,
+        writer_errors=writer_errors,
+    )
+
+
+def process_start_identity(process_id: int) -> str | None:
+    """Return a Windows process creation identity without using tasklist."""
+    if os.name != "nt":
+        raise RuntimeError("Windows process identities are unavailable")
+    if process_id <= 0:
+        raise ValueError("process_id must be positive")
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    process_handle = kernel32.OpenProcess(0x1000, False, process_id)
+    if not process_handle:
+        error = ctypes.get_last_error()
+        if error in {87, 1168}:
+            return None
+        raise RuntimeError(f"OpenProcess failed for {process_id}: {error}")
+    creation = wintypes.FILETIME()
+    exit_time = wintypes.FILETIME()
+    kernel = wintypes.FILETIME()
+    user = wintypes.FILETIME()
+    try:
+        exit_code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(process_handle, ctypes.byref(exit_code)):
+            raise RuntimeError(
+                f"GetExitCodeProcess failed for {process_id}: {ctypes.get_last_error()}"
+            )
+        if exit_code.value != 259:
+            return None
+        if not kernel32.GetProcessTimes(
+            process_handle,
+            ctypes.byref(creation),
+            ctypes.byref(exit_time),
+            ctypes.byref(kernel),
+            ctypes.byref(user),
+        ):
+            raise RuntimeError(
+                f"GetProcessTimes failed for {process_id}: {ctypes.get_last_error()}"
+            )
+        value = (int(creation.dwHighDateTime) << 32) | int(creation.dwLowDateTime)
+        return f"windows-filetime:{value}"
+    finally:
+        kernel32.CloseHandle(process_handle)
+
+
+def _create_job() -> int:
+    import ctypes
+    from ctypes import wintypes
+
+    class BasicLimitInformation(ctypes.Structure):
+        _fields_ = [
+            ("PerProcessUserTimeLimit", ctypes.c_longlong),
+            ("PerJobUserTimeLimit", ctypes.c_longlong),
+            ("LimitFlags", wintypes.DWORD),
+            ("MinimumWorkingSetSize", ctypes.c_size_t),
+            ("MaximumWorkingSetSize", ctypes.c_size_t),
+            ("ActiveProcessLimit", wintypes.DWORD),
+            ("Affinity", ctypes.c_size_t),
+            ("PriorityClass", wintypes.DWORD),
+            ("SchedulingClass", wintypes.DWORD),
+        ]
+
+    class IoCounters(ctypes.Structure):
+        _fields_ = [
+            (name, ctypes.c_ulonglong)
+            for name in (
+                "ReadOperationCount",
+                "WriteOperationCount",
+                "OtherOperationCount",
+                "ReadTransferCount",
+                "WriteTransferCount",
+                "OtherTransferCount",
+            )
+        ]
+
+    class ExtendedLimitInformation(ctypes.Structure):
+        _fields_ = [
+            ("BasicLimitInformation", BasicLimitInformation),
+            ("IoInfo", IoCounters),
+            ("ProcessMemoryLimit", ctypes.c_size_t),
+            ("JobMemoryLimit", ctypes.c_size_t),
+            ("PeakProcessMemoryUsed", ctypes.c_size_t),
+            ("PeakJobMemoryUsed", ctypes.c_size_t),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+    handle = kernel32.CreateJobObjectW(None, None)
+    if not handle:
+        raise RuntimeError(f"CreateJobObjectW failed: {ctypes.get_last_error()}")
+    information = ExtendedLimitInformation()
+    information.BasicLimitInformation.LimitFlags = 0x00002000
+    if not kernel32.SetInformationJobObject(
+        handle,
+        9,
+        ctypes.byref(information),
+        ctypes.sizeof(information),
+    ):
+        error = ctypes.get_last_error()
+        kernel32.CloseHandle(handle)
+        raise RuntimeError(f"SetInformationJobObject failed: {error}")
+    return int(handle)
+
+
+def _assign_process(handle: int, process: subprocess.Popen[Any]) -> None:
+    import ctypes
+    from ctypes import wintypes
+
+    process_handle = getattr(process, "_handle", None)
+    if process_handle is None:
+        raise RuntimeError("Popen did not expose a Windows process handle")
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+    if not kernel32.AssignProcessToJobObject(handle, int(process_handle)):
+        raise RuntimeError(
+            f"AssignProcessToJobObject failed: {ctypes.get_last_error()}"
+        )
+
+
+def _terminate_job(handle: int) -> None:
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.TerminateJobObject.argtypes = [wintypes.HANDLE, wintypes.UINT]
+    if not kernel32.TerminateJobObject(handle, 1):
+        raise RuntimeError(f"TerminateJobObject failed: {ctypes.get_last_error()}")
+
+
+def _active_processes(handle: int) -> int:
+    import ctypes
+    from ctypes import wintypes
+
+    class AccountingInformation(ctypes.Structure):
+        _fields_ = [
+            ("TotalUserTime", ctypes.c_longlong),
+            ("TotalKernelTime", ctypes.c_longlong),
+            ("ThisPeriodTotalUserTime", ctypes.c_longlong),
+            ("ThisPeriodTotalKernelTime", ctypes.c_longlong),
+            ("TotalPageFaultCount", wintypes.DWORD),
+            ("TotalProcesses", wintypes.DWORD),
+            ("ActiveProcesses", wintypes.DWORD),
+            ("TotalTerminatedProcesses", wintypes.DWORD),
+        ]
+
+    information = AccountingInformation()
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    if not kernel32.QueryInformationJobObject(
+        handle,
+        1,
+        ctypes.byref(information),
+        ctypes.sizeof(information),
+        None,
+    ):
+        raise RuntimeError(
+            f"QueryInformationJobObject failed: {ctypes.get_last_error()}"
+        )
+    return int(information.ActiveProcesses)
+
+
+def _wait_until_empty(handle: int, *, timeout_seconds: float) -> None:
+    active = _active_after_wait(handle, timeout_seconds=timeout_seconds)
+    if active:
+        raise RuntimeError(f"Windows Job Object remained populated: {active}")
+
+
+def _active_after_wait(handle: int, *, timeout_seconds: float) -> int:
+    """Return the residual count after a bounded natural-exit grace period."""
+    deadline = time.monotonic() + timeout_seconds
+    active = _active_processes(handle)
+    while active and time.monotonic() < deadline:
+        time.sleep(_POLL_SECONDS)
+        active = _active_processes(handle)
+    return active
+
+
+def _close_handle(handle: int) -> None:
+    import ctypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    if not kernel32.CloseHandle(handle):
+        raise RuntimeError(f"CloseHandle failed: {ctypes.get_last_error()}")

--- a/jarvis_cd/util/private_path.py
+++ b/jarvis_cd/util/private_path.py
@@ -1,0 +1,318 @@
+"""Cross-platform owner-private state-path enforcement."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+
+def reject_private_path_redirection(path: Path) -> None:
+    """Reject symbolic links and Windows reparse points in a path ancestry.
+
+    The final path is allowed not to exist so callers can perform this check
+    before creating private state.  The check intentionally uses ``lstat`` and
+    an absolute, unresolved path: resolving first would hide the redirection
+    that this boundary is meant to reject.
+
+    :param path: Prospective or existing private-state path.
+    """
+    current = Path(os.path.abspath(path))
+    existing: list[tuple[Path, os.stat_result]] = []
+    while True:
+        try:
+            information = current.lstat()
+        except FileNotFoundError:
+            pass
+        else:
+            existing.append((current, information))
+        if current == current.parent:
+            break
+        current = current.parent
+    for component, information in reversed(existing):
+        if _is_path_redirection(information):
+            raise RuntimeError(
+                "private path cannot traverse a symbolic link or reparse point: "
+                f"{component}"
+            )
+
+
+def ensure_private_path(path: Path, *, directory: bool) -> None:
+    """Normalize and verify one owner-controlled file or directory.
+
+    POSIX paths use owner/mode checks. Windows paths receive a protected DACL
+    granting full control only to the current user, LocalSystem, and local
+    Administrators; reparse points are rejected on both platforms.
+
+    :param path: Existing path to protect and verify.
+    :param directory: Whether the path must be a directory.
+    """
+    target = Path(os.path.abspath(path))
+    reject_private_path_redirection(target)
+    information = target.lstat()
+    expected_type = (
+        stat.S_ISDIR(information.st_mode)
+        if directory
+        else stat.S_ISREG(information.st_mode)
+    )
+    if not expected_type or stat.S_ISLNK(information.st_mode):
+        kind = "directory" if directory else "file"
+        raise RuntimeError(f"private path is not a regular {kind}: {target}")
+    if not directory and information.st_nlink != 1:
+        raise RuntimeError(f"private file must have exactly one link: {target}")
+    if os.name == "nt":
+        _ensure_private_windows_path(target, directory=directory)
+        return
+    getuid = getattr(os, "geteuid", None)
+    if not callable(getuid) or information.st_uid != getuid():
+        raise RuntimeError(f"private path is not owned by this user: {target}")
+    target.chmod(0o700 if directory else 0o600)
+    verified = target.lstat()
+    if stat.S_IMODE(verified.st_mode) & 0o077:
+        raise RuntimeError(f"private path permissions are too broad: {target}")
+
+
+def ensure_private_descriptor(
+    path: Path,
+    descriptor: int,
+    *,
+    directory: bool,
+) -> None:
+    """Normalize and verify the exact object held by a file descriptor.
+
+    This closes the path-normalization/open race for private records and lock
+    files.  On Windows, ``ReOpenFile`` obtains the security rights on the same
+    kernel object rather than reopening its potentially replaced pathname.
+
+    :param path: Path that must still identify ``descriptor``.
+    :param descriptor: Open operating-system file descriptor.
+    :param directory: Whether the held object must be a directory.
+    """
+    target = Path(os.path.abspath(path))
+    reject_private_path_redirection(target)
+    descriptor_information = os.fstat(descriptor)
+    path_information = target.lstat()
+    expected_type = (
+        stat.S_ISDIR(descriptor_information.st_mode)
+        if directory
+        else stat.S_ISREG(descriptor_information.st_mode)
+    )
+    if (
+        not expected_type
+        or _is_path_redirection(descriptor_information)
+        or _is_path_redirection(path_information)
+        or (descriptor_information.st_dev, descriptor_information.st_ino)
+        != (path_information.st_dev, path_information.st_ino)
+    ):
+        raise RuntimeError(f"private path changed during secure open: {target}")
+    if not directory and descriptor_information.st_nlink != 1:
+        raise RuntimeError(f"private file must have exactly one link: {target}")
+    if os.name == "nt":
+        _ensure_private_windows_descriptor(
+            target,
+            descriptor,
+            directory=directory,
+        )
+    else:
+        getuid = getattr(os, "geteuid", None)
+        if not callable(getuid) or descriptor_information.st_uid != getuid():
+            raise RuntimeError(f"private path is not owned by this user: {target}")
+        os.fchmod(descriptor, 0o700 if directory else 0o600)
+        verified = os.fstat(descriptor)
+        if stat.S_IMODE(verified.st_mode) & 0o077:
+            raise RuntimeError(f"private path permissions are too broad: {target}")
+    final_path_information = target.lstat()
+    final_descriptor_information = os.fstat(descriptor)
+    if _is_path_redirection(final_path_information) or (
+        final_descriptor_information.st_dev,
+        final_descriptor_information.st_ino,
+    ) != (final_path_information.st_dev, final_path_information.st_ino):
+        raise RuntimeError(f"private path changed during secure open: {target}")
+
+
+def _ensure_private_windows_path(path: Path, *, directory: bool) -> None:
+    """Open a no-follow handle and apply a protected Windows DACL."""
+    import win32api
+    import win32con
+    import win32file
+
+    handle = win32file.CreateFile(
+        str(path),
+        win32con.READ_CONTROL | win32con.WRITE_DAC,
+        win32file.FILE_SHARE_READ
+        | win32file.FILE_SHARE_WRITE
+        | win32file.FILE_SHARE_DELETE,
+        None,
+        win32con.OPEN_EXISTING,
+        win32file.FILE_FLAG_OPEN_REPARSE_POINT | win32file.FILE_FLAG_BACKUP_SEMANTICS,
+        None,
+    )
+    try:
+        _ensure_private_windows_handle(path, handle, directory=directory)
+        _verify_windows_path_identity(path, handle)
+    finally:
+        close_handle: Any = win32api.CloseHandle
+        close_handle(handle)
+
+
+def _ensure_private_windows_descriptor(
+    path: Path,
+    descriptor: int,
+    *,
+    directory: bool,
+) -> None:
+    """Apply a protected DACL to the exact object held by ``descriptor``."""
+    import msvcrt
+    import win32api
+    import win32con
+    import win32file
+
+    operating_system_handle = msvcrt.get_osfhandle(descriptor)
+    handle = win32file.ReOpenFile(
+        operating_system_handle,
+        win32con.READ_CONTROL | win32con.WRITE_DAC,
+        win32file.FILE_SHARE_READ
+        | win32file.FILE_SHARE_WRITE
+        | win32file.FILE_SHARE_DELETE,
+        win32file.FILE_FLAG_OPEN_REPARSE_POINT | win32file.FILE_FLAG_BACKUP_SEMANTICS,
+    )
+    try:
+        _ensure_private_windows_handle(path, handle, directory=directory)
+    finally:
+        close_handle: Any = win32api.CloseHandle
+        close_handle(handle)
+
+
+def _ensure_private_windows_handle(
+    path: Path,
+    handle: Any,
+    *,
+    directory: bool,
+) -> None:
+    """Apply and read back the private ACL on one pinned Windows handle."""
+    import ntsecuritycon
+    import win32api
+    import win32file
+    import win32security
+
+    information = win32file.GetFileInformationByHandle(handle)
+    attributes = int(information[0])
+    is_directory = bool(attributes & stat.FILE_ATTRIBUTE_DIRECTORY)
+    if is_directory != directory or attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT:
+        kind = "directory" if directory else "file"
+        raise RuntimeError(f"private Windows path is not a regular {kind}: {path}")
+    if not directory and int(information[7]) != 1:
+        raise RuntimeError(f"private file must have exactly one link: {path}")
+
+    token = win32security.OpenProcessToken(
+        win32api.GetCurrentProcess(),
+        win32security.TOKEN_QUERY,
+    )
+    try:
+        user_sid = win32security.GetTokenInformation(
+            token,
+            win32security.TokenUser,
+        )[0]
+    finally:
+        close_handle: Any = win32api.CloseHandle
+        close_handle(token)
+    system_sid = win32security.CreateWellKnownSid(
+        win32security.WinLocalSystemSid,
+        None,
+    )
+    administrators_sid = win32security.CreateWellKnownSid(
+        win32security.WinBuiltinAdministratorsSid,
+        None,
+    )
+    initial_descriptor = win32security.GetSecurityInfo(
+        handle,
+        win32security.SE_FILE_OBJECT,
+        win32security.OWNER_SECURITY_INFORMATION,
+    )
+    owner = initial_descriptor.GetSecurityDescriptorOwner()
+    if owner is None or _sid_text(owner, win32security) != _sid_text(
+        user_sid,
+        win32security,
+    ):
+        raise RuntimeError(f"private Windows path has the wrong owner: {path}")
+    inherit_flags = (
+        win32security.OBJECT_INHERIT_ACE | win32security.CONTAINER_INHERIT_ACE
+        if directory
+        else 0
+    )
+    dacl = win32security.ACL()
+    expected_sids = (user_sid, system_sid, administrators_sid)
+    for sid in expected_sids:
+        dacl.AddAccessAllowedAceEx(
+            win32security.ACL_REVISION_DS,
+            inherit_flags,
+            ntsecuritycon.FILE_ALL_ACCESS,
+            sid,
+        )
+    set_security_info: Any = win32security.SetSecurityInfo
+    set_security_info(
+        handle,
+        win32security.SE_FILE_OBJECT,
+        win32security.DACL_SECURITY_INFORMATION
+        | win32security.PROTECTED_DACL_SECURITY_INFORMATION,
+        None,
+        None,
+        dacl,
+        None,
+    )
+    descriptor = win32security.GetSecurityInfo(
+        handle,
+        win32security.SE_FILE_OBJECT,
+        win32security.OWNER_SECURITY_INFORMATION
+        | win32security.DACL_SECURITY_INFORMATION,
+    )
+    owner = descriptor.GetSecurityDescriptorOwner()
+    if _sid_text(owner, win32security) != _sid_text(user_sid, win32security):
+        raise RuntimeError(f"private Windows path has the wrong owner: {path}")
+    control, _revision = descriptor.GetSecurityDescriptorControl()
+    if not control & 0x1000:  # SE_DACL_PROTECTED
+        raise RuntimeError(f"private Windows path still inherits permissions: {path}")
+    verified_dacl = descriptor.GetSecurityDescriptorDacl()
+    if verified_dacl is None or verified_dacl.GetAceCount() != len(expected_sids):
+        raise RuntimeError(f"private Windows path has an unexpected ACL: {path}")
+    expected_sid_text = {_sid_text(sid, win32security) for sid in expected_sids}
+    actual_sid_text: set[str] = set()
+    for index in range(verified_dacl.GetAceCount()):
+        header, access_mask, sid = verified_dacl.GetAce(index)
+        ace_type, ace_flags = header
+        if (
+            ace_type != win32security.ACCESS_ALLOWED_ACE_TYPE
+            or ace_flags != inherit_flags
+            or access_mask != ntsecuritycon.FILE_ALL_ACCESS
+        ):
+            raise RuntimeError(f"private Windows path grants unexpected access: {path}")
+        actual_sid_text.add(_sid_text(sid, win32security))
+    if actual_sid_text != expected_sid_text:
+        raise RuntimeError(f"private Windows path ACL is not owner-private: {path}")
+
+
+def _verify_windows_path_identity(path: Path, handle: Any) -> None:
+    """Confirm that a pinned Windows handle still has the requested pathname."""
+    import win32file
+
+    information = win32file.GetFileInformationByHandle(handle)
+    handle_file_id = (int(information[8]) << 32) | int(information[9])
+    path_information = path.lstat()
+    if (
+        _is_path_redirection(path_information)
+        or path_information.st_ino != handle_file_id
+    ):
+        raise RuntimeError(f"private path changed during secure open: {path}")
+
+
+def _is_path_redirection(information: os.stat_result) -> bool:
+    """Return whether an ``lstat``/``fstat`` result denotes redirection."""
+    attributes = getattr(information, "st_file_attributes", 0)
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    return stat.S_ISLNK(information.st_mode) or bool(attributes & reparse_flag)
+
+
+def _sid_text(sid: Any, win32security: Any) -> str:
+    """Return a stable string form for a pywin32 SID object."""
+    return str(win32security.ConvertSidToStringSid(sid))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,9 @@
 name = "jarvis_cd"
 description = "Jarvis-CD: Unified platform for deploying applications and benchmarks"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.11"
 dynamic = ["version"]
+license = "BSD-3-Clause"
 authors = [
   {name = "Luke Logan", email = "llogan@hawk.iit.edu"},
 ]
@@ -14,7 +15,6 @@ classifiers = [
   "Environment :: Console",
   "Intended Audience :: Developers",
   "Intended Audience :: System Administrators",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: System :: Systems Administration",
@@ -26,16 +26,24 @@ dependencies = [
   "podman-compose",
 ]
 
+[dependency-groups]
+dev = [
+  "pytest==9.1.1",
+  "pytest-cov==7.1.0",
+  "ruff==0.15.21",
+  "twine==6.2.0",
+]
+
 [project.urls]
-Documentation = "https://github.com/iowarp/ppi-jarvis-cd"
-issue-tracker = "https://github.com/iowarp/ppi-jarvis-cd/issues"
-source-code = "https://github.com/iowarp/ppi-jarvis-cd"
+Documentation = "https://github.com/grc-iit/jarvis-cd#readme"
+issue-tracker = "https://github.com/grc-iit/jarvis-cd/issues"
+source-code = "https://github.com/grc-iit/jarvis-cd"
 
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "setuptools>=42",
-  "setuptools-scm>=7",
+  "setuptools==80.9.0",
+  "setuptools-scm==8.3.1",
 ]
 
 [tool.setuptools]
@@ -51,7 +59,7 @@ builtin = ["pipelines/**/*.yaml", "pipelines/**/*.yml"]
 jarvis = "jarvis_cd.core.cli:main"
 
 [project.entry-points."clio_relay.package_progress_adapters"]
-jarvis_lammps = "jarvis_cd.progress.lammps:adapter_from_package"
+lammps = "jarvis_cd.progress.lammps:adapter_from_package"
 
 [tool.setuptools_scm]
 version_scheme = "no-guess-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "pyyaml",
   "pandas",
   "podman-compose",
+  "pywin32>=311 ; sys_platform == 'win32'",
 ]
 
 [dependency-groups]
@@ -60,6 +61,7 @@ jarvis = "jarvis_cd.core.cli:main"
 
 [project.entry-points."clio_relay.package_progress_adapters"]
 lammps = "jarvis_cd.progress.lammps:adapter_from_package"
+paraview = "jarvis_cd.progress.paraview:adapter_from_package"
 
 [tool.setuptools_scm]
 version_scheme = "no-guess-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ requires = [
 ]
 
 [tool.setuptools]
-packages = ["jarvis_cd", "jarvis_cd.core", "jarvis_cd.shell", "jarvis_cd.util", "builtin", "builtin.builtin"]
+packages = ["jarvis_cd", "jarvis_cd.core", "jarvis_cd.progress", "jarvis_cd.shell", "jarvis_cd.util", "builtin", "builtin.builtin"]
 include-package-data = true
 
 [tool.setuptools.package-data]
@@ -49,6 +49,9 @@ builtin = ["pipelines/**/*.yaml", "pipelines/**/*.yml"]
 
 [project.scripts]
 jarvis = "jarvis_cd.core.cli:main"
+
+[project.entry-points."clio_relay.package_progress_adapters"]
+jarvis_lammps = "jarvis_cd.progress.lammps:adapter_from_package"
 
 [tool.setuptools_scm]
 version_scheme = "no-guess-dev"

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,3 @@ import setuptools
 setuptools.setup(
     scripts=['bin/jarvis', 'bin/jarvis_resource_graph'],
 )
-
-# Install builtin packages immediately after setup
-try:
-    from jarvis_cd.post_install import install_builtin_packages
-    install_builtin_packages()
-except Exception as e:
-    print(f"Warning: Could not install builtin packages: {e}")

--- a/test/unit/core/test_core_exports.py
+++ b/test/unit/core/test_core_exports.py
@@ -1,0 +1,44 @@
+"""Tests for the lightweight :mod:`jarvis_cd.core` import boundary."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_core_public_exports_remain_compatible() -> None:
+    """Legacy public class imports resolve to their canonical definitions."""
+    from jarvis_cd.core import (
+        Application,
+        ContainerApplication,
+        ContainerService,
+        Service,
+    )
+    from jarvis_cd.core.pkg import Application as CanonicalApplication
+    from jarvis_cd.core.pkg import Service as CanonicalService
+
+    assert Application is CanonicalApplication
+    assert Service is CanonicalService
+    assert ContainerApplication is CanonicalApplication
+    assert ContainerService is CanonicalService
+
+
+def test_execution_module_invocation_is_warning_free() -> None:
+    """The execution CLI module is not imported before runpy executes it."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "error::RuntimeWarning",
+            "-m",
+            "jarvis_cd.core.execution",
+            "--help",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "RuntimeWarning" not in result.stderr

--- a/test/unit/core/test_execution.py
+++ b/test/unit/core/test_execution.py
@@ -1,0 +1,1055 @@
+"""Durable JARVIS execution handle and record tests."""
+
+from __future__ import annotations
+
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from pathlib import Path
+from threading import Event
+from types import SimpleNamespace
+from typing import Any, Iterator
+from unittest.mock import Mock, patch
+
+import jarvis_cd.core.execution as execution_module
+import jarvis_cd.core.pipeline as pipeline_module
+import jarvis_cd.shell
+import pytest
+
+from jarvis_cd.core.execution import (
+    HANDLE_SCHEMA,
+    PROGRESS_SNAPSHOT_SCHEMA,
+    RECORD_NAME,
+    ExecutionHandle,
+    ExecutionRecord,
+    ExecutionStore,
+    direct_execution_lease,
+    finalize_execution,
+    prepare_direct_execution_lease,
+    validate_pipeline_id,
+)
+from jarvis_cd.core.pipeline import Pipeline, _validate_execution_cleanup_receipt
+from jarvis_cd.core.scheduler import SlurmScheduler
+
+
+@pytest.mark.parametrize("pipeline_id", ["visualization", "case.2026", "a-b_c"])
+def test_pipeline_id_accepts_portable_path_components(pipeline_id: str) -> None:
+    """Portable pipeline identities remain usable across supported systems."""
+    assert validate_pipeline_id(pipeline_id) == pipeline_id
+
+
+@pytest.mark.parametrize(
+    "pipeline_id",
+    ["", "../outside", "nested/name", r"nested\name", ".hidden", "CON", "bad."],
+)
+def test_pipeline_id_rejects_path_aliases(pipeline_id: str) -> None:
+    """Pipeline identity can never become traversal or a reserved path alias."""
+    with pytest.raises(ValueError, match="pipeline_id"):
+        validate_pipeline_id(pipeline_id)
+
+
+def test_pipeline_constructor_rejects_invalid_query_before_config_access() -> None:
+    """A named query validates identity before reading any pipeline path."""
+    with patch("jarvis_cd.core.pipeline.Jarvis.get_instance") as get_instance:
+        with pytest.raises(ValueError, match="pipeline_id"):
+            Pipeline("../outside")
+
+    get_instance.assert_not_called()
+
+
+def test_pipeline_create_and_destroy_reject_escape_before_path_access() -> None:
+    """Mutation boundaries reject traversal before asking config for a path."""
+    pipeline = Pipeline.__new__(Pipeline)
+    pipeline.name = None
+    pipeline._execution_root = None
+    pipeline.jarvis = SimpleNamespace(
+        get_current_pipeline=Mock(return_value=None),
+        get_pipeline_dir=Mock(),
+        get_pipeline_shared_dir=Mock(),
+        get_pipeline_private_dir=Mock(),
+    )
+
+    with pytest.raises(ValueError, match="pipeline_id"):
+        pipeline.create("../outside")
+    with pytest.raises(ValueError, match="pipeline_id"):
+        pipeline.destroy("../outside")
+
+    pipeline.jarvis.get_pipeline_dir.assert_not_called()
+    pipeline.jarvis.get_pipeline_shared_dir.assert_not_called()
+    pipeline.jarvis.get_pipeline_private_dir.assert_not_called()
+
+
+def test_pipeline_yaml_rejects_unsafe_name_before_loading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A site YAML cannot choose an out-of-root pipeline storage identity."""
+    pipeline_file = tmp_path / "pipeline.yaml"
+    pipeline_file.write_text("name: ../outside\npkgs: []\n", encoding="utf-8")
+    monkeypatch.delenv("JARVIS_PIPELINE_SNAPSHOT_DIR", raising=False)
+    pipeline = Pipeline.__new__(Pipeline)
+
+    with pytest.raises(ValueError, match="pipeline_id"):
+        pipeline._load_from_file("yaml", str(pipeline_file))
+
+
+def test_cleanup_receipt_rejects_duplicate_identity_keys() -> None:
+    """Cleanup authorization never applies JSON last-key-wins semantics."""
+    payload = (
+        b'{"cleanup_nonce":"nonce","execution_id":"owned",'
+        b'"execution_id":"other","pipeline_name":"example",'
+        b'"schema_version":"jarvis.execution-cleanup.v1",'
+        b'"state":"completed","submitted":false,"terminal":true,'
+        b'"tombstone_device":1,"tombstone_inode":1}'
+    )
+
+    with pytest.raises(RuntimeError, match="invalid execution cleanup receipt"):
+        _validate_execution_cleanup_receipt(
+            payload,
+            receipt_label="receipt.json",
+            expected_nonce="nonce",
+            expected_execution_id="owned",
+        )
+
+
+def test_handle_round_trip_uses_explicit_nullable_scheduler_fields() -> None:
+    """Direct handles carry JARVIS identity and explicit null scheduler fields."""
+    handle = ExecutionHandle(
+        execution_id="direct-1",
+        pipeline_id="example",
+        mode="direct",
+    )
+
+    document = handle.to_dict()
+
+    assert document == {
+        "schema_version": HANDLE_SCHEMA,
+        "execution_id": "direct-1",
+        "pipeline_id": "example",
+        "mode": "direct",
+        "scheduler_provider": None,
+        "scheduler_native_id": None,
+        "cluster": None,
+    }
+    assert ExecutionHandle.from_dict(document) == handle
+
+
+def test_handle_rejects_ambiguous_or_extended_documents() -> None:
+    """Scheduler identity cannot leak into direct handles or omit its provider."""
+    with pytest.raises(ValueError, match="direct execution"):
+        ExecutionHandle(
+            execution_id="direct-1",
+            pipeline_id="example",
+            mode="direct",
+            scheduler_provider="slurm",
+        )
+    with pytest.raises(ValueError, match="require scheduler_provider"):
+        ExecutionHandle(
+            execution_id="scheduled-1",
+            pipeline_id="example",
+            mode="scheduler",
+        )
+    document = ExecutionHandle(
+        execution_id="scheduled-1",
+        pipeline_id="example",
+        mode="scheduler",
+        scheduler_provider="slurm",
+    ).to_dict()
+    document["unexpected"] = True
+    with pytest.raises(ValueError, match="schema"):
+        ExecutionHandle.from_dict(document)
+
+
+def test_store_persists_independent_records_and_queryable_handles(
+    tmp_path: Path,
+) -> None:
+    """Each execution remains queryable after later executions are created."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    first = store.create("first", mode="direct")
+    first = store.update(
+        "first",
+        state="running",
+        metadata={
+            "progress_files": {
+                "render": {
+                    "filename": "render.jsonl",
+                    "package_name": "builtin.paraview",
+                }
+            }
+        },
+    )
+    first = store.update(
+        "first",
+        state="completed",
+        terminal=True,
+        return_code=0,
+    )
+    second = store.create(
+        "second",
+        mode="scheduler",
+        scheduler_provider="slurm",
+    )
+    second = store.update(
+        "second",
+        state="submitting",
+        scheduler_provider="slurm",
+    )
+    second = store.update(
+        "second",
+        state="submitted",
+        submitted=True,
+        native_id="9123",
+        cluster="ares",
+    )
+
+    records = store.list()
+
+    assert [record.execution_id for record in records] == ["first", "second"]
+    assert first.handle.refresh().state == "completed"
+    assert second.handle.refresh().scheduler_native_id == "9123"
+    assert second.handle.to_dict()["cluster"] == "ares"
+
+
+def test_execution_store_rejects_junction_ancestor_without_writing(
+    tmp_path: Path,
+) -> None:
+    """An execution collection is never created through path redirection."""
+    target = tmp_path / "outside"
+    target.mkdir()
+    redirected = tmp_path / "redirected"
+    if os.name == "nt":
+        import _winapi
+
+        _winapi.CreateJunction(str(target), str(redirected))
+    else:
+        redirected.symlink_to(target, target_is_directory=True)
+
+    store = ExecutionStore(redirected / "executions", "example")
+    with pytest.raises(RuntimeError, match="symbolic link or reparse point"):
+        store.create("blocked", mode="direct")
+    assert not (target / "executions").exists()
+
+
+def test_windows_record_reader_does_not_block_atomic_replacement(
+    tmp_path: Path,
+) -> None:
+    """A live reader remains pinned while a Windows writer replaces the path."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create("replaceable", mode="direct")
+    record_path = store.executions_dir / "replaceable" / RECORD_NAME
+    descriptor = os.open(record_path, os.O_RDONLY)
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(store.update, "replaceable", state="running")
+            temporary_pattern = f".{RECORD_NAME}.*.tmp"
+            for _ in range(1_000):
+                if list(record_path.parent.glob(temporary_pattern)):
+                    break
+                Event().wait(0.001)
+            else:
+                raise AssertionError("record writer did not reach atomic replacement")
+            os.close(descriptor)
+            descriptor = -1
+            updated = future.result(timeout=5)
+        assert updated.state == "running"
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def test_store_rejects_non_json_metadata_and_terminal_regression(
+    tmp_path: Path,
+) -> None:
+    """Durable records accept only bounded JSON and never reopen terminal work."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    with pytest.raises(ValueError, match="JSON"):
+        store.create("bad-json", mode="direct", metadata={"path": tmp_path})
+    store.create("done", mode="direct")
+    store.update("done", state="running")
+    store.update("done", state="completed", terminal=True, return_code=0)
+    with pytest.raises(ValueError, match="transition|nonterminal"):
+        store.update("done", state="running", terminal=False)
+
+
+def test_store_rejects_boolean_or_incoherent_terminal_return_codes(
+    tmp_path: Path,
+) -> None:
+    """A successful write can never create a record its reader rejects."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    for execution_id in ("boolean", "completed-bad", "failed-bad"):
+        store.create(execution_id, mode="direct")
+        store.update(execution_id, state="running")
+
+    with pytest.raises(ValueError, match="integer"):
+        store.update(
+            "boolean",
+            state="completed",
+            terminal=True,
+            return_code=True,
+        )
+    with pytest.raises(ValueError, match="return_code=0"):
+        store.update(
+            "completed-bad",
+            state="completed",
+            terminal=True,
+            return_code=7,
+        )
+    with pytest.raises(ValueError, match="nonzero"):
+        store.update(
+            "failed-bad",
+            state="failed",
+            terminal=True,
+            return_code=0,
+        )
+    assert store.get("boolean").state == "running"
+
+
+def test_scheduler_activation_is_identity_bound_and_scripted_only(
+    tmp_path: Path,
+) -> None:
+    """Only the scheduler helper can safely activate a generated script."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create("manual", mode="scheduler", scheduler_provider="slurm")
+    store.update("manual", state="scripted", terminal=True)
+
+    activated = store.activate_scheduler(
+        "manual",
+        provider="slurm",
+        native_id="41",
+        cluster="ares",
+    )
+
+    assert activated.state == "running"
+    assert activated.submitted is True
+    assert activated.terminal is False
+    assert activated.scheduler_native_id == "41"
+    assert activated.cluster == "ares"
+    with pytest.raises(ValueError, match="cannot change"):
+        store.activate_scheduler(
+            "manual",
+            provider="slurm",
+            native_id="42",
+            cluster="ares",
+        )
+    with pytest.raises(ValueError, match="numeric"):
+        store.activate_scheduler(
+            "manual",
+            provider="slurm",
+            native_id="not-a-job",
+        )
+
+
+def test_record_reader_rejects_unknown_fields_and_symlink_roots(
+    tmp_path: Path,
+) -> None:
+    """Record reads fail closed for schema expansion and path replacement."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create("owned", mode="direct")
+    record_path = store.executions_dir / "owned" / RECORD_NAME
+    document = json.loads(record_path.read_text(encoding="utf-8"))
+    document["unexpected"] = "field"
+    record_path.write_text(json.dumps(document), encoding="utf-8")
+    if record_path.stat().st_mode & 0o077:
+        record_path.chmod(0o600)
+    with pytest.raises(RuntimeError, match="invalid execution record"):
+        store.get("owned")
+
+    if not hasattr(Path, "symlink_to"):
+        return
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = store.executions_dir / "linked"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        return
+    with pytest.raises(RuntimeError, match="real directory"):
+        store.get("linked")
+
+
+def test_record_reader_rejects_duplicate_json_keys(tmp_path: Path) -> None:
+    """Duplicate ownership fields never receive last-key-wins semantics."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create("owned", mode="direct")
+    record_path = store.executions_dir / "owned" / RECORD_NAME
+    payload = record_path.read_text(encoding="utf-8")
+    payload = payload.replace(
+        '"execution_id":"owned"',
+        '"execution_id":"owned","execution_id":"other"',
+        1,
+    )
+    record_path.write_text(payload, encoding="utf-8")
+    if record_path.stat().st_mode & 0o077:
+        record_path.chmod(0o600)
+
+    with pytest.raises(RuntimeError, match="invalid execution record"):
+        store.get("owned")
+
+
+def _pipeline_double(tmp_path: Path) -> Pipeline:
+    """Return a minimal Pipeline whose lifecycle is safe for direct-run tests."""
+    pipeline = Pipeline.__new__(Pipeline)
+    pipeline.name = "example"
+    pipeline.jarvis = SimpleNamespace(
+        get_pipeline_shared_dir=lambda _name: tmp_path / "shared" / "example"
+    )
+    pipeline.env = {"KEEP": "value"}
+    pipeline.container_image = ""
+    pipeline._execution_root = None
+    pipeline._execution_id = None
+    pipeline.configure_all_packages = Mock()
+    pipeline.start = Mock()
+    pipeline.stop = Mock()
+    return pipeline
+
+
+def _terminal_execution_for_cleanup(
+    tmp_path: Path,
+    execution_id: str,
+) -> tuple[Pipeline, ExecutionStore]:
+    """Create a minimal terminal execution accepted by exact cleanup."""
+    shared_dir = tmp_path / "shared" / "example"
+    store = ExecutionStore(shared_dir / "executions", "example")
+    store.create(execution_id, mode="direct")
+    store.update(execution_id, state="running")
+    store.update(
+        execution_id,
+        state="completed",
+        terminal=True,
+        return_code=0,
+    )
+    pipeline = Pipeline.__new__(Pipeline)
+    pipeline.name = "example"
+    pipeline._execution_root = None
+    pipeline.jarvis = SimpleNamespace(
+        get_pipeline_shared_dir=lambda _name: shared_dir,
+    )
+    return pipeline, store
+
+
+def test_cleanup_waits_for_inflight_record_writer_before_detach(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A writer already inside its transaction commits before cleanup inspects."""
+    pipeline, store = _terminal_execution_for_cleanup(tmp_path, "writer-first")
+    writer_at_commit = Event()
+    release_writer = Event()
+    cleanup_attempted_lock = Event()
+    ordering: list[str] = []
+    real_atomic_write = execution_module._atomic_write_record
+    real_cleanup_lock = pipeline_module.execution_transaction_lock
+    real_inspect = pipeline_module._inspect_execution_root
+
+    def blocked_atomic_write(path: Path, record: ExecutionRecord) -> None:
+        if record.metadata.get("writer_revision") == 1:
+            writer_at_commit.set()
+            if not release_writer.wait(timeout=5):
+                raise AssertionError("writer interleaving was not released")
+            real_atomic_write(path, record)
+            ordering.append("writer-committed")
+            return
+        real_atomic_write(path, record)
+
+    @contextmanager
+    def observed_cleanup_lock(
+        executions_dir: Path,
+        execution_id: str,
+        *,
+        timeout: float = 30.0,
+    ) -> Iterator[None]:
+        cleanup_attempted_lock.set()
+        with real_cleanup_lock(
+            executions_dir,
+            execution_id,
+            timeout=timeout,
+        ):
+            yield
+
+    def observed_inspect(
+        path: Path,
+        *,
+        executions_descriptor: int | None,
+        expected_execution_id: str,
+    ) -> tuple[dict[str, Any], tuple[int, int]]:
+        ordering.append("cleanup-inspected")
+        return real_inspect(
+            path,
+            executions_descriptor=executions_descriptor,
+            expected_execution_id=expected_execution_id,
+        )
+
+    monkeypatch.setattr(execution_module, "_atomic_write_record", blocked_atomic_write)
+    monkeypatch.setattr(
+        pipeline_module,
+        "execution_transaction_lock",
+        observed_cleanup_lock,
+    )
+    monkeypatch.setattr(pipeline_module, "_inspect_execution_root", observed_inspect)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        writer = executor.submit(
+            store.update,
+            "writer-first",
+            metadata={"writer_revision": 1},
+        )
+        assert writer_at_commit.wait(timeout=5)
+        cleanup = executor.submit(pipeline.cleanup_executions, ["writer-first"])
+        assert cleanup_attempted_lock.wait(timeout=5)
+        release_writer.set()
+
+        updated = writer.result(timeout=5)
+        removed = cleanup.result(timeout=5)
+
+    assert updated.metadata["writer_revision"] == 1
+    assert removed == ["writer-first"]
+    assert ordering == ["writer-committed", "cleanup-inspected"]
+    assert not (store.executions_dir / "writer-first").exists()
+
+
+def test_record_writer_waits_for_cleanup_and_cannot_resurrect_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Cleanup holding the transaction lock wins before a later writer reads."""
+    pipeline, store = _terminal_execution_for_cleanup(tmp_path, "cleanup-first")
+    cleanup_inside_lock = Event()
+    release_cleanup = Event()
+    writer_attempted_lock = Event()
+    real_inspect = pipeline_module._inspect_execution_root
+    real_writer_lock = execution_module.execution_transaction_lock
+
+    def blocked_inspect(
+        path: Path,
+        *,
+        executions_descriptor: int | None,
+        expected_execution_id: str,
+    ) -> tuple[dict[str, Any], tuple[int, int]]:
+        cleanup_inside_lock.set()
+        if not release_cleanup.wait(timeout=5):
+            raise AssertionError("cleanup interleaving was not released")
+        return real_inspect(
+            path,
+            executions_descriptor=executions_descriptor,
+            expected_execution_id=expected_execution_id,
+        )
+
+    @contextmanager
+    def observed_writer_lock(
+        executions_dir: Path,
+        execution_id: str,
+        *,
+        timeout: float = 30.0,
+    ) -> Iterator[None]:
+        writer_attempted_lock.set()
+        with real_writer_lock(
+            executions_dir,
+            execution_id,
+            timeout=timeout,
+        ):
+            yield
+
+    monkeypatch.setattr(pipeline_module, "_inspect_execution_root", blocked_inspect)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        cleanup = executor.submit(pipeline.cleanup_executions, ["cleanup-first"])
+        assert cleanup_inside_lock.wait(timeout=5)
+        monkeypatch.setattr(
+            execution_module,
+            "execution_transaction_lock",
+            observed_writer_lock,
+        )
+        writer = executor.submit(
+            store.update,
+            "cleanup-first",
+            metadata={"too_late": True},
+        )
+        assert writer_attempted_lock.wait(timeout=5)
+        release_cleanup.set()
+
+        assert cleanup.result(timeout=5) == ["cleanup-first"]
+        with pytest.raises((FileNotFoundError, RuntimeError)):
+            writer.result(timeout=5)
+
+    assert not (store.executions_dir / "cleanup-first").exists()
+    assert not (store.executions_dir / ".remove-cleanup-first").exists()
+
+
+def test_direct_run_returns_handle_and_restores_named_context(tmp_path: Path) -> None:
+    """Blocking direct execution is durable while runtime paths remain isolated."""
+    pipeline = _pipeline_double(tmp_path)
+    observed: dict[str, object] = {}
+
+    def inspect_running_record() -> None:
+        observed["root"] = pipeline._execution_root
+        observed["record"] = pipeline.get_execution("direct-run")
+
+    pipeline.start.side_effect = inspect_running_record
+
+    handle = pipeline.run(execution_id="direct-run")
+
+    running = observed["record"]
+    assert isinstance(running, ExecutionRecord)
+    assert running.state == "running"
+    assert Path(observed["root"]) == (
+        tmp_path / "shared" / "example" / "executions" / "direct-run"
+    )
+    assert handle.mode == "direct"
+    assert handle.scheduler_native_id is None
+    assert handle.refresh().state == "completed"
+    assert pipeline._execution_root is None
+    assert pipeline._execution_id is None
+    assert pipeline.env == {"KEEP": "value"}
+
+
+def test_direct_run_failure_is_durable_and_original_error_survives(
+    tmp_path: Path,
+) -> None:
+    """A failed blocking run records failure before re-raising its cause."""
+    pipeline = _pipeline_double(tmp_path)
+    pipeline.start.side_effect = RuntimeError("package exploded\nwith detail")
+
+    with pytest.raises(RuntimeError, match="package exploded"):
+        pipeline.run(execution_id="failed-run")
+
+    record = pipeline.get_execution("failed-run")
+    assert record.state == "failed"
+    assert record.terminal is True
+    assert record.return_code == 1
+    assert record.error == "package exploded\nwith detail"
+
+
+class _FatalExecutionSignal(BaseException):
+    """Test-only non-Exception interruption."""
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        pytest.param(KeyboardInterrupt(), id="keyboard-interrupt"),
+        pytest.param(SystemExit(9), id="system-exit"),
+        pytest.param(_FatalExecutionSignal("fatal signal"), id="base-exception"),
+    ],
+)
+def test_direct_run_base_exception_is_terminal_and_re_raised(
+    tmp_path: Path,
+    failure: BaseException,
+) -> None:
+    """Interruptions cannot leave a direct execution indefinitely running."""
+    pipeline = _pipeline_double(tmp_path)
+    pipeline.start.side_effect = failure
+
+    with pytest.raises(type(failure)):
+        pipeline.run(execution_id="interrupted-run")
+
+    record = pipeline.get_execution("interrupted-run")
+    assert record.state == "failed"
+    assert record.terminal is True
+    assert record.return_code == 1
+    assert record.error == (str(failure) or type(failure).__name__)
+    assert pipeline._execution_root is None
+    assert pipeline._execution_id is None
+    assert pipeline.env == {"KEEP": "value"}
+
+
+def test_direct_run_terminalizes_when_cleanup_is_also_interrupted(
+    tmp_path: Path,
+) -> None:
+    """A cleanup interruption is noted without replacing the original failure."""
+    pipeline = _pipeline_double(tmp_path)
+    original = RuntimeError("package failed")
+    pipeline.start.side_effect = original
+    pipeline.stop.side_effect = KeyboardInterrupt()
+
+    with pytest.raises(RuntimeError, match="package failed") as raised:
+        pipeline.run(execution_id="cleanup-interrupted")
+
+    assert raised.value is original
+    assert any("cleanup also failed" in note for note in original.__notes__)
+    record = pipeline.get_execution("cleanup-interrupted")
+    assert record.state == "failed"
+    assert record.terminal is True
+
+
+def test_nonblocking_direct_run_returns_live_queryable_handle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Local work can return its generated ID before the workload completes."""
+    pipeline = _pipeline_double(tmp_path)
+    pipeline.save = Mock()
+
+    def write_snapshot(
+        execution_root: Path,
+        scheduler_spec: dict[str, object],
+    ) -> tuple[Path, Path, str]:
+        assert scheduler_spec == {}
+        runtime = execution_root / "runtime"
+        inputs = execution_root / "input"
+        runtime.mkdir()
+        inputs.mkdir()
+        return runtime, inputs, "abc123"
+
+    pipeline._write_execution_snapshot = Mock(side_effect=write_snapshot)
+
+    class Process:
+        pid = 4242
+
+    monkeypatch.setattr(
+        "jarvis_cd.core.pipeline.subprocess.Popen", lambda *a, **k: Process()
+    )
+    monkeypatch.setattr(
+        "jarvis_cd.core.execution._process_is_running", lambda _pid: True
+    )
+
+    handle = pipeline.run(execution_id="background", wait=False)
+
+    assert handle.execution_id == "background"
+    assert handle.mode == "direct"
+    assert handle.scheduler_native_id is None
+    record = handle.refresh()
+    assert record.state == "preparing"
+    assert record.terminal is False
+    assert record.metadata["direct_process_id"] == 4242
+    assert handle.progress().execution_id == "background"
+
+
+def test_nonblocking_direct_record_reconciles_a_crashed_child(tmp_path: Path) -> None:
+    """A lost detached process cannot leave a durable record running forever."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    record = store.create(
+        "orphaned",
+        mode="direct",
+        metadata={
+            "direct_launch": {
+                "schema_version": "jarvis.direct-launch.v1",
+                "phase": "spawned",
+                "launcher_pid": os.getpid(),
+                "child_pid": os.getpid(),
+            }
+        },
+    )
+    assert record._record_path is not None
+    prepare_direct_execution_lease(record._record_path.parent)
+    store.update("orphaned", state="running")
+
+    reconciled = store.get("orphaned")
+
+    assert reconciled.state == "failed"
+    assert reconciled.terminal is True
+    assert reconciled.return_code == 1
+    assert reconciled.metadata["failure_stage"] == "direct_orphan_reconciliation"
+
+
+def test_nonblocking_direct_record_stays_live_while_child_holds_lease(
+    tmp_path: Path,
+) -> None:
+    """A held process lease is authoritative even during concurrent queries."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    record = store.create(
+        "active",
+        mode="direct",
+        metadata={
+            "direct_launch": {
+                "schema_version": "jarvis.direct-launch.v1",
+                "phase": "spawned",
+                "launcher_pid": os.getpid(),
+                "child_pid": os.getpid(),
+            }
+        },
+    )
+    assert record._record_path is not None
+    execution_root = record._record_path.parent
+    prepare_direct_execution_lease(execution_root)
+    with direct_execution_lease(execution_root):
+        store.update("active", state="running")
+        assert store.get("active").state == "running"
+
+    assert store.get("active").state == "failed"
+
+
+def test_package_progress_environment_is_execution_owned(tmp_path: Path) -> None:
+    """Aliases receive distinct authoritative progress sidecars under the run root."""
+    pipeline = _pipeline_double(tmp_path)
+    store = pipeline._execution_store()
+    store.create("run", mode="direct")
+    store.update("run", state="running")
+    pipeline._execution_root = store.executions_dir / "run"
+    pipeline._execution_id = "run"
+
+    pipeline._bind_package_execution_environment(
+        {"pkg_id": "render-left", "pkg_type": "builtin.paraview"}
+    )
+
+    progress_path = Path(pipeline.env["JARVIS_PROGRESS_PATH"])
+    assert pipeline.env["JARVIS_EXECUTION_ID"] == "run"
+    assert pipeline.env["JARVIS_PACKAGE_ID"] == "render-left"
+    assert pipeline.env["JARVIS_PACKAGE_NAME"] == "builtin.paraview"
+    assert pipeline.env["JARVIS_PROGRESS_TRANSPORT"] == "sidecar"
+    assert progress_path.parent == store.executions_dir / "run" / "progress"
+    assert store.get("run").metadata["progress_files"] == {
+        "render-left": {
+            "filename": progress_path.name,
+            "package_name": "builtin.paraview",
+        }
+    }
+
+
+def test_handle_progress_returns_identity_checked_path_free_snapshot(
+    tmp_path: Path,
+) -> None:
+    """A handle exposes current progress without leaking its sidecar path."""
+    from jarvis_cd.progress import ProgressEvent, ProgressStore
+
+    store = ExecutionStore(tmp_path / "executions", "example")
+    record = store.create("progress-run", mode="direct")
+    filename = "render-a.jsonl"
+    store.update(
+        "progress-run",
+        state="running",
+        metadata={
+            "progress_files": {
+                "render-a": {
+                    "filename": filename,
+                    "package_name": "builtin.paraview",
+                }
+            }
+        },
+    )
+    ProgressStore(store.executions_dir / "progress-run" / "progress" / filename).append(
+        ProgressEvent(
+            package_name="builtin.paraview",
+            package_id="render-a",
+            execution_id="progress-run",
+            label="frame",
+            current=3,
+            total=8,
+            unit="frame",
+            sequence=1,
+        )
+    )
+
+    snapshot = record.handle.progress()
+    document = snapshot.to_dict()
+
+    assert document["schema_version"] == PROGRESS_SNAPSHOT_SCHEMA
+    assert document["execution_id"] == "progress-run"
+    assert document["packages"][0]["event_count"] == 1
+    assert document["packages"][0]["latest"]["current"] == 3.0
+    assert "path" not in json.dumps(document)
+
+
+def test_execution_progress_rejects_index_escape_and_event_mismatch(
+    tmp_path: Path,
+) -> None:
+    """Queries cannot follow metadata outside the exact owned execution."""
+    from jarvis_cd.progress import ProgressEvent, ProgressStore
+
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create(
+        "escape",
+        mode="direct",
+        metadata={
+            "progress_files": {
+                "render": {
+                    "filename": "../outside.jsonl",
+                    "package_name": "builtin.paraview",
+                }
+            }
+        },
+    )
+    with pytest.raises(RuntimeError, match="invalid path"):
+        store.progress("escape")
+
+    store.create(
+        "mismatch",
+        mode="direct",
+        metadata={
+            "progress_files": {
+                "render": {
+                    "filename": "render.jsonl",
+                    "package_name": "builtin.paraview",
+                }
+            }
+        },
+    )
+    sidecar = store.executions_dir / "mismatch" / "progress" / "render.jsonl"
+    ProgressStore(sidecar).append(
+        ProgressEvent(
+            package_name="builtin.paraview",
+            package_id="other",
+            execution_id="mismatch",
+            label="frame",
+            current=1,
+            total=2,
+            unit="frame",
+            sequence=1,
+        )
+    )
+    with pytest.raises(RuntimeError, match="identity mismatch"):
+        store.progress("mismatch")
+
+
+def test_container_start_forwards_execution_owned_progress(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Container package launch receives the same owned progress contract."""
+    pipeline = _pipeline_double(tmp_path)
+    store = pipeline._execution_store()
+    store.create("container-run", mode="direct")
+    store.update("container-run", state="running")
+    pipeline._execution_root = store.executions_dir / "container-run"
+    pipeline._execution_id = "container-run"
+    pipeline.container_engine = "docker"
+    pipeline.container_image = "example:latest"
+    pipeline.packages = [
+        {
+            "pkg_id": "render-container",
+            "pkg_type": "builtin.paraview",
+        }
+    ]
+    pipeline._started_instances = []
+    pipeline._hostfile_is_local_only = Mock(return_value=True)
+    pipeline.get_hostfile = Mock(return_value=SimpleNamespace(hosts=["localhost"]))
+    pipeline._apply_interceptors_to_package = Mock()
+    shared_dir = pipeline.get_pipeline_shared_dir()
+    shared_dir.mkdir(parents=True)
+    (shared_dir / "docker-compose.yaml").write_text(
+        "services: {}\n",
+        encoding="utf-8",
+    )
+
+    observed: dict[str, str] = {}
+
+    class Package:
+        env: dict[str, str] = {}
+
+        def start(self) -> None:
+            observed.update(self.env)
+
+    def load_package(
+        _definition: dict[str, object],
+        environment: dict[str, str],
+    ) -> Package:
+        package = Package()
+        package.env = dict(environment)
+        return package
+
+    class SuccessfulExec:
+        def __init__(self, _command: str, _exec_info: object) -> None:
+            self.exit_code = {"localhost": 0}
+
+        def run(self) -> "SuccessfulExec":
+            return self
+
+    pipeline._load_package_instance = Mock(side_effect=load_package)
+    monkeypatch.setattr(jarvis_cd.shell, "Exec", SuccessfulExec)
+
+    pipeline._start_containerized_pipeline()
+
+    progress_path = Path(observed["JARVIS_PROGRESS_PATH"])
+    assert observed["JARVIS_EXECUTION_ID"] == "container-run"
+    assert observed["JARVIS_PACKAGE_NAME"] == "builtin.paraview"
+    assert observed["JARVIS_PACKAGE_ID"] == "render-container"
+    assert observed["JARVIS_PROGRESS_TRANSPORT"] == "stdout"
+    assert progress_path.parent == store.executions_dir / "container-run" / "progress"
+    assert pipeline._started_instances
+
+
+def test_scheduler_finalizer_covers_failures_before_pipeline_run(
+    tmp_path: Path,
+) -> None:
+    """The scheduler EXIT helper makes pre-run script failures terminal."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create(
+        "scheduled",
+        mode="scheduler",
+        scheduler_provider="slurm",
+    )
+    store.update("scheduled", state="submitting")
+    store.update("scheduled", state="submitted", submitted=True, native_id="55")
+
+    finalized = finalize_execution(store.executions_dir / "scheduled", "scheduled", 7)
+
+    assert finalized.state == "failed"
+    assert finalized.return_code == 7
+    assert finalized.error == "scheduler script exited with status 7"
+
+
+def test_scheduler_snapshot_run_and_script_finalize_the_same_record(
+    tmp_path: Path,
+) -> None:
+    """The runtime snapshot advances its submit-created record without a new ID."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create("scheduled", mode="scheduler", scheduler_provider="slurm")
+    store.update("scheduled", state="submitting")
+    store.update("scheduled", state="submitted", submitted=True, native_id="55")
+    pipeline = _pipeline_double(tmp_path)
+    pipeline._execution_root = store.executions_dir / "scheduled"
+    pipeline._execution_id = "scheduled"
+
+    handle = pipeline.run()
+
+    assert handle.execution_id == "scheduled"
+    assert store.get("scheduled").state == "running"
+    assert finalize_execution(
+        store.executions_dir / "scheduled", "scheduled", 0
+    ).state == ("completed")
+
+
+def test_submit_projection_preserves_runtime_terminal_outcome(tmp_path: Path) -> None:
+    """A submit-process status cannot overwrite the workload finalizer."""
+    pipeline = _pipeline_double(tmp_path)
+    store = pipeline._execution_store()
+    store.create("runtime-wins", mode="scheduler", scheduler_provider="slurm")
+    store.update("runtime-wins", state="submitting")
+    store.update(
+        "runtime-wins",
+        state="running",
+        submitted=True,
+        native_id="41",
+    )
+    store.update(
+        "runtime-wins",
+        state="failed",
+        terminal=True,
+        return_code=7,
+        error="runtime failed",
+    )
+    pipeline.last_submission = {
+        "execution_id": "runtime-wins",
+        "provider": "slurm",
+        "scheduler_job_id": "41",
+        "scheduler_cluster": None,
+        "state": "completed",
+        "submitted": True,
+        "terminal": True,
+        "terminal_returncode": 0,
+        "scheduler_stderr": "submitter disagreed",
+        "script_path": str(store.executions_dir / "runtime-wins" / "submit.slurm"),
+    }
+
+    pipeline._update_execution_marker(store.executions_dir / "runtime-wins")
+
+    record = store.get("runtime-wins")
+    assert record.state == "failed"
+    assert record.return_code == 7
+    assert record.error == "runtime failed"
+
+
+def test_slurm_script_installs_durable_exit_finalizer(tmp_path: Path) -> None:
+    """Hostfile and hook failures are recorded even before JARVIS starts."""
+    execution_root = tmp_path / "executions" / "scheduled"
+    scheduler = SlurmScheduler(
+        {"name": "slurm"},
+        execution_root,
+        pipeline_snapshot_dir=execution_root / "runtime",
+    )
+
+    rendered = scheduler.render()
+
+    assert "trap jarvis_finalize_execution EXIT" in rendered
+    assert "-m jarvis_cd.core.execution finalize" in rendered
+    assert "--execution-id scheduled" in rendered

--- a/test/unit/core/test_execution.py
+++ b/test/unit/core/test_execution.py
@@ -364,7 +364,10 @@ def test_record_reader_rejects_unknown_fields_and_symlink_roots(
         link.symlink_to(outside, target_is_directory=True)
     except OSError:
         return
-    with pytest.raises(RuntimeError, match="real directory"):
+    with pytest.raises(
+        RuntimeError,
+        match="real directory|symbolic link or reparse point",
+    ):
         store.get("linked")
 
 

--- a/test/unit/core/test_execution_cli.py
+++ b/test/unit/core/test_execution_cli.py
@@ -1,0 +1,147 @@
+"""Machine-readable execution CLI tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from jarvis_cd.core.cli import JarvisCLI
+from jarvis_cd.core.execution import ExecutionHandle, ExecutionStore
+
+
+def _completed_record(tmp_path: Path):
+    """Create one completed record for CLI projection tests."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create("run-1", mode="direct")
+    store.update("run-1", state="running")
+    return store.update("run-1", state="completed", terminal=True, return_code=0)
+
+
+def test_execution_get_json_is_one_clean_record(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """The query command emits a directly parseable JSON document."""
+    record = _completed_record(tmp_path)
+    pipeline = SimpleNamespace(get_execution=Mock(return_value=record))
+    cli = JarvisCLI()
+    cli.kwargs = {"execution_id": "run-1", "json": True}
+    cli._ensure_initialized = Mock()
+    cli._require_current_pipeline = Mock(return_value=pipeline)
+
+    cli.execution_get()
+
+    assert json.loads(capsys.readouterr().out) == record.to_dict()
+    pipeline.get_execution.assert_called_once_with("run-1")
+
+
+def test_execution_list_can_query_noncurrent_pipeline(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """A handle remains queryable after the operator changes pipelines."""
+    record = _completed_record(tmp_path)
+    pipeline = SimpleNamespace(
+        name="example", list_executions=Mock(return_value=[record])
+    )
+    cli = JarvisCLI()
+    cli.kwargs = {"pipeline_id": "example", "json": True}
+    cli._ensure_initialized = Mock()
+
+    with patch("jarvis_cd.core.cli.Pipeline", return_value=pipeline) as constructor:
+        cli.execution_list()
+
+    document = json.loads(capsys.readouterr().out)
+    assert document["schema_version"] == "jarvis.execution.list.v1"
+    assert document["pipeline_id"] == "example"
+    assert document["executions"] == [record.to_dict()]
+    constructor.assert_called_once_with("example")
+
+
+def test_execution_progress_json_can_query_noncurrent_pipeline(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Agents can poll a handle after the current pipeline changes."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    record = store.create("run-1", mode="direct")
+    snapshot = store.progress("run-1")
+    pipeline = SimpleNamespace(
+        get_execution_progress=Mock(return_value=snapshot),
+    )
+    cli = JarvisCLI()
+    cli.kwargs = {
+        "execution_id": record.execution_id,
+        "pipeline_id": "example",
+        "json": True,
+    }
+    cli._ensure_initialized = Mock()
+
+    with patch("jarvis_cd.core.cli.Pipeline", return_value=pipeline) as constructor:
+        cli.execution_progress()
+
+    assert json.loads(capsys.readouterr().out) == snapshot.to_dict()
+    pipeline.get_execution_progress.assert_called_once_with("run-1")
+    constructor.assert_called_once_with("example")
+
+
+def test_json_handle_is_emitted_as_one_final_line(capsys) -> None:
+    """Run and submit handlers share the exact handle serialization."""
+    handle = ExecutionHandle(
+        execution_id="run-1",
+        pipeline_id="example",
+        mode="scheduler",
+        scheduler_provider="slurm",
+        scheduler_native_id="17",
+        cluster="ares",
+    )
+
+    JarvisCLI._emit_execution_handle(handle, json_output=True)
+
+    assert json.loads(capsys.readouterr().out) == handle.to_dict()
+
+
+@pytest.mark.parametrize("option", ["--execution-id", "--execution_id"])
+def test_submit_parser_accepts_execution_id_spellings(option: str) -> None:
+    """The documented hyphenated flag and legacy underscore flag are aliases."""
+    cli = JarvisCLI()
+    cli.define_options()
+    cli.ppl_submit = Mock()
+
+    parsed = cli.parse(["ppl", "submit", "pipeline.yaml", option, "run-1", "+json"])
+
+    assert parsed["pipeline_file"] == "pipeline.yaml"
+    assert parsed["execution_id"] == "run-1"
+    assert parsed["json"] is True
+    cli.ppl_submit.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("command", "method_name"),
+    [
+        (["execution", "get", "run-1"], "execution_get"),
+        (["execution", "list"], "execution_list"),
+        (["execution", "progress", "run-1"], "execution_progress"),
+    ],
+)
+@pytest.mark.parametrize("option", ["--pipeline-id", "--pipeline_id"])
+def test_execution_query_parser_accepts_pipeline_id_spellings(
+    command: list[str],
+    method_name: str,
+    option: str,
+) -> None:
+    """All record queries accept the documented pipeline identity option."""
+    cli = JarvisCLI()
+    cli.define_options()
+    handler = Mock()
+    setattr(cli, method_name, handler)
+
+    parsed = cli.parse([*command, option, "visualization", "+json"])
+
+    assert parsed["pipeline_id"] == "visualization"
+    assert parsed["json"] is True
+    handler.assert_called_once_with()

--- a/test/unit/core/test_lammps_package_runtime.py
+++ b/test/unit/core/test_lammps_package_runtime.py
@@ -1,0 +1,156 @@
+"""Runtime-contract tests for the builtin JARVIS LAMMPS package."""
+
+from __future__ import annotations
+
+import shlex
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def _load_lammps_package() -> ModuleType:
+    """Load the package implementation without changing JARVIS repo imports."""
+    package_path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "lammps"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_lammps_runtime_package", package_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load the LAMMPS package from {package_path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+lammps_package = _load_lammps_package()
+
+
+class _CapturedExec:
+    """Capture a package launch without executing the application."""
+
+    commands: list[str] = []
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+        self.commands.append(command)
+
+    def run(self) -> _CapturedExec:
+        """Record the launch only."""
+        return self
+
+
+class _FailedCleanupExec(_CapturedExec):
+    """Capture a launch whose package-owned log cleanup fails."""
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        super().__init__(command, exec_info)
+        if command.startswith("rm -f "):
+            self.exit_code = {"node1": 1}
+
+
+def test_default_launch_owns_deterministic_lammps_log(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The builtin package must launch LAMMPS with its declared progress log."""
+    output_dir = tmp_path / "output with spaces"
+    script = tmp_path / "input with spaces.lmp"
+    package = object.__new__(lammps_package.Lammps)
+    package.config = {
+        "kokkos_gpu": False,
+        "lmp_bin": "/opt/spack/bin/lmp",
+        "nprocs": 2,
+        "out": str(output_dir),
+        "ppn": 2,
+        "script": str(script),
+    }
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: None)
+    package.env = {}
+    package.mod_env = {}
+    _CapturedExec.commands = []
+    monkeypatch.setattr(lammps_package, "Exec", _CapturedExec)
+
+    package.start()
+
+    assert len(_CapturedExec.commands) == 2
+    expected_log = output_dir.resolve() / "log.lammps"
+    assert _CapturedExec.commands[0] == f"rm -f {shlex.quote(str(expected_log))}"
+    command = _CapturedExec.commands[1]
+    assert f"-log {shlex.quote(str(expected_log))}" in command
+    assert f"-in {shlex.quote(str(script))}" in command
+
+
+def test_container_launch_creates_log_directory_before_lammps(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Container LAMMPS must be able to open its explicit log at startup."""
+    output_dir = tmp_path / "container output"
+    package = object.__new__(lammps_package.Lammps)
+    package.config = {
+        "deploy_mode": "container",
+        "kokkos_gpu": False,
+        "nprocs": 2,
+        "out": str(output_dir),
+        "ppn": 2,
+        "script": None,
+    }
+    package.pipeline = SimpleNamespace(
+        _has_containerized_packages=lambda: True,
+        container_engine="docker",
+        container_ssh_port=22,
+        get_hostfile=lambda: None,
+        name="example",
+    )
+    package.env = {}
+    package.mod_env = {}
+    package.private_dir = tmp_path
+    package.shared_dir = tmp_path
+    _CapturedExec.commands = []
+    monkeypatch.setattr(lammps_package, "Exec", _CapturedExec)
+
+    package.start()
+
+    assert len(_CapturedExec.commands) == 2
+    expected_log = output_dir.resolve() / "log.lammps"
+    assert _CapturedExec.commands[0] == f"rm -f {shlex.quote(str(expected_log))}"
+    argv = shlex.split(_CapturedExec.commands[1])
+    assert argv[:2] == ["bash", "-c"]
+    assert argv[2] == (
+        f"mkdir -p {shlex.quote(str(output_dir.resolve()))} "
+        f"&& exec /usr/local/bin/lmp -log {shlex.quote(str(expected_log))}"
+    )
+
+
+def test_launch_fails_closed_when_stale_log_cannot_be_removed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A cleanup failure cannot silently expose stale progress as a new run."""
+    package = object.__new__(lammps_package.Lammps)
+    package.config = {
+        "kokkos_gpu": False,
+        "lmp_bin": "/opt/spack/bin/lmp",
+        "nprocs": 1,
+        "out": str(tmp_path),
+        "ppn": 1,
+        "script": None,
+    }
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: None)
+    package.env = {}
+    package.mod_env = {}
+    _FailedCleanupExec.commands = []
+    monkeypatch.setattr(lammps_package, "Exec", _FailedCleanupExec)
+
+    with pytest.raises(RuntimeError, match="Failed to remove stale LAMMPS log"):
+        package.start()
+
+    assert len(_FailedCleanupExec.commands) == 1

--- a/test/unit/core/test_lammps_progress.py
+++ b/test/unit/core/test_lammps_progress.py
@@ -7,6 +7,11 @@ from pathlib import Path
 
 import pytest
 
+from jarvis_cd.progress import (
+    PackageProgressProvider,
+    ProgressObservation,
+    RelayProgressAdapter,
+)
 from jarvis_cd.progress.lammps import (
     LammpsThermoProgressAdapter,
     adapter_from_package,
@@ -28,11 +33,14 @@ def test_adapter_is_owned_by_builtin_lammps(tmp_path: Path) -> None:
 
     assert isinstance(adapter, LammpsThermoProgressAdapter)
     assert adapter.package_name == "builtin.lammps"
+    assert adapter.package_id == "lammps"
     assert adapter.package_version
     assert adapter.application_profile == "jarvis-cd.builtin.lammps"
     assert adapter.log_visibility == "shared"
     assert adapter.total_steps == 100
     assert adapter.progress_log_paths() == [tmp_path / "log.lammps"]
+    assert isinstance(adapter, PackageProgressProvider)
+    assert isinstance(adapter, RelayProgressAdapter)
 
     container_adapter = adapter_from_package(
         {
@@ -89,9 +97,23 @@ def test_adapter_observes_only_lammps_jarvis_scope() -> None:
     assert isinstance(metadata, dict)
     assert metadata["source"] == "jarvis_package"
     assert metadata["package_name"] == "builtin.lammps"
+    assert metadata["package_id"] == "lammps"
     assert metadata["run_id"] == "job_1"
     assert metadata["execution_id"] == "job_1"
     assert adapter.acceptance_progress_valid(metadata)
+
+
+def test_lammps_provider_exposes_typed_jarvis_observations() -> None:
+    """JARVIS core consumes a typed SPI independently of the relay projection."""
+    provider = LammpsThermoProgressAdapter(total_steps=10)
+
+    observations = provider.observe_progress(
+        "run 10\nStep Temp CPU\n0 1.0 0.0\n5 1.1 1.0\n"
+    )
+
+    assert all(isinstance(item, ProgressObservation) for item in observations)
+    assert [item.current for item in observations] == [0.0, 5.0]
+    assert [item.total for item in observations] == [10, 10]
 
 
 def test_adapter_rejects_unobserved_acceptance_claims() -> None:

--- a/test/unit/core/test_lammps_progress.py
+++ b/test/unit/core/test_lammps_progress.py
@@ -1,0 +1,81 @@
+"""Tests for the package-owned builtin LAMMPS progress provider."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jarvis_cd.progress.lammps import (
+    LammpsThermoProgressAdapter,
+    adapter_from_package,
+)
+
+
+def test_adapter_is_owned_by_builtin_lammps(tmp_path: Path) -> None:
+    """The factory must activate only for the JARVIS builtin package."""
+    assert adapter_from_package({"pkg_type": "builtin.echo"}) is None
+
+    adapter = adapter_from_package(
+        {
+            "pkg_type": "builtin.lammps",
+            "pkg_version": "1.2",
+            "out": str(tmp_path),
+            "progress": {"total_steps": 100},
+        }
+    )
+
+    assert isinstance(adapter, LammpsThermoProgressAdapter)
+    assert adapter.package_name == "builtin.lammps"
+    assert adapter.package_version == "1.2"
+    assert adapter.total_steps == 100
+    assert adapter.progress_log_paths() == [tmp_path / "log.lammps"]
+
+
+def test_adapter_observes_only_lammps_jarvis_scope() -> None:
+    """Unscoped or unrelated stdout must not create trusted progress."""
+    adapter = LammpsThermoProgressAdapter(total_steps=100, run_id="job_1")
+    thermo = "run 100\nStep Temp CPU\n0 1.0 0.0\n25 1.1 1.0\n50 1.2 2.0\n75 1.3 3.0\n"
+
+    assert adapter.observe_jarvis_stdout(thermo) == []
+    assert (
+        adapter.observe_jarvis_stdout(
+            "[builtin.echo] [START] BEGIN\n" + thermo + "[builtin.echo] [START] END\n"
+        )
+        == []
+    )
+
+    records = adapter.observe_jarvis_stdout(
+        "[builtin.lammps] [START] BEGIN\n" + thermo + "[builtin.lammps] [START] END\n"
+    )
+
+    assert [record["current"] for record in records] == [0.0, 25.0, 50.0, 75.0]
+    metadata = records[-1]["metadata"]
+    assert isinstance(metadata, dict)
+    assert metadata["source"] == "jarvis_package"
+    assert metadata["package_name"] == "builtin.lammps"
+    assert metadata["run_id"] == "job_1"
+    assert metadata["execution_id"] == "job_1"
+    assert adapter.acceptance_progress_valid(metadata)
+
+
+def test_adapter_rejects_unobserved_acceptance_claims() -> None:
+    """Acceptance requires LAMMPS-owned timing and a real step record."""
+    adapter = LammpsThermoProgressAdapter()
+
+    assert not adapter.acceptance_progress_valid(
+        {
+            "adapter": "lammps",
+            "prediction_status": "claimed",
+            "timing_source": "lammps_thermo_cpu",
+            "eta_seconds": 1.0,
+            "absolute_step": 10.0,
+        }
+    )
+    assert not adapter.acceptance_progress_valid(
+        {
+            "adapter": "lammps",
+            "prediction_status": "observed_lammps_timing",
+            "timing_source": "lammps_thermo_cpu",
+            "eta_seconds": -1.0,
+            "absolute_step": 10.0,
+        }
+    )

--- a/test/unit/core/test_lammps_progress.py
+++ b/test/unit/core/test_lammps_progress.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+
+import pytest
 
 from jarvis_cd.progress.lammps import (
     LammpsThermoProgressAdapter,
@@ -19,15 +22,49 @@ def test_adapter_is_owned_by_builtin_lammps(tmp_path: Path) -> None:
             "pkg_type": "builtin.lammps",
             "pkg_version": "1.2",
             "out": str(tmp_path),
-            "progress": {"total_steps": 100},
+            "progress": {"log_visibility": "shared", "total_steps": 100},
         }
     )
 
     assert isinstance(adapter, LammpsThermoProgressAdapter)
     assert adapter.package_name == "builtin.lammps"
-    assert adapter.package_version == "1.2"
+    assert adapter.package_version
+    assert adapter.application_profile == "jarvis-cd.builtin.lammps"
+    assert adapter.log_visibility == "shared"
     assert adapter.total_steps == 100
     assert adapter.progress_log_paths() == [tmp_path / "log.lammps"]
+
+    container_adapter = adapter_from_package(
+        {
+            "deploy_mode": "container",
+            "out": "/tmp/container-only",
+            "pkg_type": "builtin.lammps",
+        }
+    )
+    assert isinstance(container_adapter, LammpsThermoProgressAdapter)
+    assert container_adapter.progress_log_paths() == []
+    assert container_adapter.log_visibility == "scoped_stdout"
+
+    inherited_container_adapter = adapter_from_package(
+        {
+            "effective_deploy_mode": "container",
+            "out": "/tmp/container-only",
+            "pkg_type": "builtin.lammps",
+        }
+    )
+    assert isinstance(inherited_container_adapter, LammpsThermoProgressAdapter)
+    assert inherited_container_adapter.progress_log_paths() == []
+
+    node_local_adapter = adapter_from_package(
+        {
+            "out": "/tmp/node-local-lammps",
+            "pkg_type": "builtin.lammps",
+            "progress": {"total_steps": 100},
+        }
+    )
+    assert isinstance(node_local_adapter, LammpsThermoProgressAdapter)
+    assert node_local_adapter.progress_log_paths() == []
+    assert node_local_adapter.log_visibility == "scoped_stdout"
 
 
 def test_adapter_observes_only_lammps_jarvis_scope() -> None:
@@ -79,3 +116,182 @@ def test_adapter_rejects_unobserved_acceptance_claims() -> None:
             "absolute_step": 10.0,
         }
     )
+
+
+def test_adapter_buffers_partial_stdout_lines() -> None:
+    """Arbitrary pipe and log chunk boundaries must not lose thermo records."""
+    adapter = LammpsThermoProgressAdapter(total_steps=100, run_id="job_chunked")
+
+    assert adapter.observe_stdout("run 100\nStep Temp C") == []
+    first = adapter.observe_stdout("PU\n0 1.0 0.0\n25 1.1 ")
+    second = adapter.observe_stdout("1.0\n50 1.2 2.0\n75 1.3 3.0\n")
+
+    assert [record["current"] for record in first + second] == [0.0, 25.0, 50.0, 75.0]
+    metadata = second[-1]["metadata"]
+    assert isinstance(metadata, dict)
+    assert adapter.acceptance_progress_valid(metadata)
+
+
+def test_adapter_flushes_unterminated_fragments_at_eof() -> None:
+    """The stream owner can explicitly flush a final unterminated thermo row."""
+    adapter = LammpsThermoProgressAdapter(total_steps=100)
+
+    assert adapter.observe_stdout("run 100\nStep Temp CPU\n0 1.0 0.0") == []
+    records = adapter.finalize_stdout()
+
+    assert [record["current"] for record in records] == [0.0]
+    assert adapter.stdout_fragment == ""
+
+
+def test_adapter_flushes_unterminated_jarvis_scope_at_eof() -> None:
+    """EOF flushing preserves a final row and closes JARVIS package scope."""
+    adapter = LammpsThermoProgressAdapter(total_steps=100)
+
+    assert (
+        adapter.observe_jarvis_stdout(
+            "[builtin.lammps] [START] BEGIN\nrun 100\nStep Temp CPU\n0 1.0 0.0"
+        )
+        == []
+    )
+    records = adapter.finalize_jarvis_stdout()
+
+    assert [record["current"] for record in records] == [0.0]
+    assert adapter.jarvis_stdout_fragment == ""
+    assert adapter.active_package_stdout is False
+
+
+def test_adapter_rejects_nonfinite_input_and_predictions(tmp_path: Path) -> None:
+    """NaN and infinity must never escape into progress JSON or messages."""
+    adapter = adapter_from_package(
+        {
+            "pkg_type": "builtin.lammps",
+            "out": str(tmp_path),
+            "progress": {"total_steps": float("inf")},
+        }
+    )
+    assert isinstance(adapter, LammpsThermoProgressAdapter)
+    assert adapter.total_steps is None
+    assert adapter.observe_stdout("Step Temp CPU\nnan 1.0 0.0\ninf 1.0 1.0\n") == []
+
+    huge = adapter_from_package(
+        {
+            "pkg_type": "builtin.lammps",
+            "progress": {"total_steps": 10**10000},
+        }
+    )
+    assert isinstance(huge, LammpsThermoProgressAdapter)
+    assert huge.total_steps is None
+
+    overflow = LammpsThermoProgressAdapter(total_steps=1e308)
+    records = overflow.observe_stdout(
+        "run 1e308\nStep Temp CPU\n0 1.0 0\n1 1.0 5e307\n2 1.0 1e308\n3 1.0 1.5e308\n"
+    )
+
+    assert records[-1]["metadata"]["prediction_status"] == (
+        "nonfinite_prediction_rejected"
+    )
+    json.dumps(records, allow_nan=False)
+    assert not overflow.acceptance_progress_valid(
+        {
+            "adapter": "lammps",
+            "prediction_status": "observed_lammps_timing",
+            "timing_source": "lammps_thermo_cpu",
+            "eta_seconds": float("inf"),
+            "absolute_step": 3.0,
+        }
+    )
+    assert not overflow.acceptance_progress_valid(
+        {
+            "adapter": "lammps",
+            "prediction_status": "observed_lammps_timing",
+            "timing_source": "lammps_thermo_cpu",
+            "eta_seconds": 10**10000,
+            "absolute_step": 3.0,
+        }
+    )
+
+
+@pytest.mark.parametrize("first_source", ["package_log", "jarvis_stdout"])
+def test_adapter_never_double_counts_dual_source_replay(first_source: str) -> None:
+    """A thermo run replayed from the second channel must not advance twice."""
+    adapter = LammpsThermoProgressAdapter(total_steps=100)
+    thermo = (
+        "run 100\nStep Temp CPU\n"
+        "0 1.0 0.0\n50 1.1 1.0\n100 1.2 2.0\n"
+        "Loop time of 2.0 on 1 procs for 100 steps\n"
+    )
+    jarvis = f"[builtin.lammps] [START] BEGIN\n{thermo}[builtin.lammps] [START] END\n"
+
+    if first_source == "package_log":
+        first = adapter.observe_stdout(thermo)
+        replay = adapter.observe_jarvis_stdout(jarvis)
+    else:
+        first = adapter.observe_jarvis_stdout(jarvis)
+        replay = adapter.observe_stdout(thermo)
+
+    assert [record["current"] for record in first] == [0.0, 50.0, 100.0]
+    assert replay == []
+    assert adapter.authoritative_source == first_source
+    assert adapter.completed_steps == 100.0
+
+
+def test_adapter_resets_package_log_after_replacement() -> None:
+    """A replaced or truncated log begins a fresh execution at step zero."""
+    adapter = LammpsThermoProgressAdapter(total_steps=100)
+    thermo = (
+        "run 100\nStep Temp CPU\n"
+        "0 1.0 0.0\n50 1.1 1.0\n100 1.2 2.0\n"
+        "Loop time of 2.0 on 1 procs for 100 steps\n"
+    )
+    assert [record["current"] for record in adapter.observe_stdout(thermo)] == [
+        0.0,
+        50.0,
+        100.0,
+    ]
+
+    adapter.reset_stdout()
+    replacement = adapter.observe_stdout(
+        "run 100\nStep Temp CPU\n0 1.0 0.0\n25 1.1 1.0\n"
+    )
+
+    assert [record["current"] for record in replacement] == [0.0, 25.0]
+    assert adapter.authoritative_source == "package_log"
+    assert adapter.completed_steps == 0.0
+
+
+def test_adapter_counts_run_upto_from_observed_timestep_delta() -> None:
+    """LAMMPS ``run N upto`` uses N as a target, not a relative run length."""
+    adapter = LammpsThermoProgressAdapter(total_steps=150)
+
+    records = adapter.observe_stdout(
+        "reset_timestep 100\nrun 200 upto\nStep Temp CPU\n"
+        "100 1.0 0.0\n150 1.1 1.0\n200 1.2 2.0\n"
+        "Loop time of 2.0 on 1 procs for 100 steps\n"
+        "run 50\nStep Temp CPU\n"
+        "200 1.2 0.0\n225 1.3 1.0\n250 1.4 2.0\n"
+        "Loop time of 2.0 on 1 procs for 50 steps\n"
+    )
+
+    assert [record["current"] for record in records] == [
+        0.0,
+        50.0,
+        100.0,
+        100.0,
+        125.0,
+        150.0,
+    ]
+    assert adapter.completed_steps == 150.0
+
+
+def test_adapter_rejects_zero_elapsed_rate_for_eta() -> None:
+    """Rounded duplicate CPU timestamps cannot claim an observed zero ETA."""
+    adapter = LammpsThermoProgressAdapter(total_steps=100)
+
+    records = adapter.observe_stdout(
+        "run 100\nStep Temp CPU\n0 1.0 0.0\n25 1.1 0.0\n50 1.2 0.0\n75 1.3 0.0\n"
+    )
+
+    metadata = records[-1]["metadata"]
+    assert metadata["prediction_status"] == "warming_up"
+    assert "eta_seconds" not in metadata
+    assert not adapter.acceptance_progress_valid(metadata)

--- a/test/unit/core/test_paraview_progress.py
+++ b/test/unit/core/test_paraview_progress.py
@@ -1,0 +1,357 @@
+"""Tests for generic builtin ParaView progress and batch execution."""
+
+from __future__ import annotations
+
+import ast
+import io
+import os
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.progress.paraview import (
+    ParaViewProgressAdapter,
+    ParaViewProgressReporter,
+    adapter_from_package,
+)
+from jarvis_cd.progress import ProgressStore
+
+
+def _structured_lines() -> tuple[str, list[dict[str, Any]]]:
+    stream = io.StringIO()
+    reporter = ParaViewProgressReporter(
+        package_name="builtin.paraview",
+        package_id="asteroid_render",
+        execution_id="exec_asteroid",
+        stream=stream,
+    )
+    first = reporter.frame_completed(1, total_frames=2, timestep=0.0)
+    second = reporter.frame_completed(
+        2,
+        total_frames=2,
+        timestep=1.0,
+        output_path="frame-0002.png",
+    )
+    assert first is not None and second is not None
+    return stream.getvalue(), [first, second]
+
+
+def test_standalone_reporter_is_python_310_stdlib() -> None:
+    """Ares pvbatch can parse the helper without importing JARVIS Python."""
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "paraview"
+        / "progress_reporter.py"
+    )
+    source = path.read_text(encoding="utf-8")
+
+    ast.parse(source, filename=str(path), feature_version=(3, 10))
+    assert "import jarvis" not in source
+
+
+def test_pvbatch_reports_only_completed_units_with_real_optional_total() -> None:
+    """Determinate progress exists only when the render script knows its total."""
+    lines, events = _structured_lines()
+    assert events[0]["determinate"] is True
+    assert events[1]["state"] == "completed"
+    assert events[1]["metadata"]["completed_after_render"] is True
+
+    adapter = ParaViewProgressAdapter(
+        package_id="asteroid_render",
+        run_id="exec_asteroid",
+    )
+    framed = (
+        "[builtin.paraview] [START] BEGIN\n"
+        + lines
+        + "[builtin.paraview] [START] END\n"
+    )
+    records = adapter.observe_jarvis_stdout(framed)
+
+    assert [record["current"] for record in records] == [1.0, 2.0]
+    assert [record["total"] for record in records] == [2.0, 2.0]
+    assert adapter.acceptance_progress_valid(records[-1]["metadata"])
+
+    stream = io.StringIO()
+    reporter = ParaViewProgressReporter(
+        package_name="builtin.paraview",
+        package_id="open_ended",
+        execution_id="exec_open",
+        stream=stream,
+    )
+    event = reporter.timestep_completed(1, timestep=3.5)
+    assert event is not None
+    assert event["determinate"] is False
+    assert "total" not in event
+    assert event["metadata"]["completion_signal"] == "pipeline_update_returned"
+    assert event["metadata"]["completed_after_update"] is True
+    assert "completed_after_render" not in event["metadata"]
+
+
+def test_pvbatch_nonroot_rank_does_not_duplicate_progress() -> None:
+    """Only MPI rank zero emits the shared pvbatch progress stream."""
+    stream = io.StringIO()
+    reporter = ParaViewProgressReporter(
+        package_name="builtin.paraview",
+        package_id="parallel_render",
+        execution_id="exec_parallel",
+        stream=stream,
+        rank=1,
+    )
+
+    assert reporter.frame_completed(1, total_frames=2) is None
+    assert stream.getvalue() == ""
+
+
+def test_pvserver_readiness_is_an_indeterminate_state() -> None:
+    """A real server-ready marker is not presented as a percentage."""
+    adapter = ParaViewProgressAdapter(package_id="server", run_id="exec_server")
+
+    records = adapter.observe_jarvis_stdout(
+        "[builtin.paraview] [START] BEGIN\n"
+        "Waiting for client... Accepting connection(s): localhost:11111\n"
+        "[builtin.paraview] [START] END\n"
+    )
+
+    assert len(records) == 1
+    assert "total" not in records[0]
+    assert records[0]["current"] == 0.0
+    metadata = records[0]["metadata"]
+    assert metadata["determinate"] is False
+    assert metadata["compatibility_projection"] == "indeterminate_state_ordinal"
+    assert metadata["readiness_signal"] == "pvserver_accepting_connections"
+    assert adapter.acceptance_progress_valid(metadata)
+
+    waiting_adapter = ParaViewProgressAdapter(
+        package_id="waiting-server",
+        run_id="exec_waiting",
+    )
+    waiting = waiting_adapter.observe_jarvis_stdout(
+        "[builtin.paraview] [START] BEGIN\n"
+        "Waiting for client on port 11111\n"
+        "[builtin.paraview] [START] END\n"
+    )
+    assert len(waiting) == 1
+    waiting_metadata = waiting[0]["metadata"]
+    assert waiting_metadata["readiness_signal"] == "pvserver_waiting_for_client"
+    assert waiting[0]["message"] == "ParaView server is waiting for a client"
+    assert waiting_adapter.acceptance_progress_valid(waiting_metadata)
+
+
+def test_paraview_factory_is_package_local_and_path_is_not_config_owned(
+    tmp_path: Path,
+) -> None:
+    """An arbitrary YAML path cannot become the authoritative sidecar."""
+    assert adapter_from_package({"pkg_type": "builtin.lammps"}) is None
+    adapter = adapter_from_package(
+        {
+            "pkg_type": "builtin.paraview",
+            "pkg_id": "render_a",
+            "progress": {
+                "log_visibility": "shared",
+                "path": str(tmp_path / "untrusted.jsonl"),
+            },
+        }
+    )
+    assert isinstance(adapter, ParaViewProgressAdapter)
+    assert adapter.package_id == "render_a"
+    assert adapter.progress_log_paths() == []
+
+
+def _load_paraview_package() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "paraview"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_paraview_runtime_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load ParaView package: {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _CapturedExec:
+    commands: list[tuple[str, Any]] = []
+    exit_codes: dict[str, int] = {"localhost": 0}
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = dict(self.exit_codes)
+        self.commands.append((command, exec_info))
+
+    def run(self) -> "_CapturedExec":
+        return self
+
+
+def test_generic_paraview_batch_honors_binary_options_and_hostfile(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Ares can select pvbatch, --mesa, and the allocated hostfile generically."""
+    module = _load_paraview_package()
+    package = object.__new__(module.Paraview)
+    assert module.__file__ is not None
+    package.pkg_dir = str(Path(module.__file__).resolve().parent)
+    hostfile = object()
+    package.pkg_id = "asteroid_render"
+    package.pkg_type = "builtin.paraview"
+    package.global_id = "paraview_progress.asteroid_render"
+    package.shared_dir = str(tmp_path / "shared" / "asteroid_render")
+    package.private_dir = str(tmp_path / "private" / "asteroid_render")
+    package.config = {
+        "cwd": str(tmp_path),
+        "force_offscreen_rendering": True,
+        "mode": "batch",
+        "nprocs": 2,
+        "ppn": 2,
+        "pvbatch_bin": "/opt/paraview/bin/pvbatch",
+        "pvbatch_options": "--mesa --verbosity INFO",
+        "script": str(tmp_path / "asteroid script.py"),
+        "script_args": "--frames 2",
+    }
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: hostfile)
+    package.env = {}
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec_asteroid",
+        "JARVIS_PACKAGE_ID": "asteroid_render",
+        "JARVIS_PROGRESS_PATH": str(tmp_path / "progress.jsonl"),
+    }
+    _CapturedExec.commands = []
+    _CapturedExec.exit_codes = {"localhost": 0}
+    monkeypatch.setattr(module, "Exec", _CapturedExec)
+
+    package.start()
+
+    command, exec_info = _CapturedExec.commands[0]
+    assert command.startswith("/opt/paraview/bin/pvbatch --mesa --verbosity INFO")
+    assert "--force-offscreen-rendering" in command
+    assert exec_info.hostfile is hostfile
+    assert exec_info.env["JARVIS_PACKAGE_NAME"] == "builtin.paraview"
+    assert exec_info.env["JARVIS_PACKAGE_ID"] == "asteroid_render"
+    assert exec_info.env["JARVIS_PROGRESS_TRANSPORT"] == "stdout"
+    reporter_path = Path(exec_info.env["JARVIS_PARAVIEW_REPORTER"])
+    assert reporter_path.parent == Path(package.shared_dir) / ".jarvis-progress"
+    assert module.__file__ is not None
+    assert (
+        reporter_path.read_bytes()
+        == (
+            Path(module.__file__).resolve().parent / "progress_reporter.py"
+        ).read_bytes()
+    )
+
+    lines, _ = _structured_lines()
+    for line in lines.splitlines(keepends=True):
+        exec_info.line_callback("stdout", line)
+    events = ProgressStore(tmp_path / "progress.jsonl").read_all()
+    assert [event.current for event in events] == [1.0, 2.0]
+
+
+def test_single_process_container_stages_reporter_and_uses_local_exec(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A mounted package path carries the reporter into a one-rank container."""
+    module = _load_paraview_package()
+    package = object.__new__(module.Paraview)
+    assert module.__file__ is not None
+    package.pkg_dir = str(Path(module.__file__).resolve().parent)
+    hostfile = object()
+    package.pkg_id = "container_render"
+    package.pkg_type = "builtin.paraview"
+    package.global_id = "paraview_progress.container_render"
+    package.shared_dir = str(tmp_path / "shared" / "container_render")
+    package.private_dir = str(tmp_path / "private" / "container_render")
+    package.config = {
+        "cwd": str(tmp_path),
+        "deploy_mode": "container",
+        "force_offscreen_rendering": True,
+        "mode": "batch",
+        "nprocs": 1,
+        "ppn": 1,
+        "pvbatch_bin": "pvbatch",
+        "pvbatch_options": "--mesa",
+        "script": str(tmp_path / "render.py"),
+        "script_args": "--frames 2",
+    }
+    package.pipeline = SimpleNamespace(
+        container_engine="apptainer",
+        execution_container_name="paraview-progress-exec",
+        get_hostfile=lambda: hostfile,
+        name="paraview_progress",
+        _has_containerized_packages=lambda: True,
+    )
+    package.env = {}
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec_container",
+        "JARVIS_PACKAGE_ID": "container_render",
+        "JARVIS_PROGRESS_PATH": str(tmp_path / "progress.jsonl"),
+    }
+    _CapturedExec.commands = []
+    _CapturedExec.exit_codes = {"localhost": 0}
+    monkeypatch.setattr(module, "Exec", _CapturedExec)
+
+    package.start()
+
+    _, exec_info = _CapturedExec.commands[0]
+    assert isinstance(exec_info, module.LocalExecInfo)
+    assert exec_info.container == "apptainer"
+    assert exec_info.container_image == "paraview-progress-exec"
+    assert exec_info.shared_dir == package.shared_dir
+    assert exec_info.bind_mounts == [
+        f"{package.shared_dir}:{package.shared_dir}",
+        f"{package.private_dir}:{package.private_dir}",
+    ]
+    reporter_path = Path(exec_info.env["JARVIS_PARAVIEW_REPORTER"])
+    assert reporter_path.is_file()
+    assert reporter_path.parent == Path(package.shared_dir) / ".jarvis-progress"
+    assert exec_info.env["PYTHONPATH"].split(os.pathsep)[0] == str(reporter_path.parent)
+
+
+@pytest.mark.parametrize(
+    ("mode", "operation"),
+    [("batch", "ParaView batch"), ("server", "ParaView server")],
+)
+def test_paraview_exit_failure_propagates_to_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mode: str,
+    operation: str,
+) -> None:
+    """A failed pvbatch or pvserver process cannot become a completed run."""
+    module = _load_paraview_package()
+    package = object.__new__(module.Paraview)
+    package.pkg_id = "failed_render"
+    package.pkg_type = "builtin.paraview"
+    package.shared_dir = str(tmp_path / "shared" / "failed_render")
+    package.private_dir = str(tmp_path / "private" / "failed_render")
+    package.config = {
+        "cwd": str(tmp_path),
+        "force_offscreen_rendering": True,
+        "mode": mode,
+        "nprocs": 1,
+        "ppn": 1,
+        "port_id": 11111,
+        "pvbatch_bin": "pvbatch",
+        "pvbatch_options": "--mesa",
+        "script": str(tmp_path / "render.py"),
+        "script_args": "",
+        "time_out": 10,
+    }
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: object())
+    package.env = {}
+    package.mod_env = {}
+    _CapturedExec.commands = []
+    _CapturedExec.exit_codes = {"compute-1": 7}
+    monkeypatch.setattr(module, "Exec", _CapturedExec)
+
+    with pytest.raises(RuntimeError, match=rf"{operation} failed.*compute-1=7"):
+        package.start()

--- a/test/unit/core/test_pipeline_coverage.py
+++ b/test/unit/core/test_pipeline_coverage.py
@@ -12,40 +12,44 @@ Covers:
 - pipeline._generate_pipeline_container_yaml()
 - pipeline._validate_required_config()
 """
+
 import os
 import sys
 import shutil
 import tempfile
 import unittest
+from unittest.mock import patch
 import yaml
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
 from jarvis_cd.core.config import Jarvis
 from jarvis_cd.core.pipeline import Pipeline
+from jarvis_cd.shell.exec_info import ExecType
+from jarvis_cd.util.hostfile import Hostfile
 
 
 # ---------------------------------------------------------------------------
 # Test helpers
 # ---------------------------------------------------------------------------
 
+
 def initialize_jarvis_for_test(config_dir, private_dir, shared_dir):
     jarvis = Jarvis.get_instance()
     saved_config = None
     if jarvis.config_file.exists():
-        with open(jarvis.config_file, 'r') as f:
+        with open(jarvis.config_file, "r") as f:
             saved_config = yaml.safe_load(f)
     jarvis.initialize(config_dir, private_dir, shared_dir, force=False)
     return jarvis, saved_config
 
 
 class TestPipelineCoverage(unittest.TestCase):
-
     def setUp(self):
-        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_pipeline_coverage_')
-        self.config_dir = os.path.join(self.test_dir, 'config')
-        self.private_dir = os.path.join(self.test_dir, 'private')
-        self.shared_dir = os.path.join(self.test_dir, 'shared')
+        self.test_dir = tempfile.mkdtemp(prefix="jarvis_test_pipeline_coverage_")
+        self.config_dir = os.path.join(self.test_dir, "config")
+        self.private_dir = os.path.join(self.test_dir, "private")
+        self.shared_dir = os.path.join(self.test_dir, "shared")
         for d in [self.config_dir, self.private_dir, self.shared_dir]:
             os.makedirs(d, exist_ok=True)
 
@@ -57,9 +61,11 @@ class TestPipelineCoverage(unittest.TestCase):
         if self._saved_config:
             jarvis = Jarvis.get_instance()
             jarvis.save_config(self._saved_config)
-            jarvis.config_dir = self._saved_config.get('config_dir', jarvis.config_dir)
-            jarvis.private_dir = self._saved_config.get('private_dir', jarvis.private_dir)
-            jarvis.shared_dir = self._saved_config.get('shared_dir', jarvis.shared_dir)
+            jarvis.config_dir = self._saved_config.get("config_dir", jarvis.config_dir)
+            jarvis.private_dir = self._saved_config.get(
+                "private_dir", jarvis.private_dir
+            )
+            jarvis.shared_dir = self._saved_config.get("shared_dir", jarvis.shared_dir)
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
@@ -74,17 +80,23 @@ class TestPipelineCoverage(unittest.TestCase):
 
     def _make_ior_pkg_def(self, pipeline_name):
         return {
-            'pkg_type': 'builtin.ior',
-            'pkg_id': 'ior',
-            'pkg_name': 'ior',
-            'global_id': f'{pipeline_name}.ior',
-            'config': {
-                'nprocs': 2, 'ppn': 2,
-                'block': '32m', 'xfer': '1m',
-                'api': 'posix', 'out': '/tmp/ior.bin',
-                'write': True, 'read': False,
-                'fpp': False, 'reps': 1, 'direct': False,
-                'interceptors': [],
+            "pkg_type": "builtin.ior",
+            "pkg_id": "ior",
+            "pkg_name": "ior",
+            "global_id": f"{pipeline_name}.ior",
+            "config": {
+                "nprocs": 2,
+                "ppn": 2,
+                "block": "32m",
+                "xfer": "1m",
+                "api": "posix",
+                "out": os.path.join(self.shared_dir, "ior.bin"),
+                "write": True,
+                "read": False,
+                "fpp": False,
+                "reps": 1,
+                "direct": False,
+                "interceptors": [],
             },
         }
 
@@ -94,15 +106,16 @@ class TestPipelineCoverage(unittest.TestCase):
 
     def test_destroy_removes_pipeline_dirs(self):
         """destroy() should remove config/shared/private dirs for the pipeline."""
-        pipeline = self._make_pipeline('destroy_test')
+        pipeline = self._make_pipeline("destroy_test")
 
-        config_dir = self.jarvis.get_pipeline_dir('destroy_test')
-        shared_dir = self.jarvis.get_pipeline_shared_dir('destroy_test')
-        private_dir = self.jarvis.get_pipeline_private_dir('destroy_test')
+        config_dir = self.jarvis.get_pipeline_dir("destroy_test")
+        shared_dir = self.jarvis.get_pipeline_shared_dir("destroy_test")
+        private_dir = self.jarvis.get_pipeline_private_dir("destroy_test")
 
         # All three directories must exist before destroy
         self.assertTrue(config_dir.exists(), "config dir should exist before destroy")
         self.assertTrue(shared_dir.exists(), "shared dir should exist before destroy")
+        self.assertTrue(private_dir.exists(), "private dir should exist before destroy")
 
         pipeline.destroy()
 
@@ -114,22 +127,22 @@ class TestPipelineCoverage(unittest.TestCase):
 
     def test_rm_package_removes_from_list(self):
         """rm() removes the named package from pipeline.packages."""
-        pipeline = self._make_pipeline('rm_test')
-        pkg_def = self._make_ior_pkg_def('rm_test')
+        pipeline = self._make_pipeline("rm_test")
+        pkg_def = self._make_ior_pkg_def("rm_test")
         pipeline.packages.append(pkg_def)
         pipeline._propagate_deploy_mode()
         pipeline.save()
 
         self.assertEqual(len(pipeline.packages), 1)
-        pipeline.rm('ior')
+        pipeline.rm("ior")
         self.assertEqual(len(pipeline.packages), 0)
 
     def test_rm_nonexistent_package_no_crash(self):
         """rm() on a non-existent package ID must not raise."""
-        pipeline = self._make_pipeline('rm_noexist')
+        pipeline = self._make_pipeline("rm_noexist")
         # Should print a message but not raise
         try:
-            pipeline.rm('nonexistent')
+            pipeline.rm("nonexistent")
         except Exception as e:
             self.fail(f"rm() raised unexpectedly: {e}")
 
@@ -139,7 +152,7 @@ class TestPipelineCoverage(unittest.TestCase):
 
     def test_status_returns_string(self):
         """status() must return a string (even with no packages)."""
-        pipeline = self._make_pipeline('status_test')
+        pipeline = self._make_pipeline("status_test")
         result = pipeline.status()
         self.assertIsInstance(result, str)
 
@@ -161,8 +174,8 @@ class TestPipelineCoverage(unittest.TestCase):
 
     def test_validate_unique_ids_passes_for_unique(self):
         """_validate_unique_ids() does not raise when IDs are distinct."""
-        pipeline = self._make_pipeline('uid_pass')
-        pkg_def = self._make_ior_pkg_def('uid_pass')
+        pipeline = self._make_pipeline("uid_pass")
+        pkg_def = self._make_ior_pkg_def("uid_pass")
         pipeline.packages.append(pkg_def)
         # interceptors dict is empty — no conflict
         try:
@@ -172,16 +185,16 @@ class TestPipelineCoverage(unittest.TestCase):
 
     def test_validate_unique_ids_raises_for_duplicate(self):
         """_validate_unique_ids() raises when a package ID collides with an interceptor ID."""
-        pipeline = self._make_pipeline('uid_fail')
-        pkg_def = self._make_ior_pkg_def('uid_fail')
+        pipeline = self._make_pipeline("uid_fail")
+        pkg_def = self._make_ior_pkg_def("uid_fail")
         pipeline.packages.append(pkg_def)
         # Add a fake interceptor with the same id 'ior'
-        pipeline.interceptors['ior'] = {
-            'pkg_type': 'builtin.ior',
-            'pkg_id': 'ior',
-            'pkg_name': 'ior',
-            'global_id': 'uid_fail.ior',
-            'config': {},
+        pipeline.interceptors["ior"] = {
+            "pkg_type": "builtin.ior",
+            "pkg_id": "ior",
+            "pkg_name": "ior",
+            "global_id": "uid_fail.ior",
+            "config": {},
         }
         with self.assertRaises((ValueError, Exception)):
             pipeline._validate_unique_ids()
@@ -192,8 +205,8 @@ class TestPipelineCoverage(unittest.TestCase):
 
     def test_get_package_default_config_returns_dict(self):
         """_get_package_default_config('builtin.ior') must return a non-empty dict."""
-        pipeline = self._make_pipeline('defcfg_test')
-        result = pipeline._get_package_default_config('builtin.ior')
+        pipeline = self._make_pipeline("defcfg_test")
+        result = pipeline._get_package_default_config("builtin.ior")
         self.assertIsInstance(result, dict)
         self.assertGreater(len(result), 0)
 
@@ -203,18 +216,55 @@ class TestPipelineCoverage(unittest.TestCase):
 
     def test_configure_package_updates_config(self):
         """configure_package() updates the config field for the named package."""
-        pipeline = self._make_pipeline('cfgpkg_test')
-        pkg_def = self._make_ior_pkg_def('cfgpkg_test')
+        pipeline = self._make_pipeline("cfgpkg_test")
+        pkg_def = self._make_ior_pkg_def("cfgpkg_test")
         pipeline.packages.append(pkg_def)
         pipeline._propagate_deploy_mode()
         pipeline.save()
 
         # nprocs starts at 2; reconfigure to 8
-        pipeline.configure_package('ior', ['--nprocs=8'])
+        pipeline.configure_package("ior", ["--nprocs=8"])
 
         # Reload pipeline and confirm nprocs was persisted
-        pipeline2 = Pipeline('cfgpkg_test')
-        self.assertEqual(pipeline2.packages[0]['config'].get('nprocs'), 8)
+        pipeline2 = Pipeline("cfgpkg_test")
+        self.assertEqual(pipeline2.packages[0]["config"].get("nprocs"), 8)
+
+    def test_configure_localhost_does_not_require_ssh(self):
+        """Local IOR setup remains usable when localhost SSH is unavailable."""
+        pipeline = self._make_pipeline("cfgpkg_local")
+        pkg_def = self._make_ior_pkg_def("cfgpkg_local")
+        pipeline.packages.append(pkg_def)
+        pipeline._propagate_deploy_mode()
+        pipeline.save()
+
+        with patch(
+            "jarvis_cd.shell.ssh_exec.SshExec",
+            side_effect=AssertionError("localhost SSH must not be attempted"),
+        ) as ssh_exec:
+            pipeline.configure_package("ior", ["--nprocs=4"])
+
+        ssh_exec.assert_not_called()
+        self.assertTrue(os.path.isdir(os.path.dirname(pkg_def["config"]["out"])))
+        self.assertEqual(pkg_def["config"]["nprocs"], 4)
+
+    def test_configure_remote_directory_uses_bounded_pssh(self):
+        """Remote IOR setup retains all-host PSSH with a hard time bound."""
+        pipeline = self._make_pipeline("cfgpkg_remote")
+        pipeline.hostfile = Hostfile(hosts=["node-a"], find_ips=False)
+        pkg_def = self._make_ior_pkg_def("cfgpkg_remote")
+        pipeline.packages.append(pkg_def)
+        pipeline._propagate_deploy_mode()
+        pipeline.save()
+
+        with patch("builtin.ior.pkg.Mkdir") as mkdir:
+            pipeline.configure_package("ior", ["--nprocs=4"])
+
+        mkdir.assert_called_once()
+        mkdir.return_value.run.assert_called_once_with()
+        exec_info = mkdir.call_args.args[1]
+        self.assertEqual(exec_info.exec_type, ExecType.PSSH)
+        self.assertEqual(exec_info.hostfile.hosts, ["node-a"])
+        self.assertEqual(exec_info.timeout, 30)
 
     # ------------------------------------------------------------------
     # save / load container fields
@@ -222,39 +272,39 @@ class TestPipelineCoverage(unittest.TestCase):
 
     def test_save_load_container_engine(self):
         """container_engine is persisted across save/load cycles."""
-        pipeline = self._make_pipeline('ce_test')
-        pipeline.container_engine = 'podman'
+        pipeline = self._make_pipeline("ce_test")
+        pipeline.container_engine = "podman"
         pipeline.save()
 
-        pipeline2 = Pipeline('ce_test')
-        self.assertEqual(pipeline2.container_engine, 'podman')
+        pipeline2 = Pipeline("ce_test")
+        self.assertEqual(pipeline2.container_engine, "podman")
 
     def test_save_load_base_deploy_mode(self):
         """base_deploy_mode='container' is persisted across save/load cycles."""
-        pipeline = self._make_pipeline('im_test')
-        pipeline.base_deploy_mode = 'container'
+        pipeline = self._make_pipeline("im_test")
+        pipeline.base_deploy_mode = "container"
         pipeline.save()
 
-        pipeline2 = Pipeline('im_test')
-        self.assertEqual(pipeline2.base_deploy_mode, 'container')
+        pipeline2 = Pipeline("im_test")
+        self.assertEqual(pipeline2.base_deploy_mode, "container")
 
     def test_save_load_container_base(self):
         """container_base is persisted across save/load cycles."""
-        pipeline = self._make_pipeline('cb_test')
-        pipeline.container_base = 'ubuntu:22.04'
+        pipeline = self._make_pipeline("cb_test")
+        pipeline.container_base = "ubuntu:22.04"
         pipeline.save()
 
-        pipeline2 = Pipeline('cb_test')
-        self.assertEqual(pipeline2.container_base, 'ubuntu:22.04')
+        pipeline2 = Pipeline("cb_test")
+        self.assertEqual(pipeline2.container_base, "ubuntu:22.04")
 
     def test_save_load_deploy_image(self):
         """container_image (deploy image) is persisted across save/load cycles."""
-        pipeline = self._make_pipeline('di_test')
-        pipeline.container_image = 'myimg:latest'
+        pipeline = self._make_pipeline("di_test")
+        pipeline.container_image = "myimg:latest"
         pipeline.save()
 
-        pipeline2 = Pipeline('di_test')
-        self.assertEqual(pipeline2.container_image, 'myimg:latest')
+        pipeline2 = Pipeline("di_test")
+        self.assertEqual(pipeline2.container_image, "myimg:latest")
 
     # ------------------------------------------------------------------
     # _generate_pipeline_container_yaml()
@@ -262,32 +312,33 @@ class TestPipelineCoverage(unittest.TestCase):
 
     def test_generate_container_yaml_creates_file(self):
         """_generate_pipeline_container_yaml() writes pipeline.yaml to shared_dir."""
-        pipeline = self._make_pipeline('gcy_test')
-        pkg_def = self._make_ior_pkg_def('gcy_test')
+        pipeline = self._make_pipeline("gcy_test")
+        pkg_def = self._make_ior_pkg_def("gcy_test")
         pipeline.packages.append(pkg_def)
         pipeline.save()
 
         yaml_path = pipeline._generate_pipeline_container_yaml()
 
-        self.assertTrue(os.path.exists(str(yaml_path)),
-                        f"Expected YAML file at {yaml_path}")
+        self.assertTrue(
+            os.path.exists(str(yaml_path)), f"Expected YAML file at {yaml_path}"
+        )
 
     def test_generate_container_yaml_has_packages(self):
         """The generated YAML file contains the pipeline packages."""
-        pipeline = self._make_pipeline('gcy_pkgs_test')
-        pkg_def = self._make_ior_pkg_def('gcy_pkgs_test')
+        pipeline = self._make_pipeline("gcy_pkgs_test")
+        pkg_def = self._make_ior_pkg_def("gcy_pkgs_test")
         pipeline.packages.append(pkg_def)
         pipeline.save()
 
         yaml_path = pipeline._generate_pipeline_container_yaml()
 
-        with open(str(yaml_path), 'r') as f:
+        with open(str(yaml_path), "r") as f:
             data = yaml.safe_load(f)
 
-        self.assertIn('pkgs', data)
-        self.assertGreater(len(data['pkgs']), 0)
-        pkg_types = [p['pkg_type'] for p in data['pkgs']]
-        self.assertIn('builtin.ior', pkg_types)
+        self.assertIn("pkgs", data)
+        self.assertGreater(len(data["pkgs"]), 0)
+        pkg_types = [p["pkg_type"] for p in data["pkgs"]]
+        self.assertIn("builtin.ior", pkg_types)
 
     # ------------------------------------------------------------------
     # _validate_required_config()
@@ -295,25 +346,31 @@ class TestPipelineCoverage(unittest.TestCase):
 
     def test_validate_required_passes_when_all_present(self):
         """_validate_required_config() does not raise when config has all fields."""
-        pipeline = self._make_pipeline('vrc_pass')
+        pipeline = self._make_pipeline("vrc_pass")
         # Provide a full IOR config so nothing is missing
         full_config = {
-            'nprocs': 2, 'ppn': 2,
-            'block': '32m', 'xfer': '1m',
-            'api': 'posix', 'out': '/tmp/ior.bin',
-            'write': True, 'read': False,
-            'fpp': False, 'reps': 1, 'direct': False,
-            'interceptors': [],
+            "nprocs": 2,
+            "ppn": 2,
+            "block": "32m",
+            "xfer": "1m",
+            "api": "posix",
+            "out": "/tmp/ior.bin",
+            "write": True,
+            "read": False,
+            "fpp": False,
+            "reps": 1,
+            "direct": False,
+            "interceptors": [],
         }
         try:
-            pipeline._validate_required_config('builtin.ior', full_config)
+            pipeline._validate_required_config("builtin.ior", full_config)
         except ValueError as e:
-            if 'Missing required' in str(e):
+            if "Missing required" in str(e):
                 self.fail(f"_validate_required_config raised unexpectedly: {e}")
 
     def test_validate_required_raises_when_missing(self):
         """_validate_required_config() raises ValueError when required fields are absent."""
-        pipeline = self._make_pipeline('vrc_fail')
+        pipeline = self._make_pipeline("vrc_fail")
 
         # Use a package type that is known to have required fields with no default.
         # We patch configure_menu to inject a required field ourselves so the
@@ -322,14 +379,14 @@ class TestPipelineCoverage(unittest.TestCase):
 
         mock_pkg = MagicMock()
         mock_pkg.configure_menu.return_value = [
-            {'name': 'required_field', 'default': None},
+            {"name": "required_field", "default": None},
         ]
 
-        with patch.object(pipeline, '_load_package_instance', return_value=mock_pkg):
+        with patch.object(pipeline, "_load_package_instance", return_value=mock_pkg):
             with self.assertRaises(ValueError) as ctx:
-                pipeline._validate_required_config('builtin.ior', {})
-        self.assertIn('Missing required', str(ctx.exception))
+                pipeline._validate_required_config("builtin.ior", {})
+        self.assertIn("Missing required", str(ctx.exception))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/unit/core/test_pkg_methods.py
+++ b/test/unit/core/test_pkg_methods.py
@@ -2,15 +2,16 @@
 Comprehensive unit tests for jarvis_cd/core/pkg.py
 Focuses on methods with low test coverage to improve overall coverage from 34% to 70%+
 """
+
 import unittest
 import sys
 import os
 import tempfile
 import shutil
 from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
 from jarvis_cd.core.pkg import Pkg, Application, Service, Interceptor
 from jarvis_cd.core.config import Jarvis
@@ -23,7 +24,8 @@ def initialize_jarvis_for_test(config_dir, private_dir, shared_dir):
     saved_config = None
     if jarvis.config_file.exists():
         import yaml
-        with open(jarvis.config_file, 'r') as f:
+
+        with open(jarvis.config_file, "r") as f:
             saved_config = yaml.safe_load(f)
     jarvis.initialize(config_dir, private_dir, shared_dir, force=False)
 
@@ -35,33 +37,36 @@ class TestPkgLoadStandalone(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment"""
-        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_standalone_')
-        self.config_dir = os.path.join(self.test_dir, 'config')
-        self.private_dir = os.path.join(self.test_dir, 'private')
-        self.shared_dir = os.path.join(self.test_dir, 'shared')
+        self.test_dir = tempfile.mkdtemp(prefix="jarvis_test_standalone_")
+        self.config_dir = os.path.join(self.test_dir, "config")
+        self.private_dir = os.path.join(self.test_dir, "private")
+        self.shared_dir = os.path.join(self.test_dir, "shared")
         os.makedirs(self.config_dir, exist_ok=True)
         os.makedirs(self.private_dir, exist_ok=True)
         os.makedirs(self.shared_dir, exist_ok=True)
 
         # Initialize Jarvis config
-        os.environ['JARVIS_CONFIG'] = self.config_dir
-        os.environ['JARVIS_PRIVATE'] = self.private_dir
-        os.environ['JARVIS_SHARED'] = self.shared_dir
+        os.environ["JARVIS_CONFIG"] = self.config_dir
+        os.environ["JARVIS_PRIVATE"] = self.private_dir
+        os.environ["JARVIS_SHARED"] = self.shared_dir
 
         # Initialize Jarvis properly
-        self.jarvis, self._saved_config = initialize_jarvis_for_test(self.config_dir, self.private_dir, self.shared_dir)
+        self.jarvis, self._saved_config = initialize_jarvis_for_test(
+            self.config_dir, self.private_dir, self.shared_dir
+        )
 
         self.original_env = os.environ.copy()
 
     def tearDown(self):
         """Clean up test environment"""
         if self._saved_config:
-            import yaml
             jarvis = Jarvis.get_instance()
             jarvis.save_config(self._saved_config)
-            jarvis.config_dir = self._saved_config.get('config_dir', jarvis.config_dir)
-            jarvis.private_dir = self._saved_config.get('private_dir', jarvis.private_dir)
-            jarvis.shared_dir = self._saved_config.get('shared_dir', jarvis.shared_dir)
+            jarvis.config_dir = self._saved_config.get("config_dir", jarvis.config_dir)
+            jarvis.private_dir = self._saved_config.get(
+                "private_dir", jarvis.private_dir
+            )
+            jarvis.shared_dir = self._saved_config.get("shared_dir", jarvis.shared_dir)
 
         os.environ.clear()
         os.environ.update(self.original_env)
@@ -70,19 +75,19 @@ class TestPkgLoadStandalone(unittest.TestCase):
             shutil.rmtree(self.test_dir)
 
         # Reset Jarvis singleton
-        if hasattr(Jarvis, '_instance'):
+        if hasattr(Jarvis, "_instance"):
             Jarvis._instance = None
 
     def test_load_standalone_with_full_spec(self):
         """Test load_standalone() with full package specification (repo.pkg)"""
         # Load example_app with full specification
-        pkg = Pkg.load_standalone('builtin.example_app')
+        pkg = Pkg.load_standalone("builtin.example_app")
 
         self.assertIsNotNone(pkg)
-        self.assertEqual(pkg.pkg_id, 'example_app')
-        self.assertEqual(pkg.global_id, 'standalone.example_app')
+        self.assertEqual(pkg.pkg_id, "example_app")
+        self.assertEqual(pkg.global_id, "standalone.example_app")
         self.assertIsNotNone(pkg.pipeline)
-        self.assertEqual(pkg.pipeline.name, 'standalone')
+        self.assertEqual(pkg.pipeline.name, "standalone")
         self.assertIsNotNone(pkg.config_dir)
         self.assertIsNotNone(pkg.shared_dir)
         self.assertIsNotNone(pkg.private_dir)
@@ -90,33 +95,33 @@ class TestPkgLoadStandalone(unittest.TestCase):
     def test_load_standalone_with_package_name_only(self):
         """Test load_standalone() with just package name (searches repos)"""
         # This should find example_app in builtin repo
-        pkg = Pkg.load_standalone('example_app')
+        pkg = Pkg.load_standalone("example_app")
 
         self.assertIsNotNone(pkg)
-        self.assertEqual(pkg.pkg_id, 'example_app')
-        self.assertEqual(pkg.global_id, 'standalone.example_app')
+        self.assertEqual(pkg.pkg_id, "example_app")
+        self.assertEqual(pkg.global_id, "standalone.example_app")
 
     def test_load_standalone_nonexistent_package(self):
         """Test load_standalone() with non-existent package"""
         with self.assertRaises(ValueError) as context:
-            Pkg.load_standalone('nonexistent.package')
+            Pkg.load_standalone("nonexistent.package")
 
-        self.assertIn('Repository not found', str(context.exception))
+        self.assertIn("Repository not found", str(context.exception))
 
     def test_load_standalone_invalid_package_name(self):
         """Test load_standalone() with invalid package name"""
         with self.assertRaises(ValueError) as context:
-            Pkg.load_standalone('completely_nonexistent_pkg')
+            Pkg.load_standalone("completely_nonexistent_pkg")
 
-        self.assertIn('Package not found', str(context.exception))
+        self.assertIn("Package not found", str(context.exception))
 
     def test_load_standalone_interceptor(self):
         """Test load_standalone() with interceptor package"""
-        pkg = Pkg.load_standalone('builtin.example_interceptor')
+        pkg = Pkg.load_standalone("builtin.example_interceptor")
 
         self.assertIsNotNone(pkg)
         self.assertIsInstance(pkg, Interceptor)
-        self.assertEqual(pkg.pkg_id, 'example_interceptor')
+        self.assertEqual(pkg.pkg_id, "example_interceptor")
 
 
 class TestPkgEnvironmentMethods(unittest.TestCase):
@@ -125,34 +130,37 @@ class TestPkgEnvironmentMethods(unittest.TestCase):
     def setUp(self):
         """Set up test environment with mock pipeline"""
         self.mock_pipeline = Mock()
-        self.mock_pipeline.name = 'test_pipeline'
+        self.mock_pipeline.name = "test_pipeline"
 
-        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_env_')
-        self.config_dir = os.path.join(self.test_dir, 'config')
-        self.private_dir = os.path.join(self.test_dir, 'private')
-        self.shared_dir = os.path.join(self.test_dir, 'shared')
+        self.test_dir = tempfile.mkdtemp(prefix="jarvis_test_env_")
+        self.config_dir = os.path.join(self.test_dir, "config")
+        self.private_dir = os.path.join(self.test_dir, "private")
+        self.shared_dir = os.path.join(self.test_dir, "shared")
         os.makedirs(self.config_dir, exist_ok=True)
         os.makedirs(self.private_dir, exist_ok=True)
         os.makedirs(self.shared_dir, exist_ok=True)
 
-        os.environ['JARVIS_CONFIG'] = self.config_dir
-        os.environ['JARVIS_PRIVATE'] = self.private_dir
-        os.environ['JARVIS_SHARED'] = self.shared_dir
+        os.environ["JARVIS_CONFIG"] = self.config_dir
+        os.environ["JARVIS_PRIVATE"] = self.private_dir
+        os.environ["JARVIS_SHARED"] = self.shared_dir
 
         # Initialize Jarvis properly
-        self.jarvis, self._saved_config = initialize_jarvis_for_test(self.config_dir, self.private_dir, self.shared_dir)
+        self.jarvis, self._saved_config = initialize_jarvis_for_test(
+            self.config_dir, self.private_dir, self.shared_dir
+        )
 
         self.original_env = os.environ.copy()
 
     def tearDown(self):
         """Clean up test environment"""
         if self._saved_config:
-            import yaml
             jarvis = Jarvis.get_instance()
             jarvis.save_config(self._saved_config)
-            jarvis.config_dir = self._saved_config.get('config_dir', jarvis.config_dir)
-            jarvis.private_dir = self._saved_config.get('private_dir', jarvis.private_dir)
-            jarvis.shared_dir = self._saved_config.get('shared_dir', jarvis.shared_dir)
+            jarvis.config_dir = self._saved_config.get("config_dir", jarvis.config_dir)
+            jarvis.private_dir = self._saved_config.get(
+                "private_dir", jarvis.private_dir
+            )
+            jarvis.shared_dir = self._saved_config.get("shared_dir", jarvis.shared_dir)
 
         os.environ.clear()
         os.environ.update(self.original_env)
@@ -160,7 +168,7 @@ class TestPkgEnvironmentMethods(unittest.TestCase):
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
-        if hasattr(Jarvis, '_instance'):
+        if hasattr(Jarvis, "_instance"):
             Jarvis._instance = None
 
     def test_track_env_basic(self):
@@ -168,107 +176,104 @@ class TestPkgEnvironmentMethods(unittest.TestCase):
         pkg = Pkg(pipeline=self.mock_pipeline)
 
         env_dict = {
-            'PATH': '/usr/bin:/bin',
-            'MY_VAR': 'test_value',
-            'ANOTHER_VAR': 'another_value'
+            "PATH": "/usr/bin:/bin",
+            "MY_VAR": "test_value",
+            "ANOTHER_VAR": "another_value",
         }
 
         pkg.track_env(env_dict)
 
         # Check that variables were added to env
-        self.assertEqual(pkg.env['PATH'], '/usr/bin:/bin')
-        self.assertEqual(pkg.env['MY_VAR'], 'test_value')
-        self.assertEqual(pkg.env['ANOTHER_VAR'], 'another_value')
+        self.assertEqual(pkg.env["PATH"], "/usr/bin:/bin")
+        self.assertEqual(pkg.env["MY_VAR"], "test_value")
+        self.assertEqual(pkg.env["ANOTHER_VAR"], "another_value")
 
         # Check that mod_env is a copy of env
-        self.assertEqual(pkg.mod_env['PATH'], '/usr/bin:/bin')
-        self.assertEqual(pkg.mod_env['MY_VAR'], 'test_value')
+        self.assertEqual(pkg.mod_env["PATH"], "/usr/bin:/bin")
+        self.assertEqual(pkg.mod_env["MY_VAR"], "test_value")
 
     def test_track_env_with_ld_preload(self):
         """Test track_env() with LD_PRELOAD (should only go to mod_env)"""
         pkg = Pkg(pipeline=self.mock_pipeline)
 
-        env_dict = {
-            'PATH': '/usr/bin',
-            'LD_PRELOAD': '/lib/interceptor.so'
-        }
+        env_dict = {"PATH": "/usr/bin", "LD_PRELOAD": "/lib/interceptor.so"}
 
         pkg.track_env(env_dict)
 
         # LD_PRELOAD should NOT be in env
-        self.assertNotIn('LD_PRELOAD', pkg.env)
+        self.assertNotIn("LD_PRELOAD", pkg.env)
 
         # But should be in mod_env
-        self.assertEqual(pkg.mod_env['LD_PRELOAD'], '/lib/interceptor.so')
+        self.assertEqual(pkg.mod_env["LD_PRELOAD"], "/lib/interceptor.so")
 
         # Other vars should be in both
-        self.assertEqual(pkg.env['PATH'], '/usr/bin')
-        self.assertEqual(pkg.mod_env['PATH'], '/usr/bin')
+        self.assertEqual(pkg.env["PATH"], "/usr/bin")
+        self.assertEqual(pkg.mod_env["PATH"], "/usr/bin")
 
     def test_prepend_env_regular_variable(self):
         """Test prepend_env() with regular environment variable"""
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.env['PATH'] = '/usr/bin'
-        pkg.mod_env['PATH'] = '/usr/bin'
+        pkg.env["PATH"] = "/usr/bin"
+        pkg.mod_env["PATH"] = "/usr/bin"
 
-        pkg.prepend_env('PATH', '/custom/bin')
+        pkg.prepend_env("PATH", "/custom/bin")
 
-        self.assertEqual(pkg.env['PATH'], '/custom/bin:/usr/bin')
-        self.assertEqual(pkg.mod_env['PATH'], '/custom/bin:/usr/bin')
+        self.assertEqual(pkg.env["PATH"], "/custom/bin:/usr/bin")
+        self.assertEqual(pkg.mod_env["PATH"], "/custom/bin:/usr/bin")
 
     def test_prepend_env_empty_variable(self):
         """Test prepend_env() when variable doesn't exist yet"""
         pkg = Pkg(pipeline=self.mock_pipeline)
 
-        pkg.prepend_env('NEW_PATH', '/some/path')
+        pkg.prepend_env("NEW_PATH", "/some/path")
 
-        self.assertEqual(pkg.env['NEW_PATH'], '/some/path')
-        self.assertEqual(pkg.mod_env['NEW_PATH'], '/some/path')
+        self.assertEqual(pkg.env["NEW_PATH"], "/some/path")
+        self.assertEqual(pkg.mod_env["NEW_PATH"], "/some/path")
 
     def test_prepend_env_ld_preload(self):
         """Test prepend_env() with LD_PRELOAD (should only modify mod_env)"""
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.mod_env['LD_PRELOAD'] = '/lib/existing.so'
+        pkg.mod_env["LD_PRELOAD"] = "/lib/existing.so"
 
-        pkg.prepend_env('LD_PRELOAD', '/lib/new.so')
+        pkg.prepend_env("LD_PRELOAD", "/lib/new.so")
 
         # LD_PRELOAD should NOT be in env
-        self.assertNotIn('LD_PRELOAD', pkg.env)
+        self.assertNotIn("LD_PRELOAD", pkg.env)
 
         # Should be prepended in mod_env
-        self.assertEqual(pkg.mod_env['LD_PRELOAD'], '/lib/new.so:/lib/existing.so')
+        self.assertEqual(pkg.mod_env["LD_PRELOAD"], "/lib/new.so:/lib/existing.so")
 
     def test_setenv_regular_variable(self):
         """Test setenv() with regular environment variable"""
         pkg = Pkg(pipeline=self.mock_pipeline)
 
-        pkg.setenv('MY_VAR', 'my_value')
+        pkg.setenv("MY_VAR", "my_value")
 
-        self.assertEqual(pkg.env['MY_VAR'], 'my_value')
-        self.assertEqual(pkg.mod_env['MY_VAR'], 'my_value')
+        self.assertEqual(pkg.env["MY_VAR"], "my_value")
+        self.assertEqual(pkg.mod_env["MY_VAR"], "my_value")
 
     def test_setenv_ld_preload(self):
         """Test setenv() with LD_PRELOAD (should only set mod_env)"""
         pkg = Pkg(pipeline=self.mock_pipeline)
 
-        pkg.setenv('LD_PRELOAD', '/lib/interceptor.so')
+        pkg.setenv("LD_PRELOAD", "/lib/interceptor.so")
 
         # LD_PRELOAD should NOT be in env
-        self.assertNotIn('LD_PRELOAD', pkg.env)
+        self.assertNotIn("LD_PRELOAD", pkg.env)
 
         # Should be in mod_env
-        self.assertEqual(pkg.mod_env['LD_PRELOAD'], '/lib/interceptor.so')
+        self.assertEqual(pkg.mod_env["LD_PRELOAD"], "/lib/interceptor.so")
 
     def test_setenv_overwrites_existing(self):
         """Test setenv() overwrites existing values"""
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.env['VAR'] = 'old_value'
-        pkg.mod_env['VAR'] = 'old_value'
+        pkg.env["VAR"] = "old_value"
+        pkg.mod_env["VAR"] = "old_value"
 
-        pkg.setenv('VAR', 'new_value')
+        pkg.setenv("VAR", "new_value")
 
-        self.assertEqual(pkg.env['VAR'], 'new_value')
-        self.assertEqual(pkg.mod_env['VAR'], 'new_value')
+        self.assertEqual(pkg.env["VAR"], "new_value")
+        self.assertEqual(pkg.mod_env["VAR"], "new_value")
 
 
 class TestPkgFindLibrary(unittest.TestCase):
@@ -276,38 +281,41 @@ class TestPkgFindLibrary(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment"""
-        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_lib_')
-        self.lib_dir = os.path.join(self.test_dir, 'lib')
+        self.test_dir = tempfile.mkdtemp(prefix="jarvis_test_lib_")
+        self.lib_dir = os.path.join(self.test_dir, "lib")
         os.makedirs(self.lib_dir, exist_ok=True)
 
         self.mock_pipeline = Mock()
-        self.mock_pipeline.name = 'test_pipeline'
+        self.mock_pipeline.name = "test_pipeline"
 
-        self.config_dir = os.path.join(self.test_dir, 'config')
-        self.private_dir = os.path.join(self.test_dir, 'private')
-        self.shared_dir = os.path.join(self.test_dir, 'shared')
+        self.config_dir = os.path.join(self.test_dir, "config")
+        self.private_dir = os.path.join(self.test_dir, "private")
+        self.shared_dir = os.path.join(self.test_dir, "shared")
         os.makedirs(self.config_dir, exist_ok=True)
         os.makedirs(self.private_dir, exist_ok=True)
         os.makedirs(self.shared_dir, exist_ok=True)
 
-        os.environ['JARVIS_CONFIG'] = self.config_dir
-        os.environ['JARVIS_PRIVATE'] = self.private_dir
-        os.environ['JARVIS_SHARED'] = self.shared_dir
+        os.environ["JARVIS_CONFIG"] = self.config_dir
+        os.environ["JARVIS_PRIVATE"] = self.private_dir
+        os.environ["JARVIS_SHARED"] = self.shared_dir
 
         # Initialize Jarvis properly
-        self.jarvis, self._saved_config = initialize_jarvis_for_test(self.config_dir, self.private_dir, self.shared_dir)
+        self.jarvis, self._saved_config = initialize_jarvis_for_test(
+            self.config_dir, self.private_dir, self.shared_dir
+        )
 
         self.original_env = os.environ.copy()
 
     def tearDown(self):
         """Clean up test environment"""
         if self._saved_config:
-            import yaml
             jarvis = Jarvis.get_instance()
             jarvis.save_config(self._saved_config)
-            jarvis.config_dir = self._saved_config.get('config_dir', jarvis.config_dir)
-            jarvis.private_dir = self._saved_config.get('private_dir', jarvis.private_dir)
-            jarvis.shared_dir = self._saved_config.get('shared_dir', jarvis.shared_dir)
+            jarvis.config_dir = self._saved_config.get("config_dir", jarvis.config_dir)
+            jarvis.private_dir = self._saved_config.get(
+                "private_dir", jarvis.private_dir
+            )
+            jarvis.shared_dir = self._saved_config.get("shared_dir", jarvis.shared_dir)
 
         os.environ.clear()
         os.environ.update(self.original_env)
@@ -315,45 +323,45 @@ class TestPkgFindLibrary(unittest.TestCase):
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
-        if hasattr(Jarvis, '_instance'):
+        if hasattr(Jarvis, "_instance"):
             Jarvis._instance = None
 
     def test_find_library_with_standard_name(self):
         """Test find_library() finds library with standard libXXX.so naming"""
         # Create a test library file
-        lib_path = os.path.join(self.lib_dir, 'libtest.so')
+        lib_path = os.path.join(self.lib_dir, "libtest.so")
         Path(lib_path).touch()
 
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.setenv('LD_LIBRARY_PATH', self.lib_dir)
+        pkg.setenv("LD_LIBRARY_PATH", self.lib_dir)
 
-        result = pkg.find_library('test')
+        result = pkg.find_library("test")
 
         self.assertIsNotNone(result)
         self.assertEqual(result, lib_path)
 
     def test_find_library_with_so_extension(self):
         """Test find_library() finds library with .so extension"""
-        lib_path = os.path.join(self.lib_dir, 'mylib.so')
+        lib_path = os.path.join(self.lib_dir, "mylib.so")
         Path(lib_path).touch()
 
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.setenv('LD_LIBRARY_PATH', self.lib_dir)
+        pkg.setenv("LD_LIBRARY_PATH", self.lib_dir)
 
-        result = pkg.find_library('mylib')
+        result = pkg.find_library("mylib")
 
         self.assertIsNotNone(result)
         self.assertEqual(result, lib_path)
 
     def test_find_library_static_library(self):
         """Test find_library() finds static library (.a)"""
-        lib_path = os.path.join(self.lib_dir, 'libstatic.a')
+        lib_path = os.path.join(self.lib_dir, "libstatic.a")
         Path(lib_path).touch()
 
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.setenv('LD_LIBRARY_PATH', self.lib_dir)
+        pkg.setenv("LD_LIBRARY_PATH", self.lib_dir)
 
-        result = pkg.find_library('static')
+        result = pkg.find_library("static")
 
         self.assertIsNotNone(result)
         self.assertEqual(result, lib_path)
@@ -361,39 +369,39 @@ class TestPkgFindLibrary(unittest.TestCase):
     def test_find_library_not_found(self):
         """Test find_library() returns None when library not found"""
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.setenv('LD_LIBRARY_PATH', self.lib_dir)
+        pkg.setenv("LD_LIBRARY_PATH", self.lib_dir)
 
-        result = pkg.find_library('nonexistent')
+        result = pkg.find_library("nonexistent")
 
         self.assertIsNone(result)
 
     def test_find_library_multiple_paths(self):
         """Test find_library() searches multiple paths in LD_LIBRARY_PATH"""
-        lib_dir2 = os.path.join(self.test_dir, 'lib2')
+        lib_dir2 = os.path.join(self.test_dir, "lib2")
         os.makedirs(lib_dir2, exist_ok=True)
 
         # Create library in second directory
-        lib_path = os.path.join(lib_dir2, 'libfound.so')
+        lib_path = os.path.join(lib_dir2, "libfound.so")
         Path(lib_path).touch()
 
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.setenv('LD_LIBRARY_PATH', f'{self.lib_dir}:{lib_dir2}')
+        pkg.setenv("LD_LIBRARY_PATH", os.pathsep.join([self.lib_dir, lib_dir2]))
 
-        result = pkg.find_library('found')
+        result = pkg.find_library("found")
 
         self.assertIsNotNone(result)
         self.assertEqual(result, lib_path)
 
     def test_find_library_uses_mod_env(self):
         """Test find_library() checks mod_env for LD_LIBRARY_PATH"""
-        lib_path = os.path.join(self.lib_dir, 'libmodenv.so')
+        lib_path = os.path.join(self.lib_dir, "libmodenv.so")
         Path(lib_path).touch()
 
         pkg = Pkg(pipeline=self.mock_pipeline)
         # Set in mod_env directly (simulating LD_PRELOAD scenario)
-        pkg.mod_env['LD_LIBRARY_PATH'] = self.lib_dir
+        pkg.mod_env["LD_LIBRARY_PATH"] = self.lib_dir
 
-        result = pkg.find_library('modenv')
+        result = pkg.find_library("modenv")
 
         self.assertIsNotNone(result)
 
@@ -403,38 +411,41 @@ class TestPkgCopyTemplateFile(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment"""
-        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_template_')
-        self.template_dir = os.path.join(self.test_dir, 'templates')
+        self.test_dir = tempfile.mkdtemp(prefix="jarvis_test_template_")
+        self.template_dir = os.path.join(self.test_dir, "templates")
         os.makedirs(self.template_dir, exist_ok=True)
 
         self.mock_pipeline = Mock()
-        self.mock_pipeline.name = 'test_pipeline'
+        self.mock_pipeline.name = "test_pipeline"
 
-        self.config_dir = os.path.join(self.test_dir, 'config')
-        self.private_dir = os.path.join(self.test_dir, 'private')
-        self.shared_dir = os.path.join(self.test_dir, 'shared')
+        self.config_dir = os.path.join(self.test_dir, "config")
+        self.private_dir = os.path.join(self.test_dir, "private")
+        self.shared_dir = os.path.join(self.test_dir, "shared")
         os.makedirs(self.config_dir, exist_ok=True)
         os.makedirs(self.private_dir, exist_ok=True)
         os.makedirs(self.shared_dir, exist_ok=True)
 
-        os.environ['JARVIS_CONFIG'] = self.config_dir
-        os.environ['JARVIS_PRIVATE'] = self.private_dir
-        os.environ['JARVIS_SHARED'] = self.shared_dir
+        os.environ["JARVIS_CONFIG"] = self.config_dir
+        os.environ["JARVIS_PRIVATE"] = self.private_dir
+        os.environ["JARVIS_SHARED"] = self.shared_dir
 
         # Initialize Jarvis properly
-        self.jarvis, self._saved_config = initialize_jarvis_for_test(self.config_dir, self.private_dir, self.shared_dir)
+        self.jarvis, self._saved_config = initialize_jarvis_for_test(
+            self.config_dir, self.private_dir, self.shared_dir
+        )
 
         self.original_env = os.environ.copy()
 
     def tearDown(self):
         """Clean up test environment"""
         if self._saved_config:
-            import yaml
             jarvis = Jarvis.get_instance()
             jarvis.save_config(self._saved_config)
-            jarvis.config_dir = self._saved_config.get('config_dir', jarvis.config_dir)
-            jarvis.private_dir = self._saved_config.get('private_dir', jarvis.private_dir)
-            jarvis.shared_dir = self._saved_config.get('shared_dir', jarvis.shared_dir)
+            jarvis.config_dir = self._saved_config.get("config_dir", jarvis.config_dir)
+            jarvis.private_dir = self._saved_config.get(
+                "private_dir", jarvis.private_dir
+            )
+            jarvis.shared_dir = self._saved_config.get("shared_dir", jarvis.shared_dir)
 
         os.environ.clear()
         os.environ.update(self.original_env)
@@ -442,59 +453,59 @@ class TestPkgCopyTemplateFile(unittest.TestCase):
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
-        if hasattr(Jarvis, '_instance'):
+        if hasattr(Jarvis, "_instance"):
             Jarvis._instance = None
 
     def test_copy_template_basic(self):
         """Test copy_template_file() with basic template"""
         # Create template file
-        template_path = os.path.join(self.template_dir, 'test.txt')
-        with open(template_path, 'w') as f:
-            f.write('Hello World')
+        template_path = os.path.join(self.template_dir, "test.txt")
+        with open(template_path, "w") as f:
+            f.write("Hello World")
 
-        dest_path = os.path.join(self.test_dir, 'output.txt')
+        dest_path = os.path.join(self.test_dir, "output.txt")
 
         pkg = Pkg(pipeline=self.mock_pipeline)
         pkg.copy_template_file(template_path, dest_path)
 
         # Verify file was copied
         self.assertTrue(os.path.exists(dest_path))
-        with open(dest_path, 'r') as f:
+        with open(dest_path, "r") as f:
             content = f.read()
-        self.assertEqual(content, 'Hello World')
+        self.assertEqual(content, "Hello World")
 
     def test_copy_template_with_replacements(self):
         """Test copy_template_file() with template replacements"""
-        template_path = os.path.join(self.template_dir, 'config.xml')
-        with open(template_path, 'w') as f:
-            f.write('<config>\n  <host>##HOST##</host>\n  <port>##PORT##</port>\n</config>')
+        template_path = os.path.join(self.template_dir, "config.xml")
+        with open(template_path, "w") as f:
+            f.write(
+                "<config>\n  <host>##HOST##</host>\n  <port>##PORT##</port>\n</config>"
+            )
 
-        dest_path = os.path.join(self.test_dir, 'config_output.xml')
+        dest_path = os.path.join(self.test_dir, "config_output.xml")
 
         pkg = Pkg(pipeline=self.mock_pipeline)
         pkg.copy_template_file(
-            template_path,
-            dest_path,
-            replacements={'HOST': 'localhost', 'PORT': '8080'}
+            template_path, dest_path, replacements={"HOST": "localhost", "PORT": "8080"}
         )
 
         # Verify replacements were made
-        with open(dest_path, 'r') as f:
+        with open(dest_path, "r") as f:
             content = f.read()
 
-        self.assertIn('<host>localhost</host>', content)
-        self.assertIn('<port>8080</port>', content)
-        self.assertNotIn('##HOST##', content)
-        self.assertNotIn('##PORT##', content)
+        self.assertIn("<host>localhost</host>", content)
+        self.assertIn("<port>8080</port>", content)
+        self.assertNotIn("##HOST##", content)
+        self.assertNotIn("##PORT##", content)
 
     def test_copy_template_creates_dest_directory(self):
         """Test copy_template_file() creates destination directory if needed"""
-        template_path = os.path.join(self.template_dir, 'test.txt')
-        with open(template_path, 'w') as f:
-            f.write('Test content')
+        template_path = os.path.join(self.template_dir, "test.txt")
+        with open(template_path, "w") as f:
+            f.write("Test content")
 
         # Destination in non-existent directory
-        dest_path = os.path.join(self.test_dir, 'subdir', 'deep', 'output.txt')
+        dest_path = os.path.join(self.test_dir, "subdir", "deep", "output.txt")
 
         pkg = Pkg(pipeline=self.mock_pipeline)
         pkg.copy_template_file(template_path, dest_path)
@@ -504,23 +515,21 @@ class TestPkgCopyTemplateFile(unittest.TestCase):
 
     def test_copy_template_with_numeric_replacements(self):
         """Test copy_template_file() with numeric replacement values"""
-        template_path = os.path.join(self.template_dir, 'numeric.txt')
-        with open(template_path, 'w') as f:
-            f.write('Threads: ##THREADS##, Memory: ##MEMORY##MB')
+        template_path = os.path.join(self.template_dir, "numeric.txt")
+        with open(template_path, "w") as f:
+            f.write("Threads: ##THREADS##, Memory: ##MEMORY##MB")
 
-        dest_path = os.path.join(self.test_dir, 'numeric_output.txt')
+        dest_path = os.path.join(self.test_dir, "numeric_output.txt")
 
         pkg = Pkg(pipeline=self.mock_pipeline)
         pkg.copy_template_file(
-            template_path,
-            dest_path,
-            replacements={'THREADS': 16, 'MEMORY': 4096}
+            template_path, dest_path, replacements={"THREADS": 16, "MEMORY": 4096}
         )
 
-        with open(dest_path, 'r') as f:
+        with open(dest_path, "r") as f:
             content = f.read()
 
-        self.assertEqual(content, 'Threads: 16, Memory: 4096MB')
+        self.assertEqual(content, "Threads: 16, Memory: 4096MB")
 
     def test_copy_template_file_not_found(self):
         """Test copy_template_file() raises error when template not found"""
@@ -528,8 +537,7 @@ class TestPkgCopyTemplateFile(unittest.TestCase):
 
         with self.assertRaises(FileNotFoundError):
             pkg.copy_template_file(
-                '/nonexistent/template.txt',
-                os.path.join(self.test_dir, 'output.txt')
+                "/nonexistent/template.txt", os.path.join(self.test_dir, "output.txt")
             )
 
 
@@ -538,35 +546,38 @@ class TestPkgDisplayMethods(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment"""
-        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_display_')
+        self.test_dir = tempfile.mkdtemp(prefix="jarvis_test_display_")
         self.mock_pipeline = Mock()
-        self.mock_pipeline.name = 'test_pipeline'
+        self.mock_pipeline.name = "test_pipeline"
 
-        self.config_dir = os.path.join(self.test_dir, 'config')
-        self.private_dir = os.path.join(self.test_dir, 'private')
-        self.shared_dir = os.path.join(self.test_dir, 'shared')
+        self.config_dir = os.path.join(self.test_dir, "config")
+        self.private_dir = os.path.join(self.test_dir, "private")
+        self.shared_dir = os.path.join(self.test_dir, "shared")
         os.makedirs(self.config_dir, exist_ok=True)
         os.makedirs(self.private_dir, exist_ok=True)
         os.makedirs(self.shared_dir, exist_ok=True)
 
-        os.environ['JARVIS_CONFIG'] = self.config_dir
-        os.environ['JARVIS_PRIVATE'] = self.private_dir
-        os.environ['JARVIS_SHARED'] = self.shared_dir
+        os.environ["JARVIS_CONFIG"] = self.config_dir
+        os.environ["JARVIS_PRIVATE"] = self.private_dir
+        os.environ["JARVIS_SHARED"] = self.shared_dir
 
         # Initialize Jarvis properly
-        self.jarvis, self._saved_config = initialize_jarvis_for_test(self.config_dir, self.private_dir, self.shared_dir)
+        self.jarvis, self._saved_config = initialize_jarvis_for_test(
+            self.config_dir, self.private_dir, self.shared_dir
+        )
 
         self.original_env = os.environ.copy()
 
     def tearDown(self):
         """Clean up test environment"""
         if self._saved_config:
-            import yaml
             jarvis = Jarvis.get_instance()
             jarvis.save_config(self._saved_config)
-            jarvis.config_dir = self._saved_config.get('config_dir', jarvis.config_dir)
-            jarvis.private_dir = self._saved_config.get('private_dir', jarvis.private_dir)
-            jarvis.shared_dir = self._saved_config.get('shared_dir', jarvis.shared_dir)
+            jarvis.config_dir = self._saved_config.get("config_dir", jarvis.config_dir)
+            jarvis.private_dir = self._saved_config.get(
+                "private_dir", jarvis.private_dir
+            )
+            jarvis.shared_dir = self._saved_config.get("shared_dir", jarvis.shared_dir)
 
         os.environ.clear()
         os.environ.update(self.original_env)
@@ -574,18 +585,18 @@ class TestPkgDisplayMethods(unittest.TestCase):
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
-        if hasattr(Jarvis, '_instance'):
+        if hasattr(Jarvis, "_instance"):
             Jarvis._instance = None
 
     def test_show_readme_exists(self):
         """Test show_readme() when README.md exists"""
         # Use the actual example_app package which has pkg_dir set
-        pkg = Pkg.load_standalone('builtin.example_app')
+        pkg = Pkg.load_standalone("builtin.example_app")
 
         # Create README in pkg_dir
-        readme_path = os.path.join(pkg.pkg_dir, 'README.md')
-        with open(readme_path, 'w') as f:
-            f.write('# Example App\n\nThis is a test README.')
+        readme_path = os.path.join(pkg.pkg_dir, "README.md")
+        with open(readme_path, "w") as f:
+            f.write("# Example App\n\nThis is a test README.")
 
         # Capture output
         import io
@@ -596,8 +607,8 @@ class TestPkgDisplayMethods(unittest.TestCase):
             pkg.show_readme()
 
         output = f.getvalue()
-        self.assertIn('Example App', output)
-        self.assertIn('test README', output)
+        self.assertIn("Example App", output)
+        self.assertIn("test README", output)
 
         # Clean up
         os.remove(readme_path)
@@ -615,7 +626,7 @@ class TestPkgDisplayMethods(unittest.TestCase):
             pkg.show_readme()
 
         output = f.getvalue()
-        self.assertIn('No README found', output)
+        self.assertIn("No README found", output)
 
     def test_show_readme_no_pkg_dir(self):
         """Test show_readme() when pkg_dir is not set"""
@@ -630,12 +641,12 @@ class TestPkgDisplayMethods(unittest.TestCase):
             pkg.show_readme()
 
         output = f.getvalue()
-        self.assertIn('Package directory not set', output)
+        self.assertIn("Package directory not set", output)
 
     def test_show_paths_config(self):
         """Test show_paths() with conf flag"""
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.pkg_id = 'test_pkg'
+        pkg.pkg_id = "test_pkg"
         pkg._ensure_directories()
 
         import io
@@ -643,15 +654,15 @@ class TestPkgDisplayMethods(unittest.TestCase):
 
         f = io.StringIO()
         with redirect_stdout(f):
-            pkg.show_paths({'conf': True})
+            pkg.show_paths({"conf": True})
 
         output = f.getvalue()
-        self.assertIn('config.yaml', output)
+        self.assertIn("config.yaml", output)
 
     def test_show_paths_multiple_flags(self):
         """Test show_paths() with multiple flags"""
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.pkg_id = 'test_pkg'
+        pkg.pkg_id = "test_pkg"
         pkg._ensure_directories()
 
         import io
@@ -659,35 +670,31 @@ class TestPkgDisplayMethods(unittest.TestCase):
 
         f = io.StringIO()
         with redirect_stdout(f):
-            pkg.show_paths({
-                'conf_dir': True,
-                'shared_dir': True,
-                'priv_dir': True
-            })
+            pkg.show_paths({"conf_dir": True, "shared_dir": True, "priv_dir": True})
 
         output = f.getvalue()
-        lines = output.strip().split('\n')
+        lines = output.strip().split("\n")
 
         # Should output 3 paths
         self.assertEqual(len(lines), 3)
-        self.assertTrue(any('config' in line for line in lines))
-        self.assertTrue(any('shared' in line for line in lines))
-        self.assertTrue(any('private' in line for line in lines))
+        self.assertTrue(any("config" in line for line in lines))
+        self.assertTrue(any("shared" in line for line in lines))
+        self.assertTrue(any("private" in line for line in lines))
 
     def test_show_paths_pkg_dir(self):
         """Test show_paths() with pkg_dir flag"""
-        pkg = Pkg.load_standalone('builtin.example_app')
+        pkg = Pkg.load_standalone("builtin.example_app")
 
         import io
         from contextlib import redirect_stdout
 
         f = io.StringIO()
         with redirect_stdout(f):
-            pkg.show_paths({'pkg_dir': True})
+            pkg.show_paths({"pkg_dir": True})
 
         output = f.getvalue().strip()
         self.assertTrue(os.path.exists(output))
-        self.assertIn('example_app', output)
+        self.assertIn("example_app", output)
 
 
 class TestPkgConfigurationMethods(unittest.TestCase):
@@ -695,35 +702,38 @@ class TestPkgConfigurationMethods(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment"""
-        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_config_')
+        self.test_dir = tempfile.mkdtemp(prefix="jarvis_test_config_")
         self.mock_pipeline = Mock()
-        self.mock_pipeline.name = 'test_pipeline'
+        self.mock_pipeline.name = "test_pipeline"
 
-        self.config_dir = os.path.join(self.test_dir, 'config')
-        self.private_dir = os.path.join(self.test_dir, 'private')
-        self.shared_dir = os.path.join(self.test_dir, 'shared')
+        self.config_dir = os.path.join(self.test_dir, "config")
+        self.private_dir = os.path.join(self.test_dir, "private")
+        self.shared_dir = os.path.join(self.test_dir, "shared")
         os.makedirs(self.config_dir, exist_ok=True)
         os.makedirs(self.private_dir, exist_ok=True)
         os.makedirs(self.shared_dir, exist_ok=True)
 
-        os.environ['JARVIS_CONFIG'] = self.config_dir
-        os.environ['JARVIS_PRIVATE'] = self.private_dir
-        os.environ['JARVIS_SHARED'] = self.shared_dir
+        os.environ["JARVIS_CONFIG"] = self.config_dir
+        os.environ["JARVIS_PRIVATE"] = self.private_dir
+        os.environ["JARVIS_SHARED"] = self.shared_dir
 
         # Initialize Jarvis properly
-        self.jarvis, self._saved_config = initialize_jarvis_for_test(self.config_dir, self.private_dir, self.shared_dir)
+        self.jarvis, self._saved_config = initialize_jarvis_for_test(
+            self.config_dir, self.private_dir, self.shared_dir
+        )
 
         self.original_env = os.environ.copy()
 
     def tearDown(self):
         """Clean up test environment"""
         if self._saved_config:
-            import yaml
             jarvis = Jarvis.get_instance()
             jarvis.save_config(self._saved_config)
-            jarvis.config_dir = self._saved_config.get('config_dir', jarvis.config_dir)
-            jarvis.private_dir = self._saved_config.get('private_dir', jarvis.private_dir)
-            jarvis.shared_dir = self._saved_config.get('shared_dir', jarvis.shared_dir)
+            jarvis.config_dir = self._saved_config.get("config_dir", jarvis.config_dir)
+            jarvis.private_dir = self._saved_config.get(
+                "private_dir", jarvis.private_dir
+            )
+            jarvis.shared_dir = self._saved_config.get("shared_dir", jarvis.shared_dir)
 
         os.environ.clear()
         os.environ.update(self.original_env)
@@ -731,51 +741,53 @@ class TestPkgConfigurationMethods(unittest.TestCase):
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
-        if hasattr(Jarvis, '_instance'):
+        if hasattr(Jarvis, "_instance"):
             Jarvis._instance = None
 
     def test_apply_menu_defaults(self):
         """Test _apply_menu_defaults() applies default values from menu"""
+
         # Create a custom package class with menu
         class TestPkg(Pkg):
             def _configure_menu(self):
                 return [
-                    {'name': 'option1', 'default': 'default1'},
-                    {'name': 'option2', 'default': 42},
-                    {'name': 'option3', 'default': True}
+                    {"name": "option1", "default": "default1"},
+                    {"name": "option2", "default": 42},
+                    {"name": "option3", "default": True},
                 ]
 
         pkg = TestPkg(pipeline=self.mock_pipeline)
         pkg._apply_menu_defaults()
 
-        self.assertEqual(pkg.config['option1'], 'default1')
-        self.assertEqual(pkg.config['option2'], 42)
-        self.assertEqual(pkg.config['option3'], True)
+        self.assertEqual(pkg.config["option1"], "default1")
+        self.assertEqual(pkg.config["option2"], 42)
+        self.assertEqual(pkg.config["option3"], True)
 
     def test_apply_menu_defaults_doesnt_overwrite(self):
         """Test _apply_menu_defaults() doesn't overwrite existing config"""
+
         class TestPkg(Pkg):
             def _configure_menu(self):
-                return [
-                    {'name': 'option1', 'default': 'default1'}
-                ]
+                return [{"name": "option1", "default": "default1"}]
 
         pkg = TestPkg(pipeline=self.mock_pipeline)
-        pkg.config['option1'] = 'existing_value'
+        pkg.config["option1"] = "existing_value"
         pkg._apply_menu_defaults()
 
         # Should not overwrite
-        self.assertEqual(pkg.config['option1'], 'existing_value')
+        self.assertEqual(pkg.config["option1"], "existing_value")
 
     def test_update_config(self):
         """Test update_config() method"""
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.config = {'existing': 'value'}
+        pkg.config = {"existing": "value"}
 
-        pkg.update_config({'new_key': 'new_value', 'existing': 'updated'}, rebuild=False)
+        pkg.update_config(
+            {"new_key": "new_value", "existing": "updated"}, rebuild=False
+        )
 
-        self.assertEqual(pkg.config['new_key'], 'new_value')
-        self.assertEqual(pkg.config['existing'], 'updated')
+        self.assertEqual(pkg.config["new_key"], "new_value")
+        self.assertEqual(pkg.config["existing"], "updated")
 
     def test_configure_menu_includes_common_params(self):
         """Test configure_menu() includes common parameters"""
@@ -783,21 +795,21 @@ class TestPkgConfigurationMethods(unittest.TestCase):
         menu = pkg.configure_menu()
 
         # Check for common parameters
-        param_names = [item['name'] for item in menu]
-        self.assertIn('interceptors', param_names)
-        self.assertIn('sleep', param_names)
-        self.assertIn('do_dbg', param_names)
-        self.assertIn('timeout', param_names)
+        param_names = [item["name"] for item in menu]
+        self.assertIn("interceptors", param_names)
+        self.assertIn("sleep", param_names)
+        self.assertIn("do_dbg", param_names)
+        self.assertIn("timeout", param_names)
 
     def test_get_argparse(self):
         """Test get_argparse() returns PkgArgParse instance"""
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.pkg_id = 'test_pkg'
+        pkg.pkg_id = "test_pkg"
 
         argparse = pkg.get_argparse()
 
         self.assertIsNotNone(argparse)
-        self.assertEqual(argparse.pkg_name, 'test_pkg')
+        self.assertEqual(argparse.pkg_name, "test_pkg")
 
 
 class TestPkgUtilityMethods(unittest.TestCase):
@@ -805,35 +817,38 @@ class TestPkgUtilityMethods(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment"""
-        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_util_')
+        self.test_dir = tempfile.mkdtemp(prefix="jarvis_test_util_")
         self.mock_pipeline = Mock()
-        self.mock_pipeline.name = 'test_pipeline'
+        self.mock_pipeline.name = "test_pipeline"
 
-        self.config_dir = os.path.join(self.test_dir, 'config')
-        self.private_dir = os.path.join(self.test_dir, 'private')
-        self.shared_dir = os.path.join(self.test_dir, 'shared')
+        self.config_dir = os.path.join(self.test_dir, "config")
+        self.private_dir = os.path.join(self.test_dir, "private")
+        self.shared_dir = os.path.join(self.test_dir, "shared")
         os.makedirs(self.config_dir, exist_ok=True)
         os.makedirs(self.private_dir, exist_ok=True)
         os.makedirs(self.shared_dir, exist_ok=True)
 
-        os.environ['JARVIS_CONFIG'] = self.config_dir
-        os.environ['JARVIS_PRIVATE'] = self.private_dir
-        os.environ['JARVIS_SHARED'] = self.shared_dir
+        os.environ["JARVIS_CONFIG"] = self.config_dir
+        os.environ["JARVIS_PRIVATE"] = self.private_dir
+        os.environ["JARVIS_SHARED"] = self.shared_dir
 
         # Initialize Jarvis properly
-        self.jarvis, self._saved_config = initialize_jarvis_for_test(self.config_dir, self.private_dir, self.shared_dir)
+        self.jarvis, self._saved_config = initialize_jarvis_for_test(
+            self.config_dir, self.private_dir, self.shared_dir
+        )
 
         self.original_env = os.environ.copy()
 
     def tearDown(self):
         """Clean up test environment"""
         if self._saved_config:
-            import yaml
             jarvis = Jarvis.get_instance()
             jarvis.save_config(self._saved_config)
-            jarvis.config_dir = self._saved_config.get('config_dir', jarvis.config_dir)
-            jarvis.private_dir = self._saved_config.get('private_dir', jarvis.private_dir)
-            jarvis.shared_dir = self._saved_config.get('shared_dir', jarvis.shared_dir)
+            jarvis.config_dir = self._saved_config.get("config_dir", jarvis.config_dir)
+            jarvis.private_dir = self._saved_config.get(
+                "private_dir", jarvis.private_dir
+            )
+            jarvis.shared_dir = self._saved_config.get("shared_dir", jarvis.shared_dir)
 
         os.environ.clear()
         os.environ.update(self.original_env)
@@ -841,14 +856,15 @@ class TestPkgUtilityMethods(unittest.TestCase):
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
-        if hasattr(Jarvis, '_instance'):
+        if hasattr(Jarvis, "_instance"):
             Jarvis._instance = None
 
     def test_sleep_with_config(self):
         """Test sleep() uses config value"""
         import time
+
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.config['sleep'] = 0.1
+        pkg.config["sleep"] = 0.1
 
         start = time.time()
         pkg.sleep()
@@ -860,8 +876,9 @@ class TestPkgUtilityMethods(unittest.TestCase):
     def test_sleep_with_parameter(self):
         """Test sleep() with explicit parameter overrides config"""
         import time
+
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.config['sleep'] = 10  # Would take too long
+        pkg.config["sleep"] = 10  # Would take too long
 
         start = time.time()
         pkg.sleep(time_sec=0.05)
@@ -873,8 +890,9 @@ class TestPkgUtilityMethods(unittest.TestCase):
     def test_sleep_zero(self):
         """Test sleep(0) completes immediately"""
         import time
+
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.config['sleep'] = 0
+        pkg.config["sleep"] = 0
 
         start = time.time()
         pkg.sleep()
@@ -885,7 +903,7 @@ class TestPkgUtilityMethods(unittest.TestCase):
     def test_ensure_directories_creates_dirs(self):
         """Test _ensure_directories() creates all necessary directories"""
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.pkg_id = 'test_pkg'
+        pkg.pkg_id = "test_pkg"
         pkg._ensure_directories()
 
         self.assertTrue(os.path.exists(pkg.config_dir))
@@ -895,7 +913,7 @@ class TestPkgUtilityMethods(unittest.TestCase):
     def test_ensure_directories_idempotent(self):
         """Test _ensure_directories() can be called multiple times safely"""
         pkg = Pkg(pipeline=self.mock_pipeline)
-        pkg.pkg_id = 'test_pkg'
+        pkg.pkg_id = "test_pkg"
 
         pkg._ensure_directories()
         dir1 = pkg.config_dir
@@ -911,35 +929,38 @@ class TestPkgSubclasses(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment"""
-        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_subclass_')
+        self.test_dir = tempfile.mkdtemp(prefix="jarvis_test_subclass_")
         self.mock_pipeline = Mock()
-        self.mock_pipeline.name = 'test_pipeline'
+        self.mock_pipeline.name = "test_pipeline"
 
-        self.config_dir = os.path.join(self.test_dir, 'config')
-        self.private_dir = os.path.join(self.test_dir, 'private')
-        self.shared_dir = os.path.join(self.test_dir, 'shared')
+        self.config_dir = os.path.join(self.test_dir, "config")
+        self.private_dir = os.path.join(self.test_dir, "private")
+        self.shared_dir = os.path.join(self.test_dir, "shared")
         os.makedirs(self.config_dir, exist_ok=True)
         os.makedirs(self.private_dir, exist_ok=True)
         os.makedirs(self.shared_dir, exist_ok=True)
 
-        os.environ['JARVIS_CONFIG'] = self.config_dir
-        os.environ['JARVIS_PRIVATE'] = self.private_dir
-        os.environ['JARVIS_SHARED'] = self.shared_dir
+        os.environ["JARVIS_CONFIG"] = self.config_dir
+        os.environ["JARVIS_PRIVATE"] = self.private_dir
+        os.environ["JARVIS_SHARED"] = self.shared_dir
 
         # Initialize Jarvis properly
-        self.jarvis, self._saved_config = initialize_jarvis_for_test(self.config_dir, self.private_dir, self.shared_dir)
+        self.jarvis, self._saved_config = initialize_jarvis_for_test(
+            self.config_dir, self.private_dir, self.shared_dir
+        )
 
         self.original_env = os.environ.copy()
 
     def tearDown(self):
         """Clean up test environment"""
         if self._saved_config:
-            import yaml
             jarvis = Jarvis.get_instance()
             jarvis.save_config(self._saved_config)
-            jarvis.config_dir = self._saved_config.get('config_dir', jarvis.config_dir)
-            jarvis.private_dir = self._saved_config.get('private_dir', jarvis.private_dir)
-            jarvis.shared_dir = self._saved_config.get('shared_dir', jarvis.shared_dir)
+            jarvis.config_dir = self._saved_config.get("config_dir", jarvis.config_dir)
+            jarvis.private_dir = self._saved_config.get(
+                "private_dir", jarvis.private_dir
+            )
+            jarvis.shared_dir = self._saved_config.get("shared_dir", jarvis.shared_dir)
 
         os.environ.clear()
         os.environ.update(self.original_env)
@@ -947,7 +968,7 @@ class TestPkgSubclasses(unittest.TestCase):
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
-        if hasattr(Jarvis, '_instance'):
+        if hasattr(Jarvis, "_instance"):
             Jarvis._instance = None
 
     def test_service_initialization(self):
@@ -978,20 +999,20 @@ class TestPkgSubclasses(unittest.TestCase):
         """Test Interceptor has modify_env() method"""
         interceptor = Interceptor(pipeline=self.mock_pipeline)
 
-        self.assertTrue(hasattr(interceptor, 'modify_env'))
+        self.assertTrue(hasattr(interceptor, "modify_env"))
         self.assertTrue(callable(interceptor.modify_env))
 
     def test_example_interceptor_modify_env(self):
         """Test example_interceptor's modify_env() implementation"""
-        pkg = Pkg.load_standalone('builtin.example_interceptor')
-        pkg.configure(library_path='/lib/test.so', custom_env_var='test123')
+        pkg = Pkg.load_standalone("builtin.example_interceptor")
+        pkg.configure(library_path="/lib/test.so", custom_env_var="test123")
 
         pkg.modify_env()
 
         # Check environment was modified
-        self.assertEqual(pkg.env.get('EXAMPLE_INTERCEPTOR_ACTIVE'), 'true')
-        self.assertEqual(pkg.env.get('EXAMPLE_CUSTOM_VAR'), 'test123')
-        self.assertIn('/lib/test.so', pkg.mod_env.get('LD_PRELOAD', ''))
+        self.assertEqual(pkg.env.get("EXAMPLE_INTERCEPTOR_ACTIVE"), "true")
+        self.assertEqual(pkg.env.get("EXAMPLE_CUSTOM_VAR"), "test123")
+        self.assertIn("/lib/test.so", pkg.mod_env.get("LD_PRELOAD", ""))
 
 
 class TestPkgLifecycleMethods(unittest.TestCase):
@@ -999,35 +1020,38 @@ class TestPkgLifecycleMethods(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment"""
-        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_lifecycle_')
+        self.test_dir = tempfile.mkdtemp(prefix="jarvis_test_lifecycle_")
         self.mock_pipeline = Mock()
-        self.mock_pipeline.name = 'test_pipeline'
+        self.mock_pipeline.name = "test_pipeline"
 
-        self.config_dir = os.path.join(self.test_dir, 'config')
-        self.private_dir = os.path.join(self.test_dir, 'private')
-        self.shared_dir = os.path.join(self.test_dir, 'shared')
+        self.config_dir = os.path.join(self.test_dir, "config")
+        self.private_dir = os.path.join(self.test_dir, "private")
+        self.shared_dir = os.path.join(self.test_dir, "shared")
         os.makedirs(self.config_dir, exist_ok=True)
         os.makedirs(self.private_dir, exist_ok=True)
         os.makedirs(self.shared_dir, exist_ok=True)
 
-        os.environ['JARVIS_CONFIG'] = self.config_dir
-        os.environ['JARVIS_PRIVATE'] = self.private_dir
-        os.environ['JARVIS_SHARED'] = self.shared_dir
+        os.environ["JARVIS_CONFIG"] = self.config_dir
+        os.environ["JARVIS_PRIVATE"] = self.private_dir
+        os.environ["JARVIS_SHARED"] = self.shared_dir
 
         # Initialize Jarvis properly
-        self.jarvis, self._saved_config = initialize_jarvis_for_test(self.config_dir, self.private_dir, self.shared_dir)
+        self.jarvis, self._saved_config = initialize_jarvis_for_test(
+            self.config_dir, self.private_dir, self.shared_dir
+        )
 
         self.original_env = os.environ.copy()
 
     def tearDown(self):
         """Clean up test environment"""
         if self._saved_config:
-            import yaml
             jarvis = Jarvis.get_instance()
             jarvis.save_config(self._saved_config)
-            jarvis.config_dir = self._saved_config.get('config_dir', jarvis.config_dir)
-            jarvis.private_dir = self._saved_config.get('private_dir', jarvis.private_dir)
-            jarvis.shared_dir = self._saved_config.get('shared_dir', jarvis.shared_dir)
+            jarvis.config_dir = self._saved_config.get("config_dir", jarvis.config_dir)
+            jarvis.private_dir = self._saved_config.get(
+                "private_dir", jarvis.private_dir
+            )
+            jarvis.shared_dir = self._saved_config.get("shared_dir", jarvis.shared_dir)
 
         os.environ.clear()
         os.environ.update(self.original_env)
@@ -1035,18 +1059,18 @@ class TestPkgLifecycleMethods(unittest.TestCase):
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
-        if hasattr(Jarvis, '_instance'):
+        if hasattr(Jarvis, "_instance"):
             Jarvis._instance = None
 
     def test_default_lifecycle_methods_exist(self):
         """Test default lifecycle methods exist and are callable"""
         pkg = Pkg(pipeline=self.mock_pipeline)
 
-        self.assertTrue(hasattr(pkg, 'start'))
-        self.assertTrue(hasattr(pkg, 'stop'))
-        self.assertTrue(hasattr(pkg, 'kill'))
-        self.assertTrue(hasattr(pkg, 'clean'))
-        self.assertTrue(hasattr(pkg, 'status'))
+        self.assertTrue(hasattr(pkg, "start"))
+        self.assertTrue(hasattr(pkg, "stop"))
+        self.assertTrue(hasattr(pkg, "kill"))
+        self.assertTrue(hasattr(pkg, "clean"))
+        self.assertTrue(hasattr(pkg, "status"))
 
         # Should not raise errors
         pkg.start()
@@ -1059,22 +1083,22 @@ class TestPkgLifecycleMethods(unittest.TestCase):
 
     def test_example_app_lifecycle(self):
         """Test example_app implements lifecycle methods correctly"""
-        pkg = Pkg.load_standalone('builtin.example_app')
-        pkg.configure(message='test message', output_file='test.txt')
+        pkg = Pkg.load_standalone("builtin.example_app")
+        pkg.configure(message="test message", output_file="test.txt")
 
         # Start should create marker
         pkg.start()
-        start_marker = os.path.join(pkg.shared_dir, 'start.marker')
+        start_marker = os.path.join(pkg.shared_dir, "start.marker")
         self.assertTrue(os.path.exists(start_marker))
 
         # Stop should create marker
         pkg.stop()
-        stop_marker = os.path.join(pkg.shared_dir, 'stop.marker')
+        stop_marker = os.path.join(pkg.shared_dir, "stop.marker")
         self.assertTrue(os.path.exists(stop_marker))
 
         # Kill should create marker
         pkg.kill()
-        kill_marker = os.path.join(pkg.shared_dir, 'kill.marker')
+        kill_marker = os.path.join(pkg.shared_dir, "kill.marker")
         self.assertTrue(os.path.exists(kill_marker))
 
         # Clean should remove all markers
@@ -1084,5 +1108,5 @@ class TestPkgLifecycleMethods(unittest.TestCase):
         self.assertFalse(os.path.exists(kill_marker))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/unit/core/test_progress_spi.py
+++ b/test/unit/core/test_progress_spi.py
@@ -1,0 +1,395 @@
+"""Tests for JARVIS-owned generic package progress semantics."""
+
+from __future__ import annotations
+
+import io
+import os
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from jarvis_cd.core.pkg import Pkg
+from jarvis_cd.progress import (
+    PROGRESS_LINE_PREFIX,
+    ProgressEvent,
+    ProgressObservation,
+    ProgressReporter,
+    ProgressState,
+    ProgressStore,
+    event_from_progress_line,
+    provider_from_package,
+)
+
+
+def _event(*, sequence: int = 1) -> ProgressEvent:
+    return ProgressEvent(
+        package_name="site.application",
+        package_id="simulation_a",
+        execution_id="exec_123",
+        label="iteration",
+        current=2,
+        total=10,
+        unit="iteration",
+        message="Completed iteration 2 of 10",
+        sequence=sequence,
+        metadata={"source": "application"},
+    )
+
+
+def test_progress_event_round_trip_preserves_instance_identity() -> None:
+    """The schema distinguishes a package type from its pipeline alias."""
+    event = _event()
+
+    restored = ProgressEvent.from_json(event.to_json())
+
+    assert restored == event
+    assert restored.determinate
+    assert restored.as_adapter_record()["metadata"]["package_id"] == "simulation_a"
+
+
+def test_progress_event_rejects_unknown_duplicate_and_nonfinite_fields() -> None:
+    """Untrusted JSON cannot smuggle ambiguous or non-finite progress."""
+    payload = _event().as_dict()
+    payload["unexpected"] = True
+    with pytest.raises(ValueError, match="unknown progress event fields"):
+        ProgressEvent.from_dict(payload)
+
+    duplicate = (
+        _event()
+        .to_json()
+        .replace(
+            '"package_id":"simulation_a"',
+            '"package_id":"simulation_a","package_id":"other"',
+        )
+    )
+    with pytest.raises(ValueError, match="not valid JSON"):
+        ProgressEvent.from_json(duplicate)
+
+    payload = _event().as_dict()
+    payload["current"] = float("nan")
+    with pytest.raises(ValueError, match="finite"):
+        ProgressEvent.from_dict(payload)
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        replace(_event(), sequence=cast(Any, 1.5))
+    with pytest.raises(ValueError, match="ProgressState"):
+        replace(_event(), state=cast(Any, "running"))
+
+
+def test_indeterminate_event_never_invents_a_total() -> None:
+    """Lifecycle readiness remains truthful rather than a made-up percentage."""
+    event = ProgressEvent(
+        package_name="builtin.paraview",
+        package_id="visualizer",
+        execution_id="exec_ready",
+        label="pvserver",
+        state=ProgressState.READY,
+        sequence=1,
+        message="Ready for a client",
+    )
+
+    assert not event.determinate
+    assert "current" not in event.as_dict()
+    assert "total" not in event.as_dict()
+
+
+def test_reporter_emits_stdout_and_owned_sidecar(tmp_path: Path) -> None:
+    """The same event schema works over structured lines and durable JSONL."""
+    stream = io.StringIO()
+    reporter = ProgressReporter(
+        package_name="site.application",
+        package_id="app_a",
+        execution_id="exec_line",
+        stream=stream,
+    )
+    emitted = reporter.emit(label="phase", message="Application is running")
+    assert stream.getvalue().startswith(PROGRESS_LINE_PREFIX)
+    assert event_from_progress_line(stream.getvalue()) == emitted
+
+    path = tmp_path / "owned" / "progress.jsonl"
+    sidecar = ProgressReporter(
+        package_name="site.application",
+        package_id="app_b",
+        execution_id="exec_file",
+        path=path,
+    )
+    event = sidecar.emit(label="item", current=1, total=2, unit="item")
+
+    assert ProgressStore(path).latest() == event
+    if os.name != "nt":
+        assert path.stat().st_mode & 0o077 == 0
+
+
+def test_reporter_honors_stdout_transport_inside_container(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A container reporter emits framed stdout instead of opening a host path."""
+    sidecar = tmp_path / "unmounted" / "progress.jsonl"
+    stream = io.StringIO()
+    monkeypatch.setenv("JARVIS_PROGRESS_PATH", str(sidecar))
+    monkeypatch.setenv("JARVIS_PROGRESS_TRANSPORT", "stdout")
+
+    reporter = ProgressReporter(
+        package_name="site.application",
+        package_id="container_app",
+        execution_id="exec_container",
+        stream=stream,
+    )
+    reporter.emit(label="phase", message="Container phase completed")
+
+    assert stream.getvalue().startswith(PROGRESS_LINE_PREFIX)
+    assert not sidecar.exists()
+
+
+def test_store_rejects_sequence_replay_and_symlink(tmp_path: Path) -> None:
+    """Durable query fails closed on ambiguous ordering and redirected files."""
+    path = tmp_path / "progress.jsonl"
+    store = ProgressStore(path)
+    store.append(_event(sequence=1))
+    with pytest.raises(ValueError, match="increase strictly"):
+        store.append(_event(sequence=1))
+
+    if hasattr(os, "symlink"):
+        target = tmp_path / "target.jsonl"
+        target.write_text(_event().to_json() + "\n", encoding="utf-8")
+        link = tmp_path / "redirected.jsonl"
+        try:
+            link.symlink_to(target)
+        except OSError:
+            # Unprivileged Windows commonly disables symlink creation. The
+            # sequence-replay assertion above still exercises fail-closed
+            # durable reads on that platform.
+            return
+        with pytest.raises(ValueError, match="symlink"):
+            ProgressStore(link).read_all()
+
+
+def test_store_rejects_junction_ancestor_without_writing(tmp_path: Path) -> None:
+    """Windows junctions and POSIX symlinks cannot redirect a sidecar root."""
+    target = tmp_path / "outside"
+    target.mkdir()
+    redirected = tmp_path / "redirected"
+    if os.name == "nt":
+        import _winapi
+
+        _winapi.CreateJunction(str(target), str(redirected))
+    else:
+        redirected.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="redirected"):
+        ProgressStore(redirected / "created" / "progress.jsonl").append(_event())
+    assert not (target / "created").exists()
+
+
+def test_store_rejects_identity_changes_and_incomplete_framing(
+    tmp_path: Path,
+) -> None:
+    """One sidecar cannot mix identities or append after a torn JSONL record."""
+    path = tmp_path / "progress.jsonl"
+    store = ProgressStore(path)
+    store.append(_event(sequence=1))
+    with pytest.raises(ValueError, match="identity must remain stable"):
+        store.append(replace(_event(sequence=2), execution_id="different_execution"))
+
+    path.write_text(_event(sequence=1).to_json(), encoding="utf-8")
+    if os.name != "nt":
+        path.chmod(0o600)
+    with pytest.raises(ValueError, match="incomplete final JSONL record"):
+        store.append(_event(sequence=2))
+    with pytest.raises(ValueError, match="incomplete final JSONL record"):
+        store.read_all()
+
+
+def test_store_reader_rejects_preexisting_mixed_identity(tmp_path: Path) -> None:
+    """A tampered or legacy mixed-identity stream fails closed on query."""
+    path = tmp_path / "progress.jsonl"
+    first = _event(sequence=1)
+    second = replace(first, sequence=2, package_id="different_package")
+    path.write_text(
+        first.to_json() + "\n" + second.to_json() + "\n",
+        encoding="utf-8",
+    )
+    if os.name != "nt":
+        path.chmod(0o600)
+
+    with pytest.raises(ValueError, match="identity must remain stable"):
+        ProgressStore(path).read_all()
+
+
+def test_reporter_adopts_only_a_matching_existing_stream(tmp_path: Path) -> None:
+    """Reporter sequence adoption cannot cross execution or package identity."""
+    path = tmp_path / "progress.jsonl"
+    ProgressStore(path).append(_event(sequence=1))
+
+    reporter = ProgressReporter(
+        package_name="site.application",
+        package_id="simulation_a",
+        execution_id="exec_123",
+        path=path,
+    )
+    emitted = reporter.emit(label="iteration", current=3, total=10)
+    assert emitted.sequence == 2
+
+    with pytest.raises(ValueError, match="does not match this reporter"):
+        ProgressReporter(
+            package_name="site.application",
+            package_id="simulation_a",
+            execution_id="different_execution",
+            path=path,
+        )
+
+
+def test_package_binding_uses_owned_execution_environment(tmp_path: Path) -> None:
+    """Packages receive identity and sidecar paths from execution core only."""
+    package = object.__new__(Pkg)
+    package.pkg_type = "site.application"
+    package.pkg_id = "application_a"
+    package.env = {}
+    package.mod_env = {}
+    path = (tmp_path / "progress.jsonl").resolve()
+
+    package.bind_execution_progress("exec_owned", path)
+
+    assert package.env == package.mod_env
+    assert package.mod_env["JARVIS_EXECUTION_ID"] == "exec_owned"
+    assert package.mod_env["JARVIS_PACKAGE_NAME"] == "site.application"
+    assert package.mod_env["JARVIS_PACKAGE_ID"] == "application_a"
+    assert package.mod_env["JARVIS_PROGRESS_PATH"] == str(path)
+    assert package.mod_env["JARVIS_PROGRESS_TRANSPORT"] == "sidecar"
+    with pytest.raises(ValueError, match="absolute"):
+        package.bind_execution_progress("exec_owned", "relative.jsonl")
+
+
+def test_package_callback_persists_typed_final_observation(tmp_path: Path) -> None:
+    """JARVIS owns identity and flushes a provider's final stdout fragment."""
+
+    class Provider:
+        def __init__(self) -> None:
+            self.text = ""
+
+        def observe_progress(self, text: str) -> list[ProgressObservation]:
+            self.text += text
+            return []
+
+        def finalize_progress(self) -> list[ProgressObservation]:
+            return [
+                ProgressObservation(
+                    label="phase",
+                    message=self.text,
+                    metadata={"provider_semantic": "complete_fragment"},
+                )
+            ]
+
+        def reset_progress(self) -> None:
+            self.text = ""
+
+    path = (tmp_path / "progress.jsonl").resolve()
+    package = object.__new__(Pkg)
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec_typed",
+        "JARVIS_PACKAGE_ID": "app_a",
+        "JARVIS_PACKAGE_NAME": "site.application",
+        "JARVIS_PROGRESS_PATH": str(path),
+    }
+    provider = Provider()
+    package.get_progress_provider = lambda: provider  # type: ignore[method-assign]
+
+    callback = package.progress_line_callback()
+    assert callback is not None
+    callback("stdout", "unterminated output")
+    finalizer = getattr(callback, "finalize")
+    finalizer()
+    finalizer()
+
+    event = ProgressStore(path).latest()
+    assert event is not None
+    assert event.execution_id == "exec_typed"
+    assert event.package_name == "site.application"
+    assert event.package_id == "app_a"
+    assert event.message == "unterminated output"
+    assert event.sequence == 1
+
+
+def test_container_callback_persists_structured_stdout_without_provider(
+    tmp_path: Path,
+) -> None:
+    """Generic container instrumentation needs no application-specific parser."""
+    path = (tmp_path / "progress.jsonl").resolve()
+    stream = io.StringIO()
+    child_reporter = ProgressReporter(
+        package_name="site.application",
+        package_id="container_app",
+        execution_id="exec_container",
+        stream=stream,
+    )
+    child_reporter.emit(label="frame", current=1, total=2, unit="frame")
+
+    package = object.__new__(Pkg)
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec_container",
+        "JARVIS_PACKAGE_ID": "container_app",
+        "JARVIS_PACKAGE_NAME": "site.application",
+        "JARVIS_PROGRESS_PATH": str(path),
+        "JARVIS_PROGRESS_TRANSPORT": "stdout",
+    }
+    package.get_progress_provider = lambda: None  # type: ignore[method-assign]
+
+    callback = package.progress_line_callback()
+    assert callback is not None
+    callback("stdout", stream.getvalue())
+    getattr(callback, "finalize")()
+
+    event = ProgressStore(path).latest()
+    assert event is not None
+    assert event.execution_id == "exec_container"
+    assert event.package_id == "container_app"
+    assert event.current == 1
+
+
+def test_filesystem_repository_discovers_sibling_progress_module(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A registered repository does not need a distribution entry point."""
+    repository = tmp_path / "site_repo"
+    package_dir = repository / "demo"
+    package_dir.mkdir(parents=True)
+    (repository / "__init__.py").write_text("", encoding="utf-8")
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    (package_dir / "pkg.py").write_text(
+        "class Demo:\n    pass\n",
+        encoding="utf-8",
+    )
+    (package_dir / "progress.py").write_text(
+        """
+class Provider:
+    def observe_progress(self, text): return []
+    def finalize_progress(self): return []
+    def reset_progress(self): pass
+def adapter_from_package(package):
+    return Provider() if package.get("pkg_type") == "site_repo.demo" else None
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    module = __import__("site_repo.demo.pkg", fromlist=["Demo"])
+    package = module.Demo()
+    package.config = {}
+    package.pkg_type = "site_repo.demo"
+    package.pkg_id = "demo_a"
+    package.global_id = "pipeline.demo_a"
+    package.pipeline = SimpleNamespace()
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec_fs",
+        "JARVIS_PROGRESS_PATH": str(tmp_path / "fs.jsonl"),
+    }
+
+    provider = provider_from_package(package)
+
+    assert provider is not None
+    assert provider.observe_progress("anything") == []

--- a/test/unit/core/test_scheduler_submission.py
+++ b/test/unit/core/test_scheduler_submission.py
@@ -15,7 +15,12 @@ import pytest
 import yaml
 
 from jarvis_cd.core.config import Jarvis
-from jarvis_cd.core.pipeline import Pipeline, _atomic_yaml_dump
+from jarvis_cd.core.pipeline import (
+    Pipeline,
+    _atomic_yaml_dump,
+    _remove_execution_tree,
+    _unlock_execution_input_for_cleanup,
+)
 from jarvis_cd.core.scheduler import SlurmScheduler
 
 
@@ -753,31 +758,243 @@ def test_script_only_execution_is_explicitly_cleanup_eligible(tmp_path: Path) ->
     assert not (tmp_path / "shared" / "example" / "executions" / "script-only").exists()
 
 
-def test_failed_execution_cleanup_reseals_and_restores_exact_root(
+def test_failed_execution_cleanup_leaves_resumable_tombstone(
     tmp_path: Path,
 ) -> None:
-    """A deletion failure restores both the exact root and its prior input mode."""
+    """A deletion failure never restores a possibly damaged live execution."""
     pipeline = _real_pipeline(tmp_path)
     pipeline.submit(submit=False, execution_id="cleanup-rollback")
     execution_root = tmp_path / "shared" / "example" / "executions" / "cleanup-rollback"
+    quarantine = execution_root.parent / ".remove-cleanup-rollback"
 
     with (
         patch(
-            "jarvis_cd.core.pipeline._set_execution_input_mode",
-            side_effect=[0o500, 0o700],
-        ) as set_mode,
+            "jarvis_cd.core.pipeline._unlock_execution_input_for_cleanup",
+        ),
         patch(
-            "jarvis_cd.core.pipeline.shutil.rmtree",
+            "jarvis_cd.core.pipeline._remove_execution_tree",
             side_effect=PermissionError("injected deletion failure"),
         ),
         pytest.raises(PermissionError, match="injected deletion failure"),
     ):
         pipeline.cleanup_executions(["cleanup-rollback"])
 
-    assert execution_root.is_dir()
-    assert not list(execution_root.parent.glob(".remove-cleanup-rollback-*"))
-    assert set_mode.call_count == 2
-    quarantine = set_mode.call_args_list[0].args[0]
-    assert quarantine.name.startswith(".remove-cleanup-rollback-")
-    assert set_mode.call_args_list[1].args == (quarantine,)
-    assert set_mode.call_args_list[1].kwargs == {"mode": 0o500}
+    assert not execution_root.exists()
+    assert quarantine.is_dir()
+    assert pipeline.cleanup_executions(["cleanup-rollback"]) == ["cleanup-rollback"]
+    assert not quarantine.exists()
+
+
+def test_partial_execution_cleanup_never_restores_damaged_root(tmp_path: Path) -> None:
+    """A retry resumes the tombstone after an injected partial tree deletion."""
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.submit(submit=False, execution_id="partial-cleanup")
+    execution_root = tmp_path / "shared" / "example" / "executions" / "partial-cleanup"
+    quarantine = execution_root.parent / ".remove-partial-cleanup"
+
+    def delete_one_file_then_fail(*_args: object, **_kwargs: object) -> None:
+        (quarantine / "input" / "pipeline.yaml").unlink()
+        raise OSError("injected partial deletion")
+
+    with (
+        patch(
+            "jarvis_cd.core.pipeline._remove_execution_tree",
+            side_effect=delete_one_file_then_fail,
+        ),
+        pytest.raises(OSError, match="injected partial deletion"),
+    ):
+        pipeline.cleanup_executions(["partial-cleanup"])
+
+    assert not execution_root.exists()
+    assert quarantine.is_dir()
+    assert not (quarantine / "input" / "pipeline.yaml").exists()
+    assert pipeline.cleanup_executions(["partial-cleanup"]) == ["partial-cleanup"]
+    assert not quarantine.exists()
+
+
+def test_unlock_failure_leaves_execution_under_cleanup_tombstone(
+    tmp_path: Path,
+) -> None:
+    """A post-fchmod failure cannot return an unsealed execution to service."""
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.submit(submit=False, execution_id="unlock-failure")
+    execution_root = tmp_path / "shared" / "example" / "executions" / "unlock-failure"
+    quarantine = execution_root.parent / ".remove-unlock-failure"
+
+    def fail_after_mode_change(
+        _execution_root: Path,
+        *,
+        root_descriptor: int | None = None,
+    ) -> None:
+        if os.name != "nt":
+            assert root_descriptor is not None
+            descriptor = os.open(
+                "input",
+                os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+                dir_fd=root_descriptor,
+            )
+            try:
+                os.fchmod(descriptor, 0o700)
+            finally:
+                os.close(descriptor)
+        raise OSError("injected unlock durability failure")
+
+    with (
+        patch(
+            "jarvis_cd.core.pipeline._unlock_execution_input_for_cleanup",
+            side_effect=fail_after_mode_change,
+        ),
+        pytest.raises(OSError, match="injected unlock durability failure"),
+    ):
+        pipeline.cleanup_executions(["unlock-failure"])
+
+    assert not execution_root.exists()
+    assert quarantine.is_dir()
+    if os.name != "nt":
+        assert ((quarantine / "input").stat().st_mode & 0o777) == 0o700
+    assert pipeline.cleanup_executions(["unlock-failure"]) == ["unlock-failure"]
+    assert not quarantine.exists()
+
+
+def test_cleanup_receipt_finalizes_after_tree_was_already_removed(
+    tmp_path: Path,
+) -> None:
+    """A crash after tree deletion leaves a receipt-only retry state."""
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.submit(submit=False, execution_id="receipt-only")
+    execution_root = tmp_path / "shared" / "example" / "executions" / "receipt-only"
+    quarantine = execution_root.parent / ".remove-receipt-only"
+
+    def remove_tree_then_fail(
+        path: Path,
+        *,
+        executions_descriptor: int | None,
+        root_descriptor: int | None,
+        windows_root_handle: int | None,
+        root_identity: tuple[int, int],
+    ) -> None:
+        _remove_execution_tree(
+            path,
+            executions_descriptor=executions_descriptor,
+            root_descriptor=root_descriptor,
+            windows_root_handle=windows_root_handle,
+            root_identity=root_identity,
+        )
+        raise OSError("injected post-tree crash")
+
+    with (
+        patch(
+            "jarvis_cd.core.pipeline._remove_execution_tree",
+            side_effect=remove_tree_then_fail,
+        ),
+        pytest.raises(OSError, match="injected post-tree crash"),
+    ):
+        pipeline.cleanup_executions(["receipt-only"])
+
+    assert not execution_root.exists()
+    assert not quarantine.exists()
+    receipts = list(execution_root.parent.glob(".remove-receipt-only-*.json"))
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt.is_file()
+    assert pipeline.cleanup_executions(["receipt-only"]) == ["receipt-only"]
+    assert not receipt.exists()
+
+
+def test_cleanup_unlock_never_follows_execution_root_symlink(tmp_path: Path) -> None:
+    """POSIX cleanup opens both the root and input relative to trusted handles."""
+    if os.name == "nt":
+        _unlock_execution_input_for_cleanup(tmp_path / "missing")
+        return
+
+    outside = tmp_path / "outside"
+    outside_input = outside / "input"
+    outside_input.mkdir(parents=True)
+    outside_input.chmod(0o500)
+    quarantine = tmp_path / ".remove-symlink"
+    quarantine.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(OSError):
+        _unlock_execution_input_for_cleanup(quarantine)
+
+    assert (outside_input.stat().st_mode & 0o777) == 0o500
+
+
+def test_cleanup_never_deletes_root_replacement_after_validation(
+    tmp_path: Path,
+) -> None:
+    """A validated tombstone swap fails closed without deleting the replacement."""
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.submit(submit=False, execution_id="race-delete")
+    executions = tmp_path / "shared" / "example" / "executions"
+    quarantine = executions / ".remove-race-delete"
+    stolen = executions / ".stolen-owned"
+    victim = executions / ".victim-source"
+    victim.mkdir()
+    (victim / "sentinel.txt").write_text("keep", encoding="utf-8")
+
+    def unlock_then_swap(
+        execution_root: Path,
+        *,
+        root_descriptor: int | None = None,
+    ) -> None:
+        _unlock_execution_input_for_cleanup(
+            execution_root,
+            root_descriptor=root_descriptor,
+        )
+        os.replace(quarantine, stolen)
+        os.replace(victim, quarantine)
+
+    with (
+        patch(
+            "jarvis_cd.core.pipeline._unlock_execution_input_for_cleanup",
+            side_effect=unlock_then_swap,
+        ),
+        pytest.raises(PermissionError if os.name == "nt" else RuntimeError),
+    ):
+        pipeline.cleanup_executions(["race-delete"])
+
+    if os.name == "nt":
+        assert (victim / "sentinel.txt").read_text(encoding="utf-8") == "keep"
+        assert quarantine.is_dir()
+        assert not stolen.exists()
+    else:
+        assert (quarantine / "sentinel.txt").read_text(encoding="utf-8") == "keep"
+        assert stolen.is_dir()
+
+
+def test_live_cleanup_revalidates_identity_after_rename(tmp_path: Path) -> None:
+    """A candidate replacement in the detach window is never accepted."""
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.submit(submit=False, execution_id="race-live")
+    executions = tmp_path / "shared" / "example" / "executions"
+    candidate = executions / "race-live"
+    quarantine = executions / ".remove-race-live"
+    stolen = executions / ".stolen-live"
+    victim = executions / ".victim-live"
+    victim.mkdir()
+    (victim / "sentinel.txt").write_text("keep", encoding="utf-8")
+    real_replace = os.replace
+    swapped = False
+
+    def replace_after_swap(
+        source: object,
+        destination: object,
+        **kwargs: object,
+    ) -> None:
+        nonlocal swapped
+        if not swapped and Path(str(source)).name == "race-live":
+            swapped = True
+            real_replace(candidate, stolen)
+            real_replace(victim, candidate)
+        real_replace(source, destination, **kwargs)
+
+    with (
+        patch("jarvis_cd.core.pipeline.os.replace", side_effect=replace_after_swap),
+        pytest.raises(RuntimeError, match="execution changed before cleanup"),
+    ):
+        pipeline.cleanup_executions(["race-live"])
+
+    assert swapped is True
+    assert (quarantine / "sentinel.txt").read_text(encoding="utf-8") == "keep"
+    assert stolen.is_dir()

--- a/test/unit/core/test_scheduler_submission.py
+++ b/test/unit/core/test_scheduler_submission.py
@@ -15,6 +15,7 @@ import pytest
 import yaml
 
 from jarvis_cd.core.config import Jarvis
+from jarvis_cd.core.execution import ExecutionStore
 from jarvis_cd.core.pipeline import (
     Pipeline,
     _atomic_yaml_dump,
@@ -192,6 +193,189 @@ def test_slurm_hostfile_generation_failure_preserves_previous_file(
     assert list(tmp_path.glob(".hostfile.txt.jarvis.*")) == []
 
 
+def _run_execution_scheduler_script(
+    tmp_path: Path,
+    *,
+    execution_id: str,
+    scontrol_script: str,
+    initial_state: str = "submitted",
+) -> tuple[subprocess.CompletedProcess[str], ExecutionStore, Path]:
+    """Execute a rendered scheduler script with deterministic local commands."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create(
+        execution_id,
+        mode="scheduler",
+        scheduler_provider="slurm",
+    )
+    if initial_state == "scripted":
+        store.update(execution_id, state="scripted", terminal=True)
+    else:
+        store.update(execution_id, state="submitting")
+        if initial_state == "submitted":
+            store.update(
+                execution_id,
+                state="submitted",
+                submitted=True,
+                native_id="41",
+            )
+        elif initial_state != "submitting":
+            raise ValueError(f"unsupported test execution state: {initial_state}")
+    execution_root = store.executions_dir / execution_id
+    scheduler = SlurmScheduler(
+        {"name": "slurm"},
+        execution_root,
+        pipeline_snapshot_dir=execution_root / "runtime",
+    )
+
+    executable_dir = tmp_path / "bin"
+    executable_dir.mkdir()
+    scontrol = executable_dir / "scontrol"
+    scontrol.write_text(scontrol_script, encoding="utf-8")
+    scontrol.chmod(0o700)
+    jarvis = executable_dir / "jarvis"
+    jarvis.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    jarvis.chmod(0o700)
+    environment = dict(os.environ)
+    environment["PATH"] = f"{executable_dir}{os.pathsep}{environment['PATH']}"
+    environment["SLURM_JOB_NODELIST"] = "ignored"
+    environment["SLURM_JOB_ID"] = "41"
+    environment["SLURM_CLUSTER_NAME"] = "ares"
+    completed = subprocess.run(
+        ["bash", "-c", scheduler.render()],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+    )
+    return completed, store, execution_root
+
+
+def test_slurm_exit_handler_finalizes_success_after_hostfile_publish(
+    tmp_path: Path,
+) -> None:
+    """Hostfile setup cannot clear the durable execution finalizer."""
+    if os.name == "nt":
+        rendered = SlurmScheduler(
+            {"name": "slurm"},
+            tmp_path / "executions" / "success",
+            pipeline_snapshot_dir=(tmp_path / "executions" / "success" / "runtime"),
+        ).render()
+        assert rendered.count("trap jarvis_finalize_execution EXIT") == 1
+        assert (
+            "trap - EXIT"
+            not in rendered.split("trap jarvis_finalize_execution EXIT", maxsplit=1)[1]
+        )
+        return
+
+    completed, store, execution_root = _run_execution_scheduler_script(
+        tmp_path,
+        execution_id="success",
+        scontrol_script="#!/bin/sh\nprintf 'node-1\\n'\n",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    record = store.get("success")
+    assert record.state == "completed"
+    assert record.terminal is True
+    assert record.return_code == 0
+    assert record.scheduler_native_id == "41"
+    assert record.cluster == "ares"
+    assert list(execution_root.glob(".hostfile.txt.jarvis.*")) == []
+
+
+def test_slurm_runtime_identity_closes_submitter_crash_window(
+    tmp_path: Path,
+) -> None:
+    """The allocation binds native identity even before submit stdout is saved."""
+    if os.name == "nt":
+        rendered = SlurmScheduler(
+            {"name": "slurm"},
+            tmp_path / "executions" / "crash-window",
+            pipeline_snapshot_dir=(
+                tmp_path / "executions" / "crash-window" / "runtime"
+            ),
+        ).render()
+        assert '--native-id "$SLURM_JOB_ID"' in rendered
+        assert '"${jarvis_scheduler_cluster_args[@]}"' in rendered
+        return
+
+    completed, store, _execution_root = _run_execution_scheduler_script(
+        tmp_path,
+        execution_id="crash-window",
+        scontrol_script="#!/bin/sh\nprintf 'node-1\\n'\n",
+        initial_state="submitting",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    record = store.get("crash-window")
+    assert record.state == "completed"
+    assert record.scheduler_native_id == "41"
+    assert record.cluster == "ares"
+
+
+def test_generated_script_can_activate_and_complete_after_manual_submission(
+    tmp_path: Path,
+) -> None:
+    """A script-only handle remains safely activatable by a real allocation."""
+    if os.name == "nt":
+        store = ExecutionStore(tmp_path / "executions", "example")
+        store.create("manual", mode="scheduler", scheduler_provider="slurm")
+        store.update("manual", state="scripted", terminal=True)
+        activated = store.activate_scheduler(
+            "manual",
+            provider="slurm",
+            native_id="41",
+            cluster="ares",
+        )
+        assert activated.state == "running"
+        assert activated.terminal is False
+        return
+
+    completed, store, _execution_root = _run_execution_scheduler_script(
+        tmp_path,
+        execution_id="manual",
+        scontrol_script="#!/bin/sh\nprintf 'node-1\\n'\n",
+        initial_state="scripted",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    record = store.get("manual")
+    assert record.state == "completed"
+    assert record.scheduler_native_id == "41"
+
+
+def test_slurm_exit_handler_cleans_temp_and_finalizes_hostfile_failure(
+    tmp_path: Path,
+) -> None:
+    """An early hostfile failure both removes its temp and records failure."""
+    if os.name == "nt":
+        rendered = SlurmScheduler(
+            {"name": "slurm"},
+            tmp_path / "executions" / "hostfile-failure",
+            pipeline_snapshot_dir=(
+                tmp_path / "executions" / "hostfile-failure" / "runtime"
+            ),
+        ).render()
+        assert "jarvis_cleanup_hostfile_tmp" not in rendered
+        assert 'rm -f -- "$jarvis_hostfile_tmp"' in rendered
+        return
+
+    completed, store, execution_root = _run_execution_scheduler_script(
+        tmp_path,
+        execution_id="hostfile-failure",
+        scontrol_script="#!/bin/sh\nprintf 'partial-node\\n'\nexit 23\n",
+    )
+
+    assert completed.returncode != 0
+    assert "Could not expand the SLURM allocation hostfile" in completed.stderr
+    record = store.get("hostfile-failure")
+    assert record.state == "failed"
+    assert record.terminal is True
+    assert record.return_code == completed.returncode
+    assert list(execution_root.glob(".hostfile.txt.jarvis.*")) == []
+
+
 def test_atomic_yaml_dump_preserves_existing_document_when_serialization_fails(
     tmp_path: Path,
 ) -> None:
@@ -297,7 +481,7 @@ def test_pipeline_persists_provider_owned_submission_identity(tmp_path: Path) ->
         with patch("jarvis_cd.shell.Exec", return_value=executor):
             returned = pipeline.submit(submit=True, wait=False)
 
-    assert returned == script_path
+    assert returned.script_path == script_path
     assert pipeline.last_submission == {
         "schema_version": "jarvis.scheduler.submission.v1",
         "execution_id": pipeline.last_submission["execution_id"],
@@ -329,6 +513,71 @@ def test_pipeline_persists_provider_owned_submission_identity(tmp_path: Path) ->
     assert saved_submissions[2]["scheduler_job_id"] == "24680"
     assert saved_submissions[2]["submitted"] is True
     assert saved_submissions[3]["state"] == "submitted"
+
+
+def test_pre_submit_persistence_failure_is_terminal_without_scheduler_effect(
+    tmp_path: Path,
+) -> None:
+    """Failure before invoking sbatch is known local failure, not ambiguity."""
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.save = Mock(side_effect=[None, RuntimeError("state save failed"), None])
+
+    with patch("jarvis_cd.shell.Exec") as executor:
+        with pytest.raises(RuntimeError, match="state save failed"):
+            pipeline.submit(submit=True, execution_id="pre-submit-failure")
+
+    executor.assert_not_called()
+    record = pipeline.get_execution("pre-submit-failure")
+    assert record.state == "failed"
+    assert record.terminal is True
+    assert record.return_code == 1
+    assert record.metadata["failure_stage"] == "scheduler_pre_submit_persistence"
+
+
+def test_scheduler_executor_exception_is_durably_ambiguous(tmp_path: Path) -> None:
+    """An exception around sbatch never falsely claims that no job exists."""
+    pipeline = _real_pipeline(tmp_path)
+    executor = Mock()
+    executor.run.side_effect = RuntimeError("submit transport disappeared")
+
+    with patch("jarvis_cd.shell.Exec", return_value=executor):
+        with pytest.raises(RuntimeError, match="submit transport disappeared"):
+            pipeline.submit(submit=True, execution_id="ambiguous-submit")
+
+    record = pipeline.get_execution("ambiguous-submit")
+    assert record.state == "unknown"
+    assert record.terminal is False
+    assert record.scheduler_native_id is None
+    assert record.metadata["failure_stage"] == "scheduler_submit_side_effect"
+
+
+def test_accepted_identity_survives_submitter_persistence_failure(
+    tmp_path: Path,
+) -> None:
+    """An accepted job remains identifiable when compatibility save fails."""
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.save = Mock(
+        side_effect=[None, None, RuntimeError("compatibility save failed"), None]
+    )
+    execution = SimpleNamespace(
+        exit_code={"localhost": 0},
+        stdout={"localhost": "41;ares\n"},
+        stderr={"localhost": ""},
+    )
+    executor = Mock()
+    executor.run.return_value = execution
+
+    with patch("jarvis_cd.shell.Exec", return_value=executor):
+        with pytest.raises(RuntimeError, match="accepted job 41"):
+            pipeline.submit(submit=True, execution_id="identity-save-failure")
+
+    record = pipeline.get_execution("identity-save-failure")
+    assert record.state == "unknown"
+    assert record.submitted is True
+    assert record.terminal is False
+    assert record.scheduler_native_id == "41"
+    assert record.cluster == "ares"
+    assert record.metadata["failure_stage"] == "scheduler_identity_persistence"
 
 
 def test_pipeline_never_accepts_unstructured_submission_stdout(tmp_path: Path) -> None:
@@ -468,7 +717,9 @@ def test_scheduler_submission_uses_isolated_pipeline_environment_and_paths(
     """A queued job references only its immutable execution-scoped snapshot."""
     pipeline = _real_pipeline(tmp_path)
 
-    script_a = pipeline.submit(submit=False, execution_id="execution-a")
+    handle_a = pipeline.submit(submit=False, execution_id="execution-a")
+    script_a = handle_a.script_path
+    assert script_a is not None
     submission_a = dict(pipeline.last_submission)
     runtime_a = Path(submission_a["pipeline_snapshot_path"])
     input_a = Path(submission_a["pipeline_input_path"])
@@ -476,7 +727,9 @@ def test_scheduler_submission_uses_isolated_pipeline_environment_and_paths(
 
     pipeline.env = {"PATH": "/spack/b/bin", "SPACK_ROOT": "/opt/spack"}
     pipeline.save()
-    script_b = pipeline.submit(submit=False, execution_id="execution-b")
+    handle_b = pipeline.submit(submit=False, execution_id="execution-b")
+    script_b = handle_b.script_path
+    assert script_b is not None
     submission_b = dict(pipeline.last_submission)
     runtime_b = Path(submission_b["pipeline_snapshot_path"])
 
@@ -627,7 +880,9 @@ def test_scheduler_submission_rejects_invalid_or_reused_execution_ids(
     with pytest.raises(ValueError, match="execution_id"):
         pipeline.submit(submit=False, execution_id="../outside")
 
-    script = pipeline.submit(submit=False, execution_id="stable-id")
+    handle = pipeline.submit(submit=False, execution_id="stable-id")
+    script = handle.script_path
+    assert script is not None
     original = script.read_bytes()
     with pytest.raises(FileExistsError):
         pipeline.submit(submit=False, execution_id="stable-id")
@@ -636,10 +891,10 @@ def test_scheduler_submission_rejects_invalid_or_reused_execution_ids(
     assert not (tmp_path / "shared" / "outside").exists()
 
 
-def test_scheduler_submission_removes_incomplete_execution_snapshot(
+def test_scheduler_submission_records_incomplete_execution_snapshot_failure(
     tmp_path: Path,
 ) -> None:
-    """A pre-submit snapshot failure leaves no execution-shaped residue."""
+    """A pre-submit snapshot failure remains durably queryable and terminal."""
     pipeline = _real_pipeline(tmp_path)
     pipeline._write_execution_snapshot = Mock(
         side_effect=RuntimeError("snapshot failed")
@@ -648,7 +903,10 @@ def test_scheduler_submission_removes_incomplete_execution_snapshot(
     with pytest.raises(RuntimeError, match="snapshot failed"):
         pipeline.submit(submit=False, execution_id="incomplete")
 
-    assert not (tmp_path / "shared" / "example" / "executions" / "incomplete").exists()
+    record = pipeline.get_execution("incomplete")
+    assert record.state == "failed"
+    assert record.terminal is True
+    assert record.metadata["failure_stage"] == "scheduler_preparation"
 
 
 def test_real_packages_use_execution_scoped_config_shared_and_private_roots(

--- a/test/unit/core/test_scheduler_submission.py
+++ b/test/unit/core/test_scheduler_submission.py
@@ -751,3 +751,33 @@ def test_script_only_execution_is_explicitly_cleanup_eligible(tmp_path: Path) ->
 
     assert removed == ["script-only"]
     assert not (tmp_path / "shared" / "example" / "executions" / "script-only").exists()
+
+
+def test_failed_execution_cleanup_reseals_and_restores_exact_root(
+    tmp_path: Path,
+) -> None:
+    """A deletion failure restores both the exact root and its prior input mode."""
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.submit(submit=False, execution_id="cleanup-rollback")
+    execution_root = tmp_path / "shared" / "example" / "executions" / "cleanup-rollback"
+
+    with (
+        patch(
+            "jarvis_cd.core.pipeline._set_execution_input_mode",
+            side_effect=[0o500, 0o700],
+        ) as set_mode,
+        patch(
+            "jarvis_cd.core.pipeline.shutil.rmtree",
+            side_effect=PermissionError("injected deletion failure"),
+        ),
+        pytest.raises(PermissionError, match="injected deletion failure"),
+    ):
+        pipeline.cleanup_executions(["cleanup-rollback"])
+
+    assert execution_root.is_dir()
+    assert not list(execution_root.parent.glob(".remove-cleanup-rollback-*"))
+    assert set_mode.call_count == 2
+    quarantine = set_mode.call_args_list[0].args[0]
+    assert quarantine.name.startswith(".remove-cleanup-rollback-")
+    assert set_mode.call_args_list[1].args == (quarantine,)
+    assert set_mode.call_args_list[1].kwargs == {"mode": 0o500}

--- a/test/unit/core/test_scheduler_submission.py
+++ b/test/unit/core/test_scheduler_submission.py
@@ -96,6 +96,7 @@ def test_pipeline_persists_provider_owned_submission_identity(tmp_path: Path) ->
         "submitted": True,
         "wait": False,
         "terminal": False,
+        "scheduler_stderr": None,
         "submission_returncode": 0,
         "terminal_returncode": None,
     }
@@ -198,7 +199,8 @@ def test_pipeline_records_true_submission_failure_without_job_identity(
     )
     execution = SimpleNamespace(
         exit_code={"localhost": 1},
-        stdout={"localhost": "sbatch: error: invalid account\n"},
+        stderr={"localhost": "sbatch: error: invalid account\n"},
+        stdout={"localhost": ""},
     )
     executor = Mock()
     executor.run.return_value = execution
@@ -211,13 +213,19 @@ def test_pipeline_records_true_submission_failure_without_job_identity(
 
     with patch("jarvis_cd.core.scheduler.make_scheduler", return_value=scheduler):
         with patch("jarvis_cd.shell.Exec", return_value=executor):
-            with pytest.raises(RuntimeError, match="Scheduler submission failed"):
+            with pytest.raises(
+                RuntimeError,
+                match="Scheduler submission failed.*invalid account",
+            ):
                 pipeline.submit(submit=True, wait=False)
 
     assert pipeline.last_submission["scheduler_job_id"] is None
     assert pipeline.last_submission["state"] == "submission_failed"
     assert pipeline.last_submission["submitted"] is False
     assert pipeline.last_submission["terminal"] is False
+    assert pipeline.last_submission["scheduler_stderr"] == (
+        "sbatch: error: invalid account"
+    )
     assert pipeline.last_submission["submission_returncode"] == 1
     assert pipeline.last_submission["terminal_returncode"] is None
     pipeline.save.assert_called_once_with()

--- a/test/unit/core/test_scheduler_submission.py
+++ b/test/unit/core/test_scheduler_submission.py
@@ -1,13 +1,79 @@
 """Structured scheduler-submission contract tests."""
 
+import multiprocessing
+import os
+import shlex
+import subprocess
+from copy import deepcopy
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+import yaml
 
-from jarvis_cd.core.pipeline import Pipeline
+from jarvis_cd.core.config import Jarvis
+from jarvis_cd.core.pipeline import Pipeline, _atomic_yaml_dump
 from jarvis_cd.core.scheduler import SlurmScheduler
+
+
+def _prepare_snapshot_submission(pipeline: Pipeline, tmp_path: Path) -> None:
+    """Give a low-level Pipeline test double an isolated snapshot result."""
+    pipeline.last_submission = None
+    pipeline._execution_snapshot_dir = None
+    pipeline._write_execution_snapshot = Mock(
+        return_value=(
+            tmp_path / "runtime",
+            tmp_path / "input",
+            "a" * 64,
+        )
+    )
+
+
+def _real_pipeline(tmp_path: Path) -> Pipeline:
+    """Create a real Pipeline whose config/shared/private roots are test-local."""
+    repository_root = Path(__file__).parents[3]
+    jarvis = SimpleNamespace(
+        hostfile=None,
+        get_pipeline_dir=lambda name: tmp_path / "config" / "pipelines" / name,
+        get_pipeline_shared_dir=lambda name: tmp_path / "shared" / name,
+        get_pipeline_private_dir=lambda name: tmp_path / "private" / name,
+        get_builtin_repo_path=lambda: repository_root / "builtin",
+        set_current_pipeline=lambda _name: None,
+    )
+    with patch("jarvis_cd.core.pipeline.Jarvis.get_instance", return_value=jarvis):
+        pipeline = Pipeline()
+    pipeline.create("example")
+    pipeline.scheduler = {"name": "slurm", "nodes": 1}
+    pipeline.packages = [
+        {
+            "pkg_type": "builtin.echo",
+            "pkg_id": "echo",
+            "pkg_name": "echo",
+            "global_id": "example.echo",
+            "config": {},
+        }
+    ]
+    pipeline.env = {"PATH": "/spack/a/bin", "SPACK_ROOT": "/opt/spack"}
+    pipeline.last_loaded_file = "/operator/source.yaml"
+    pipeline.save()
+    return pipeline
+
+
+def _load_real_scheduler_snapshot(
+    jarvis_root: str,
+    runtime_dir: str,
+    result_queue: Any,
+) -> None:
+    """Load one execution snapshot in an independent real Jarvis process."""
+    Jarvis._instance = None
+    Jarvis.get_instance(jarvis_root)
+    os.environ["JARVIS_PIPELINE_SNAPSHOT_DIR"] = runtime_dir
+    pipeline = Pipeline()
+    pipeline.load("yaml", str(Path(runtime_dir) / "pipeline.yaml"))
+    result_queue.put(pipeline._execution_id)
 
 
 def test_slurm_submission_uses_and_parses_parsable_identity(tmp_path: Path) -> None:
@@ -34,6 +100,144 @@ def test_slurm_submission_uses_and_parses_parsable_identity(tmp_path: Path) -> N
         "scheduler_cluster": "ares",
         "identity_source": "scheduler_submit_api",
     }
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {"name": "slurm", "job_name": "safe\n#SBATCH --nodes=999"},
+        {"name": "slurm", "hostfile": "/tmp/hosts\nrm -rf /"},
+        {"name": "slurm", "bad-key": "value"},
+        {"name": "slurm", "sbatch_args": ["--nodes=1\n#SBATCH --exclusive"]},
+        {"name": "slurm", "sbatch_args": ["nodes=1"]},
+        {"name": "slurm", "suffix": "-40g\nattacker"},
+        {"name": "slurm", "pre_cmds": ["echo safe\necho injected"]},
+    ],
+)
+def test_slurm_renderer_rejects_structural_injection(
+    tmp_path: Path,
+    spec: dict[str, object],
+) -> None:
+    """Untrusted scheduler values cannot create directives or script lines."""
+    with pytest.raises(ValueError):
+        SlurmScheduler(spec, tmp_path)
+
+
+def test_slurm_renderer_atomically_publishes_allocation_hostfile(
+    tmp_path: Path,
+) -> None:
+    """The rendered script stages, flushes, and renames its hostfile."""
+    hostfile = tmp_path / "allocation hosts.txt"
+    script = SlurmScheduler(
+        {"name": "slurm", "hostfile": str(hostfile)},
+        tmp_path,
+    ).render()
+
+    assert f"jarvis_hostfile={shlex.quote(str(hostfile))}" in script
+    assert "jarvis_hostfile_tmp=$(mktemp -- " in script
+    assert "if ! { scontrol show hostnames" in script
+    assert 'if [ ! -s "$jarvis_hostfile_tmp" ]; then' in script
+    assert "os.fsync(stream.fileno())" in script
+    assert "os.replace(temporary_path, final_path)" in script
+    assert "os.fsync(directory)" in script
+    assert '> "$jarvis_hostfile_tmp"' in script
+    assert f"> {shlex.quote(str(hostfile))}" not in script
+
+
+def test_slurm_hostfile_generation_failure_preserves_previous_file(
+    tmp_path: Path,
+) -> None:
+    """A failed scontrol command cannot truncate a prior valid hostfile."""
+    hostfile = tmp_path / "hostfile.txt"
+    hostfile.write_text("known-good-node\n", encoding="utf-8")
+    script = SlurmScheduler(
+        {"name": "slurm", "hostfile": str(hostfile)},
+        tmp_path,
+    ).render()
+
+    if os.name == "nt":
+        assert 'if ! { scontrol show hostnames "$SLURM_JOB_NODELIST"; }' in script
+        assert '> "$jarvis_hostfile_tmp"' in script
+        return
+
+    executable_dir = tmp_path / "bin"
+    executable_dir.mkdir()
+    scontrol = executable_dir / "scontrol"
+    scontrol.write_text(
+        "#!/bin/sh\nprintf 'partial-node\\n'\nexit 23\n",
+        encoding="utf-8",
+    )
+    scontrol.chmod(0o700)
+    environment = dict(os.environ)
+    environment["PATH"] = f"{executable_dir}{os.pathsep}{environment['PATH']}"
+    environment["SLURM_JOB_NODELIST"] = "ignored"
+
+    completed = subprocess.run(
+        ["bash", "-c", script],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+    )
+
+    assert completed.returncode != 0
+    assert "Could not expand the SLURM allocation hostfile" in completed.stderr
+    assert hostfile.read_text(encoding="utf-8") == "known-good-node\n"
+    assert list(tmp_path.glob(".hostfile.txt.jarvis.*")) == []
+
+
+def test_atomic_yaml_dump_preserves_existing_document_when_serialization_fails(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "pipeline.yaml"
+    target.write_text("state: previous\n", encoding="utf-8")
+
+    def fail_after_partial_write(value, stream, *, default_flow_style):
+        del value, default_flow_style
+        stream.write("state: partial\n")
+        raise RuntimeError("serialization interrupted")
+
+    with patch(
+        "jarvis_cd.core.pipeline.yaml.dump", side_effect=fail_after_partial_write
+    ):
+        with pytest.raises(RuntimeError, match="serialization interrupted"):
+            _atomic_yaml_dump(target, {"state": "new"})
+
+    assert target.read_text(encoding="utf-8") == "state: previous\n"
+    assert list(tmp_path.glob(".pipeline.yaml.*.tmp")) == []
+
+
+def test_scheduler_script_fdopen_failure_closes_mkstemp_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scheduler script setup failures do not leak the raw mkstemp handle."""
+    import jarvis_cd.core.scheduler as scheduler_module
+
+    descriptors: list[int] = []
+    real_mkstemp = scheduler_module.tempfile.mkstemp
+
+    def capture_mkstemp(*args: object, **kwargs: object) -> tuple[int, str]:
+        descriptor, name = real_mkstemp(*args, **kwargs)
+        descriptors.append(descriptor)
+        return descriptor, name
+
+    monkeypatch.setattr(scheduler_module.tempfile, "mkstemp", capture_mkstemp)
+    monkeypatch.setattr(
+        scheduler_module.os,
+        "fdopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("fdopen failed")),
+    )
+    scheduler = SlurmScheduler({"name": "slurm"}, tmp_path)
+
+    with pytest.raises(OSError, match="fdopen failed"):
+        scheduler.write_script()
+
+    assert len(descriptors) == 1
+    with pytest.raises(OSError):
+        scheduler_module.os.fstat(descriptors[0])
+    assert list(tmp_path.glob(".submit.slurm.*.tmp")) == []
 
 
 @pytest.mark.parametrize(
@@ -74,11 +278,15 @@ def test_pipeline_persists_provider_owned_submission_identity(tmp_path: Path) ->
     executor = Mock()
     executor.run.return_value = execution
     pipeline = Pipeline.__new__(Pipeline)
-    pipeline.scheduler = {"name": "slurm"}
+    pipeline.scheduler = {"name": "slurm", "job_name": "clio-relay-unit-marker"}
     pipeline.name = "example"
     pipeline.last_loaded_file = None
     pipeline.jarvis = SimpleNamespace(get_pipeline_shared_dir=lambda _name: tmp_path)
-    pipeline.save = Mock()
+    _prepare_snapshot_submission(pipeline, tmp_path)
+    saved_submissions: list[dict[str, object]] = []
+    pipeline.save = Mock(
+        side_effect=lambda: saved_submissions.append(deepcopy(pipeline.last_submission))
+    )
 
     with patch("jarvis_cd.core.scheduler.make_scheduler", return_value=scheduler):
         with patch("jarvis_cd.shell.Exec", return_value=executor):
@@ -87,8 +295,14 @@ def test_pipeline_persists_provider_owned_submission_identity(tmp_path: Path) ->
     assert returned == script_path
     assert pipeline.last_submission == {
         "schema_version": "jarvis.scheduler.submission.v1",
+        "execution_id": pipeline.last_submission["execution_id"],
         "provider": "slurm",
         "script_path": str(script_path),
+        "hostfile_path": str(tmp_path / "hostfile.txt"),
+        "pipeline_snapshot_path": str(tmp_path / "runtime"),
+        "pipeline_input_path": str(tmp_path / "input"),
+        "execution_root_path": pipeline.last_submission["execution_root_path"],
+        "pipeline_snapshot_sha256": "a" * 64,
         "scheduler_job_id": "24680",
         "scheduler_cluster": "ares",
         "identity_source": "scheduler_submit_api",
@@ -99,9 +313,17 @@ def test_pipeline_persists_provider_owned_submission_identity(tmp_path: Path) ->
         "scheduler_stderr": None,
         "submission_returncode": 0,
         "terminal_returncode": None,
+        "reconciliation_marker": "clio-relay-unit-marker",
     }
     scheduler.parse_submission_output.assert_called_once_with("24680;ares\n")
-    pipeline.save.assert_called_once_with()
+    assert pipeline.save.call_count == 4
+    assert saved_submissions[0] is None
+    assert saved_submissions[1]["state"] == "scripted"
+    assert saved_submissions[1]["scheduler_job_id"] is None
+    assert saved_submissions[1]["reconciliation_marker"] == "clio-relay-unit-marker"
+    assert saved_submissions[2]["scheduler_job_id"] == "24680"
+    assert saved_submissions[2]["submitted"] is True
+    assert saved_submissions[3]["state"] == "submitted"
 
 
 def test_pipeline_never_accepts_unstructured_submission_stdout(tmp_path: Path) -> None:
@@ -124,6 +346,7 @@ def test_pipeline_never_accepts_unstructured_submission_stdout(tmp_path: Path) -
     pipeline.name = "example"
     pipeline.last_loaded_file = None
     pipeline.jarvis = SimpleNamespace(get_pipeline_shared_dir=lambda _name: tmp_path)
+    _prepare_snapshot_submission(pipeline, tmp_path)
     pipeline.save = Mock()
 
     with patch("jarvis_cd.core.scheduler.make_scheduler", return_value=scheduler):
@@ -133,7 +356,7 @@ def test_pipeline_never_accepts_unstructured_submission_stdout(tmp_path: Path) -
 
     assert pipeline.last_submission["scheduler_job_id"] is None
     assert pipeline.last_submission["state"] == "identity_failed"
-    pipeline.save.assert_called_once_with()
+    assert pipeline.save.call_count == 3
 
 
 def test_pipeline_preserves_waited_job_identity_when_workload_fails(
@@ -167,6 +390,7 @@ def test_pipeline_preserves_waited_job_identity_when_workload_fails(
     pipeline.name = "example"
     pipeline.last_loaded_file = None
     pipeline.jarvis = SimpleNamespace(get_pipeline_shared_dir=lambda _name: tmp_path)
+    _prepare_snapshot_submission(pipeline, tmp_path)
     pipeline.save = Mock()
 
     with patch("jarvis_cd.core.scheduler.make_scheduler", return_value=scheduler):
@@ -183,7 +407,7 @@ def test_pipeline_preserves_waited_job_identity_when_workload_fails(
     assert pipeline.last_submission["terminal"] is True
     assert pipeline.last_submission["submission_returncode"] == 9
     assert pipeline.last_submission["terminal_returncode"] == 9
-    pipeline.save.assert_called_once_with()
+    assert pipeline.save.call_count == 4
 
 
 def test_pipeline_records_true_submission_failure_without_job_identity(
@@ -209,6 +433,7 @@ def test_pipeline_records_true_submission_failure_without_job_identity(
     pipeline.name = "example"
     pipeline.last_loaded_file = None
     pipeline.jarvis = SimpleNamespace(get_pipeline_shared_dir=lambda _name: tmp_path)
+    _prepare_snapshot_submission(pipeline, tmp_path)
     pipeline.save = Mock()
 
     with patch("jarvis_cd.core.scheduler.make_scheduler", return_value=scheduler):
@@ -222,10 +447,307 @@ def test_pipeline_records_true_submission_failure_without_job_identity(
     assert pipeline.last_submission["scheduler_job_id"] is None
     assert pipeline.last_submission["state"] == "submission_failed"
     assert pipeline.last_submission["submitted"] is False
-    assert pipeline.last_submission["terminal"] is False
+    assert pipeline.last_submission["terminal"] is True
     assert pipeline.last_submission["scheduler_stderr"] == (
         "sbatch: error: invalid account"
     )
     assert pipeline.last_submission["submission_returncode"] == 1
     assert pipeline.last_submission["terminal_returncode"] is None
-    pipeline.save.assert_called_once_with()
+    assert pipeline.save.call_count == 3
+
+
+def test_scheduler_submission_uses_isolated_pipeline_environment_and_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A queued job references only its immutable execution-scoped snapshot."""
+    pipeline = _real_pipeline(tmp_path)
+
+    script_a = pipeline.submit(submit=False, execution_id="execution-a")
+    submission_a = dict(pipeline.last_submission)
+    runtime_a = Path(submission_a["pipeline_snapshot_path"])
+    input_a = Path(submission_a["pipeline_input_path"])
+    environment_a = yaml.safe_load((runtime_a / "environment.yaml").read_text())
+
+    pipeline.env = {"PATH": "/spack/b/bin", "SPACK_ROOT": "/opt/spack"}
+    pipeline.save()
+    script_b = pipeline.submit(submit=False, execution_id="execution-b")
+    submission_b = dict(pipeline.last_submission)
+    runtime_b = Path(submission_b["pipeline_snapshot_path"])
+
+    assert script_a != script_b
+    assert script_a.parent.name == "execution-a"
+    assert script_b.parent.name == "execution-b"
+    assert submission_a["hostfile_path"] != submission_b["hostfile_path"]
+    assert yaml.safe_load((runtime_a / "environment.yaml").read_text()) == environment_a
+    assert yaml.safe_load((runtime_b / "environment.yaml").read_text())["PATH"] == (
+        "/spack/b/bin"
+    )
+    script_text = script_a.read_text(encoding="utf-8")
+    assert "JARVIS_PIPELINE_SNAPSHOT_DIR" in script_text
+    assert str(runtime_a) in script_text
+    assert "jarvis cd example" not in script_text
+    assert len(str(submission_a["pipeline_snapshot_sha256"])) == 64
+    assert (input_a / "pipeline.yaml").is_file()
+
+    monkeypatch.setenv("JARVIS_PIPELINE_SNAPSHOT_DIR", str(runtime_a))
+    with patch(
+        "jarvis_cd.core.pipeline.Jarvis.get_instance",
+        return_value=pipeline.jarvis,
+    ):
+        loaded = Pipeline()
+    loaded.load("yaml", str(runtime_a / "pipeline.yaml"))
+    assert loaded.env == environment_a
+    loaded.env["PATH"] = "/runtime-only/bin"
+    loaded.save()
+    canonical_env = yaml.safe_load(
+        (pipeline.jarvis.get_pipeline_dir("example") / "environment.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert canonical_env["PATH"] == "/spack/b/bin"
+    assert yaml.safe_load((runtime_a / "environment.yaml").read_text())["PATH"] == (
+        "/runtime-only/bin"
+    )
+
+
+def test_queued_snapshot_round_trips_container_gpu_and_expanded_tmp_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Queued execution snapshots retain the effective container runtime state."""
+    pipeline = _real_pipeline(tmp_path)
+    node_tmp = tmp_path / "node-local-tmp"
+    monkeypatch.setenv("JARVIS_NODE_TMP", str(node_tmp))
+    pipeline.container_gpu = True
+    pipeline.tmp_bind_root = os.path.expandvars("$JARVIS_NODE_TMP")
+    pipeline.save()
+
+    pipeline.submit(submit=False, execution_id="container-runtime")
+    runtime = Path(pipeline.last_submission["pipeline_snapshot_path"])
+    snapshot = yaml.safe_load((runtime / "pipeline.yaml").read_text(encoding="utf-8"))
+
+    assert snapshot["container_gpu"] is True
+    assert snapshot["tmp_bind_root"] == str(node_tmp)
+
+    monkeypatch.setenv("JARVIS_PIPELINE_SNAPSHOT_DIR", str(runtime))
+    with patch(
+        "jarvis_cd.core.pipeline.Jarvis.get_instance",
+        return_value=pipeline.jarvis,
+    ):
+        loaded = Pipeline()
+    loaded.load("yaml", str(runtime / "pipeline.yaml"))
+
+    assert loaded.container_gpu is True
+    assert loaded.tmp_bind_root == str(node_tmp)
+
+
+def test_concurrent_real_snapshot_loads_do_not_change_operator_selection(
+    tmp_path: Path,
+) -> None:
+    """Independent queued jobs cannot race on the real global Jarvis config."""
+    original_instance = Jarvis._instance
+    processes: list[multiprocessing.Process] = []
+    result_queue: Any = None
+    try:
+        Jarvis._instance = None
+        jarvis_root = tmp_path / "jarvis-root"
+        jarvis = Jarvis.get_instance(str(jarvis_root))
+        jarvis.initialize(
+            str(tmp_path / "config"),
+            str(tmp_path / "private"),
+            str(tmp_path / "shared"),
+            force=False,
+        )
+
+        runtimes: list[Path] = []
+        for name in ("alpha", "beta"):
+            pipeline = Pipeline()
+            pipeline.create(name)
+            pipeline.scheduler = {"name": "slurm", "nodes": 1}
+            pipeline.packages = [
+                {
+                    "pkg_type": "builtin.echo",
+                    "pkg_id": "echo",
+                    "pkg_name": "echo",
+                    "global_id": f"{name}.echo",
+                    "config": {},
+                }
+            ]
+            pipeline.env = {"PATH": os.environ.get("PATH", "")}
+            pipeline.save()
+            pipeline.submit(submit=False, execution_id=f"{name}-queued")
+            runtimes.append(Path(pipeline.last_submission["pipeline_snapshot_path"]))
+
+        jarvis.set_current_pipeline("operator-selection")
+        context = multiprocessing.get_context("spawn")
+        result_queue = context.Queue()
+        processes = [
+            context.Process(
+                target=_load_real_scheduler_snapshot,
+                args=(str(jarvis_root), str(runtime), result_queue),
+            )
+            for runtime in runtimes
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=30)
+            assert not process.is_alive()
+            assert process.exitcode == 0
+
+        loaded_ids = {result_queue.get(timeout=5) for _process in processes}
+        assert loaded_ids == {"alpha-queued", "beta-queued"}
+        persisted_config = yaml.safe_load(
+            jarvis.config_file.read_text(encoding="utf-8")
+        )
+        assert persisted_config["current_pipeline"] == "operator-selection"
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+        if result_queue is not None:
+            result_queue.close()
+            result_queue.join_thread()
+        Jarvis._instance = original_instance
+
+
+def test_scheduler_submission_rejects_invalid_or_reused_execution_ids(
+    tmp_path: Path,
+) -> None:
+    """Execution identities cannot escape or overwrite an existing snapshot."""
+    pipeline = _real_pipeline(tmp_path)
+
+    with pytest.raises(ValueError, match="execution_id"):
+        pipeline.submit(submit=False, execution_id="../outside")
+
+    script = pipeline.submit(submit=False, execution_id="stable-id")
+    original = script.read_bytes()
+    with pytest.raises(FileExistsError):
+        pipeline.submit(submit=False, execution_id="stable-id")
+
+    assert script.read_bytes() == original
+    assert not (tmp_path / "shared" / "outside").exists()
+
+
+def test_scheduler_submission_removes_incomplete_execution_snapshot(
+    tmp_path: Path,
+) -> None:
+    """A pre-submit snapshot failure leaves no execution-shaped residue."""
+    pipeline = _real_pipeline(tmp_path)
+    pipeline._write_execution_snapshot = Mock(
+        side_effect=RuntimeError("snapshot failed")
+    )
+
+    with pytest.raises(RuntimeError, match="snapshot failed"):
+        pipeline.submit(submit=False, execution_id="incomplete")
+
+    assert not (tmp_path / "shared" / "example" / "executions" / "incomplete").exists()
+
+
+def test_real_packages_use_execution_scoped_config_shared_and_private_roots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two queued copies of a real package never share mutable directories."""
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.submit(submit=False, execution_id="package-a")
+    runtime_a = Path(pipeline.last_submission["pipeline_snapshot_path"])
+    pipeline.submit(submit=False, execution_id="package-b")
+    runtime_b = Path(pipeline.last_submission["pipeline_snapshot_path"])
+
+    loaded: list[Pipeline] = []
+    for runtime in (runtime_a, runtime_b):
+        monkeypatch.setenv("JARVIS_PIPELINE_SNAPSHOT_DIR", str(runtime))
+        with patch(
+            "jarvis_cd.core.pipeline.Jarvis.get_instance",
+            return_value=pipeline.jarvis,
+        ):
+            execution = Pipeline()
+        execution.load("yaml", str(runtime / "pipeline.yaml"))
+        loaded.append(execution)
+    monkeypatch.delenv("JARVIS_PIPELINE_SNAPSHOT_DIR")
+
+    packages = [
+        execution._load_package_instance(execution.packages[0], execution.env)
+        for execution in loaded
+    ]
+    roots = []
+    for package in packages:
+        roots.append(
+            (
+                Path(package.config_dir),
+                Path(package.shared_dir),
+                Path(package.private_dir),
+            )
+        )
+    assert roots[0] != roots[1]
+    for index, execution in enumerate(loaded):
+        execution_root = Path(execution._execution_root)
+        assert roots[index] == (
+            execution_root / "runtime" / "packages" / "echo",
+            execution_root / "shared" / "echo",
+            execution_root / "private" / "echo",
+        )
+    assert loaded[0].execution_container_name != loaded[1].execution_container_name
+    assert packages[0].deploy_image_name() != packages[1].deploy_image_name()
+
+    def write_package_state(index: int) -> None:
+        for directory in roots[index]:
+            (directory / "owner.txt").write_text(str(index), encoding="utf-8")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        list(executor.map(write_package_state, (0, 1)))
+
+    for index, directories in enumerate(roots):
+        for directory in directories:
+            assert (directory / "owner.txt").read_text(encoding="utf-8") == str(index)
+    named_config = pipeline.jarvis.get_pipeline_dir("example") / "packages" / "echo"
+    named_shared = pipeline.jarvis.get_pipeline_shared_dir("example") / "echo"
+    named_private = pipeline.jarvis.get_pipeline_private_dir("example") / "echo"
+    assert not named_config.exists()
+    assert not named_shared.exists()
+    assert not named_private.exists()
+
+
+def test_queued_execution_blocks_destroy_and_requires_verified_exact_cleanup(
+    tmp_path: Path,
+) -> None:
+    """Destroy cannot erase an async scheduler snapshot still potentially active."""
+    pipeline = _real_pipeline(tmp_path)
+    execution = SimpleNamespace(
+        exit_code={"localhost": 0},
+        stdout={"localhost": "31415;cluster\n"},
+        stderr={"localhost": ""},
+    )
+    executor = Mock()
+    executor.run.return_value = execution
+    with patch("jarvis_cd.shell.Exec", return_value=executor):
+        pipeline.submit(submit=True, wait=False, execution_id="queued-job")
+
+    execution_root = tmp_path / "shared" / "example" / "executions" / "queued-job"
+    with pytest.raises(RuntimeError, match="execution snapshots"):
+        pipeline.destroy()
+    assert execution_root.is_dir()
+    assert pipeline.jarvis.get_pipeline_dir("example").is_dir()
+    with pytest.raises(RuntimeError, match="not terminal"):
+        pipeline.cleanup_executions(["queued-job"])
+    with pytest.raises(ValueError, match="execution_id"):
+        pipeline.cleanup_executions(["../queued-job"], force=True)
+
+    assert pipeline.cleanup_executions(
+        ["queued-job"], terminal_verified=["queued-job"]
+    ) == ["queued-job"]
+    assert not execution_root.exists()
+
+
+def test_script_only_execution_is_explicitly_cleanup_eligible(tmp_path: Path) -> None:
+    """A script-only root is terminal but still removed only by exact ID."""
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.submit(submit=False, execution_id="script-only")
+
+    removed = pipeline.cleanup_executions(["script-only"])
+
+    assert removed == ["script-only"]
+    assert not (tmp_path / "shared" / "example" / "executions" / "script-only").exists()

--- a/test/unit/core/test_scheduler_submission.py
+++ b/test/unit/core/test_scheduler_submission.py
@@ -1,0 +1,223 @@
+"""Structured scheduler-submission contract tests."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from jarvis_cd.core.pipeline import Pipeline
+from jarvis_cd.core.scheduler import SlurmScheduler
+
+
+def test_slurm_submission_uses_and_parses_parsable_identity(tmp_path: Path) -> None:
+    scheduler = SlurmScheduler(
+        {"name": "slurm"},
+        tmp_path,
+        pipeline_name="example",
+    )
+
+    assert scheduler.submit_command() == [
+        "sbatch",
+        "--parsable",
+        str(tmp_path / "submit.slurm"),
+    ]
+    assert scheduler.submit_command(wait=True) == [
+        "sbatch",
+        "--parsable",
+        "--wait",
+        str(tmp_path / "submit.slurm"),
+    ]
+    assert scheduler.parse_submission_output("12345;ares\n") == {
+        "provider": "slurm",
+        "scheduler_job_id": "12345",
+        "scheduler_cluster": "ares",
+        "identity_source": "scheduler_submit_api",
+    }
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    ["Submitted batch job 12345\n", "12345\napplication output\n", "abc;ares\n"],
+)
+def test_slurm_submission_rejects_human_or_ambiguous_output(
+    tmp_path: Path,
+    stdout: str,
+) -> None:
+    scheduler = SlurmScheduler({"name": "slurm"}, tmp_path)
+
+    with pytest.raises(ValueError, match="parsable"):
+        scheduler.parse_submission_output(stdout)
+
+
+def test_pipeline_persists_provider_owned_submission_identity(tmp_path: Path) -> None:
+    script_path = tmp_path / "submit.slurm"
+    script_path.write_text("#!/bin/bash\n", encoding="utf-8")
+    scheduler = SimpleNamespace(
+        NAME="slurm",
+        hostfile=str(tmp_path / "hostfile.txt"),
+        write_script=Mock(return_value=script_path),
+        submit_command=Mock(return_value=["sbatch", "--parsable", str(script_path)]),
+        parse_submission_output=Mock(
+            return_value={
+                "provider": "slurm",
+                "scheduler_job_id": "24680",
+                "scheduler_cluster": "ares",
+                "identity_source": "scheduler_submit_api",
+            }
+        ),
+    )
+    execution = SimpleNamespace(
+        exit_code={"localhost": 0},
+        stdout={"localhost": "24680;ares\n"},
+    )
+    executor = Mock()
+    executor.run.return_value = execution
+    pipeline = Pipeline.__new__(Pipeline)
+    pipeline.scheduler = {"name": "slurm"}
+    pipeline.name = "example"
+    pipeline.last_loaded_file = None
+    pipeline.jarvis = SimpleNamespace(get_pipeline_shared_dir=lambda _name: tmp_path)
+    pipeline.save = Mock()
+
+    with patch("jarvis_cd.core.scheduler.make_scheduler", return_value=scheduler):
+        with patch("jarvis_cd.shell.Exec", return_value=executor):
+            returned = pipeline.submit(submit=True, wait=False)
+
+    assert returned == script_path
+    assert pipeline.last_submission == {
+        "schema_version": "jarvis.scheduler.submission.v1",
+        "provider": "slurm",
+        "script_path": str(script_path),
+        "scheduler_job_id": "24680",
+        "scheduler_cluster": "ares",
+        "identity_source": "scheduler_submit_api",
+        "state": "submitted",
+        "submitted": True,
+        "wait": False,
+        "terminal": False,
+        "submission_returncode": 0,
+        "terminal_returncode": None,
+    }
+    scheduler.parse_submission_output.assert_called_once_with("24680;ares\n")
+    pipeline.save.assert_called_once_with()
+
+
+def test_pipeline_never_accepts_unstructured_submission_stdout(tmp_path: Path) -> None:
+    script_path = tmp_path / "submit.slurm"
+    scheduler = SimpleNamespace(
+        NAME="slurm",
+        hostfile=str(tmp_path / "hostfile.txt"),
+        write_script=Mock(return_value=script_path),
+        submit_command=Mock(return_value=["sbatch", "--parsable", str(script_path)]),
+        parse_submission_output=Mock(side_effect=ValueError("not parsable")),
+    )
+    execution = SimpleNamespace(
+        exit_code={"localhost": 0},
+        stdout={"localhost": "Submitted batch job 13579\n"},
+    )
+    executor = Mock()
+    executor.run.return_value = execution
+    pipeline = Pipeline.__new__(Pipeline)
+    pipeline.scheduler = {"name": "slurm"}
+    pipeline.name = "example"
+    pipeline.last_loaded_file = None
+    pipeline.jarvis = SimpleNamespace(get_pipeline_shared_dir=lambda _name: tmp_path)
+    pipeline.save = Mock()
+
+    with patch("jarvis_cd.core.scheduler.make_scheduler", return_value=scheduler):
+        with patch("jarvis_cd.shell.Exec", return_value=executor):
+            with pytest.raises(RuntimeError, match="structured job identity"):
+                pipeline.submit(submit=True, wait=False)
+
+    assert pipeline.last_submission["scheduler_job_id"] is None
+    assert pipeline.last_submission["state"] == "identity_failed"
+    pipeline.save.assert_called_once_with()
+
+
+def test_pipeline_preserves_waited_job_identity_when_workload_fails(
+    tmp_path: Path,
+) -> None:
+    script_path = tmp_path / "submit.slurm"
+    scheduler = SimpleNamespace(
+        NAME="slurm",
+        hostfile=str(tmp_path / "hostfile.txt"),
+        write_script=Mock(return_value=script_path),
+        submit_command=Mock(
+            return_value=["sbatch", "--parsable", "--wait", str(script_path)]
+        ),
+        parse_submission_output=Mock(
+            return_value={
+                "provider": "slurm",
+                "scheduler_job_id": "97531",
+                "scheduler_cluster": "ares",
+                "identity_source": "scheduler_submit_api",
+            }
+        ),
+    )
+    execution = SimpleNamespace(
+        exit_code={"localhost": 9},
+        stdout={"localhost": "97531;ares\n"},
+    )
+    executor = Mock()
+    executor.run.return_value = execution
+    pipeline = Pipeline.__new__(Pipeline)
+    pipeline.scheduler = {"name": "slurm"}
+    pipeline.name = "example"
+    pipeline.last_loaded_file = None
+    pipeline.jarvis = SimpleNamespace(get_pipeline_shared_dir=lambda _name: tmp_path)
+    pipeline.save = Mock()
+
+    with patch("jarvis_cd.core.scheduler.make_scheduler", return_value=scheduler):
+        with patch("jarvis_cd.shell.Exec", return_value=executor):
+            with pytest.raises(RuntimeError, match="accepted, but the workload failed"):
+                pipeline.submit(submit=True, wait=True)
+
+    scheduler.parse_submission_output.assert_called_once_with("97531;ares\n")
+    assert pipeline.last_submission["scheduler_job_id"] == "97531"
+    assert pipeline.last_submission["scheduler_cluster"] == "ares"
+    assert pipeline.last_submission["identity_source"] == "scheduler_submit_api"
+    assert pipeline.last_submission["state"] == "workload_failed"
+    assert pipeline.last_submission["submitted"] is True
+    assert pipeline.last_submission["terminal"] is True
+    assert pipeline.last_submission["submission_returncode"] == 9
+    assert pipeline.last_submission["terminal_returncode"] == 9
+    pipeline.save.assert_called_once_with()
+
+
+def test_pipeline_records_true_submission_failure_without_job_identity(
+    tmp_path: Path,
+) -> None:
+    script_path = tmp_path / "submit.slurm"
+    scheduler = SimpleNamespace(
+        NAME="slurm",
+        hostfile=str(tmp_path / "hostfile.txt"),
+        write_script=Mock(return_value=script_path),
+        submit_command=Mock(return_value=["sbatch", "--parsable", str(script_path)]),
+        parse_submission_output=Mock(side_effect=ValueError("not parsable")),
+    )
+    execution = SimpleNamespace(
+        exit_code={"localhost": 1},
+        stdout={"localhost": "sbatch: error: invalid account\n"},
+    )
+    executor = Mock()
+    executor.run.return_value = execution
+    pipeline = Pipeline.__new__(Pipeline)
+    pipeline.scheduler = {"name": "slurm"}
+    pipeline.name = "example"
+    pipeline.last_loaded_file = None
+    pipeline.jarvis = SimpleNamespace(get_pipeline_shared_dir=lambda _name: tmp_path)
+    pipeline.save = Mock()
+
+    with patch("jarvis_cd.core.scheduler.make_scheduler", return_value=scheduler):
+        with patch("jarvis_cd.shell.Exec", return_value=executor):
+            with pytest.raises(RuntimeError, match="Scheduler submission failed"):
+                pipeline.submit(submit=True, wait=False)
+
+    assert pipeline.last_submission["scheduler_job_id"] is None
+    assert pipeline.last_submission["state"] == "submission_failed"
+    assert pipeline.last_submission["submitted"] is False
+    assert pipeline.last_submission["terminal"] is False
+    assert pipeline.last_submission["submission_returncode"] == 1
+    assert pipeline.last_submission["terminal_returncode"] is None
+    pipeline.save.assert_called_once_with()

--- a/test/unit/shell/test_env_forwarding.py
+++ b/test/unit/shell/test_env_forwarding.py
@@ -2,294 +2,442 @@ import unittest
 import sys
 import os
 import subprocess
+from typing import Optional
 
 # Add the project root to the path so we can import jarvis_cd
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from jarvis_cd.shell.core_exec import LocalExec
 from jarvis_cd.shell.ssh_exec import SshExec, PsshExec
 from jarvis_cd.shell.exec_factory import Exec as MpiExec
-from jarvis_cd.shell.exec_info import LocalExecInfo, SshExecInfo, PsshExecInfo, MpiExecInfo
+from jarvis_cd.shell.exec_info import (
+    LocalExecInfo,
+    SshExecInfo,
+    PsshExecInfo,
+    MpiExecInfo,
+)
+from jarvis_cd.shell.mpi_exec import MpichExec
 from jarvis_cd.util.hostfile import Hostfile
 
 
-class TestLocalExecEnvForwarding(unittest.TestCase):
+_SSH_TIMEOUT_SECONDS = 5
+_SSH_LAUNCHER = (
+    "ssh -o BatchMode=yes -o ConnectionAttempts=1 "
+    "-o ServerAliveInterval=2 -o ServerAliveCountMax=1"
+)
 
+
+def _probe_localhost_ssh() -> tuple[bool, str]:
+    """Return whether non-interactive localhost SSH is ready for live tests."""
+    command = [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectionAttempts=1",
+        "-o",
+        f"ConnectTimeout={_SSH_TIMEOUT_SECONDS}",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "LogLevel=ERROR",
+        "localhost",
+        "echo jarvis-ssh-probe",
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=_SSH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except FileNotFoundError:
+        return False, "ssh executable is unavailable"
+    except subprocess.TimeoutExpired:
+        return False, "localhost SSH capability probe timed out"
+    if result.returncode != 0:
+        diagnostic = (result.stderr or result.stdout).strip()
+        return False, diagnostic or f"ssh exited {result.returncode}"
+    if "jarvis-ssh-probe" not in result.stdout:
+        return False, "localhost SSH probe omitted its response token"
+    return True, ""
+
+
+class TestLocalExecEnvForwarding(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures"""
-        self.print_env = os.path.join(os.path.dirname(__file__), 'print_env.py')
+        self.print_env = os.path.join(os.path.dirname(__file__), "print_env.py")
 
     def test_single_custom_env_var(self):
         """Test LocalExec forwards single custom environment variable"""
-        exec_info = LocalExecInfo(env={'CUSTOM_VAR': 'HELLO'})
-        local_exec = LocalExec(f'python3 {self.print_env} CUSTOM_VAR', exec_info)
+        exec_info = LocalExecInfo(env={"CUSTOM_VAR": "HELLO"})
+        local_exec = LocalExec(f"python3 {self.print_env} CUSTOM_VAR", exec_info)
 
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
-        self.assertIn('CUSTOM_VAR=HELLO', local_exec.stdout['localhost'])
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        self.assertIn("CUSTOM_VAR=HELLO", local_exec.stdout["localhost"])
 
     def test_multiple_custom_env_vars(self):
         """Test LocalExec forwards multiple custom environment variables"""
-        exec_info = LocalExecInfo(env={
-            'CUSTOM_VAR': 'HELLO',
-            'ANOTHER_VAR': 'WORLD',
-            'THIRD_VAR': 'TEST'
-        })
-        local_exec = LocalExec(f'python3 {self.print_env} CUSTOM_VAR ANOTHER_VAR THIRD_VAR', exec_info)
+        exec_info = LocalExecInfo(
+            env={"CUSTOM_VAR": "HELLO", "ANOTHER_VAR": "WORLD", "THIRD_VAR": "TEST"}
+        )
+        local_exec = LocalExec(
+            f"python3 {self.print_env} CUSTOM_VAR ANOTHER_VAR THIRD_VAR", exec_info
+        )
 
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
-        stdout = local_exec.stdout['localhost']
-        self.assertIn('CUSTOM_VAR=HELLO', stdout)
-        self.assertIn('ANOTHER_VAR=WORLD', stdout)
-        self.assertIn('THIRD_VAR=TEST', stdout)
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        stdout = local_exec.stdout["localhost"]
+        self.assertIn("CUSTOM_VAR=HELLO", stdout)
+        self.assertIn("ANOTHER_VAR=WORLD", stdout)
+        self.assertIn("THIRD_VAR=TEST", stdout)
 
     def test_env_var_with_spaces(self):
         """Test LocalExec forwards environment variable with spaces"""
-        exec_info = LocalExecInfo(env={'CUSTOM_VAR': 'HELLO WORLD'})
-        local_exec = LocalExec(f'python3 {self.print_env} CUSTOM_VAR', exec_info)
+        exec_info = LocalExecInfo(env={"CUSTOM_VAR": "HELLO WORLD"})
+        local_exec = LocalExec(f"python3 {self.print_env} CUSTOM_VAR", exec_info)
 
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
-        self.assertIn('CUSTOM_VAR=HELLO WORLD', local_exec.stdout['localhost'])
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        self.assertIn("CUSTOM_VAR=HELLO WORLD", local_exec.stdout["localhost"])
 
     def test_env_var_with_special_chars(self):
         """Test LocalExec forwards environment variable with special characters"""
-        exec_info = LocalExecInfo(env={'CUSTOM_VAR': 'HELLO@#$%'})
-        local_exec = LocalExec(f'python3 {self.print_env} CUSTOM_VAR', exec_info)
+        exec_info = LocalExecInfo(env={"CUSTOM_VAR": "HELLO@#$%"})
+        local_exec = LocalExec(f"python3 {self.print_env} CUSTOM_VAR", exec_info)
 
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
-        self.assertIn('CUSTOM_VAR=HELLO@#$%', local_exec.stdout['localhost'])
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        self.assertIn("CUSTOM_VAR=HELLO@#$%", local_exec.stdout["localhost"])
 
     def test_numeric_env_var(self):
         """Test LocalExec forwards numeric environment variable"""
-        exec_info = LocalExecInfo(env={'CUSTOM_VAR': 12345})
-        local_exec = LocalExec(f'python3 {self.print_env} CUSTOM_VAR', exec_info)
+        exec_info = LocalExecInfo(env={"CUSTOM_VAR": 12345})
+        local_exec = LocalExec(f"python3 {self.print_env} CUSTOM_VAR", exec_info)
 
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
-        self.assertIn('CUSTOM_VAR=12345', local_exec.stdout['localhost'])
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        self.assertIn("CUSTOM_VAR=12345", local_exec.stdout["localhost"])
 
     def test_env_not_forwarded_without_setting(self):
         """Test that custom env var is not available without setting it"""
         exec_info = LocalExecInfo(env={})
-        local_exec = LocalExec(f'python3 {self.print_env} CUSTOM_VAR', exec_info)
+        local_exec = LocalExec(f"python3 {self.print_env} CUSTOM_VAR", exec_info)
 
         # Should fail because CUSTOM_VAR is not set
-        self.assertNotEqual(local_exec.exit_code['localhost'], 0)
-        self.assertIn('CUSTOM_VAR not found', local_exec.stderr['localhost'])
+        self.assertNotEqual(local_exec.exit_code["localhost"], 0)
+        self.assertIn("CUSTOM_VAR not found", local_exec.stderr["localhost"])
 
 
 class TestSshExecEnvForwarding(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Probe the exact non-interactive SSH capability once per class."""
+        cls.ssh_available, cls.ssh_unavailable_reason = _probe_localhost_ssh()
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test fixtures"""
-        self.print_env = os.path.join(os.path.dirname(__file__), 'print_env.py')
+        self.print_env = os.path.join(os.path.dirname(__file__), "print_env.py")
         # Use localhost for SSH tests to avoid needing remote hosts
-        self.hostfile = Hostfile(hosts=['localhost'], find_ips=False)
+        self.hostfile = Hostfile(hosts=["localhost"], find_ips=False)
+
+    def assert_ssh_forwarding(
+        self,
+        command: str,
+        environment: dict[str, object],
+        expected_output: list[str],
+        expected_command: list[str],
+    ) -> Optional[SshExec]:
+        """Exercise live SSH or its deterministic command contract."""
+        exec_info = SshExecInfo(
+            hostfile=self.hostfile,
+            env=environment,
+            timeout=_SSH_TIMEOUT_SECONDS,
+            ssh_cmd=_SSH_LAUNCHER,
+        )
+        if not self.ssh_available:
+            self.assertTrue(self.ssh_unavailable_reason)
+            dry_run = SshExec(command, exec_info.mod(dry_run=True))
+            rendered = dry_run.get_cmd()
+            self.assertIn("BatchMode=yes", rendered)
+            self.assertIn(
+                f"ConnectTimeout={_SSH_TIMEOUT_SECONDS}",
+                rendered,
+            )
+            for value in expected_command:
+                self.assertIn(value, rendered)
+            return None
+
+        ssh_exec = SshExec(command, exec_info)
+        self.assertEqual(
+            ssh_exec.exit_code["localhost"],
+            0,
+            ssh_exec.stderr["localhost"],
+        )
+        for value in expected_output:
+            self.assertIn(value, ssh_exec.stdout["localhost"])
+        return ssh_exec
 
     def test_single_custom_env_var(self):
         """Test SshExec forwards single custom environment variable"""
-        exec_info = SshExecInfo(
-            hostfile=self.hostfile,
-            env={'CUSTOM_VAR': 'HELLO'}
+        self.assert_ssh_forwarding(
+            f"python3 {self.print_env} CUSTOM_VAR",
+            {"CUSTOM_VAR": "HELLO"},
+            ["CUSTOM_VAR=HELLO"],
+            ['CUSTOM_VAR="HELLO"'],
         )
-        ssh_exec = SshExec(f'python3 {self.print_env} CUSTOM_VAR', exec_info)
-
-        self.assertEqual(ssh_exec.exit_code['localhost'], 0)
-        self.assertIn('CUSTOM_VAR=HELLO', ssh_exec.stdout['localhost'])
 
     def test_multiple_custom_env_vars(self):
         """Test SshExec forwards multiple custom environment variables"""
-        exec_info = SshExecInfo(
-            hostfile=self.hostfile,
-            env={
-                'CUSTOM_VAR': 'HELLO',
-                'ANOTHER_VAR': 'WORLD',
-                'THIRD_VAR': 'TEST'
-            }
+        self.assert_ssh_forwarding(
+            f"python3 {self.print_env} CUSTOM_VAR ANOTHER_VAR THIRD_VAR",
+            {"CUSTOM_VAR": "HELLO", "ANOTHER_VAR": "WORLD", "THIRD_VAR": "TEST"},
+            [
+                "CUSTOM_VAR=HELLO",
+                "ANOTHER_VAR=WORLD",
+                "THIRD_VAR=TEST",
+            ],
+            [
+                'CUSTOM_VAR="HELLO"',
+                'ANOTHER_VAR="WORLD"',
+                'THIRD_VAR="TEST"',
+            ],
         )
-        ssh_exec = SshExec(f'python3 {self.print_env} CUSTOM_VAR ANOTHER_VAR THIRD_VAR', exec_info)
-
-        self.assertEqual(ssh_exec.exit_code['localhost'], 0)
-        stdout = ssh_exec.stdout['localhost']
-        self.assertIn('CUSTOM_VAR=HELLO', stdout)
-        self.assertIn('ANOTHER_VAR=WORLD', stdout)
-        self.assertIn('THIRD_VAR=TEST', stdout)
 
     def test_env_var_with_spaces(self):
         """Test SshExec forwards environment variable with spaces"""
-        exec_info = SshExecInfo(
-            hostfile=self.hostfile,
-            env={'CUSTOM_VAR': 'HELLO WORLD'}
+        self.assert_ssh_forwarding(
+            f"python3 {self.print_env} CUSTOM_VAR",
+            {"CUSTOM_VAR": "HELLO WORLD"},
+            ["CUSTOM_VAR=HELLO WORLD"],
+            ['CUSTOM_VAR="HELLO WORLD"'],
         )
-        ssh_exec = SshExec(f'python3 {self.print_env} CUSTOM_VAR', exec_info)
-
-        self.assertEqual(ssh_exec.exit_code['localhost'], 0)
-        self.assertIn('CUSTOM_VAR=HELLO WORLD', ssh_exec.stdout['localhost'])
 
     def test_env_var_with_quotes(self):
         """Test SshExec forwards environment variable with quotes"""
-        exec_info = SshExecInfo(
-            hostfile=self.hostfile,
-            env={'CUSTOM_VAR': 'HELLO "QUOTED" WORLD'}
+        self.assert_ssh_forwarding(
+            f"python3 {self.print_env} CUSTOM_VAR",
+            {"CUSTOM_VAR": 'HELLO "QUOTED" WORLD'},
+            ["CUSTOM_VAR=", "HELLO", "WORLD"],
+            ['CUSTOM_VAR="HELLO \\"QUOTED\\" WORLD"'],
         )
-        ssh_exec = SshExec(f'python3 {self.print_env} CUSTOM_VAR', exec_info)
-
-        self.assertEqual(ssh_exec.exit_code['localhost'], 0)
-        # The quotes might be escaped differently, so just check the key parts
-        stdout = ssh_exec.stdout['localhost']
-        self.assertIn('CUSTOM_VAR=', stdout)
-        self.assertIn('HELLO', stdout)
-        self.assertIn('WORLD', stdout)
 
     def test_numeric_env_var(self):
         """Test SshExec forwards numeric environment variable"""
-        exec_info = SshExecInfo(
-            hostfile=self.hostfile,
-            env={'CUSTOM_VAR': 12345}
+        self.assert_ssh_forwarding(
+            f"python3 {self.print_env} CUSTOM_VAR",
+            {"CUSTOM_VAR": 12345},
+            ["CUSTOM_VAR=12345"],
+            ['CUSTOM_VAR="12345"'],
         )
-        ssh_exec = SshExec(f'python3 {self.print_env} CUSTOM_VAR', exec_info)
-
-        self.assertEqual(ssh_exec.exit_code['localhost'], 0)
-        self.assertIn('CUSTOM_VAR=12345', ssh_exec.stdout['localhost'])
 
 
 class TestPsshExecEnvForwarding(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Probe the exact non-interactive SSH capability once per class."""
+        cls.ssh_available, cls.ssh_unavailable_reason = _probe_localhost_ssh()
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test fixtures"""
-        self.print_env = os.path.join(os.path.dirname(__file__), 'print_env.py')
+        self.print_env = os.path.join(os.path.dirname(__file__), "print_env.py")
         # Use localhost for PSSH tests
-        self.hostfile = Hostfile(hosts=['localhost'], find_ips=False)
+        self.hostfile = Hostfile(hosts=["localhost"], find_ips=False)
+
+    def assert_pssh_forwarding(
+        self,
+        command: str,
+        environment: dict[str, object],
+        expected_output: list[str],
+        expected_command: list[str],
+    ) -> PsshExec:
+        """Exercise live PSSH or its deterministic per-host command contract."""
+        exec_info = PsshExecInfo(
+            hostfile=self.hostfile,
+            env=environment,
+            timeout=_SSH_TIMEOUT_SECONDS,
+            ssh_cmd=_SSH_LAUNCHER,
+            dry_run=not self.ssh_available,
+        )
+        if not self.ssh_available:
+            self.assertTrue(self.ssh_unavailable_reason)
+        pssh_exec = PsshExec(command, exec_info)
+        if not self.ssh_available:
+            rendered = pssh_exec.ssh_executors["localhost"].get_cmd()
+            self.assertIn("BatchMode=yes", rendered)
+            self.assertIn(
+                f"ConnectTimeout={_SSH_TIMEOUT_SECONDS}",
+                rendered,
+            )
+            for value in expected_command:
+                self.assertIn(value, rendered)
+            return pssh_exec
+
+        self.assertEqual(
+            pssh_exec.exit_code["localhost"],
+            0,
+            pssh_exec.stderr["localhost"],
+        )
+        for value in expected_output:
+            self.assertIn(value, pssh_exec.stdout["localhost"])
+        return pssh_exec
 
     def test_single_custom_env_var(self):
         """Test PsshExec forwards single custom environment variable"""
-        exec_info = PsshExecInfo(
-            hostfile=self.hostfile,
-            env={'CUSTOM_VAR': 'HELLO'}
+        self.assert_pssh_forwarding(
+            f"python3 {self.print_env} CUSTOM_VAR",
+            {"CUSTOM_VAR": "HELLO"},
+            ["CUSTOM_VAR=HELLO"],
+            ['CUSTOM_VAR="HELLO"'],
         )
-        pssh_exec = PsshExec(f'python3 {self.print_env} CUSTOM_VAR', exec_info)
-
-        self.assertEqual(pssh_exec.exit_code['localhost'], 0)
-        self.assertIn('CUSTOM_VAR=HELLO', pssh_exec.stdout['localhost'])
 
     def test_multiple_custom_env_vars(self):
         """Test PsshExec forwards multiple custom environment variables"""
-        exec_info = PsshExecInfo(
-            hostfile=self.hostfile,
-            env={
-                'CUSTOM_VAR': 'HELLO',
-                'ANOTHER_VAR': 'WORLD'
-            }
+        self.assert_pssh_forwarding(
+            f"python3 {self.print_env} CUSTOM_VAR ANOTHER_VAR",
+            {"CUSTOM_VAR": "HELLO", "ANOTHER_VAR": "WORLD"},
+            ["CUSTOM_VAR=HELLO", "ANOTHER_VAR=WORLD"],
+            ['CUSTOM_VAR="HELLO"', 'ANOTHER_VAR="WORLD"'],
         )
-        pssh_exec = PsshExec(f'python3 {self.print_env} CUSTOM_VAR ANOTHER_VAR', exec_info)
-
-        self.assertEqual(pssh_exec.exit_code['localhost'], 0)
-        stdout = pssh_exec.stdout['localhost']
-        self.assertIn('CUSTOM_VAR=HELLO', stdout)
-        self.assertIn('ANOTHER_VAR=WORLD', stdout)
 
 
 class TestMpiExecEnvForwarding(unittest.TestCase):
-
     def setUp(self):
         """Set up test fixtures"""
-        self.print_env = os.path.join(os.path.dirname(__file__), 'print_env.py')
-        self.hostfile = Hostfile(hosts=['localhost'], find_ips=False)
+        self.print_env = os.path.join(os.path.dirname(__file__), "print_env.py")
+        self.hostfile = Hostfile(hosts=["localhost"], find_ips=False)
 
         # Check if mpiexec is available
         try:
-            subprocess.run(['mpiexec', '--version'], capture_output=True, check=True)
+            subprocess.run(
+                ["mpiexec", "--version"],
+                capture_output=True,
+                check=True,
+                timeout=5,
+            )
             self.mpi_available = True
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            FileNotFoundError,
+        ):
             self.mpi_available = False
 
-    @unittest.skipIf(not hasattr(unittest.TestCase, 'mpi_available'), "MPI not available")
-    @unittest.skipIf(not hasattr(unittest.TestCase, 'mpi_available'), "MPI not available")
+    def assert_dry_run_forwarding(self, command, exec_info, expected):
+        """Assert the capability-independent MPICH command construction path."""
+        dry_run = MpichExec(command, exec_info.mod(dry_run=True))
+        for value in expected:
+            self.assertIn(value, dry_run.cmd)
+
     def test_single_custom_env_var(self):
         """Test MpiExec forwards single custom environment variable"""
-        if not self.mpi_available:
-            self.skipTest("MPI not available")
-
         exec_info = MpiExecInfo(
-            nprocs=1,
-            hostfile=self.hostfile,
-            env={'CUSTOM_VAR': 'HELLO'}
+            nprocs=1, hostfile=self.hostfile, timeout=15, env={"CUSTOM_VAR": "HELLO"}
         )
-        mpi_exec = MpiExec(f'python3 {self.print_env} CUSTOM_VAR', exec_info)
+        if not self.mpi_available:
+            self.assert_dry_run_forwarding(
+                f"python3 {self.print_env} CUSTOM_VAR",
+                exec_info,
+                ['-genv CUSTOM_VAR="HELLO"', "-n 1"],
+            )
+            return
+        mpi_exec = MpiExec(f"python3 {self.print_env} CUSTOM_VAR", exec_info)
+        delegate = mpi_exec.run()
 
-        self.assertEqual(mpi_exec.exit_code['localhost'], 0)
-        self.assertIn('CUSTOM_VAR=HELLO', mpi_exec.stdout['localhost'])
+        self.assertIs(mpi_exec._delegate, delegate)
+        self.assertIn("localhost", mpi_exec.processes)
+        self.assertIsNotNone(mpi_exec.processes["localhost"].poll())
+        self.assertEqual(mpi_exec.exit_code["localhost"], 0)
+        self.assertIn("CUSTOM_VAR=HELLO", mpi_exec.stdout["localhost"])
 
     def test_multiple_custom_env_vars(self):
         """Test MpiExec forwards multiple custom environment variables"""
-        if not self.mpi_available:
-            self.skipTest("MPI not available")
-
         exec_info = MpiExecInfo(
             nprocs=1,
             hostfile=self.hostfile,
-            env={
-                'CUSTOM_VAR': 'HELLO',
-                'ANOTHER_VAR': 'WORLD',
-                'THIRD_VAR': 'TEST'
-            }
+            timeout=15,
+            env={"CUSTOM_VAR": "HELLO", "ANOTHER_VAR": "WORLD", "THIRD_VAR": "TEST"},
         )
-        mpi_exec = MpiExec(f'python3 {self.print_env} CUSTOM_VAR ANOTHER_VAR THIRD_VAR', exec_info)
+        if not self.mpi_available:
+            self.assert_dry_run_forwarding(
+                f"python3 {self.print_env} CUSTOM_VAR ANOTHER_VAR THIRD_VAR",
+                exec_info,
+                [
+                    '-genv CUSTOM_VAR="HELLO"',
+                    '-genv ANOTHER_VAR="WORLD"',
+                    '-genv THIRD_VAR="TEST"',
+                ],
+            )
+            return
+        mpi_exec = MpiExec(
+            f"python3 {self.print_env} CUSTOM_VAR ANOTHER_VAR THIRD_VAR", exec_info
+        )
         mpi_exec.run()
 
-        self.assertEqual(mpi_exec.exit_code['localhost'], 0)
-        stdout = mpi_exec.stdout['localhost']
-        self.assertIn('CUSTOM_VAR=HELLO', stdout)
-        self.assertIn('ANOTHER_VAR=WORLD', stdout)
-        self.assertIn('THIRD_VAR=TEST', stdout)
+        self.assertEqual(mpi_exec.exit_code["localhost"], 0)
+        stdout = mpi_exec.stdout["localhost"]
+        self.assertIn("CUSTOM_VAR=HELLO", stdout)
+        self.assertIn("ANOTHER_VAR=WORLD", stdout)
+        self.assertIn("THIRD_VAR=TEST", stdout)
 
     def test_env_var_with_spaces(self):
         """Test MpiExec forwards environment variable with spaces"""
-        if not self.mpi_available:
-            self.skipTest("MPI not available")
-
         exec_info = MpiExecInfo(
             nprocs=1,
             hostfile=self.hostfile,
-            env={'CUSTOM_VAR': 'HELLO WORLD'}
+            timeout=15,
+            env={"CUSTOM_VAR": "HELLO WORLD"},
         )
-        mpi_exec = MpiExec(f'python3 {self.print_env} CUSTOM_VAR', exec_info)
+        if not self.mpi_available:
+            self.assert_dry_run_forwarding(
+                f"python3 {self.print_env} CUSTOM_VAR",
+                exec_info,
+                ['-genv CUSTOM_VAR="HELLO WORLD"'],
+            )
+            return
+        mpi_exec = MpiExec(f"python3 {self.print_env} CUSTOM_VAR", exec_info)
         mpi_exec.run()
 
-        self.assertEqual(mpi_exec.exit_code['localhost'], 0)
-        self.assertIn('CUSTOM_VAR=HELLO WORLD', mpi_exec.stdout['localhost'])
+        self.assertEqual(mpi_exec.exit_code["localhost"], 0)
+        self.assertIn("CUSTOM_VAR=HELLO WORLD", mpi_exec.stdout["localhost"])
 
     def test_numeric_env_var(self):
         """Test MpiExec forwards numeric environment variable"""
-        if not self.mpi_available:
-            self.skipTest("MPI not available")
-
         exec_info = MpiExecInfo(
-            nprocs=1,
-            hostfile=self.hostfile,
-            env={'CUSTOM_VAR': 54321}
+            nprocs=1, hostfile=self.hostfile, timeout=15, env={"CUSTOM_VAR": 54321}
         )
-        mpi_exec = MpiExec(f'python3 {self.print_env} CUSTOM_VAR', exec_info)
+        if not self.mpi_available:
+            self.assert_dry_run_forwarding(
+                f"python3 {self.print_env} CUSTOM_VAR",
+                exec_info,
+                ['-genv CUSTOM_VAR="54321"'],
+            )
+            return
+        mpi_exec = MpiExec(f"python3 {self.print_env} CUSTOM_VAR", exec_info)
         mpi_exec.run()
 
-        self.assertEqual(mpi_exec.exit_code['localhost'], 0)
-        self.assertIn('CUSTOM_VAR=54321', mpi_exec.stdout['localhost'])
+        self.assertEqual(mpi_exec.exit_code["localhost"], 0)
+        self.assertIn("CUSTOM_VAR=54321", mpi_exec.stdout["localhost"])
 
     def test_env_forwarding_with_multiple_procs(self):
         """Test MpiExec forwards env vars with multiple processes"""
-        if not self.mpi_available:
-            self.skipTest("MPI not available")
-
         exec_info = MpiExecInfo(
-            nprocs=2,
-            hostfile=self.hostfile,
-            env={'CUSTOM_VAR': 'HELLO'}
+            nprocs=2, hostfile=self.hostfile, timeout=15, env={"CUSTOM_VAR": "HELLO"}
         )
-        mpi_exec = MpiExec(f'python3 {self.print_env} CUSTOM_VAR', exec_info)
+        if not self.mpi_available:
+            self.assert_dry_run_forwarding(
+                f"python3 {self.print_env} CUSTOM_VAR",
+                exec_info,
+                ['-genv CUSTOM_VAR="HELLO"', "-n 2"],
+            )
+            return
+        mpi_exec = MpiExec(f"python3 {self.print_env} CUSTOM_VAR", exec_info)
         mpi_exec.run()
 
-        self.assertEqual(mpi_exec.exit_code['localhost'], 0)
+        self.assertEqual(mpi_exec.exit_code["localhost"], 0)
         # With 2 processes, we should see the output twice (or at least once)
-        self.assertIn('CUSTOM_VAR=HELLO', mpi_exec.stdout['localhost'])
+        self.assertIn("CUSTOM_VAR=HELLO", mpi_exec.stdout["localhost"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/unit/shell/test_local_exec.py
+++ b/test/unit/shell/test_local_exec.py
@@ -1,138 +1,148 @@
 import unittest
 import sys
 import os
+import subprocess
 import tempfile
 import time
+from unittest.mock import patch
 
 # Add the project root to the path so we can import jarvis_cd
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from jarvis_cd.shell.core_exec import LocalExec
 from jarvis_cd.shell.exec_info import LocalExecInfo
+from jarvis_cd.shell.windows_job import process_start_identity
 
 
 class TestLocalExec(unittest.TestCase):
-
     def setUp(self):
         """Set up test fixtures"""
-        self.test_binary = os.path.join(os.path.dirname(__file__), 'test_env_checker')
+        self.print_env = os.path.join(os.path.dirname(__file__), "print_env.py")
 
-        # Verify the test binary exists
-        if not os.path.exists(self.test_binary):
-            raise RuntimeError(f"Test binary not found: {self.test_binary}")
+    def env_command(self, *names: str) -> str:
+        """Return a cross-platform command for the Python environment probe."""
+        return subprocess.list2cmdline([sys.executable, self.print_env, *names])
+
+    @staticmethod
+    def python_command(code: str) -> str:
+        """Return a cross-platform command for one inline Python program."""
+        return subprocess.list2cmdline([sys.executable, "-c", code])
 
     def test_basic_execution(self):
         """Test basic command execution"""
         exec_info = LocalExecInfo()
         local_exec = LocalExec('echo "hello world"', exec_info)
 
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
-        self.assertIn('hello world', local_exec.stdout['localhost'])
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        self.assertIn("hello world", local_exec.stdout["localhost"])
 
     def test_single_env_variable(self):
         """Test execution with a single environment variable"""
-        exec_info = LocalExecInfo(env={'TEST_VAR': 'test_value'})
-        local_exec = LocalExec(f'{self.test_binary} TEST_VAR', exec_info)
+        exec_info = LocalExecInfo(env={"TEST_VAR": "test_value"})
+        local_exec = LocalExec(self.env_command("TEST_VAR"), exec_info)
 
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
-        self.assertIn('TEST_VAR=test_value', local_exec.stdout['localhost'])
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        self.assertIn("TEST_VAR=test_value", local_exec.stdout["localhost"])
 
     def test_multiple_env_variables(self):
         """Test execution with multiple environment variables"""
-        exec_info = LocalExecInfo(env={
-            'VAR1': 'value1',
-            'VAR2': 'value2',
-            'VAR3': 'value3'
-        })
-        local_exec = LocalExec(f'{self.test_binary} VAR1 VAR2 VAR3', exec_info)
+        exec_info = LocalExecInfo(
+            env={"VAR1": "value1", "VAR2": "value2", "VAR3": "value3"}
+        )
+        local_exec = LocalExec(self.env_command("VAR1", "VAR2", "VAR3"), exec_info)
 
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
-        stdout = local_exec.stdout['localhost']
-        self.assertIn('VAR1=value1', stdout)
-        self.assertIn('VAR2=value2', stdout)
-        self.assertIn('VAR3=value3', stdout)
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        stdout = local_exec.stdout["localhost"]
+        self.assertIn("VAR1=value1", stdout)
+        self.assertIn("VAR2=value2", stdout)
+        self.assertIn("VAR3=value3", stdout)
 
     def test_env_variable_with_special_chars(self):
         """Test environment variables with special characters"""
         special_value = "value with spaces and 'quotes' and \"double quotes\""
-        exec_info = LocalExecInfo(env={'SPECIAL_VAR': special_value})
-        local_exec = LocalExec(f'{self.test_binary} SPECIAL_VAR', exec_info)
+        exec_info = LocalExecInfo(env={"SPECIAL_VAR": special_value})
+        local_exec = LocalExec(self.env_command("SPECIAL_VAR"), exec_info)
 
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
-        self.assertIn('SPECIAL_VAR=', local_exec.stdout['localhost'])
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        self.assertIn("SPECIAL_VAR=", local_exec.stdout["localhost"])
 
     def test_env_variable_override(self):
         """Test that custom env variables override system variables"""
-        exec_info = LocalExecInfo(env={'PATH': '/custom/path'})
-        local_exec = LocalExec(f'{self.test_binary} PATH', exec_info)
+        exec_info = LocalExecInfo(env={"PATH": "/custom/path"})
+        local_exec = LocalExec(self.env_command("PATH"), exec_info)
 
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
-        self.assertIn('PATH=/custom/path', local_exec.stdout['localhost'])
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        self.assertIn("PATH=/custom/path", local_exec.stdout["localhost"])
 
     def test_empty_env(self):
         """Test execution with empty env dict"""
         exec_info = LocalExecInfo(env={})
         local_exec = LocalExec('echo "test"', exec_info)
 
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
 
     def test_none_env(self):
         """Test execution with None env (should use system env)"""
         exec_info = LocalExecInfo(env=None)
-        local_exec = LocalExec(f'{self.test_binary} PATH', exec_info)
+        local_exec = LocalExec(self.env_command("PATH"), exec_info)
 
         # PATH should exist in system environment
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
-        self.assertIn('PATH=', local_exec.stdout['localhost'])
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        self.assertIn("PATH=", local_exec.stdout["localhost"])
 
     def test_collect_output(self):
         """Test output collection"""
         exec_info = LocalExecInfo(collect_output=True)
         local_exec = LocalExec('echo "collected output"', exec_info)
 
-        self.assertIn('collected output', local_exec.stdout['localhost'])
+        self.assertIn("collected output", local_exec.stdout["localhost"])
 
     def test_hide_output(self):
         """Test hiding output (should still collect)"""
         exec_info = LocalExecInfo(hide_output=True, collect_output=True)
         local_exec = LocalExec('echo "hidden output"', exec_info)
 
-        self.assertIn('hidden output', local_exec.stdout['localhost'])
+        self.assertIn("hidden output", local_exec.stdout["localhost"])
 
     def test_stderr_collection(self):
         """Test stderr collection"""
         exec_info = LocalExecInfo(collect_output=True)
         local_exec = LocalExec('echo "error message" >&2', exec_info)
 
-        self.assertIn('error message', local_exec.stderr['localhost'])
+        self.assertIn("error message", local_exec.stderr["localhost"])
 
     def test_pipe_stdout_to_file(self):
         """Test piping stdout to a file"""
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
             temp_file = f.name
 
         try:
             exec_info = LocalExecInfo(pipe_stdout=temp_file)
-            local_exec = LocalExec('echo "piped output"', exec_info)
+            LocalExec(self.python_command('print("piped output")'), exec_info)
 
-            with open(temp_file, 'r') as f:
+            with open(temp_file, "r") as f:
                 content = f.read()
-            self.assertIn('piped output', content)
+            self.assertIn("piped output", content)
         finally:
             os.unlink(temp_file)
 
     def test_pipe_stderr_to_file(self):
         """Test piping stderr to a file"""
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
             temp_file = f.name
 
         try:
             exec_info = LocalExecInfo(pipe_stderr=temp_file)
-            local_exec = LocalExec('echo "error output" >&2', exec_info)
+            LocalExec(
+                self.python_command(
+                    'import sys; print("error output", file=sys.stderr)'
+                ),
+                exec_info,
+            )
 
-            with open(temp_file, 'r') as f:
+            with open(temp_file, "r") as f:
                 content = f.read()
-            self.assertIn('error output', content)
+            self.assertIn("error output", content)
         finally:
             os.unlink(temp_file)
 
@@ -140,79 +150,171 @@ class TestLocalExec(unittest.TestCase):
         """Test changing working directory"""
         with tempfile.TemporaryDirectory() as tmpdir:
             exec_info = LocalExecInfo(cwd=tmpdir)
-            local_exec = LocalExec('pwd', exec_info)
+            local_exec = LocalExec(
+                self.python_command("import os; print(os.getcwd())"),
+                exec_info,
+            )
 
-            self.assertIn(tmpdir, local_exec.stdout['localhost'])
+            self.assertIn(tmpdir, local_exec.stdout["localhost"])
 
     def test_async_execution(self):
         """Test asynchronous execution"""
         exec_info = LocalExecInfo(exec_async=True)
-        local_exec = LocalExec('sleep 0.1 && echo "async done"', exec_info)
+        local_exec = LocalExec(
+            self.python_command('import time; time.sleep(0.1); print("async done")'),
+            exec_info,
+        )
 
         # Process should still be running or just finished
         # Wait for it to complete
-        exit_code = local_exec.wait('localhost')
+        exit_code = local_exec.wait("localhost")
         self.assertEqual(exit_code, 0)
-        self.assertIn('async done', local_exec.stdout['localhost'])
+        self.assertIn("async done", local_exec.stdout["localhost"])
 
     def test_sleep_ms(self):
         """Test sleep after execution"""
         exec_info = LocalExecInfo(sleep_ms=100)
         start_time = time.time()
-        local_exec = LocalExec('echo "test"', exec_info)
+        LocalExec('echo "test"', exec_info)
         elapsed = time.time() - start_time
 
         # Should have slept for at least 0.1 seconds
         self.assertGreaterEqual(elapsed, 0.1)
 
+    def test_timeout_terminates_shell_process_tree(self):
+        """A bounded command returns 124 without leaving its child running."""
+        command = subprocess.list2cmdline(
+            [sys.executable, "-c", "import time; time.sleep(30)"]
+        )
+        start_time = time.monotonic()
+
+        local_exec = LocalExec(command, LocalExecInfo(timeout=0.1))
+
+        self.assertEqual(local_exec.exit_code["localhost"], 124)
+        self.assertIn(
+            "Command timed out after 0.1 seconds", local_exec.stderr["localhost"]
+        )
+        self.assertLess(time.monotonic() - start_time, 10)
+        self.assertIsNotNone(local_exec.processes["localhost"].poll())
+
+    def test_timeout_kills_descendant_that_ignores_graceful_signal(self):
+        """Timeout cleanup removes a descendant even when it ignores SIGTERM."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_path = os.path.join(tmpdir, "descendant.pid")
+            child_code = (
+                "import signal,time; "
+                "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                "time.sleep(60)"
+            )
+            parent_code = (
+                "import subprocess,time; "
+                f'child=subprocess.Popen([{sys.executable!r},"-c",{child_code!r}]); '
+                f'open({pid_path!r},"w",encoding="utf-8").write(str(child.pid)); '
+                "time.sleep(60)"
+            )
+
+            local_exec = LocalExec(
+                self.python_command(parent_code),
+                LocalExecInfo(timeout=0.5),
+            )
+
+            self.assertEqual(local_exec.exit_code["localhost"], 124)
+            descendant_pid = int(open(pid_path, encoding="utf-8").read().strip())
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                try:
+                    os.kill(descendant_pid, 0)
+                except OSError:
+                    break
+                time.sleep(0.05)
+            else:
+                self.fail(f"descendant process survived timeout: {descendant_pid}")
+
+    def test_exited_parent_cannot_leave_pipe_holding_descendant(self):
+        """Capture cleanup owns a child even after its immediate parent exits."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_path = os.path.join(tmpdir, "pipe-holder.pid")
+            child_code = "import time; time.sleep(60)"
+            parent_code = (
+                "import os,subprocess,sys; "
+                'kwargs=({"creationflags":subprocess.CREATE_NEW_PROCESS_GROUP} '
+                'if os.name=="nt" else {}); '
+                f'child=subprocess.Popen([sys.executable,"-c",{child_code!r}],**kwargs); '
+                f'open({pid_path!r},"w",encoding="ascii").write(str(child.pid))'
+            )
+            started = time.monotonic()
+
+            with patch(
+                "jarvis_cd.shell.core_exec.subprocess.run",
+                side_effect=AssertionError("taskkill-style PID cleanup is forbidden"),
+            ):
+                local_exec = LocalExec(
+                    self.python_command(parent_code),
+                    LocalExecInfo(),
+                )
+
+            self.assertEqual(local_exec.exit_code["localhost"], 0)
+            self.assertLess(time.monotonic() - started, 12)
+            descendant_pid = int(open(pid_path, encoding="ascii").read())
+            if os.name == "nt":
+                self.assertIsNone(process_start_identity(descendant_pid))
+            else:
+                with self.assertRaises(OSError):
+                    os.kill(descendant_pid, 0)
+
     def test_stdin_input(self):
         """Test providing stdin to command"""
         exec_info = LocalExecInfo(stdin="test input\n")
-        local_exec = LocalExec('cat', exec_info)
+        local_exec = LocalExec(
+            self.python_command("import sys; print(sys.stdin.read())"),
+            exec_info,
+        )
 
-        self.assertIn('test input', local_exec.stdout['localhost'])
+        self.assertIn("test input", local_exec.stdout["localhost"])
 
     def test_exit_code_on_failure(self):
         """Test that exit code is captured on command failure"""
         exec_info = LocalExecInfo()
-        local_exec = LocalExec('false', exec_info)
+        local_exec = LocalExec(self.python_command("raise SystemExit(1)"), exec_info)
 
-        self.assertNotEqual(local_exec.exit_code['localhost'], 0)
+        self.assertNotEqual(local_exec.exit_code["localhost"], 0)
 
     def test_env_preserved_across_commands(self):
         """Test that environment variables persist across shell commands"""
-        exec_info = LocalExecInfo(env={'CUSTOM_VAR': 'custom_value'})
+        exec_info = LocalExecInfo(env={"CUSTOM_VAR": "custom_value"})
         # Use shell to execute multiple commands
-        cmd = f'{self.test_binary} CUSTOM_VAR && echo "second command"'
+        second_command = self.python_command('print("second command")')
+        cmd = f"{self.env_command('CUSTOM_VAR')} && {second_command}"
         local_exec = LocalExec(cmd, exec_info)
 
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
-        stdout = local_exec.stdout['localhost']
-        self.assertIn('CUSTOM_VAR=custom_value', stdout)
-        self.assertIn('second command', stdout)
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        stdout = local_exec.stdout["localhost"]
+        self.assertIn("CUSTOM_VAR=custom_value", stdout)
+        self.assertIn("second command", stdout)
 
     def test_numeric_env_values(self):
         """Test environment variables with numeric values"""
-        exec_info = LocalExecInfo(env={
-            'INT_VAR': 42,
-            'FLOAT_VAR': 3.14,
-            'BOOL_VAR': True
-        })
-        local_exec = LocalExec(f'{self.test_binary} INT_VAR FLOAT_VAR BOOL_VAR', exec_info)
+        exec_info = LocalExecInfo(
+            env={"INT_VAR": 42, "FLOAT_VAR": 3.14, "BOOL_VAR": True}
+        )
+        local_exec = LocalExec(
+            self.env_command("INT_VAR", "FLOAT_VAR", "BOOL_VAR"),
+            exec_info,
+        )
 
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
-        stdout = local_exec.stdout['localhost']
-        self.assertIn('INT_VAR=42', stdout)
-        self.assertIn('FLOAT_VAR=3.14', stdout)
-        self.assertIn('BOOL_VAR=True', stdout)
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        stdout = local_exec.stdout["localhost"]
+        self.assertIn("INT_VAR=42", stdout)
+        self.assertIn("FLOAT_VAR=3.14", stdout)
+        self.assertIn("BOOL_VAR=True", stdout)
 
     def test_env_with_equals_in_value(self):
         """Test environment variable with equals sign in value"""
-        exec_info = LocalExecInfo(env={'CONFIG': 'key=value'})
-        local_exec = LocalExec(f'{self.test_binary} CONFIG', exec_info)
+        exec_info = LocalExecInfo(env={"CONFIG": "key=value"})
+        local_exec = LocalExec(self.env_command("CONFIG"), exec_info)
 
-        self.assertEqual(local_exec.exit_code['localhost'], 0)
-        self.assertIn('CONFIG=key=value', local_exec.stdout['localhost'])
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        self.assertIn("CONFIG=key=value", local_exec.stdout["localhost"])
 
     def test_get_cmd(self):
         """Test get_cmd returns the original command"""
@@ -223,5 +325,5 @@ class TestLocalExec(unittest.TestCase):
         self.assertEqual(local_exec.get_cmd(), cmd)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/unit/shell/test_local_exec.py
+++ b/test/unit/shell/test_local_exec.py
@@ -36,6 +36,101 @@ class TestLocalExec(unittest.TestCase):
         self.assertEqual(local_exec.exit_code["localhost"], 0)
         self.assertIn("hello world", local_exec.stdout["localhost"])
 
+    def test_line_callback_observes_complete_stdout_and_stderr(self):
+        """Execution callbacks receive live complete lines from both streams."""
+        observed = []
+        command = self.python_command(
+            'import sys; print("out"); print("err", file=sys.stderr)'
+        )
+
+        local_exec = LocalExec(
+            command,
+            LocalExecInfo(
+                hide_output=True,
+                line_callback=lambda stream, line: observed.append((stream, line)),
+            ),
+        )
+
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        self.assertIn(("stdout", "out\n"), observed)
+        self.assertIn(("stderr", "err\n"), observed)
+
+    def test_line_callback_failure_is_reported(self):
+        """A progress callback failure terminates work and stays bounded."""
+
+        callback_calls = 0
+
+        def fail_callback(stream, line):
+            nonlocal callback_calls
+            callback_calls += 1
+            raise RuntimeError(f"cannot persist {stream}: {line.strip()}")
+
+        started = time.monotonic()
+        local_exec = LocalExec(
+            self.python_command(
+                'import time; print("progress", flush=True); time.sleep(30)'
+            ),
+            LocalExecInfo(hide_output=True, line_callback=fail_callback),
+        )
+
+        self.assertNotEqual(local_exec.exit_code["localhost"], 0)
+        self.assertLess(time.monotonic() - started, 5)
+        self.assertEqual(callback_calls, 1)
+        self.assertIn("Output line callback failed", local_exec.stderr["localhost"])
+        self.assertIn("cannot persist stdout: progress", local_exec.stderr["localhost"])
+
+    def test_stateful_line_callback_finalizes_once_at_eof(self):
+        """A callback can flush an unterminated final fragment exactly once."""
+
+        class Callback:
+            def __init__(self):
+                self.lines = []
+                self.finalized = 0
+
+            def __call__(self, stream, line):
+                self.lines.append((stream, line))
+
+            def finalize(self):
+                self.finalized += 1
+
+        callback = Callback()
+        local_exec = LocalExec(
+            self.python_command('import sys; sys.stdout.write("tail")'),
+            LocalExecInfo(
+                collect_output=False,
+                hide_output=True,
+                line_callback=callback,
+            ),
+        )
+        local_exec.wait()
+
+        self.assertEqual(local_exec.exit_code["localhost"], 0)
+        self.assertEqual(callback.lines, [("stdout", "tail")])
+        self.assertEqual(callback.finalized, 1)
+
+    def test_line_callback_finalization_failure_is_reported(self):
+        """A final provider flush failure makes an otherwise clean process fail."""
+
+        class Callback:
+            def __call__(self, stream, line):
+                del stream, line
+
+            def finalize(self):
+                raise RuntimeError("cannot flush final progress fragment")
+
+        local_exec = LocalExec(
+            self.python_command("pass"),
+            LocalExecInfo(hide_output=True, line_callback=Callback()),
+        )
+
+        self.assertEqual(local_exec.exit_code["localhost"], 1)
+        self.assertIn(
+            "callback failed for finalization", local_exec.stderr["localhost"]
+        )
+        self.assertIn(
+            "cannot flush final progress fragment", local_exec.stderr["localhost"]
+        )
+
     def test_single_env_variable(self):
         """Test execution with a single environment variable"""
         exec_info = LocalExecInfo(env={"TEST_VAR": "test_value"})

--- a/test/unit/shell/test_process.py
+++ b/test/unit/shell/test_process.py
@@ -1,16 +1,25 @@
 """
 Tests for process utility classes in jarvis_cd.shell.process
 """
+
 import unittest
 import sys
 import os
 import tempfile
 
 # Add project root to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
 from jarvis_cd.shell.process import (
-    Kill, KillAll, Which, Mkdir, Rm, Chmod, Sleep, Echo, GdbServer
+    Kill,
+    KillAll,
+    Which,
+    Mkdir,
+    Rm,
+    Chmod,
+    Sleep,
+    Echo,
+    GdbServer,
 )
 from jarvis_cd.shell.exec_info import LocalExecInfo
 
@@ -20,21 +29,21 @@ class TestKill(unittest.TestCase):
 
     def test_kill_uses_exact_basename_match(self):
         """Kill should pkill -9 -x against the executable name."""
-        kill = Kill('nonexistent_test_process_xyz')
+        kill = Kill("nonexistent_test_process_xyz")
         cmd = kill.cmd
-        self.assertIn('pkill', cmd)
-        self.assertIn('-9', cmd)
-        self.assertIn('-x', cmd)
-        self.assertNotIn('-f', cmd)
-        self.assertIn('nonexistent_test_process_xyz', cmd)
+        self.assertIn("pkill", cmd)
+        self.assertIn("-9", cmd)
+        self.assertIn("-x", cmd)
+        self.assertNotIn("-f", cmd)
+        self.assertIn("nonexistent_test_process_xyz", cmd)
 
     def test_kill_with_exec_info(self):
         """Test kill with custom exec info"""
         exec_info = LocalExecInfo()
-        kill = Kill('nonexistent_myprocess_123', exec_info=exec_info)
+        kill = Kill("nonexistent_myprocess_123", exec_info=exec_info)
         # Just verify the object is created properly
         self.assertIsNotNone(kill.cmd)
-        self.assertIn('pkill', kill.cmd)
+        self.assertIn("pkill", kill.cmd)
 
 
 class TestKillAll(unittest.TestCase):
@@ -45,10 +54,10 @@ class TestKillAll(unittest.TestCase):
         # Just test command construction, don't run it (dangerous!)
         killall = KillAll()
         cmd = killall.cmd
-        self.assertIn('pkill', cmd)
-        self.assertIn('-9', cmd)
-        self.assertIn('-u', cmd)
-        self.assertIn('$(whoami)', cmd)
+        self.assertIn("pkill", cmd)
+        self.assertIn("-9", cmd)
+        self.assertIn("-u", cmd)
+        self.assertIn("$(whoami)", cmd)
 
     def test_killall_with_exec_info(self):
         """Test killall with custom exec info"""
@@ -56,7 +65,7 @@ class TestKillAll(unittest.TestCase):
         killall = KillAll(exec_info=exec_info)
         # Just verify object creation
         self.assertIsNotNone(killall.cmd)
-        self.assertIn('pkill', killall.cmd)
+        self.assertIn("pkill", killall.cmd)
 
 
 class TestWhich(unittest.TestCase):
@@ -64,27 +73,30 @@ class TestWhich(unittest.TestCase):
 
     def test_which_python(self):
         """Test finding python executable"""
-        which = Which('python3')
+        which = Which("python3")
         which.run()
 
-        self.assertEqual(which.exit_code['localhost'], 0)
+        self.assertEqual(which.exit_code["localhost"], 0)
         self.assertTrue(which.exists())
-        self.assertIn('python', which.get_path().lower())
+        self.assertIn("python", which.get_path().lower())
 
     def test_which_nonexistent(self):
         """Test finding non-existent executable"""
-        which = Which('nonexistent_executable_12345')
+        which = Which("nonexistent_executable_12345")
         which.run()
 
         self.assertFalse(which.exists())
-        self.assertEqual(which.get_path(), '')
+        self.assertEqual(which.get_path(), "")
 
     def test_which_command_construction(self):
         """Test which command construction"""
-        which = Which('bash')
+        which = Which("bash")
         which.run()
         cmd = which.get_cmd()
-        self.assertEqual(cmd, 'which bash')
+        if os.name == "nt":
+            self.assertIn("shutil.which", cmd)
+        else:
+            self.assertEqual(cmd, "which bash")
 
 
 class TestMkdir(unittest.TestCase):
@@ -92,54 +104,56 @@ class TestMkdir(unittest.TestCase):
 
     def setUp(self):
         """Set up test directory"""
-        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_mkdir_')
+        self.test_dir = tempfile.mkdtemp(prefix="jarvis_test_mkdir_")
 
     def tearDown(self):
         """Clean up test directory"""
         import shutil
+
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
     def test_mkdir_single_path(self):
         """Test creating single directory"""
-        new_dir = os.path.join(self.test_dir, 'test_dir')
+        new_dir = os.path.join(self.test_dir, "test_dir")
         mkdir = Mkdir(new_dir)
         mkdir.run()
 
-        self.assertEqual(mkdir.exit_code['localhost'], 0)
+        self.assertEqual(mkdir.exit_code["localhost"], 0)
         self.assertTrue(os.path.exists(new_dir))
 
     def test_mkdir_multiple_paths(self):
         """Test creating multiple directories"""
         paths = [
-            os.path.join(self.test_dir, 'dir1'),
-            os.path.join(self.test_dir, 'dir2'),
-            os.path.join(self.test_dir, 'dir3')
+            os.path.join(self.test_dir, "dir1"),
+            os.path.join(self.test_dir, "dir2"),
+            os.path.join(self.test_dir, "dir3"),
         ]
         mkdir = Mkdir(paths)
         mkdir.run()
 
-        self.assertEqual(mkdir.exit_code['localhost'], 0)
+        self.assertEqual(mkdir.exit_code["localhost"], 0)
         for path in paths:
             self.assertTrue(os.path.exists(path))
 
     def test_mkdir_with_parents(self):
         """Test creating nested directories with parent flag"""
-        nested_dir = os.path.join(self.test_dir, 'parent', 'child', 'grandchild')
+        nested_dir = os.path.join(self.test_dir, "parent", "child", "grandchild")
         mkdir = Mkdir(nested_dir, parents=True)
         mkdir.run()
 
-        self.assertEqual(mkdir.exit_code['localhost'], 0)
+        self.assertEqual(mkdir.exit_code["localhost"], 0)
         self.assertTrue(os.path.exists(nested_dir))
 
     def test_mkdir_command_construction(self):
         """Test mkdir command construction"""
-        mkdir = Mkdir('/tmp/test', parents=True)
+        mkdir = Mkdir("/tmp/test", parents=True)
         mkdir.run()
         cmd = mkdir.get_cmd()
-        self.assertIn('mkdir', cmd)
-        self.assertIn('-p', cmd)
-        self.assertIn('/tmp/test', cmd)
+        self.assertIn("mkdir", cmd)
+        if os.name != "nt":
+            self.assertIn("-p", cmd)
+        self.assertIn("/tmp/test", cmd)
 
 
 class TestRm(unittest.TestCase):
@@ -147,14 +161,15 @@ class TestRm(unittest.TestCase):
 
     def setUp(self):
         """Set up test files/directories"""
-        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_rm_')
-        self.test_file = os.path.join(self.test_dir, 'test_file.txt')
-        with open(self.test_file, 'w') as f:
-            f.write('test content')
+        self.test_dir = tempfile.mkdtemp(prefix="jarvis_test_rm_")
+        self.test_file = os.path.join(self.test_dir, "test_file.txt")
+        with open(self.test_file, "w") as f:
+            f.write("test content")
 
     def tearDown(self):
         """Clean up"""
         import shutil
+
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
@@ -163,45 +178,48 @@ class TestRm(unittest.TestCase):
         rm = Rm(self.test_file)
         rm.run()
 
-        self.assertEqual(rm.exit_code['localhost'], 0)
+        self.assertEqual(rm.exit_code["localhost"], 0)
         self.assertFalse(os.path.exists(self.test_file))
 
     def test_rm_multiple_files(self):
         """Test removing multiple files"""
-        file1 = os.path.join(self.test_dir, 'file1.txt')
-        file2 = os.path.join(self.test_dir, 'file2.txt')
+        file1 = os.path.join(self.test_dir, "file1.txt")
+        file2 = os.path.join(self.test_dir, "file2.txt")
 
-        with open(file1, 'w') as f:
-            f.write('test1')
-        with open(file2, 'w') as f:
-            f.write('test2')
+        with open(file1, "w") as f:
+            f.write("test1")
+        with open(file2, "w") as f:
+            f.write("test2")
 
         rm = Rm([file1, file2])
         rm.run()
 
-        self.assertEqual(rm.exit_code['localhost'], 0)
+        self.assertEqual(rm.exit_code["localhost"], 0)
         self.assertFalse(os.path.exists(file1))
         self.assertFalse(os.path.exists(file2))
 
     def test_rm_directory_recursive(self):
         """Test removing directory recursively"""
-        test_subdir = os.path.join(self.test_dir, 'subdir')
+        test_subdir = os.path.join(self.test_dir, "subdir")
         os.makedirs(test_subdir)
 
         rm = Rm(test_subdir, recursive=True)
         rm.run()
 
-        self.assertEqual(rm.exit_code['localhost'], 0)
+        self.assertEqual(rm.exit_code["localhost"], 0)
         self.assertFalse(os.path.exists(test_subdir))
 
     def test_rm_command_construction(self):
         """Test rm command construction"""
-        rm = Rm('/tmp/test', recursive=True, force=True)
+        rm = Rm("/tmp/test", recursive=True, force=True)
         rm.run()
         cmd = rm.get_cmd()
-        self.assertIn('rm', cmd)
-        self.assertIn('-r', cmd)
-        self.assertIn('-f', cmd)
+        if os.name == "nt":
+            self.assertIn("shutil.rmtree", cmd)
+        else:
+            self.assertIn("rm", cmd)
+            self.assertIn("-r", cmd)
+            self.assertIn("-f", cmd)
 
 
 class TestChmod(unittest.TestCase):
@@ -209,55 +227,62 @@ class TestChmod(unittest.TestCase):
 
     def setUp(self):
         """Set up test file"""
-        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_chmod_')
-        self.test_file = os.path.join(self.test_dir, 'test_file.txt')
-        with open(self.test_file, 'w') as f:
-            f.write('test content')
+        self.test_dir = tempfile.mkdtemp(prefix="jarvis_test_chmod_")
+        self.test_file = os.path.join(self.test_dir, "test_file.txt")
+        with open(self.test_file, "w") as f:
+            f.write("test content")
 
     def tearDown(self):
         """Clean up"""
         import shutil
+
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
     def test_chmod_single_file(self):
         """Test changing permissions on single file"""
-        chmod = Chmod(self.test_file, '755')
+        chmod = Chmod(self.test_file, "755")
         chmod.run()
 
-        self.assertEqual(chmod.exit_code['localhost'], 0)
+        self.assertEqual(chmod.exit_code["localhost"], 0)
 
-        # Check permissions changed
-        import stat
-        st = os.stat(self.test_file)
-        mode = st.st_mode
-        self.assertTrue(mode & stat.S_IRUSR)  # User read
-        self.assertTrue(mode & stat.S_IWUSR)  # User write
-        self.assertTrue(mode & stat.S_IXUSR)  # User execute
+        # Windows supports only its read-only attribute through chmod; POSIX
+        # exposes the complete execute-bit contract.
+        if os.name != "nt":
+            import stat
+
+            st = os.stat(self.test_file)
+            mode = st.st_mode
+            self.assertTrue(mode & stat.S_IRUSR)  # User read
+            self.assertTrue(mode & stat.S_IWUSR)  # User write
+            self.assertTrue(mode & stat.S_IXUSR)  # User execute
 
     def test_chmod_multiple_files(self):
         """Test changing permissions on multiple files"""
-        file1 = os.path.join(self.test_dir, 'file1.txt')
-        file2 = os.path.join(self.test_dir, 'file2.txt')
+        file1 = os.path.join(self.test_dir, "file1.txt")
+        file2 = os.path.join(self.test_dir, "file2.txt")
 
-        with open(file1, 'w') as f:
-            f.write('test1')
-        with open(file2, 'w') as f:
-            f.write('test2')
+        with open(file1, "w") as f:
+            f.write("test1")
+        with open(file2, "w") as f:
+            f.write("test2")
 
-        chmod = Chmod([file1, file2], '+x')
+        chmod = Chmod([file1, file2], "+x")
         chmod.run()
 
-        self.assertEqual(chmod.exit_code['localhost'], 0)
+        self.assertEqual(chmod.exit_code["localhost"], 0)
 
     def test_chmod_command_construction(self):
         """Test chmod command construction"""
-        chmod = Chmod('/tmp/test', '644', recursive=True)
+        chmod = Chmod("/tmp/test", "644", recursive=True)
         chmod.run()
         cmd = chmod.get_cmd()
-        self.assertIn('chmod', cmd)
-        self.assertIn('-R', cmd)
-        self.assertIn('644', cmd)
+        if os.name == "nt":
+            self.assertIn("os.chmod", cmd)
+        else:
+            self.assertIn("chmod", cmd)
+            self.assertIn("-R", cmd)
+        self.assertIn("644", cmd)
 
 
 class TestSleep(unittest.TestCase):
@@ -268,23 +293,29 @@ class TestSleep(unittest.TestCase):
         sleep = Sleep(1)
         sleep.run()
         cmd = sleep.get_cmd()
-        self.assertEqual(cmd, 'sleep 1')
-        self.assertEqual(sleep.exit_code['localhost'], 0)
+        if os.name == "nt":
+            self.assertIn("time.sleep", cmd)
+        else:
+            self.assertEqual(cmd, "sleep 1")
+        self.assertEqual(sleep.exit_code["localhost"], 0)
 
     def test_sleep_float(self):
         """Test sleep with float duration"""
         sleep = Sleep(0.1)
         sleep.run()
         cmd = sleep.get_cmd()
-        self.assertEqual(cmd, 'sleep 0.1')
-        self.assertEqual(sleep.exit_code['localhost'], 0)
+        if os.name == "nt":
+            self.assertIn("time.sleep", cmd)
+        else:
+            self.assertEqual(cmd, "sleep 0.1")
+        self.assertEqual(sleep.exit_code["localhost"], 0)
 
     def test_sleep_with_exec_info(self):
         """Test sleep with custom exec info"""
         exec_info = LocalExecInfo()
         sleep = Sleep(1, exec_info=exec_info)
         sleep.run()
-        self.assertEqual(sleep.exit_code['localhost'], 0)
+        self.assertEqual(sleep.exit_code["localhost"], 0)
 
 
 class TestEcho(unittest.TestCase):
@@ -295,8 +326,8 @@ class TestEcho(unittest.TestCase):
         echo = Echo("Hello World")
         echo.run()
 
-        self.assertEqual(echo.exit_code['localhost'], 0)
-        self.assertIn("Hello World", echo.stdout['localhost'])
+        self.assertEqual(echo.exit_code["localhost"], 0)
+        self.assertIn("Hello World", echo.stdout["localhost"])
 
     def test_echo_with_special_chars(self):
         """Test echoing text with special characters"""
@@ -304,7 +335,7 @@ class TestEcho(unittest.TestCase):
         echo = Echo(text)
         echo.run()
 
-        self.assertEqual(echo.exit_code['localhost'], 0)
+        self.assertEqual(echo.exit_code["localhost"], 0)
         # The output will have shell expansion, just check command succeeds
 
     def test_echo_command_construction(self):
@@ -312,8 +343,8 @@ class TestEcho(unittest.TestCase):
         echo = Echo("test message")
         echo.run()
         cmd = echo.get_cmd()
-        self.assertIn('echo', cmd)
-        self.assertIn('test message', cmd)
+        self.assertIn("echo", cmd)
+        self.assertIn("test message", cmd)
 
 
 class TestGdbServer(unittest.TestCase):
@@ -324,9 +355,9 @@ class TestGdbServer(unittest.TestCase):
         gdbserver = GdbServer("./myapp", 1234)
         # Don't run it since gdbserver may not be installed
         cmd = gdbserver.cmd
-        self.assertIn('gdbserver', cmd)
-        self.assertIn(':1234', cmd)
-        self.assertIn('./myapp', cmd)
+        self.assertIn("gdbserver", cmd)
+        self.assertIn(":1234", cmd)
+        self.assertIn("./myapp", cmd)
         self.assertEqual(gdbserver.port, 1234)
 
     def test_gdbserver_with_exec_info(self):
@@ -334,10 +365,10 @@ class TestGdbServer(unittest.TestCase):
         exec_info = LocalExecInfo()
         gdbserver = GdbServer("/bin/true", 5555, exec_info=exec_info)
         cmd = gdbserver.cmd
-        self.assertIn('gdbserver', cmd)
-        self.assertIn(':5555', cmd)
+        self.assertIn("gdbserver", cmd)
+        self.assertIn(":5555", cmd)
         self.assertEqual(gdbserver.port, 5555)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/unit/shell/test_ssh_exec.py
+++ b/test/unit/shell/test_ssh_exec.py
@@ -1,22 +1,22 @@
 import unittest
 import sys
 import os
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 # Add the project root to the path so we can import jarvis_cd
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from jarvis_cd.shell.ssh_exec import SshExec, PsshExec
+from jarvis_cd.shell.core_exec import CoreExec, LocalExec
 from jarvis_cd.shell.exec_info import SshExecInfo, PsshExecInfo
 from jarvis_cd.util.hostfile import Hostfile
 
 
 class TestSshExec(unittest.TestCase):
-
     def setUp(self):
         """Set up test fixtures"""
-        self.test_binary = os.path.join(os.path.dirname(__file__), 'test_env_checker')
-        self.hostfile = Hostfile(hosts=['testhost'], find_ips=False)
+        self.test_binary = os.path.join(os.path.dirname(__file__), "test_env_checker")
+        self.hostfile = Hostfile(hosts=["testhost"], find_ips=False)
 
     def test_basic_ssh_command(self):
         """Test basic SSH command construction"""
@@ -24,244 +24,239 @@ class TestSshExec(unittest.TestCase):
         ssh_exec = SshExec('echo "hello"', exec_info)
 
         cmd = ssh_exec.get_cmd()
-        self.assertIn('ssh', cmd)
-        self.assertIn('testhost', cmd)
+        self.assertIn("ssh", cmd)
+        self.assertIn("BatchMode=yes", cmd)
+        self.assertIn("ConnectionAttempts=1", cmd)
+        self.assertIn("testhost", cmd)
         self.assertIn('echo "hello"', cmd)
 
     def test_ssh_with_user(self):
         """Test SSH command with user"""
         exec_info = SshExecInfo(
-            user='testuser',
-            hostfile=self.hostfile,
-            exec_async=True
+            user="testuser", hostfile=self.hostfile, exec_async=True
         )
         ssh_exec = SshExec('echo "test"', exec_info)
 
         cmd = ssh_exec.get_cmd()
-        self.assertIn('testuser@testhost', cmd)
+        self.assertIn("testuser@testhost", cmd)
 
     def test_ssh_with_port(self):
         """Test SSH command with custom port"""
-        exec_info = SshExecInfo(
-            port=2222,
-            hostfile=self.hostfile,
-            exec_async=True
-        )
+        exec_info = SshExecInfo(port=2222, hostfile=self.hostfile, exec_async=True)
         ssh_exec = SshExec('echo "test"', exec_info)
 
         cmd = ssh_exec.get_cmd()
-        self.assertIn('-p 2222', cmd)
+        self.assertIn("-p 2222", cmd)
 
     def test_ssh_with_pkey(self):
         """Test SSH command with private key"""
         exec_info = SshExecInfo(
-            pkey='/path/to/key.pem',
-            hostfile=self.hostfile,
-            exec_async=True
+            pkey="/path/to/key.pem", hostfile=self.hostfile, exec_async=True
         )
         ssh_exec = SshExec('echo "test"', exec_info)
 
         cmd = ssh_exec.get_cmd()
-        self.assertIn('-i /path/to/key.pem', cmd)
+        self.assertIn("-i /path/to/key.pem", cmd)
 
     def test_ssh_strict_mode(self):
         """Test SSH with strict host key checking"""
         exec_info = SshExecInfo(
-            strict_ssh=True,
-            hostfile=self.hostfile,
-            exec_async=True
+            strict_ssh=True, hostfile=self.hostfile, exec_async=True
         )
         ssh_exec = SshExec('echo "test"', exec_info)
 
         cmd = ssh_exec.get_cmd()
         # Should NOT contain StrictHostKeyChecking=no
-        self.assertNotIn('StrictHostKeyChecking=no', cmd)
+        self.assertNotIn("StrictHostKeyChecking=no", cmd)
 
     def test_ssh_non_strict_mode(self):
         """Test SSH with non-strict host key checking"""
         exec_info = SshExecInfo(
-            strict_ssh=False,
-            hostfile=self.hostfile,
-            exec_async=True
+            strict_ssh=False, hostfile=self.hostfile, exec_async=True
         )
         ssh_exec = SshExec('echo "test"', exec_info)
 
         cmd = ssh_exec.get_cmd()
-        self.assertIn('StrictHostKeyChecking=no', cmd)
+        self.assertIn("StrictHostKeyChecking=no", cmd)
 
     def test_ssh_with_single_env_variable(self):
         """Test SSH command with single environment variable"""
         exec_info = SshExecInfo(
-            env={'TEST_VAR': 'test_value'},
-            hostfile=self.hostfile,
-            exec_async=True
+            env={"TEST_VAR": "test_value"}, hostfile=self.hostfile, exec_async=True
         )
-        ssh_exec = SshExec(self.test_binary + ' TEST_VAR', exec_info)
+        ssh_exec = SshExec(self.test_binary + " TEST_VAR", exec_info)
 
         cmd = ssh_exec.get_cmd()
-        self.assertIn('TEST_VAR', cmd)
-        self.assertIn('test_value', cmd)
+        self.assertIn("TEST_VAR", cmd)
+        self.assertIn("test_value", cmd)
 
     def test_ssh_with_multiple_env_variables(self):
         """Test SSH command with multiple environment variables"""
         exec_info = SshExecInfo(
-            env={
-                'VAR1': 'value1',
-                'VAR2': 'value2',
-                'VAR3': 'value3'
-            },
+            env={"VAR1": "value1", "VAR2": "value2", "VAR3": "value3"},
             hostfile=self.hostfile,
-            exec_async=True
+            exec_async=True,
         )
-        ssh_exec = SshExec(self.test_binary + ' VAR1 VAR2 VAR3', exec_info)
+        ssh_exec = SshExec(self.test_binary + " VAR1 VAR2 VAR3", exec_info)
 
         cmd = ssh_exec.get_cmd()
-        self.assertIn('VAR1', cmd)
-        self.assertIn('value1', cmd)
-        self.assertIn('VAR2', cmd)
-        self.assertIn('value2', cmd)
-        self.assertIn('VAR3', cmd)
-        self.assertIn('value3', cmd)
+        self.assertIn("VAR1", cmd)
+        self.assertIn("value1", cmd)
+        self.assertIn("VAR2", cmd)
+        self.assertIn("value2", cmd)
+        self.assertIn("VAR3", cmd)
+        self.assertIn("value3", cmd)
 
     def test_ssh_env_with_special_characters(self):
         """Test SSH environment variables with special characters"""
         exec_info = SshExecInfo(
-            env={'SPECIAL_VAR': "value with 'quotes'"},
+            env={"SPECIAL_VAR": "value with 'quotes'"},
             hostfile=self.hostfile,
-            exec_async=True
+            exec_async=True,
         )
-        ssh_exec = SshExec('echo $SPECIAL_VAR', exec_info)
+        ssh_exec = SshExec("echo $SPECIAL_VAR", exec_info)
 
         cmd = ssh_exec.get_cmd()
         # Should properly escape quotes
-        self.assertIn('SPECIAL_VAR', cmd)
+        self.assertIn("SPECIAL_VAR", cmd)
 
     def test_ssh_with_cwd(self):
         """Test SSH command with working directory change"""
         exec_info = SshExecInfo(
-            cwd='/tmp/test',
-            hostfile=self.hostfile,
-            exec_async=True
+            cwd="/tmp/test", hostfile=self.hostfile, exec_async=True
         )
-        ssh_exec = SshExec('pwd', exec_info)
+        ssh_exec = SshExec("pwd", exec_info)
 
         cmd = ssh_exec.get_cmd()
-        self.assertIn('cd /tmp/test', cmd)
+        self.assertIn("cd /tmp/test", cmd)
 
     def test_ssh_with_sudo(self):
         """Test SSH command with sudo"""
-        exec_info = SshExecInfo(
-            sudo=True,
-            hostfile=self.hostfile,
-            exec_async=True
-        )
-        ssh_exec = SshExec('whoami', exec_info)
+        exec_info = SshExecInfo(sudo=True, hostfile=self.hostfile, exec_async=True)
+        ssh_exec = SshExec("whoami", exec_info)
 
         cmd = ssh_exec.get_cmd()
-        self.assertIn('sudo', cmd)
+        self.assertIn("sudo", cmd)
 
     def test_ssh_with_sudo_and_env(self):
         """Test SSH command with sudo preserving environment"""
         exec_info = SshExecInfo(
             sudo=True,
             sudoenv=True,
-            env={'TEST_VAR': 'value'},
+            env={"TEST_VAR": "value"},
             hostfile=self.hostfile,
-            exec_async=True
+            exec_async=True,
         )
-        ssh_exec = SshExec('echo $TEST_VAR', exec_info)
+        ssh_exec = SshExec("echo $TEST_VAR", exec_info)
 
         cmd = ssh_exec.get_cmd()
-        self.assertIn('sudo -E', cmd)
-        self.assertIn('TEST_VAR', cmd)
+        self.assertIn("sudo -E", cmd)
+        self.assertIn("TEST_VAR", cmd)
 
     def test_ssh_with_sudo_no_env(self):
         """Test SSH command with sudo not preserving environment"""
         exec_info = SshExecInfo(
             sudo=True,
             sudoenv=False,
-            env={'TEST_VAR': 'value'},
+            env={"TEST_VAR": "value"},
             hostfile=self.hostfile,
-            exec_async=True
+            exec_async=True,
         )
-        ssh_exec = SshExec('echo $TEST_VAR', exec_info)
+        ssh_exec = SshExec("echo $TEST_VAR", exec_info)
 
         cmd = ssh_exec.get_cmd()
         # Should have 'sudo' but not 'sudo -E'
-        self.assertIn('sudo', cmd)
-        self.assertNotIn('sudo -E', cmd)
+        self.assertIn("sudo", cmd)
+        self.assertNotIn("sudo -E", cmd)
 
     def test_ssh_with_timeout(self):
         """Test SSH command with connection timeout"""
-        exec_info = SshExecInfo(
-            timeout=30,
-            hostfile=self.hostfile,
-            exec_async=True
-        )
+        exec_info = SshExecInfo(timeout=30, hostfile=self.hostfile, exec_async=True)
         ssh_exec = SshExec('echo "test"', exec_info)
 
         cmd = ssh_exec.get_cmd()
-        self.assertIn('ConnectTimeout=30', cmd)
+        self.assertIn("ConnectTimeout=30", cmd)
 
     def test_ssh_hostname_override(self):
         """Test SSH execution with explicit hostname override"""
-        multi_host = Hostfile(hosts=['host1', 'host2'], find_ips=False)
+        multi_host = Hostfile(hosts=["host1", "host2"], find_ips=False)
         exec_info = SshExecInfo(hostfile=multi_host, exec_async=True)
-        ssh_exec = SshExec('echo "test"', exec_info, hostname='host2')
+        ssh_exec = SshExec('echo "test"', exec_info, hostname="host2")
 
         cmd = ssh_exec.get_cmd()
-        self.assertIn('host2', cmd)
-        self.assertNotIn('host1', cmd)
+        self.assertIn("host2", cmd)
+        self.assertNotIn("host1", cmd)
 
     def test_ssh_env_numeric_values(self):
         """Test SSH environment variables with numeric values"""
         exec_info = SshExecInfo(
-            env={
-                'INT_VAR': 42,
-                'FLOAT_VAR': 3.14
-            },
+            env={"INT_VAR": 42, "FLOAT_VAR": 3.14},
             hostfile=self.hostfile,
-            exec_async=True
+            exec_async=True,
         )
-        ssh_exec = SshExec(self.test_binary + ' INT_VAR FLOAT_VAR', exec_info)
+        ssh_exec = SshExec(self.test_binary + " INT_VAR FLOAT_VAR", exec_info)
 
         cmd = ssh_exec.get_cmd()
-        self.assertIn('INT_VAR', cmd)
-        self.assertIn('42', cmd)
-        self.assertIn('FLOAT_VAR', cmd)
-        self.assertIn('3.14', cmd)
+        self.assertIn("INT_VAR", cmd)
+        self.assertIn("42", cmd)
+        self.assertIn("FLOAT_VAR", cmd)
+        self.assertIn("3.14", cmd)
 
     def test_ssh_combined_options(self):
         """Test SSH with multiple options combined"""
         exec_info = SshExecInfo(
-            user='testuser',
+            user="testuser",
             port=2222,
-            pkey='/path/to/key',
-            cwd='/tmp',
-            env={'VAR1': 'value1', 'VAR2': 'value2'},
+            pkey="/path/to/key",
+            cwd="/tmp",
+            env={"VAR1": "value1", "VAR2": "value2"},
             sudo=True,
             sudoenv=True,
             hostfile=self.hostfile,
-            exec_async=True
+            exec_async=True,
         )
         ssh_exec = SshExec('echo "test"', exec_info)
 
         cmd = ssh_exec.get_cmd()
-        self.assertIn('testuser@testhost', cmd)
-        self.assertIn('-p 2222', cmd)
-        self.assertIn('-i /path/to/key', cmd)
-        self.assertIn('cd /tmp', cmd)
-        self.assertIn('VAR1', cmd)
-        self.assertIn('VAR2', cmd)
-        self.assertIn('sudo -E', cmd)
+        self.assertIn("testuser@testhost", cmd)
+        self.assertIn("-p 2222", cmd)
+        self.assertIn("-i /path/to/key", cmd)
+        self.assertIn("cd /tmp", cmd)
+        self.assertIn("VAR1", cmd)
+        self.assertIn("VAR2", cmd)
+        self.assertIn("sudo -E", cmd)
+
+    def test_ssh_remaps_windows_job_ownership_to_target_host(self):
+        """SSH output and Job Object ownership use the remote host key."""
+        owner = object()
+
+        def fake_local_init(instance, cmd, exec_info):
+            CoreExec.__init__(instance)
+            instance.cmd = cmd
+            instance.exec_info = exec_info
+            instance.stdout = {"localhost": ""}
+            instance.stderr = {"localhost": ""}
+            instance.exit_code = {"localhost": 0}
+            instance.processes = {"localhost": object()}
+            instance.process_groups = {"localhost": 42}
+            instance.windows_jobs = {"localhost": owner}
+            instance.output_threads = {"localhost": ()}
+
+        with patch.object(LocalExec, "__init__", fake_local_init):
+            ssh_exec = SshExec(
+                "echo test",
+                SshExecInfo(hostfile=self.hostfile, exec_async=True),
+            )
+
+        self.assertEqual(ssh_exec.windows_jobs, {"testhost": owner})
+        self.assertNotIn("localhost", ssh_exec.processes)
 
 
 class TestPsshExec(unittest.TestCase):
-
     def setUp(self):
         """Set up test fixtures"""
-        self.test_binary = os.path.join(os.path.dirname(__file__), 'test_env_checker')
-        self.multi_host = Hostfile(hosts=['host1', 'host2', 'host3'], find_ips=False)
+        self.test_binary = os.path.join(os.path.dirname(__file__), "test_env_checker")
+        self.multi_host = Hostfile(hosts=["host1", "host2", "host3"], find_ips=False)
 
     def test_pssh_requires_hostfile(self):
         """Test that PSSH requires a hostfile"""
@@ -278,7 +273,7 @@ class TestPsshExec(unittest.TestCase):
         with self.assertRaises(ValueError):
             PsshExec('echo "test"', exec_info)
 
-    @patch('jarvis_cd.shell.ssh_exec.SshExec')
+    @patch("jarvis_cd.shell.ssh_exec.SshExec")
     def test_pssh_creates_ssh_for_each_host(self, mock_ssh_exec):
         """Test that PSSH creates SSH executor for each host"""
         exec_info = PsshExecInfo(hostfile=self.multi_host, exec_async=True)
@@ -287,39 +282,37 @@ class TestPsshExec(unittest.TestCase):
         mock_instances = []
         for i in range(3):
             mock_instance = MagicMock()
-            mock_instance.processes = {f'host{i+1}': MagicMock()}
+            mock_instance.processes = {f"host{i + 1}": MagicMock()}
             mock_instances.append(mock_instance)
 
         mock_ssh_exec.side_effect = mock_instances
 
-        pssh_exec = PsshExec('echo "test"', exec_info)
+        PsshExec('echo "test"', exec_info)
 
         # Should create 3 SSH executors, one for each host
         self.assertEqual(mock_ssh_exec.call_count, 3)
 
-    @patch('jarvis_cd.shell.ssh_exec.SshExec')
+    @patch("jarvis_cd.shell.ssh_exec.SshExec")
     def test_pssh_env_forwarding(self, mock_ssh_exec):
         """Test that PSSH forwards environment variables to SSH executors"""
         exec_info = PsshExecInfo(
-            env={'TEST_VAR': 'test_value'},
-            hostfile=self.multi_host,
-            exec_async=True
+            env={"TEST_VAR": "test_value"}, hostfile=self.multi_host, exec_async=True
         )
 
         # Mock SshExec
         mock_instance = MagicMock()
-        mock_instance.processes = {'host1': MagicMock()}
+        mock_instance.processes = {"host1": MagicMock()}
         mock_ssh_exec.return_value = mock_instance
 
-        pssh_exec = PsshExec('echo $TEST_VAR', exec_info)
+        PsshExec("echo $TEST_VAR", exec_info)
 
         # Check that environment was passed to SSH executors
         for call in mock_ssh_exec.call_args_list:
             ssh_info = call[0][1]
-            self.assertIn('TEST_VAR', ssh_info.env)
-            self.assertEqual(ssh_info.env['TEST_VAR'], 'test_value')
+            self.assertIn("TEST_VAR", ssh_info.env)
+            self.assertEqual(ssh_info.env["TEST_VAR"], "test_value")
 
-    @patch('jarvis_cd.shell.ssh_exec.SshExec')
+    @patch("jarvis_cd.shell.ssh_exec.SshExec")
     def test_pssh_parallel_execution(self, mock_ssh_exec):
         """Test that PSSH executes on all hosts in parallel"""
         exec_info = PsshExecInfo(hostfile=self.multi_host, exec_async=True)
@@ -333,7 +326,7 @@ class TestPsshExec(unittest.TestCase):
 
         mock_ssh_exec.side_effect = mock_instances
 
-        pssh_exec = PsshExec('echo "test"', exec_info)
+        PsshExec('echo "test"', exec_info)
 
         # Verify SSH was created for each host with correct hostname
         self.assertEqual(mock_ssh_exec.call_count, 3)
@@ -342,23 +335,46 @@ class TestPsshExec(unittest.TestCase):
         call_hostnames = []
         for call in mock_ssh_exec.call_args_list:
             args, kwargs = call
-            if 'hostname' in kwargs:
-                call_hostnames.append(kwargs['hostname'])
+            if "hostname" in kwargs:
+                call_hostnames.append(kwargs["hostname"])
             elif len(args) > 2:
                 call_hostnames.append(args[2])
 
-        self.assertIn('host1', call_hostnames)
-        self.assertIn('host2', call_hostnames)
-        self.assertIn('host3', call_hostnames)
+        self.assertIn("host1", call_hostnames)
+        self.assertIn("host2", call_hostnames)
+        self.assertIn("host3", call_hostnames)
+
+    @patch("jarvis_cd.shell.ssh_exec.SshExec")
+    def test_pssh_copies_windows_job_ownership(self, mock_ssh_exec):
+        """PSSH can terminate a per-host Job Object through its own map."""
+        owner = object()
+        process = object()
+
+        def make_exec(_cmd, _info, hostname):
+            return MagicMock(
+                processes={hostname: process},
+                process_groups={hostname: 42},
+                windows_jobs={hostname: owner},
+            )
+
+        mock_ssh_exec.side_effect = make_exec
+        hostfile = Hostfile(hosts=["node-a"], find_ips=False)
+        pssh_exec = PsshExec(
+            "echo test",
+            PsshExecInfo(hostfile=hostfile, exec_async=True),
+        )
+
+        self.assertEqual(pssh_exec.windows_jobs, {"node-a": owner})
+        self.assertEqual(pssh_exec.process_groups, {"node-a": 42})
 
     def test_pssh_get_cmd(self):
         """Test that PSSH get_cmd returns original command"""
         exec_info = PsshExecInfo(hostfile=self.multi_host, exec_async=True)
 
-        with patch('jarvis_cd.shell.ssh_exec.SshExec'):
+        with patch("jarvis_cd.shell.ssh_exec.SshExec"):
             pssh_exec = PsshExec('echo "test"', exec_info)
             self.assertEqual(pssh_exec.get_cmd(), 'echo "test"')
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/unit/test_release_request.py
+++ b/test/unit/test_release_request.py
@@ -1,0 +1,147 @@
+"""Tests for an exact immutable-release operator request."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from ci.release_request import (
+    REQUEST_SCHEMA,
+    ReleaseRequestError,
+    canonical_release_request,
+    validate_release_request,
+)
+
+REPOSITORY = "grc-iit/jarvis-cd"
+TAG = "v2.0.0"
+COMMIT = "a" * 40
+NOW = 1_800_000_000
+
+
+def _record() -> dict[str, Any]:
+    return {
+        "schema_version": REQUEST_SCHEMA,
+        "repository": REPOSITORY,
+        "tag": TAG,
+        "commit": COMMIT,
+        "immutable_releases_enabled": True,
+        "verified_at_epoch": NOW - 30,
+    }
+
+
+def _validate(
+    record: object,
+    *,
+    repository: str = REPOSITORY,
+    tag: str = TAG,
+    commit: str = COMMIT,
+    now_epoch: int = NOW,
+    max_age_seconds: int = 3_600,
+) -> dict[str, Any]:
+    return validate_release_request(
+        json.dumps(record),
+        repository=repository,
+        tag=tag,
+        commit=commit,
+        now_epoch=now_epoch,
+        max_age_seconds=max_age_seconds,
+    )
+
+
+def test_valid_request_is_canonicalized() -> None:
+    record = _record()
+
+    canonical = canonical_release_request(
+        json.dumps(record, indent=2),
+        repository=REPOSITORY,
+        tag=TAG,
+        commit=COMMIT,
+        now_epoch=NOW,
+        max_age_seconds=3_600,
+    )
+
+    assert canonical == json.dumps(record, separators=(",", ":"), sort_keys=True)
+    assert _validate(record) == record
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda value: value.update(extra=True), "field set"),
+        (lambda value: value.update(schema_version="other"), "schema"),
+        (lambda value: value.update(repository="other/repo"), "repository"),
+        (lambda value: value.update(tag="v2.0.1"), "tag"),
+        (lambda value: value.update(commit="b" * 40), "commit"),
+        (
+            lambda value: value.update(immutable_releases_enabled=False),
+            "not observed as enabled",
+        ),
+        (lambda value: value.update(verified_at_epoch=1.0), "integer epoch"),
+        (lambda value: value.update(verified_at_epoch=True), "integer epoch"),
+    ],
+)
+def test_request_rejects_field_drift(
+    mutate: Callable[[dict[str, Any]], object],
+    message: str,
+) -> None:
+    record = _record()
+    mutate(record)
+
+    with pytest.raises(ReleaseRequestError, match=message):
+        _validate(record)
+
+
+def test_request_rejects_future_and_expired_records() -> None:
+    future = _record()
+    future["verified_at_epoch"] = NOW + 1
+    with pytest.raises(ReleaseRequestError, match="future"):
+        _validate(future)
+
+    expired = _record()
+    expired["verified_at_epoch"] = NOW - 3_601
+    with pytest.raises(ReleaseRequestError, match="expired"):
+        _validate(expired)
+
+
+@pytest.mark.parametrize("tag", ["2.0.0", "v2.0", "v2.0.0rc1", "v02.0.0"])
+def test_request_rejects_nonstable_expected_tag(tag: str) -> None:
+    with pytest.raises(ReleaseRequestError, match="stable"):
+        _validate(_record(), tag=tag)
+
+
+def test_request_rejects_malformed_or_oversized_json() -> None:
+    with pytest.raises(ReleaseRequestError, match="valid JSON"):
+        validate_release_request(
+            "{",
+            repository=REPOSITORY,
+            tag=TAG,
+            commit=COMMIT,
+            now_epoch=NOW,
+            max_age_seconds=3_600,
+        )
+    with pytest.raises(ReleaseRequestError, match="byte limit"):
+        validate_release_request(
+            " " * 4_097,
+            repository=REPOSITORY,
+            tag=TAG,
+            commit=COMMIT,
+            now_epoch=NOW,
+            max_age_seconds=3_600,
+        )
+
+
+def test_request_rejects_duplicate_json_fields() -> None:
+    duplicate = json.dumps(_record())[:-1] + ',"tag":"v2.0.0"}'
+
+    with pytest.raises(ReleaseRequestError, match="duplicate field: tag"):
+        validate_release_request(
+            duplicate,
+            repository=REPOSITORY,
+            tag=TAG,
+            commit=COMMIT,
+            now_epoch=NOW,
+            max_age_seconds=3_600,
+        )

--- a/test/unit/test_release_workflow.py
+++ b/test/unit/test_release_workflow.py
@@ -1,0 +1,53 @@
+"""Production invariants for the JARVIS-CD release workflow."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = (REPOSITORY_ROOT / ".github" / "workflows" / "release.yml").read_text(
+    encoding="utf-8"
+)
+
+
+def test_external_actions_are_immutable_commit_pins() -> None:
+    """Release jobs must not execute mutable third-party action tags."""
+    uses = re.findall(r"^\s*uses:\s*([^\s#]+)", WORKFLOW, flags=re.MULTILINE)
+    assert uses
+    for action in uses:
+        if action.startswith("./"):
+            continue
+        assert re.fullmatch(r"[^@]+@[0-9a-f]{40}", action), action
+
+
+def test_immutable_release_preflight_gates_artifact_build() -> None:
+    """Release work starts only after repository immutability is enforced."""
+    preflight_index = WORKFLOW.index("  release-preflight:")
+    build_index = WORKFLOW.index("  build:")
+    assert preflight_index < build_index
+    assert 'gh api "repos/$REPOSITORY/immutable-releases" --jq .enabled' in WORKFLOW
+    build_block = WORKFLOW[build_index : WORKFLOW.index("  release:")]
+    assert "    needs: release-preflight" in build_block
+
+
+def test_release_resume_is_exact_byte_and_fail_closed() -> None:
+    """Reruns may resume exact releases but cannot overwrite or accept drift."""
+    assert "load_and_verify_assets true" in WORKFLOW
+    assert WORKFLOW.count("load_and_verify_assets false") >= 3
+    assert "cmp --silent" in WORKFLOW
+    assert "release asset digest mismatch" in WORKFLOW
+    assert "unexpected release asset" in WORKFLOW
+    assert "missing release asset" in WORKFLOW
+    assert "--clobber" not in WORKFLOW
+
+
+def test_final_release_requires_exact_tag_attestation_and_immutability() -> None:
+    """A completed release is pinned, attested, byte-exact, and immutable."""
+    assert WORKFLOW.count('test "$(resolve_remote_tag)" = "$GITHUB_SHA"') >= 3
+    assert "gh attestation verify" in WORKFLOW
+    assert "--deny-self-hosted-runners" in WORKFLOW
+    assert 'test "$(jq -r .draft "$release_json")" = false' in WORKFLOW
+    assert 'test "$(jq -r .immutable "$release_json")" = true' in WORKFLOW
+    assert 'gh release verify "$TAG_NAME"' in WORKFLOW

--- a/test/unit/test_release_workflow.py
+++ b/test/unit/test_release_workflow.py
@@ -22,14 +22,33 @@ def test_external_actions_are_immutable_commit_pins() -> None:
         assert re.fullmatch(r"[^@]+@[0-9a-f]{40}", action), action
 
 
-def test_immutable_release_preflight_gates_artifact_build() -> None:
-    """Release work starts only after repository immutability is enforced."""
+def test_exact_release_request_gates_artifact_build() -> None:
+    """Release work starts only after a fresh exact operator request."""
     preflight_index = WORKFLOW.index("  release-preflight:")
     build_index = WORKFLOW.index("  build:")
     assert preflight_index < build_index
-    assert 'gh api "repos/$REPOSITORY/immutable-releases" --jq .enabled' in WORKFLOW
+    assert "JARVIS_RELEASE_REQUEST" in WORKFLOW
+    assert "python ci/release_request.py" in WORKFLOW
+    assert WORKFLOW.count("python ci/release_request.py") == 2
+    assert '--repository "$REPOSITORY"' in WORKFLOW
+    assert '--tag "$TAG_NAME"' in WORKFLOW
+    assert '--commit "$GITHUB_SHA"' in WORKFLOW
+    assert "--max-age-seconds 3600" in WORKFLOW
+    assert 'gh api "repos/$REPOSITORY/immutable-releases"' not in WORKFLOW
+    assert "Verify protected release controls" in WORKFLOW
+    assert ".can_admins_bypass == false" in WORKFLOW
+    assert '"type": "tag"' in WORKFLOW
+    assert "Restrict immutable version tag creation" in WORKFLOW
+    assert "tag actor is not an approved release administrator" in WORKFLOW
+    assert "collaborators/$release_admin/permission" in WORKFLOW
+    assert '.permission == "admin" and .role_name == "admin"' in WORKFLOW
     build_block = WORKFLOW[build_index : WORKFLOW.index("  release:")]
     assert "    needs: release-preflight" in build_block
+    assert "release_request" in build_block
+    release_block = WORKFLOW[WORKFLOW.index("  release:") :]
+    assert "    environment: immutable-release" in release_block
+    assert "Revalidate fresh request and current main" in release_block
+    assert "refs/remotes/origin/main" in release_block
 
 
 def test_release_resume_is_exact_byte_and_fail_closed() -> None:
@@ -40,6 +59,12 @@ def test_release_resume_is_exact_byte_and_fail_closed() -> None:
     assert "release asset digest mismatch" in WORKFLOW
     assert "unexpected release asset" in WORKFLOW
     assert "missing release asset" in WORKFLOW
+    assert '.author.login == "github-actions[bot]"' in WORKFLOW
+    assert ".name == $tag" in WORKFLOW
+    assert ".body == $body" in WORKFLOW
+    assert ".prerelease == false" in WORKFLOW
+    assert '--notes "$release_body"' in WORKFLOW
+    assert "--generate-notes" not in WORKFLOW
     assert "--clobber" not in WORKFLOW
 
 

--- a/test/unit/util/test_private_path.py
+++ b/test/unit/util/test_private_path.py
@@ -1,0 +1,106 @@
+"""Owner-private state path tests."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from jarvis_cd.util.private_path import (
+    ensure_private_descriptor,
+    ensure_private_path,
+    reject_private_path_redirection,
+)
+
+
+def test_private_paths_are_normalized_under_a_default_parent(tmp_path: Path) -> None:
+    """State paths do not retain broad permissions from their parent."""
+    directory = tmp_path / "state"
+    directory.mkdir()
+    path = directory / "record.json"
+    path.write_text("{}\n", encoding="utf-8")
+
+    ensure_private_path(directory, directory=True)
+    ensure_private_path(path, directory=False)
+
+    if os.name != "nt":
+        assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        return
+
+    import ntsecuritycon
+    import win32security
+
+    for target, expected_flags in (
+        (
+            directory,
+            win32security.OBJECT_INHERIT_ACE | win32security.CONTAINER_INHERIT_ACE,
+        ),
+        (path, 0),
+    ):
+        descriptor = win32security.GetNamedSecurityInfo(
+            str(target),
+            win32security.SE_FILE_OBJECT,
+            win32security.OWNER_SECURITY_INFORMATION
+            | win32security.DACL_SECURITY_INFORMATION,
+        )
+        control, _revision = descriptor.GetSecurityDescriptorControl()
+        assert control & 0x1000
+        dacl = descriptor.GetSecurityDescriptorDacl()
+        assert dacl is not None
+        assert dacl.GetAceCount() == 3
+        for index in range(dacl.GetAceCount()):
+            header, mask, _sid = dacl.GetAce(index)
+            assert header == (win32security.ACCESS_ALLOWED_ACE_TYPE, expected_flags)
+            assert mask == ntsecuritycon.FILE_ALL_ACCESS
+
+
+def test_private_path_rejects_redirected_ancestor_before_creation(
+    tmp_path: Path,
+) -> None:
+    """A symlink or NTFS junction cannot relocate private state."""
+    target = tmp_path / "outside"
+    target.mkdir()
+    redirected = tmp_path / "redirected"
+    if os.name == "nt":
+        import _winapi
+
+        _winapi.CreateJunction(str(target), str(redirected))
+    else:
+        redirected.symlink_to(target, target_is_directory=True)
+
+    candidate = redirected / "not-created"
+    with pytest.raises(RuntimeError, match="symbolic link or reparse point"):
+        reject_private_path_redirection(candidate)
+    assert not (target / "not-created").exists()
+
+
+def test_private_descriptor_normalizes_the_held_object(tmp_path: Path) -> None:
+    """Descriptor-bound normalization protects the object used for I/O."""
+    path = tmp_path / "record.json"
+    path.write_text("{}\n", encoding="utf-8")
+    descriptor = os.open(path, os.O_RDWR)
+    try:
+        ensure_private_descriptor(path, descriptor, directory=False)
+        information = os.fstat(descriptor)
+        assert information.st_nlink == 1
+        assert (information.st_dev, information.st_ino) == (
+            path.lstat().st_dev,
+            path.lstat().st_ino,
+        )
+        if os.name != "nt":
+            assert stat.S_IMODE(information.st_mode) == 0o600
+    finally:
+        os.close(descriptor)
+
+
+def test_private_file_rejects_hard_link_alias(tmp_path: Path) -> None:
+    """Private state cannot retain a second pathname outside its directory."""
+    path = tmp_path / "record.json"
+    path.write_text("{}\n", encoding="utf-8")
+    os.link(path, tmp_path / "alias.json")
+
+    with pytest.raises(RuntimeError, match="exactly one link"):
+        ensure_private_path(path, directory=False)

--- a/uv.lock
+++ b/uv.lock
@@ -387,6 +387,7 @@ source = { editable = "." }
 dependencies = [
     { name = "pandas" },
     { name = "podman-compose" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "pyyaml" },
 ]
 
@@ -402,6 +403,7 @@ dev = [
 requires-dist = [
     { name = "pandas" },
     { name = "podman-compose" },
+    { name = "pywin32", marker = "sys_platform == 'win32'", specifier = ">=311" },
     { name = "pyyaml" },
 ]
 
@@ -806,6 +808,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,1084 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/68/9f3ef890cf3c6ab97bd531c5677f67613d302165d16f8142b2811782a614/cffi-2.1.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:30b65779d598c370374fefabf138d456fd6f3216bfa7bedfab1ba82025b0cd93", size = 211892, upload-time = "2026-07-06T21:32:29.565Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d7/1a74539db16d8bfd839ff1515948948efbb162e574650fd3d846896eea95/cffi-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88023dfe18799507b73f1dbb0d14326a17465de1bc9c9c7655c22845e9ddc3a2", size = 218793, upload-time = "2026-07-06T21:32:30.951Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d2/4398416cd699b35167947c6e22aca52c47e69ad5695073c9f1f2c52e04aa/cffi-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa7a1b53a2a4452ada2d1b5dade9960b2522f1e61293a811a077439e39029565", size = 217883, upload-time = "2026-07-06T21:32:35.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a5/d4fe77b589e5e82d43ebc809bf2e6474afe8e48e32ea050b9357645b6471/cffi-2.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9d8272c0e483b024e1b9ad029821470ed8ec65631dbd90217469da0e7cd89f1c", size = 221251, upload-time = "2026-07-06T21:32:36.527Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f0/a2fc43084c0433caf7f461bccc013e28f848d04ee1c5ed7fce71423cf4d9/cffi-2.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7762faa47e8ff7eb80bd261d9a7d8eea2d8baa69de5e95b70c1f338bbe712f02", size = 214250, upload-time = "2026-07-06T21:32:37.852Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8c/b925975448cf20634a9fbd5efceb807219db452653648d2897c0989cab2d/cffi-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:89095c1968b4ba8285840e131bf2891b09ae137fe2146905acae0354fbce1b5e", size = 219441, upload-time = "2026-07-06T21:32:39.146Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815, upload-time = "2026-07-06T21:32:48.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429, upload-time = "2026-07-06T21:32:49.848Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844, upload-time = "2026-07-06T21:32:53.704Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287, upload-time = "2026-07-06T21:32:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681, upload-time = "2026-07-06T21:32:56.329Z" },
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/e3/85ec501f206fb049259288c1f3506e53876937fb00edb47009348e66756b/charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5", size = 317075, upload-time = "2026-07-07T14:32:56.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/69/2a5385192e67175f7d8bd5ce4f57c24bc956439adeae5c13a99aa28a53d1/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2", size = 213837, upload-time = "2026-07-07T14:32:57.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/46/03ddc7da576d814fe0a36dd1f0fd3258e95404b4b2e3c026b7923d7e133f/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a", size = 235503, upload-time = "2026-07-07T14:32:59.205Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6e/de0229a7ef40f6f9d28a837eebf4ec47bdca5dab4e900c84f22919af636a/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4773092f8019072343a7447203308b176e10199920eb02d6195e81bbb3274c29", size = 229944, upload-time = "2026-07-07T14:33:00.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/34/49b9060e8418b14fb5cba9cf6bfb383111e2538a03a1fb18e66a95aeb3d5/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c", size = 221276, upload-time = "2026-07-07T14:33:02.199Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/80282cce0fae9c3061203d723ee87da996aed79679e65d8935050ee7ca1f/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:c0323c9daef75ef2e5083624b4585018a0c9d5e3b40f607eed81a311270b934b", size = 205260, upload-time = "2026-07-07T14:33:03.698Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/74/2f62c8821b969ea3bd67cc2e6976834f48ca5d12664d2559ebcd9bcfbed7/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:871ff67ea1aad4dfd91736464934d56b32dac49f9fbe16cddba36198a7b3a0db", size = 217786, upload-time = "2026-07-07T14:33:05.12Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8d/feabb82cb49fcad14515b1d7d1ca4787b0da7fc723a212bf89bc9e0fac52/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67830fc78e67501f47bb950471b2dcb9b35b140084429318e862895a8e89c993", size = 216798, upload-time = "2026-07-07T14:33:06.629Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ff/c946d63bc3786d5b84d960b0f7ab7e25b828486a946b5aa997625bcaf6a6/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3d92613ec25e43b05f042302531ec0f00b8445190e43325880cbd6ab7c2581da", size = 206429, upload-time = "2026-07-07T14:33:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ba/5e5007c370702f85d2ef75791fac7943ed41e080364a673b20142e430e3e/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:280081916dc341820640489a66e4696049401ef1cf6dd672f672e70ad915aca3", size = 223066, upload-time = "2026-07-07T14:33:09.783Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d5/9096aa3cf532dfad237861544eb47a0f20d5adbf1039760fed8eaae935d9/charset_normalizer-3.4.9-cp311-cp311-win32.whl", hash = "sha256:ac351b3b8014eead140e77e9717e2992c6bbe30b63bc3422422eb84865412e3d", size = 150456, upload-time = "2026-07-07T14:33:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a1/e29995109e455dc8eff8d0fac6ae509be39561318a7cfeac5d33ad029213/charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1", size = 161410, upload-time = "2026-07-07T14:33:12.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8d/1569f4d0032d6ba2a4fe4591c35bf87868c600c41a71eb5c2e1ffa8464c2/charset_normalizer-3.4.9-cp311-cp311-win_arm64.whl", hash = "sha256:1d22856ffbe153a602df38e4a5464f0b748a54002e0d69ac6d2ad0a197cc99ec", size = 152649, upload-time = "2026-07-07T14:33:14.173Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/8b/adeb62ea8951f13c4c7fef2e7a85e1a06b499c8d8237ea589d496029e53f/coverage-7.15.0.tar.gz", hash = "sha256:9ac3fe7a1435986463eaa8ee253ae2f2a268709ba4ae5c7dd1f52a05391ad78f", size = 925362, upload-time = "2026-07-02T13:10:50.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/23/82e910835ef4b8391047025e1d53aa48d66029f444eb8b25373c849bf503/coverage-7.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:003fff99412ea848c0aaebcc78ed2b6ce7d8a1227ed17e68470672770b78a02a", size = 220662, upload-time = "2026-07-02T13:08:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/0d/c7b213dde2f1579de5231062b386d8413f79c11667eb58c39319b25991da/coverage-7.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5cbd804bf2784ce7b45114516050f346ecd50f960c4bb630a7ee9e1d78fa2118", size = 221168, upload-time = "2026-07-02T13:08:40.471Z" },
+    { url = "https://files.pythonhosted.org/packages/33/77/d000aeedfac085088337b3c7becdad328474b1f8a9e4c9368a0c99605d68/coverage-7.15.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8773e15c23305b58882a4611fb9b2755977eae0dc2e515366a1b6c98866cc4c2", size = 251587, upload-time = "2026-07-02T13:08:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/e0/86787c56b9df17afd370d5e293515dd4d9a107a561d13054873eefad8ecc/coverage-7.15.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f50e40081494c1dc4239ebb202014cbcc3306ea96fb6302a34c8cc0967fc5ae8", size = 253497, upload-time = "2026-07-02T13:08:43.387Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/02/181bc917359299c07dead6270f94e411151c8b60cec905c33499da69afe6/coverage-7.15.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daf96f37f5fc3a7b6c6da862eb4aee61c426bd63da236ed4a73ef0e503b4bca5", size = 255607, upload-time = "2026-07-02T13:08:44.897Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/35/ca5e7427699913da6788c4f910e73ab16c5f4b59ec5d3a999dce2a45112f/coverage-7.15.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:51aa20f6ae2788fd197747766edf4cd8234fd9423309b934257fa6b21a592723", size = 257563, upload-time = "2026-07-02T13:08:46.334Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/4d/b8220bacc2fc3c4e9078e27c32e99fb411479a4718a72bdd00036a9891c8/coverage-7.15.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03d1f922757662eb7af586e77834792274cff776bc7b1d1a0b66a49ea9d84735", size = 251726, upload-time = "2026-07-02T13:08:47.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e4/2e145da1991d72189b9c3cf7eca05c716ee7080d099aaea6757cfc7df008/coverage-7.15.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a6d6acc9a7666245e6133dd15144ca038a85a9cd5026bb06d6bbae9e77440dc9", size = 253301, upload-time = "2026-07-02T13:08:49.5Z" },
+    { url = "https://files.pythonhosted.org/packages/72/28/d2c841d698bf762e481f08bd4839d370246b6d9b61dab085a7b20b201a08/coverage-7.15.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1ac2c4c27c7df851dc9a017c2d7de00b69147e84ba3d96f37a530b0b6fb51035", size = 251361, upload-time = "2026-07-02T13:08:51.304Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ed/55d9ffde994fba3897c0c783f77a7d053b0c18787f6892ed5b0aed73f469/coverage-7.15.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b761a1d504fd4bd1f20f418753964dca9f5862a511fc854dac58296b3b223671", size = 255129, upload-time = "2026-07-02T13:08:52.661Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c0/ecbf33b8c460ea2718aeb813e2df8140d0370e5f67261c31524ceb0a2a8d/coverage-7.15.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e43b045e11c16e897895758ae90e4a90cf99e93d58549e2f90c0e2272e155695", size = 251081, upload-time = "2026-07-02T13:08:54.188Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/de/fb87b4261f54448dd2b9504ef19a58be42cef0d9520595fbfe1219b15234/coverage-7.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:589b54513e901739f4b4582c705ce96b80c96f57641b1464607e2367a270e540", size = 251988, upload-time = "2026-07-02T13:08:55.726Z" },
+    { url = "https://files.pythonhosted.org/packages/df/27/3494d5f291b9a4cb868f73c11221a8bd2d5bd761a8f9acea61ff57128dd1/coverage-7.15.0-cp311-cp311-win32.whl", hash = "sha256:106781b8482749162d0b47056937ba0933508e5d9447f65a5e7d5c422f0d6bb4", size = 222754, upload-time = "2026-07-02T13:08:57.091Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ee/cd4847ebc9be6a9c0123d763645a6f1f3be6b8c58c962706368b79cbac07/coverage-7.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:821e92b3631d762a339695824cadbbc73020354eba2a23a551a99ad34938fbe6", size = 223225, upload-time = "2026-07-02T13:08:58.594Z" },
+    { url = "https://files.pythonhosted.org/packages/57/37/5011581aa7f2be498b97dcc7c9902192442a42f4f9a748aeadb3d6506b42/coverage-7.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:309990eb5fb8014b9f67cb211f7fd41876ec8a88a88d3ae76de0ed1d611e3640", size = 222774, upload-time = "2026-07-02T13:09:00.074Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/74/fd4c0901137c4f8d81a76ada99e43c65163b4c94a02ece107a4ec0c6b615/coverage-7.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b75ee5e8cb7575636ac598719b4307ac529ec8fcd79608a35c3cd4d4dada812d", size = 220838, upload-time = "2026-07-02T13:09:02.084Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2e/2347583467bd7f0402635101a916961915cc68fce652cd0db5f173ea04fc/coverage-7.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffb31267816b93b075302248cc1737506081b4f163df4401e9df1a6424aafabe", size = 221197, upload-time = "2026-07-02T13:09:03.617Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/17/99fa688541ae1d6e84543a0e544f83de0c944815b63e9e7b1ed411d15036/coverage-7.15.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e4d0bb73455bf97ab243a8f12c37c686ccf1c13bb614b7b85f1d062f06f42b2c", size = 252705, upload-time = "2026-07-02T13:09:05.059Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/02/6a95a5cd83b74839017ef9cf48d2d8c9ae60af919e17a3f336e6f9f1b7bd/coverage-7.15.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:20d9ccc4ebd0edc434d86dfd2a1dd2a8efa6b6b3073d0485a394fee86459ebb4", size = 255441, upload-time = "2026-07-02T13:09:06.559Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f2/406f6c57d600f68185942422c4c00f1a3255d60aee6e5fd961425cd9987e/coverage-7.15.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20c8a976c365c8cb12f0cbd099508772ea41fb5fa80657a8506df0e11bd278c5", size = 256556, upload-time = "2026-07-02T13:09:08.197Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8e/d3fa48489c15ecdec1ba48fd61f68798555dddd2f6716f9ad42adeb1a2a9/coverage-7.15.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f948fd5ba1b9cbca91f0ae08b4c1ce2b139509149a435e2585d056d57d70bf01", size = 258815, upload-time = "2026-07-02T13:09:09.691Z" },
+    { url = "https://files.pythonhosted.org/packages/47/2e/2d40ddd110462c6a2769677cf7f1c119a52b45f568978fc6c98e4cc0dd0f/coverage-7.15.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f58185f06edf6ad68ec9fb155d63ef650c82f3fbd7e1770e2867751fb13158f4", size = 253117, upload-time = "2026-07-02T13:09:11.212Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c0/310782f0d7c3cb2b5ac05ba8d205fe91f24a36f6bf3256098f1782181c38/coverage-7.15.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:02adc79a920c73c647c5d117f55747df7f2de94571884758ce8bc58e04f0a796", size = 254475, upload-time = "2026-07-02T13:09:13.029Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f7/702da6c275f8ae6ade423d2877243122932c9b27f5403003b9ef8c927d12/coverage-7.15.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6eb7c300fbed667fd6e3588eba71c1904cdb06110ca6fdf908c26bdd88b8e382", size = 252619, upload-time = "2026-07-02T13:09:14.699Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/84/c5b15a7e5ecba4e56218d772d99fe80a63e63f8d11f12783723a6005ab45/coverage-7.15.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b5fb23fa2de9dce1f5c36c09066d8fcda16cd96e8e26686caa2d7cb9b567d65c", size = 256689, upload-time = "2026-07-02T13:09:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2f/c8b07559b57701230c61b23a953858c052890c12ef568d81780c6c46e92e/coverage-7.15.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cec79341dbe6281484024979976d0c7f22beae08b4a254655decd25d42cbe766", size = 252189, upload-time = "2026-07-02T13:09:17.828Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/80/6d2f049dd3fd3dbfd60b62ba6b2162a04009e2c002ce70b24cf3878dec7a/coverage-7.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c664c5444b1d970b1b2a450e21fb19ee5c9cfdf151ded2dda37260031cca0da", size = 254059, upload-time = "2026-07-02T13:09:19.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/92/b0287a2c42031d25c628f815f89a3cd9f8268ee78bb1252c9356cda1c689/coverage-7.15.0-cp312-cp312-win32.whl", hash = "sha256:5f764a3fa339bde6b3aa97657f5a6a3a9451e4a5b4ea98a2892c773a43525f77", size = 222893, upload-time = "2026-07-02T13:09:20.812Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/69/e34c481915fecb499b3146975061dac528752e37706edc1804f32c822469/coverage-7.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:52f9a4d2c4c56c8848bc2f524916698354b0211488b38c49ad9ae54f6cafbff6", size = 223429, upload-time = "2026-07-02T13:09:22.315Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/98/6e878f0b571d32684ef3f38d7c03db241ca5b82a5da8a5391596a8f209c4/coverage-7.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:31e5c3e70c85307ea35a12964e2e40f56ca2ee4b1c8c721ccf4609d17071080b", size = 222810, upload-time = "2026-07-02T13:09:23.812Z" },
+    { url = "https://files.pythonhosted.org/packages/76/04/145a3748098bcc86b631a85408d2c3dc5c104e0bd86d605468239b25b6c4/coverage-7.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5be4caf3b28836f078abe700f8944dac4a65d78f16d6c600c89cb624e5535782", size = 220863, upload-time = "2026-07-02T13:09:25.371Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5c/4ed55708fed2c64b63c9bc5715daef670872202101938869b7fe5d5fbb8f/coverage-7.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dd58ad1404704303ca8d4f4b8a1095e7cbc7040ef17a66df1e6619aa10176430", size = 221230, upload-time = "2026-07-02T13:09:26.897Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/19/3a80b97d3b2a5c77a01ae359c6bed20c13738fe3d9380f08616d4fec0281/coverage-7.15.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bbcbb317c2e5ded5b21104af81c29f391be2af98d065693ffbe8d23949b948e5", size = 252227, upload-time = "2026-07-02T13:09:28.543Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/b70062750686bd7da454da27927622f48bbac6990ac7a4c4a4653e7b0036/coverage-7.15.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:27f31ecb458da3f859aab3f15ada871eb7a7768807d88df4a9f186bb17737970", size = 254823, upload-time = "2026-07-02T13:09:30.177Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/09/dad6a75a2e561b9dc5086a8c5257a7591d584246f67e23e70d2995b89ab6/coverage-7.15.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13fb759be317fdc62e0f56bffdf61cfcb45c7761ad6b71e3e583e71a67ae753c", size = 256059, upload-time = "2026-07-02T13:09:31.979Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e7/b5d2941fa9564573d44b693a871ff3156f0c42cbefe977a09fa7fdc59971/coverage-7.15.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5cf007add5ab4bb8fa9f4c77e3732127c9e6cad501d7db43355fbfafca0be84", size = 258190, upload-time = "2026-07-02T13:09:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/1d/8e895bcde3c57ccd46d896dda5f2b3d5df761a1b0c6c9d450d175dedc632/coverage-7.15.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc78d9843bd576fbe2118248258d485e968dc535f95ed504a7b0867ba9b51389", size = 252456, upload-time = "2026-07-02T13:09:35.765Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4c/f6997da343ddeb959be82c3b05322793f92c071ad45f7cb8a96336e2dd5f/coverage-7.15.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a263060f1de0b4b74b4e089c2a70b8003b3781c733329a9c8fd54995328f9950", size = 254192, upload-time = "2026-07-02T13:09:37.445Z" },
+    { url = "https://files.pythonhosted.org/packages/17/27/a0bc09d032267b9da89d95a2d874cfbef2a5aebbf0e87cf7aba221d79a99/coverage-7.15.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c48decf16e0dfd5b049c7d5e82200c23c08126719142998d4f172444e3d0529e", size = 252153, upload-time = "2026-07-02T13:09:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/54/c0/77fc233d9fba07b244c40948c53fe27308b8f21732fb3417f87fbd6fd992/coverage-7.15.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:08fb028000ed0aaa0a4cbdfbb98be7cb42f370db973fbbb469733505ab20e13e", size = 256310, upload-time = "2026-07-02T13:09:41.006Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/24/601cecfb5825becacb8d45219a018a3b55b9dbaec624efdb0ea249d08be2/coverage-7.15.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb7dc0c3b7d8a1077abea0b8546ebc5e26d6ef6ecefc2f0f5ad2b8a53bdad837", size = 251974, upload-time = "2026-07-02T13:09:42.733Z" },
+    { url = "https://files.pythonhosted.org/packages/47/1e/6f45e5a5b3d5484318d368702af6716b5ab8913b0428bec981a562fcf296/coverage-7.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cb3602054ccbe9f0d8c2dc04bbeba90d5719236e2cd06e042ddd6d3fc7b6e37", size = 253745, upload-time = "2026-07-02T13:09:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/db/4df027a77bd11d0e527f44c53557c76e54ad027413d0304252ea3a78d67e/coverage-7.15.0-cp313-cp313-win32.whl", hash = "sha256:0bf781da64326b677be344df505171435b6f58716108606621d5d27d964fff8b", size = 222902, upload-time = "2026-07-02T13:09:46.122Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/10/0355894d34e231f2c5449e71287e81a50793a325df2e2b027b7bcd9dfd19/coverage-7.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:2c57a275078ee3fa185f83e400f765bc764a549de66d99b47881645cbd4ea629", size = 223444, upload-time = "2026-07-02T13:09:47.687Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ef/bb725f263befaaff851203ab338e68af15e195d7f7b5f323162532d9b6a8/coverage-7.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:3812c61afc6685c7999b39320779ab8f43b7a3081fdb0def39976e56fbdb9a21", size = 222839, upload-time = "2026-07-02T13:09:49.717Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/9c/1e3ca54f72a3185ece06c58d871099898c48f0ed6430d17b6ab75f0d180a/coverage-7.15.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:41cb79af843222e11da87127ad0ecbfa878abadd0f770a4a99391a27d3887324", size = 220906, upload-time = "2026-07-02T13:09:51.339Z" },
+    { url = "https://files.pythonhosted.org/packages/09/37/f718613d83b274880382f6b67e78f3802549ae39b0b3e65ae5b5974df56e/coverage-7.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7d2008989ef8fe54188d3f3bfa2e3099b025af11e90a6a1b9e7dc433d04263d8", size = 221239, upload-time = "2026-07-02T13:09:53.138Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/22bae91e0b75445f68d365c7643ed0aa4880bbf77450ee74ca65bdae53a7/coverage-7.15.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:769e8ece11a596315ebf5aa7ec383aeeed016c091d2bf6363ffb996d41529092", size = 252286, upload-time = "2026-07-02T13:09:54.996Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1e/bec5e32aa508615d9d7a2790effb25fb4dc28606e995816afe400b25ece3/coverage-7.15.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:65a6b6164ee5c39e2f3803f314292d6c61a607ba7fee253d1e03c42dc3903502", size = 254789, upload-time = "2026-07-02T13:09:56.678Z" },
+    { url = "https://files.pythonhosted.org/packages/17/29/0e865435b4354e4a7c03b1b7920046d31d0a273d55decefea27e011cb9bf/coverage-7.15.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75128817f95a5c45bb01d65fd2d8b9cb54bbe03d81608fb70e3e14b437ad56c2", size = 256135, upload-time = "2026-07-02T13:09:58.343Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ff/33a870b58a13325d62fc0a6c8f01fa0ff667cef60c7498e2382a147dfa18/coverage-7.15.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9887bb428fe2d4cd4bee89bac1a6c9932f484afd5b36fbd4ff6ea5f825bb1f5e", size = 258449, upload-time = "2026-07-02T13:10:00.057Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7b/6fffe596bf3ddba8462758d02c5dad730fd91055a6634aa2e4226229181a/coverage-7.15.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0bfc0be1f702042207a93a00523b1065ee1fe951e96edf311581c0bbc2e34888", size = 252313, upload-time = "2026-07-02T13:10:01.946Z" },
+    { url = "https://files.pythonhosted.org/packages/58/1b/11468dd6c1676ab831a70cb9a8d4e198e8607fa0b7220ab918b73fe9bfbd/coverage-7.15.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f64627d55def5a43282d70e08396672692f77e4da610a5bb8bb4060b432b6859", size = 254142, upload-time = "2026-07-02T13:10:04.065Z" },
+    { url = "https://files.pythonhosted.org/packages/79/41/29328e21d16b1b95092c30dd700e08cf915bd3734f836df8f3bdb0e8fa9f/coverage-7.15.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:2c6f0fa473003905c6d5bac328ee4eba9fbea654f15bc24b8a3274b23363fa99", size = 252108, upload-time = "2026-07-02T13:10:06.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/de/05ccfb990439655b35afbfd8e0d13fe66677565a7d4eb38c3f5ef2635e1c/coverage-7.15.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2bcf9afaf064172c6ec3c58a325a9957ad1178c05dd934e25f253321776e0676", size = 256385, upload-time = "2026-07-02T13:10:08.141Z" },
+    { url = "https://files.pythonhosted.org/packages/51/0e/486828a3d2695ea7a2609f17ff572f6b01905e608379440a11da4b8dffbe/coverage-7.15.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:baf06bc987115d6fb938d403f7eab684a057766c490367999a2b71a6883110c6", size = 251923, upload-time = "2026-07-02T13:10:10.179Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c7/03582b6715f078e5e558354c87616d945b9894cda2dace8e4009b17035e4/coverage-7.15.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f0405f2ff97b1c4c0e782cb32e02f32369bcf2e6b618b591d67e1ea754575dfe", size = 253580, upload-time = "2026-07-02T13:10:12.052Z" },
+    { url = "https://files.pythonhosted.org/packages/db/dc/9e578bbaf2ecb4959a81b7e7601ad8cca772cba2892e8d144cb749b4a71a/coverage-7.15.0-cp314-cp314-win32.whl", hash = "sha256:ab282853ed5fbd64bbb162f19cb8fcb7087187508a6374b4f9c34ec1577c4e8f", size = 223107, upload-time = "2026-07-02T13:10:13.994Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3e/c8c3b75d8dbe0e35f7b0cc3ff5e949fc59500f70b21d0398813f66740664/coverage-7.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bb3040e9f4bbe26fcb0cd7cc85ac63e630d3f3a9c74f027abf4caa27e706663", size = 223597, upload-time = "2026-07-02T13:10:15.906Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/bc/3cbc9fb036eb388519bccd521f783499c39b64256013fbc362782f196fe1/coverage-7.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:346771144d34f7fa84ec28386f78e0f31653f33cf35e19d253d5b35f9e8201da", size = 223020, upload-time = "2026-07-02T13:10:17.844Z" },
+    { url = "https://files.pythonhosted.org/packages/28/00/199c4a8d656dff63102577a056c0fce2ff6a79e40adac092fc986c49cbf1/coverage-7.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d34a010905fb6401324ba016b5da03d574967f7b21ce48ea41e66f0f1f95f641", size = 221638, upload-time = "2026-07-02T13:10:19.703Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8e/9d0092c96a3d3a26951ecc7020826aa57bcb1b119ca81acbba996884ab13/coverage-7.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bb25d825d885ca8036795dacfc3924d33091fc76d71ebc99420c6b79e77d96fa", size = 221903, upload-time = "2026-07-02T13:10:21.514Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b4/c0ca3028f42c9a08e51feb4561ef1192e5de99797cd1db5b04590c215bda/coverage-7.15.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:94c9686bfe8a9a6810297aecbd99beaa3445f9e8dc2f80b1382cca0d86b64461", size = 263267, upload-time = "2026-07-02T13:10:23.261Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/aa/a375e3846e5d3c013dc600b2a3231089055c73d77f5393dd2192a8d64da6/coverage-7.15.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9bd671c25f9d85f09d7ec481d0e43d5139f486c06a37139847a7ce569788af72", size = 265390, upload-time = "2026-07-02T13:10:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e1/5783cdabb797305e1c9e4809fea496d31834c51fa772514f73dc148bcfc9/coverage-7.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:110cbdf8d2e216577312cf06ccf85539c0e5a5420ef747e4a4719b5e483c88cd", size = 267811, upload-time = "2026-07-02T13:10:27.249Z" },
+    { url = "https://files.pythonhosted.org/packages/85/31/96d8bbf58b8e9193bc8389574a91a0db48355ee98feb66aa6bf8d1b32eea/coverage-7.15.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2c5d4619214f1d9993e7b00a8600d14614b7e9d84e89507460b126aa5e6559e5", size = 268928, upload-time = "2026-07-02T13:10:29.242Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7a/5294567e811a1cb7eda93140c628fa050d66189da28da320f93d1d815c73/coverage-7.15.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:781a704516e2d8346fbbd5be6c6f3412dd824785146528b3a01816f26c081007", size = 262378, upload-time = "2026-07-02T13:10:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3f/3f48538421f899f28946f90a3d272136a4686e1abf461cc9249a783ee0f3/coverage-7.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd4a1b44bcb65ee29e947ac92bbee04956df3a6bfc6143641bb6cae7ede00fc9", size = 265263, upload-time = "2026-07-02T13:10:32.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d3/092df15efcab8a9c1467ee960eb8019bbad3f9300d115d89ea6195f369ff/coverage-7.15.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0e4950c9d6d3e39c64c991814ff315e2d0b9cb8152363594212c9e55208c0a8f", size = 262866, upload-time = "2026-07-02T13:10:35.104Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ab/0254d2b88665efb2c57ad368cc77ab5de3435bd8d5add4729c1b0e79431e/coverage-7.15.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:fe9c87ff42e5472d80d21704972e1f96e104a0a599d77c5e35db5a3c562e2571", size = 266599, upload-time = "2026-07-02T13:10:37.05Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/79/1cfa4023e489ce6fbc7be4a5d442dbc375edb4f4fda39a352cedb53263c2/coverage-7.15.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f00d5ae1dd2fe13fb8186e3e7d37bcbd8b25c0d764ff7d1b32cef9be058510a8", size = 261714, upload-time = "2026-07-02T13:10:38.966Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/eb/fee5c8665656be63f497418d410484637c438172568688e8ac92e06574e7/coverage-7.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:363ab38cc78b615f11c9cac3cf1d7eef950c18b9fdedfb9066f59461dcf84d68", size = 264025, upload-time = "2026-07-02T13:10:40.789Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/99/63005db722f91edc81abc16302f9cc2f6228c1679e46e15be9ae144b14d0/coverage-7.15.0-cp314-cp314t-win32.whl", hash = "sha256:54fd9c53a5fafff509195f1b6a3f9be615d8e8362a3629ff1de23d270c03c86b", size = 223413, upload-time = "2026-07-02T13:10:42.597Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/e8/2bc6181c4fb06f1a6b981eb85330cc57bfad7e3f710fc9c9d350013ba228/coverage-7.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:87b47553097ba185ed964866078e7e63adea9f5f51b5f39691c34f30afd21080", size = 224245, upload-time = "2026-07-02T13:10:44.47Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b8/4d959bf9cc45d0cfed2f4d35cafcab978cdb6ea02eb5100009cd740632a3/coverage-7.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aeefb2dd178fe7eee79f0ad25d75855cb35ee9ed472db2c5ea06f5b4fd00cec5", size = 223558, upload-time = "2026-07-02T13:10:46.368Z" },
+    { url = "https://files.pythonhosted.org/packages/52/30/21b2ad45959cd50e909e02ebac1e30b4ceb7162e91c11d4c570223a458b7/coverage-7.15.0-py3-none-any.whl", hash = "sha256:56da6a4cbe8f7e9e80bd072ca9cefe67d7106a440a7ec06519ec6507ac94ad19", size = 212632, upload-time = "2026-07-02T13:10:48.641Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239, upload-time = "2026-06-12T20:02:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584, upload-time = "2026-06-12T20:01:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/a4/5180d9afc57e8fca05601dd652bdff19604c218814037fe90ffc7625a50a/docutils-0.23.tar.gz", hash = "sha256:746f5060322511280a1e50eb76846ed6bf2342984b2ac04dc42caa1a8d78799e", size = 2303823, upload-time = "2026-05-27T17:41:06.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/91/30151a39f7570f448ed84529390628a651d7f27c87d73c9b887f8189695e/docutils-0.23-py3-none-any.whl", hash = "sha256:25d013af9bf23bc1c7b2b093dff4208166c53a94786c9e447808335ef1185fea", size = 634701, upload-time = "2026-05-27T17:40:58.442Z" },
+]
+
+[[package]]
+name = "id"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/04/c2156091427636080787aac190019dc64096e56a23b7364d3c1764ee3a06/id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069", size = 18088, upload-time = "2026-02-04T16:19:41.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca", size = 14689, upload-time = "2026-02-04T16:19:40.051Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jarvis-cd"
+source = { editable = "." }
+dependencies = [
+    { name = "pandas" },
+    { name = "podman-compose" },
+    { name = "pyyaml" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+    { name = "twine" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pandas" },
+    { name = "podman-compose" },
+    { name = "pyyaml" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-cov", specifier = "==7.1.0" },
+    { name = "ruff", specifier = "==0.15.21" },
+    { name = "twine", specifier = "==6.2.0" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
+]
+
+[[package]]
+name = "nh3"
+version = "0.3.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/1b/ef84624f14954d270f74060a19fc550dd4f06656399447569afb584d8c06/nh3-0.3.6.tar.gz", hash = "sha256:f3736c9dd3d1856f80cd031715b84ca75cda2bbb1ac802c3da26bfce590838d7", size = 24684, upload-time = "2026-06-22T00:47:02.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/3e/6506aa4f23dc7b7993a2d0a45dca3ce864ec48380adfe15a173e643c63e8/nh3-0.3.6-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2411e8c3cee81a1ddd62c2a5d50585c28aa5566d373ad1db92536b95ddb24ef2", size = 1421679, upload-time = "2026-06-22T00:46:20.248Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/e1/e96e7864a7a53bd6b6fab7e9632467382a2a2c1f3fed951918ad131542fb/nh3-0.3.6-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e196fa70c2ff2eb4de7d3df3108f8f358c1d69dff20d45b11f20a5aa227ffb6d", size = 792570, upload-time = "2026-06-22T00:46:22.179Z" },
+    { url = "https://files.pythonhosted.org/packages/59/62/5b6108bedaef2b2637fed04c87bdbcb5967b9961758b41f0e466ef22a022/nh3-0.3.6-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:34d2b0d934156b87ee114f599a3ba9b8b9e17b5d79652ba3a13fa50903de965e", size = 842243, upload-time = "2026-06-22T00:46:23.801Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4a/526f199626bfcb496bc01a268051b44737962005553b158e985ed7e64865/nh3-0.3.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2f14b7ae1fca99c4a66c981aac3974e7fbc1ca30a12673d223ae1df76680917", size = 1001468, upload-time = "2026-06-22T00:46:25.481Z" },
+    { url = "https://files.pythonhosted.org/packages/49/09/0d8e3101636d9ad88cdefb2914e764cb8e876ebdbb4286bfc251277d9c67/nh3-0.3.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:889932a97fb4abb6f95fef1914c0d269ebfb60011e67121c1163059b9449dbb4", size = 1082933, upload-time = "2026-06-22T00:46:27.15Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a1/ea83abe738a3fbaa203dfdb836ca7cbab0e7e9609faaee4fe1d4652599c0/nh3-0.3.6-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:edb2b4a1a27523e6cc7c417f8d21ce3d005243548b93e56b762b66b0c7f589f9", size = 1043120, upload-time = "2026-06-22T00:46:28.89Z" },
+    { url = "https://files.pythonhosted.org/packages/66/69/0654482b8635012fbae67826bd6c381abb05d841ac7388b9b4666300fdad/nh3-0.3.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:43bc1ed3fa0716295fabee29ba42b2667e4a51d140b0a68e092170a765474fa6", size = 1023824, upload-time = "2026-06-22T00:46:30.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/1f7285ffadc8307c4dbeb08d21b920536d5117785056d1079e998c4dfa44/nh3-0.3.6-cp314-cp314t-win32.whl", hash = "sha256:597a8e843bea00b2eb5520658dc24a9bb032e7fc9e7c2c0c4cd29420220c9796", size = 599253, upload-time = "2026-06-22T00:46:32.072Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ea/5542f3c45da4c00290d9d67a65e996702e23e613c4b627de3e09cb9fe357/nh3-0.3.6-cp314-cp314t-win_amd64.whl", hash = "sha256:4713502748f564fee0633b37b3403783ce0a3af3a3d148ad91025a5bdadb7bc6", size = 612553, upload-time = "2026-06-22T00:46:33.53Z" },
+    { url = "https://files.pythonhosted.org/packages/66/35/26bd47e6af5915a628281dccdac354ddf4e32f7397047894270acd8c9870/nh3-0.3.6-cp314-cp314t-win_arm64.whl", hash = "sha256:69bbb92865a693d909db3a700d3c01537533844d0948c1e9323561ce06ecda41", size = 595151, upload-time = "2026-06-22T00:46:34.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ab/a7653bce9a3b204be6a6931767a9e23595807bb84790ce6685e4d7e5bd08/nh3-0.3.6-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:a43ebd7543555c3ac1bc353023d0794e75cb76f6f18f19c32e95441496c0cc25", size = 1443564, upload-time = "2026-06-22T00:46:36.66Z" },
+    { url = "https://files.pythonhosted.org/packages/41/21/e1084ab18eb589506335c7c7576f2d4643e9a0c0e33983ef0e549a256b96/nh3-0.3.6-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1b160831c9cdb06a6c79c2f9cdb11386602938f9af260d1c457a85add4f6f69", size = 838002, upload-time = "2026-06-22T00:46:38.101Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/94/f48d08e6f72a406300fa11d8acd929fea1a80d4bf750fa292cb10785f126/nh3-0.3.6-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d14bf7982e7a77c0c775634c29c07ce08b38a046df73e1c1f139b3e82f18a38e", size = 823045, upload-time = "2026-06-22T00:46:39.495Z" },
+    { url = "https://files.pythonhosted.org/packages/25/bb/431615ba1d1d3eb63cde0f974f2114edf863a8a3f6049a12fed23fc241d3/nh3-0.3.6-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:44673b27010051ab5a5e438a86ec31bbda61d4a77d7e900af6b7be3037c1abae", size = 1093171, upload-time = "2026-06-22T00:46:41.21Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/24/a0d80182a18919665fefd19c1c06f1d1df1c9a6455d0252de40c034a0bc3/nh3-0.3.6-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6b7beece07525dc6e6b0fc2f104442de2ba328360ad00e50cbe2e1fd620447d", size = 1049217, upload-time = "2026-06-22T00:46:42.804Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/13/6f1e302ca674ac74362e150848ad56a1be5145391204f74facdb8e94df12/nh3-0.3.6-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:455469a29951edc92bc48b47ac2281c3f2609e6c4f6a047056449f8c2c23facf", size = 917372, upload-time = "2026-06-22T00:46:44.495Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/67/314f6151bad77a93d751978a344033e1fc890822f05f0416079338e34231/nh3-0.3.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:905f877dc66dd7aea4a76e54bcb26acb5ff8216f720c0017ccf63e0e6035698e", size = 806699, upload-time = "2026-06-22T00:46:45.99Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a6/bfaa00046e58603507dcfc266c4778e3ab7adf68a5dedd73b6274b8d9314/nh3-0.3.6-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:25c733bee928530556b1db0ea46c52cf5aa686146e38e60a6fc7cb801ef91cec", size = 835165, upload-time = "2026-06-22T00:46:47.617Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a8/fb2c38845efb703a9173bffdfc745fc64d2b0e55cfc73a3647d2f028250c/nh3-0.3.6-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2f90d9a0cfdbee218994fdaaeeb5a0fde62d08f35e4eef0378ec1e2200172fd0", size = 858282, upload-time = "2026-06-22T00:46:49.276Z" },
+    { url = "https://files.pythonhosted.org/packages/68/17/06e72a18ee9b572914447338237ca7eb164c0df901f141bc10d1282247a2/nh3-0.3.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:82ca5bf427ad1b216b65ede1a2e2d87dc49bec417ceba0f297213107d3cd9d78", size = 1014328, upload-time = "2026-06-22T00:46:51.026Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f9/3966c61455668c08853bf5e33b4bed93c421f3194ce4de896dc248d6f6ce/nh3-0.3.6-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f5ed5fe84aee7f39db95c214a7421bf0499fbf500fec6d86a4e29bfc37971438", size = 1098207, upload-time = "2026-06-22T00:46:52.674Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d3/479cb4ae440424825735d60525b53e3c77fd60fd6e6afc0e984f00eb0178/nh3-0.3.6-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:082675ff87b9385ec430ffe6d5847ba7456cc39b73720cd4add472f9f4cffd56", size = 1056961, upload-time = "2026-06-22T00:46:54.335Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0c/6cdb5ee1e127be50dc8391e54bddc1f64e87bf4bfad0c55633320e2e02db/nh3-0.3.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36d06341bd501240d320f5942481ed5e6846136b666e1ba4faf802b78ebc875f", size = 1033829, upload-time = "2026-06-22T00:46:56.258Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/55/9de666ad975d6ccd77d799ea0add55ee2347aa81286ce21b2a97c070746b/nh3-0.3.6-cp38-abi3-win32.whl", hash = "sha256:5276ef17bdba9ad8040575c74072008b13aae429436e9d0429e718bb5f90f4da", size = 609081, upload-time = "2026-06-22T00:46:57.665Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fa/2b5d684e3edf1e81bfd02d298c78c3e3da77ca1d8a2be3183a79544a7548/nh3-0.3.6-cp38-abi3-win_amd64.whl", hash = "sha256:f338ac7d594c067679f1e99b4f5ec3906842979560f9d8f15d6bdfa39a353b10", size = 624461, upload-time = "2026-06-22T00:46:59.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e5/7cafee2f0413ca4cb0ef3bd111e94d408a48810008b283ad8aee00dd1809/nh3-0.3.6-cp38-abi3-win_arm64.whl", hash = "sha256:69f365963f63a1e9bff53bdbb3c542c7c2efed3e163c9d5d83a772a2ac468c21", size = 603060, upload-time = "2026-06-22T00:47:00.596Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/07/ec2a3f0c91761581d4b7104a740791800025983f9a4dc4e73f91a99aeac4/numpy-2.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0bfebd8695f9863592fe744be833a258120b14a9f39da255e8aa8fade2c0ddd1", size = 16796419, upload-time = "2026-07-04T17:06:40.37Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ab/ddb499fc4f8780354395face5b65c7fd107bcd6e1d667a5f07d046956f6f/numpy-2.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30b44a6b53a7ae63c54c089a8726e5563ed302716c5b7ccc85afade40b0e7ff6", size = 11765832, upload-time = "2026-07-04T17:06:42.768Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/3c28c558a09fc72100c646dac6d2fce8e834c471b0edca01a29996706117/numpy-2.5.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6165343f81b56ef8f514f396989e529b61d9dc709b99421b07e9f3e698e2287d", size = 5325143, upload-time = "2026-07-04T17:06:45.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0e/ce19b985bb15c596f4f05954e76cccc77c845083b3b8f938a6c68e523128/numpy-2.5.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4939237038ada79308dda3204ac6462df056b5672b2e25db1149cf873668b3e1", size = 6659749, upload-time = "2026-07-04T17:06:47.288Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd", size = 15164716, upload-time = "2026-07-04T17:06:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a", size = 16661440, upload-time = "2026-07-04T17:06:52.061Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d7/a41e3310c886fe457d36e670bbf24fae411aca8a7b6ad92a32afd924077c/numpy-2.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3935f3b419b244a02732676fa5317a9193cc596a4c0646db07e5b421229ac9f7", size = 16526305, upload-time = "2026-07-04T17:06:54.605Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/4333a9a707c1edd3a4e1a0c58eca52c0f31e55089fa80db02b5565b24df7/numpy-2.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc932a65ded7ce9013d120845a2514dcccb1a67bfc8deb8d37633762951904a6", size = 18423008, upload-time = "2026-07-04T17:06:57.54Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/e314a32b1c11a2ffe818ddad3a57b50b4b6e1b6c487192eb50cdef0415d0/numpy-2.5.1-cp313-cp313-win32.whl", hash = "sha256:4b4ff1608417eb7a59da7b967bbb798cacfe071d2caf526a24281cd562072ed9", size = 6063885, upload-time = "2026-07-04T17:07:00.14Z" },
+    { url = "https://files.pythonhosted.org/packages/10/70/800b3fca480af32df9e8ea9f3d4a0c8feb4b32d7f195d174eabbda4829ad/numpy-2.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:6c3fe51bc6a16453d452997053454f309e8e0ed7b42d6b361ce4ac8c32913d74", size = 12425674, upload-time = "2026-07-04T17:07:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/196350c122f50f6ca56846f2d71efd5e0d24b7b2e07355e019b2e2c7a11e/numpy-2.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f7feb014281029e628ba2d5a007407443b06e418b6fe451d1e2adcbc8eba0107", size = 10350256, upload-time = "2026-07-04T17:07:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f4/731b6085a83faf6ca843394cbd5e217280c214399f7e8b21b9f552af0ae2/numpy-2.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7c786fe9a5bbe360022e584c5a34cf6b54265c71bd7ec8ac3d8fec38968071f8", size = 16795063, upload-time = "2026-07-04T17:07:07.374Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/64/0e215f2048dd11a55bb989ed41b3585ef57452404e638d703a211a3e4157/numpy-2.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32985c896d897419ef8da6917872d80b78ad0ea26d85b23245c7366ffde76d75", size = 11776652, upload-time = "2026-07-04T17:07:09.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/59/2b844c7a6e9deff69b404a66221e1542937734f65d5e6e39411876053862/numpy-2.5.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:efd736408cc97c79b9e6917338dfc8f06013b2274f992e96b1d9a81a71e2a2c2", size = 5335944, upload-time = "2026-07-04T17:07:12.227Z" },
+    { url = "https://files.pythonhosted.org/packages/86/51/9bf7cb2cabcebc9e017e4ec7e6322b378317a542c08b4cb68479c1efc716/numpy-2.5.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:ab84dc6b074fa881cae55bea94cc4f68e285181ba7f32497bf7dee6b1496165b", size = 6656266, upload-time = "2026-07-04T17:07:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3e/fb7615b211b82a32f44d5180a6d421b61f84d4fadd578b48ba4ac34e189f/numpy-2.5.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caf3e317d33d60c37986b452613f4ab51246d0691350c03d0cb4a898627f4a95", size = 15179720, upload-time = "2026-07-04T17:07:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/0f992cb24560673496c5d68de61913b57166ce530ffda07c1f280e0cc464/numpy-2.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54ad769f17bc2d833b620851989f62054fb9ab93c969d9e1dc3c8e3d56beea21", size = 16664835, upload-time = "2026-07-04T17:07:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2f/97d6475ee91afe2587797d09446f9d3e475ad4cb681662d824809327b75a/numpy-2.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c12afb53450fa976d4c681c50a7423729a4c51c0465ed9f32b8a9cabbc472373", size = 16539135, upload-time = "2026-07-04T17:07:22.015Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/4db81e4ba0be7e2776b1de68c82aa862c7f8ec27e1b4927d4ae075e20678/numpy-2.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e8c11c405efc5ff6816d5983c96cdfa215bab3428961243af3ff59b228490438", size = 18426684, upload-time = "2026-07-04T17:07:24.941Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/64/c0ba2d90724d450279a7df8f32057241070250a26a7e2b5337d77347f481/numpy-2.5.1-cp314-cp314-win32.whl", hash = "sha256:f2479a47f8d5932d1718168a681ad6e536a9df484c83cfcf9de365e164537ace", size = 6116103, upload-time = "2026-07-04T17:07:27.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1a/837f9ed7405adcd7a40538792eb169eddd8fa5630c16a1ef49dae71a30f4/numpy-2.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:24d0eb82c0541d3415a33425db64ae439dffccd7b4dbcb30e7c35120205c506a", size = 12562177, upload-time = "2026-07-04T17:07:29.887Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/49707938b6dd0a78a9178dd93227dc89e4c11af47f5c798d70366e8d0483/numpy-2.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:5a4c988b38d261deeeaad9954e3deb091ad905c94e8bb6708654ef1d97f286b0", size = 10627739, upload-time = "2026-07-04T17:07:32.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/bb4b882cfe7f299cbc8b66e42e7dd78cf9d14e40f9469fc5e3db7e15b3bd/numpy-2.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a33276be12fa045805f477f22482088b66bb758ffbe89a9d21457de863a32e22", size = 11894709, upload-time = "2026-07-04T17:07:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/40/3f/5af7f4a7f6224aef48017aa82bb6174c7a659d724be0c75017b7e64a55b4/numpy-2.5.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f089d7b00756190aacf1f5d34bdf38c3c430ac82b4f868f8cede73380460fce7", size = 5453810, upload-time = "2026-07-04T17:07:37.495Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c9/3474309bc94d634d3f9c3eddf03250ecb8c22cd948ef16fef69a77cc5d7b/numpy-2.5.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:09e9bfd8d2cf479c7d174804fb3811c53a8e9f20a37444008606b57d6b7a826d", size = 6761189, upload-time = "2026-07-04T17:07:39.563Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8a/558ae39fdd55d7e7f7fef9a84a6e964ac6b23edbd2a07e52bb084500507d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e68d8dd1e7eba712948f2053a29ec86917bc70ba1358df869d9f06649ef9cf09", size = 15225039, upload-time = "2026-07-04T17:07:41.682Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/ca7392b2d030277bdf0273e7d23255b3ee57d57a7c170a6f4fb3981e1e5d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99d5095fa265a0c4152e7bb12759e14381ef5496152f1ce58f44bdf55c44beb4", size = 16701306, upload-time = "2026-07-04T17:07:44.611Z" },
+    { url = "https://files.pythonhosted.org/packages/02/42/03d53ae7996c44d4374a8262e9dc41671fd56cbb98f7d47ef85cf5da4c6b/numpy-2.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ab87a91b3cc3382b8956095bd8f95e00cf679bb81554339be1a2ba404a1473c1", size = 16589955, upload-time = "2026-07-04T17:07:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/15/6c1784ae469640e65db111e9a34b3d0f14d91e8a38b9ce34810ced370dbb/numpy-2.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:224ca51130ef7da85bea2191625181cb4f337f9cb64b471f10c1a12aa8b60077", size = 18464252, upload-time = "2026-07-04T17:07:50.684Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/16/b5c76b838fd9bf6ce84d3a53346b8874ec05c5f0040d75ef2c320100cd2a/pandas-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:455f6f8139d4282188f526868dbc3c828470e88a3d9d59a891bd46a455f21b98", size = 10338495, upload-time = "2026-05-11T18:52:11.558Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/b0/a4ffc4ae74d2d822200dcc46898987d8eb6032d1e2b219cae39da6f5cbcc/pandas-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4e15135e2ee5df1063313e2425ceef8ac0f4ae775893815b0923651b806a5639", size = 9938250, upload-time = "2026-05-11T18:52:17.005Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b2/3323601a52caee42c019e370090ca4544b241437240ca04f786cce82b0cf/pandas-3.0.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:05f1f1752b8533ea03f7f39a9c15b1a058d067bb48f4748948e7a8691e0510f2", size = 10770558, upload-time = "2026-05-11T18:52:19.865Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/bbecd2f867b97abebe0f9b53d750f862251b40337e061b36676ded3d920f/pandas-3.0.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a1e45c80cceb3b4a21bc5939d52e8cbd8d9b7305309219d59e9754d9ce09e27", size = 11274611, upload-time = "2026-05-11T18:52:22.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/4f/eafabf2d5fae5adf143b4d18d3706c5efdc368a7c4eb1ee8a3eddabbd0f6/pandas-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:14da8316da4d0c5a77618425996bfb1248ca87fc2c1486e6fde4652bd18b5824", size = 11784670, upload-time = "2026-05-11T18:52:25.4Z" },
+    { url = "https://files.pythonhosted.org/packages/49/44/1eb20389301b57b19cc099a1c2f662501f72f08a65f912d05822613c1532/pandas-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a55066a0505dae0ba2b50a46637db34b46f9094c65c5d4800794ef6335010938", size = 12353708, upload-time = "2026-05-11T18:52:28.139Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/c321f13b5ba1819fc8dca456c7fce578da2dcfecff1abbf0eaddf8406c0f/pandas-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:6674ab18ad8c57802867264b00e15e7bb904700cdd9046e3b2fa1fce237439ea", size = 9907609, upload-time = "2026-05-11T18:52:30.982Z" },
+    { url = "https://files.pythonhosted.org/packages/53/85/1b7f563ebc6357c27233a02a96b589bcce1fa9c6eb89fb4f0e56421d277e/pandas-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:5cc09a68b3120e0f54870dede8287a7bb1fa463907e4fcec1ea77cab6179bf7a", size = 9165596, upload-time = "2026-05-11T18:52:33.334Z" },
+    { url = "https://files.pythonhosted.org/packages/24/f1/392f8c5bfc16f66a0d2d41561c01627c228fe7ed2a0d056ef11315042570/pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09", size = 10357846, upload-time = "2026-05-11T18:52:36.143Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3d/b16412745651e855f357e5e66930248688378853a6e2698a214e331fba1f/pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4", size = 9899550, upload-time = "2026-05-11T18:52:38.976Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a8/fa2535168fffcedf67f4f6de28d2dd903a747ca7c8ea6989451aaeb3a92f/pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c", size = 10412965, upload-time = "2026-05-11T18:52:41.915Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9", size = 10894600, upload-time = "2026-05-11T18:52:45.02Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/2eb28f2fccb4ced4a2c79ab2a5dee9ade1ebf44922ebad6fea158c9f95d4/pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf", size = 11422824, upload-time = "2026-05-11T18:52:48.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/45/830bb57f533a4604b355e07edcb8ea18cf88b5f94e5fca92f27052d7c597/pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c", size = 11950889, upload-time = "2026-05-11T18:52:50.905Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/fc1b368f303087d20e8c9bf3d6ceb186263cfac0ade735cd938538bea839/pandas-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c7be265b62cef88e253a941e4698604973736dcfe242fdb5198f0f7bc473cdcc", size = 9755463, upload-time = "2026-05-11T18:52:53.386Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bd/fda8f9705b1b09c6ebe14bfc0fa0e4ec8584d54ea673628f157ff55131af/pandas-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:557409bc4178e70ee8d9ddb494798e51ebf6ea59330f6be22c51bab2a7db6c49", size = 9066158, upload-time = "2026-05-11T18:52:56.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
+    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
+    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
+    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
+    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
+    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
+    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "podman-compose"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/80/a6ada19562b12ed466dac5c3e02aef5ed7c8d0881864d80e0d94d0dc71f5/podman_compose-1.6.0.tar.gz", hash = "sha256:c83fd9bcbaa635100d581ce52a7a4b712ee0d457481232aff392efe3ebc5a217", size = 53935, upload-time = "2026-06-03T21:35:48.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/31/b38c2656bad6265168902793c60145b172788a79e4b15de212af9bd78728/podman_compose-1.6.0-py3-none-any.whl", hash = "sha256:98e48af25d44c10ecef948163bfcca002e32aa8bbb7e66593fbd4faff7270c30", size = 53722, upload-time = "2026-06-03T21:35:46.781Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "readme-renderer"
+version = "45.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "nh3" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/51/d3a6ea424652c60f05600d8c2e01a55c913755e7cdad64afabbd1aa16f44/readme_renderer-45.0.tar.gz", hash = "sha256:030a8fac74904f8fba11ad1bb6964e3f76e896dc7e5e71f16af190c9056696d1", size = 36172, upload-time = "2026-06-09T21:05:17.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/1b/295bf2fa3e740131778065e5ffa2c481f0e7210182d408e9a2c244ff5b0c/readme_renderer-45.0-py3-none-any.whl", hash = "sha256:3385ed220117104a2bceb4a9dac8c5fdf6d1f96890d7ea2a9c7174fd5c84091f", size = 14134, upload-time = "2026-06-09T21:05:15.85Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "rfc3986"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026, upload-time = "2022-01-10T00:52:30.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326, upload-time = "2022-01-10T00:52:29.594Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "twine"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "id" },
+    { name = "keyring", marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'" },
+    { name = "packaging" },
+    { name = "readme-renderer" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "rfc3986" },
+    { name = "rich" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+]


### PR DESCRIPTION
## What changed

- return a stable `jarvis.execution.handle.v1` from every direct or scheduled pipeline run and persist a queryable `jarvis.execution.record.v1`
- add durable execution get/list/progress APIs and machine-readable CLI commands, including owned asynchronous direct runs
- make SLURM an explicit scheduler provider with provider-native identity, crash-safe submission reconciliation, and isolated immutable execution snapshots
- add exact-ID cleanup transactions that preserve active work and never cancel scheduler jobs by default
- define the generic `jarvis.progress.v1` package SPI and `jarvis.execution.progress.v1` aggregate without inventing percentages for indeterminate work
- place LAMMPS and ParaView progress semantics beside their packages; keep central modules as compatibility shims
- support dependency-free ParaView reporting for pvbatch, MPI rank-zero emission, containers, completed frames/timesteps, and indeterminate server readiness
- harden private execution/progress state on POSIX and Windows, including DACL, owner, reparse-point, hard-link, atomic replacement, and transaction-lock checks
- make fresh Git source installs portable and exclude the non-runtime research-artifact submodule from dependency checkout
- retain the draft-first, attested, immutable release workflow and protected human release boundary

## Breaking change

Python 3.7?3.10 are no longer supported. These contracts are intended for JARVIS-CD v2.0.0.

## Why

clio-kit and clio-relay need JARVIS-owned execution identity, scheduler metadata, lifecycle state, and package progress. Relay can now consume structured native records instead of treating application stdout as execution authority, while application semantics remain owned by JARVIS packages.

This supplies the upstream contracts required by iowarp/clio-relay#8 and iowarp/clio-relay#9.

## Validation

- full local suite: `1038 passed, 3 subtests passed`, zero skips
- GitHub CI: Linux suite and Python 3.11/3.12 provider jobs pass
- Ruff and bounded Pyright checks: zero errors on the new execution, scheduler, progress, reporter, and private-path surfaces
- exact wheel build and Twine validation; isolated Python 3.11 installation and schema/provider smoke passed
- fresh Git dependency installation passed through clio-kit's exact isolated `uvx` path on Windows and Linux
- live Ares candidate-wheel acceptance: one SLURM job (`21864`), 12-frame cap, native progress 1..12, exactly 12 valid 1920?1080 PNGs, no cancellation; report SHA-256 `ba79fa822223258b451dacfdd94cfbd21fdb44c795d62d1465dfcf8570c4f6a8`

The Ares run is candidate evidence only, deliberately not a released-artifact or full 269-timestep claim. Merge/release remains subject to the repository's required independent human approval, followed by released-wheel validation.

