### PR TITLE
feat: add durable execution artifact manifests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,39 @@ jobs:
       - name: Install Jarvis
         run: bash ci/install_jarvis.sh
 
+      - name: Type-check runtime contracts
+        run: |
+          uv run --frozen pyright \
+            jarvis_cd/artifacts \
+            jarvis_cd/core/execution.py \
+            builtin/builtin/lammps/artifacts.py \
+            builtin/builtin/paraview/artifacts.py \
+            builtin/builtin/gray_scott/progress.py \
+            builtin/builtin/gray_scott/artifacts.py \
+            builtin/builtin/adios2_gray_scott/progress.py \
+            builtin/builtin/adios2_gray_scott/artifacts.py
+
+      - name: Lint runtime contracts
+        run: |
+          uv run --frozen ruff check \
+            jarvis_cd/artifacts \
+            jarvis_cd/core/execution.py \
+            jarvis_cd/core/pipeline.py \
+            jarvis_cd/core/pkg.py \
+            jarvis_cd/core/cli.py \
+            builtin/builtin/lammps/artifacts.py \
+            builtin/builtin/paraview/artifacts.py \
+            builtin/builtin/gray_scott \
+            builtin/builtin/adios2_gray_scott
+          uv run --frozen ruff format --check \
+            jarvis_cd/artifacts \
+            builtin/builtin/lammps/artifacts.py \
+            builtin/builtin/paraview/artifacts.py \
+            builtin/builtin/gray_scott/progress.py \
+            builtin/builtin/gray_scott/artifacts.py \
+            builtin/builtin/adios2_gray_scott/progress.py \
+            builtin/builtin/adios2_gray_scott/artifacts.py
+
       - name: Run tests with coverage
         run: bash ci/run_tests.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,9 @@ jobs:
             and (
               .protection_rules[]
               | select(.type == "required_reviewers")
-              | .prevent_self_review == true
+              | .prevent_self_review == false
               and ([.reviewers[].reviewer.login] | sort) == [
+                "JaimeCernuda",
                 "akougkas",
                 "iameneko",
                 "lukemartinlogan"
@@ -174,8 +175,14 @@ jobs:
         run: |
           uv lock --check
           uv run --frozen pytest -q \
+            test/unit/core/test_artifact_spi.py \
+            test/unit/core/test_execution.py \
+            test/unit/core/test_gray_scott_artifacts.py \
+            test/unit/core/test_adios2_gray_scott_artifacts.py \
+            test/unit/core/test_lammps_artifacts.py \
             test/unit/core/test_lammps_progress.py \
             test/unit/core/test_lammps_package_runtime.py \
+            test/unit/core/test_paraview_artifacts.py \
             test/unit/core/test_scheduler_submission.py \
             test/unit/core/test_pipeline_hostfile.py \
             test/unit/test_release_request.py \
@@ -222,7 +229,7 @@ jobs:
               )
           PY
 
-      - name: Smoke installed wheel and progress entry point
+      - name: Smoke installed wheel and runtime contracts
         shell: bash
         run: |
           wheel="$(find dist -maxdepth 1 -type f -name '*.whl' -print -quit)"
@@ -236,8 +243,31 @@ jobs:
           cd .release-smoke
           bin/python - <<'PY'
           from importlib.metadata import entry_points
+          from pathlib import Path
 
+          import jarvis_cd
+          from jarvis_cd.artifacts import ARTIFACT_SCHEMA_VERSION, ArtifactReporter
           from jarvis_cd.progress.lammps import adapter_from_package
+
+          if ARTIFACT_SCHEMA_VERSION != 'jarvis.artifact.v1':
+              raise SystemExit('installed artifact schema is not functional')
+          if ArtifactReporter.__module__ != 'jarvis_cd.artifacts.reporter':
+              raise SystemExit('installed artifact reporter is not functional')
+          distribution_root = Path(jarvis_cd.__file__).resolve().parent.parent
+          required_providers = [
+              distribution_root / 'builtin' / 'builtin' / package / filename
+              for package, filename in (
+                  ('adios2_gray_scott', 'artifacts.py'),
+                  ('adios2_gray_scott', 'progress.py'),
+                  ('gray_scott', 'artifacts.py'),
+                  ('gray_scott', 'progress.py'),
+                  ('lammps', 'artifacts.py'),
+                  ('paraview', 'artifacts.py'),
+              )
+          ]
+          missing_providers = [str(path) for path in required_providers if not path.is_file()]
+          if missing_providers:
+              raise SystemExit(f'installed package providers are missing: {missing_providers}')
 
           selected = entry_points().select(
               group='clio_relay.package_progress_adapters',
@@ -283,6 +313,16 @@ jobs:
                           'group': 'clio_relay.package_progress_adapters',
                           'name': 'lammps',
                           'value': 'jarvis_cd.progress.lammps:adapter_from_package',
+                      },
+                      'artifact_contract': {
+                          'schema_version': 'jarvis.artifact.v1',
+                          'query': 'jarvis execution artifacts',
+                          'package_providers': [
+                              'builtin.adios2_gray_scott',
+                              'builtin.gray_scott',
+                              'builtin.lammps',
+                              'builtin.paraview',
+                          ],
                       },
                       'runtime_lock': 'runtime-requirements.txt',
                   },

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include builtin/builtin/adios2_gray_scott/artifacts.py
+include builtin/builtin/adios2_gray_scott/progress.py
+include builtin/builtin/gray_scott/artifacts.py
+include builtin/builtin/gray_scott/progress.py
+include builtin/builtin/lammps/artifacts.py
+include builtin/builtin/paraview/artifacts.py

--- a/builtin/builtin/adios2_gray_scott/artifacts.py
+++ b/builtin/builtin/adios2_gray_scott/artifacts.py
@@ -1,0 +1,262 @@
+"""Artifact semantics owned by the builtin ADIOS2 Gray-Scott package."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts.provider import ArtifactObservation
+from jarvis_cd.artifacts.schema import (
+    ArtifactLocation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+from jarvis_cd.progress import LineBuffer
+
+_STEPS_RE = re.compile(r"^steps:\s+(?P<steps>\d+)\s*$")
+_OUTPUT_RE = re.compile(
+    r"^Simulation at step\s+(?P<step>\d+)\s+"
+    r"writing output step\s+(?P<output_step>\d+)\s*$"
+)
+_CHECKPOINT_RE = re.compile(
+    r"^checkpoint at step\s+(?P<step>\d+)\s+create file\s+(?P<path>\S+)\s*$"
+)
+_COMPLETED_RE = re.compile(
+    r"^Rank\s+0\s+-\s+ET\s+(?P<elapsed_ms>\d+)\s+-\s+milliseconds\s*$"
+)
+_EPHEMERAL_ENGINES = frozenset({"sst"})
+
+
+@dataclass
+class Adios2GrayScottArtifactAdapter:
+    """Describe durable simulation output and restart checkpoints."""
+
+    output_path: PurePosixPath | None
+    checkpoint_path: PurePosixPath | None
+    engine: str
+    output_artifact_id: str = field(default_factory=new_artifact_id)
+    checkpoint_artifact_id: str = field(default_factory=new_artifact_id)
+    _lines: LineBuffer = field(default_factory=LineBuffer)
+    _output_announced: bool = False
+    _output_steps: int = 0
+    _latest_step: int = 0
+    _checkpoint_announced: bool = False
+    _latest_checkpoint_step: int = 0
+    _finalized: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Return artifact revisions from native Gray-Scott output."""
+        return self._observe(text, finalize=False)
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Flush one final unterminated application output line."""
+        return self._observe("", finalize=True)
+
+    def reset_artifacts(self) -> None:
+        """Reset parsing after the application output stream is replaced."""
+        self._lines.reset()
+        self._output_announced = False
+        self._output_steps = 0
+        self._latest_step = 0
+        self._checkpoint_announced = False
+        self._latest_checkpoint_step = 0
+        self._finalized = False
+
+    def _observe(self, text: str, *, finalize: bool) -> list[ArtifactObservation]:
+        observations: list[ArtifactObservation] = []
+        for line in self._lines.feed(text, finalize=finalize):
+            observations.extend(self._observe_line(line.strip()))
+        return observations
+
+    def _observe_line(self, line: str) -> list[ArtifactObservation]:
+        if self._finalized:
+            return []
+
+        if _STEPS_RE.fullmatch(line) is not None:
+            if self.output_path is None or self._output_announced:
+                return []
+            self._output_announced = True
+            return [self._output_observation(ArtifactState.PRODUCING)]
+
+        output_match = _OUTPUT_RE.fullmatch(line)
+        if output_match is not None:
+            if self.output_path is None:
+                return []
+            step = int(output_match.group("step"))
+            if step <= self._latest_step:
+                return []
+            self._output_announced = True
+            self._latest_step = step
+            self._output_steps = int(output_match.group("output_step"))
+            return [self._output_observation(ArtifactState.PRODUCING)]
+
+        checkpoint_match = _CHECKPOINT_RE.fullmatch(line)
+        if checkpoint_match is not None:
+            if self.checkpoint_path is None:
+                return []
+            observed_path = _absolute_posix_path(checkpoint_match.group("path"))
+            if observed_path != self.checkpoint_path:
+                raise ValueError(
+                    "Gray-Scott checkpoint is outside its configured artifact path"
+                )
+            step = int(checkpoint_match.group("step"))
+            if step <= self._latest_checkpoint_step:
+                return []
+            self._checkpoint_announced = True
+            self._latest_checkpoint_step = step
+            return [self._checkpoint_observation(ArtifactState.PRODUCING)]
+
+        completed_match = _COMPLETED_RE.fullmatch(line)
+        if completed_match is None:
+            return []
+        self._finalized = True
+        elapsed_ms = int(completed_match.group("elapsed_ms"))
+        observations: list[ArtifactObservation] = []
+        if self._output_announced:
+            observations.append(
+                self._output_observation(
+                    ArtifactState.FINALIZED,
+                    elapsed_milliseconds=elapsed_ms,
+                )
+            )
+        if self._checkpoint_announced:
+            observations.append(
+                self._checkpoint_observation(
+                    ArtifactState.FINALIZED,
+                    elapsed_milliseconds=elapsed_ms,
+                )
+            )
+        return observations
+
+    def _output_observation(
+        self,
+        state: ArtifactState,
+        *,
+        elapsed_milliseconds: int | None = None,
+    ) -> ArtifactObservation:
+        if self.output_path is None:
+            raise RuntimeError("ADIOS2 Gray-Scott output location is unavailable")
+        metadata: dict[str, str | int] = {
+            "application": "gray_scott",
+            "io_backend": "adios2",
+            "engine": self.engine,
+            "output_steps_observed": self._output_steps,
+            "latest_timestep": self._latest_step,
+        }
+        if elapsed_milliseconds is not None:
+            metadata["elapsed_milliseconds"] = elapsed_milliseconds
+            metadata["completion_signal"] = "writer_closed_and_timing_reported"
+        return ArtifactObservation(
+            artifact_id=self.output_artifact_id,
+            logical_name="gray-scott-simulation-output",
+            kind="scientific_dataset",
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(self.output_path),
+            media_type="application/x-adios2-bp",
+            format=_output_format(self.engine),
+            message=(
+                "Gray-Scott ADIOS2 output finalized"
+                if state is ArtifactState.FINALIZED
+                else "Gray-Scott ADIOS2 output is being produced"
+            ),
+            metadata=metadata,
+        )
+
+    def _checkpoint_observation(
+        self,
+        state: ArtifactState,
+        *,
+        elapsed_milliseconds: int | None = None,
+    ) -> ArtifactObservation:
+        if self.checkpoint_path is None:
+            raise RuntimeError("ADIOS2 Gray-Scott checkpoint location is unavailable")
+        metadata: dict[str, str | int] = {
+            "application": "gray_scott",
+            "io_backend": "adios2",
+            "checkpoint_timestep": self._latest_checkpoint_step,
+        }
+        if elapsed_milliseconds is not None:
+            metadata["elapsed_milliseconds"] = elapsed_milliseconds
+            metadata["completion_signal"] = "application_completed_after_checkpoint"
+        return ArtifactObservation(
+            artifact_id=self.checkpoint_artifact_id,
+            logical_name="gray-scott-restart-checkpoint",
+            kind="restart_checkpoint",
+            role=ArtifactRole.CHECKPOINT,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(self.checkpoint_path),
+            media_type="application/x-adios2-bp",
+            format="adios2-bp5",
+            message=(
+                "Gray-Scott restart checkpoint finalized"
+                if state is ArtifactState.FINALIZED
+                else "Gray-Scott is writing a restart checkpoint"
+            ),
+            metadata=metadata,
+        )
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> Adios2GrayScottArtifactAdapter | None:
+    """Create artifact semantics for builtin ADIOS2 Gray-Scott."""
+    if package.get("pkg_type") != "builtin.adios2_gray_scott":
+        return None
+    engine = str(package.get("engine") or "bp5").casefold()
+    output_path = (
+        None
+        if engine in _EPHEMERAL_ENGINES
+        else _configured_cluster_path(
+            package.get("out_file"),
+            runtime_cwd=package.get("runtime_cwd"),
+        )
+    )
+    return Adios2GrayScottArtifactAdapter(
+        output_path=output_path,
+        checkpoint_path=_configured_cluster_path(
+            package.get("checkpoint_output"),
+            runtime_cwd=package.get("runtime_cwd"),
+        ),
+        engine=engine,
+    )
+
+
+def _configured_cluster_path(
+    value: object,
+    *,
+    runtime_cwd: object,
+) -> PurePosixPath | None:
+    """Resolve configured output using JARVIS-owned runtime cwd context."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    path = PurePosixPath(value)
+    if not path.is_absolute():
+        if not isinstance(runtime_cwd, str) or not runtime_cwd:
+            return None
+        runtime_path = PurePosixPath(runtime_cwd)
+        if not runtime_path.is_absolute() or ".." in runtime_path.parts:
+            raise ValueError("Gray-Scott runtime working directory must be absolute")
+        path = runtime_path / path
+    return _absolute_posix_path(path.as_posix())
+
+
+def _absolute_posix_path(value: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if not path.is_absolute() or path.as_posix() != value or ".." in path.parts:
+        raise ValueError("Gray-Scott artifacts require a normalized absolute path")
+    return path
+
+
+def _output_format(engine: str) -> str:
+    base_engine = engine.removesuffix("_derived")
+    return f"adios2-{base_engine}"

--- a/builtin/builtin/adios2_gray_scott/pkg.py
+++ b/builtin/builtin/adios2_gray_scott/pkg.py
@@ -3,11 +3,11 @@ This module provides classes and methods to launch the Gray Scott application.
 Gray Scott is a 3D 7-point stencil code for modeling the diffusion of two
 substances.
 """
+
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
 from jarvis_cd.util.config_parser import JsonFile
-import pathlib
 import os
 
 
@@ -15,14 +15,15 @@ class Adios2GrayScott(Application):
     """
     This class provides methods to launch the GrayScott application.
     """
+
     def _init(self):
         """
         Initialize paths
         """
-        self.adios2_xml_path = f'{self.shared_dir}/adios2.xml'
-        self.settings_json_path = f'{self.shared_dir}/settings-files.json'
-        self.var_json_path = f'{self.shared_dir}/var.json'
-        self.operator_json_path = f'{self.shared_dir}/operator.json'
+        self.adios2_xml_path = f"{self.shared_dir}/adios2.xml"
+        self.settings_json_path = f"{self.shared_dir}/settings-files.json"
+        self.var_json_path = f"{self.shared_dir}/var.json"
+        self.operator_json_path = f"{self.shared_dir}/operator.json"
         self.process = None  # Store process handle for async execution
 
     def _configure_menu(self):
@@ -35,163 +36,170 @@ class Adios2GrayScott(Application):
         """
         return [
             {
-                'name': 'nprocs',
-                'msg': 'Number of processes to spawn',
-                'type': int,
-                'default': 4,
+                "name": "nprocs",
+                "msg": "Number of processes to spawn",
+                "type": int,
+                "default": 4,
             },
             {
-                'name': 'ppn',
-                'msg': 'Processes per node',
-                'type': int,
-                'default': 16,
+                "name": "ppn",
+                "msg": "Processes per node",
+                "type": int,
+                "default": 16,
             },
             {
-                'name': 'L',
-                'msg': 'Grid size of cube',
-                'type': int,
-                'default': 32,
+                "name": "L",
+                "msg": "Grid size of cube",
+                "type": int,
+                "default": 32,
             },
             {
-                'name': 'Du',
-                'msg': 'Diffusion rate of substance U',
-                'type': float,
-                'default': .2,
+                "name": "Du",
+                "msg": "Diffusion rate of substance U",
+                "type": float,
+                "default": 0.2,
             },
             {
-                'name': 'Dv',
-                'msg': 'Diffusion rate of substance V',
-                'type': float,
-                'default': .1,
+                "name": "Dv",
+                "msg": "Diffusion rate of substance V",
+                "type": float,
+                "default": 0.1,
             },
             {
-                'name': 'F',
-                'msg': 'Feed rate of U',
-                'type': float,
-                'default': .01,
+                "name": "F",
+                "msg": "Feed rate of U",
+                "type": float,
+                "default": 0.01,
             },
             {
-                'name': 'k',
-                'msg': 'Kill rate of V',
-                'type': float,
-                'default': .05,
+                "name": "k",
+                "msg": "Kill rate of V",
+                "type": float,
+                "default": 0.05,
             },
             {
-                'name': 'dt',
-                'msg': 'Timestep',
-                'type': float,
-                'default': 2.0,
+                "name": "dt",
+                "msg": "Timestep",
+                "type": float,
+                "default": 2.0,
             },
             {
-                'name': 'steps',
-                'msg': 'Total number of steps to simulate',
-                'type': int,
-                'default': 100,
+                "name": "steps",
+                "msg": "Total number of steps to simulate",
+                "type": int,
+                "default": 100,
             },
             {
-                'name': 'plotgap',
-                'msg': 'Number of steps between output',
-                'type': float,
-                'default': 10,
+                "name": "plotgap",
+                "msg": "Number of steps between output",
+                "type": float,
+                "default": 10,
             },
             {
-                'name': 'noise',
-                'msg': 'Amount of noise',
-                'type': float,
-                'default': .01,
+                "name": "noise",
+                "msg": "Amount of noise",
+                "type": float,
+                "default": 0.01,
             },
             {
-                'name': 'out_file',
-                'msg': 'Absolute path to output file',
-                'type': str,
-                'default': None,
+                "name": "out_file",
+                "msg": "Absolute path to output file",
+                "type": str,
+                "default": None,
             },
             {
-                'name': 'checkpoint',
-                'msg': 'Perform checkpoints',
-                'type': bool,
-                'default': True,
+                "name": "checkpoint",
+                "msg": "Perform checkpoints",
+                "type": bool,
+                "default": True,
             },
             {
-                'name': 'checkpoint_freq',
-                'msg': 'Frequency of the checkpoints',
-                'type': int,
-                'default': 70,
+                "name": "checkpoint_freq",
+                "msg": "Frequency of the checkpoints",
+                "type": int,
+                "default": 70,
             },
             {
-                'name': 'checkpoint_output',
-                'msg': 'Output location of the checkpoint',
-                'type': str,
-                'default': 'ckpt.bp',
+                "name": "checkpoint_output",
+                "msg": "Output location of the checkpoint",
+                "type": str,
+                "default": "ckpt.bp",
             },
             {
-                'name': 'restart',
-                'msg': 'Perform restarts',
-                'type': bool,
-                'default': False,
+                "name": "restart",
+                "msg": "Perform restarts",
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'restart_input',
-                'msg': 'Input for the restart',
-                'type': str,
-                'default': 'ckpt.bp',
+                "name": "restart_input",
+                "msg": "Input for the restart",
+                "type": str,
+                "default": "ckpt.bp",
             },
             {
-                'name': 'adios_span',
-                'msg': '???',
-                'type': bool,
-                'default': False,
+                "name": "adios_span",
+                "msg": "???",
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'adios_memory_selection',
-                'msg': '???',
-                'type': bool,
-                'default': False,
+                "name": "adios_memory_selection",
+                "msg": "???",
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'mesh_type',
-                'msg': '???',
-                'type': str,
-                'default': 'image',
+                "name": "mesh_type",
+                "msg": "???",
+                "type": str,
+                "default": "image",
             },
             {
-                'name': 'engine',
-                'msg': 'Engine to be used',
-                'choices': ['bp5', 'hermes', 'bp5_derived', 'hermes_derived', 'iowarp', 'iowarp_derived', 'sst'],
-                'type': str,
-                'default': 'bp5',
+                "name": "engine",
+                "msg": "Engine to be used",
+                "choices": [
+                    "bp5",
+                    "hermes",
+                    "bp5_derived",
+                    "hermes_derived",
+                    "iowarp",
+                    "iowarp_derived",
+                    "sst",
+                ],
+                "type": str,
+                "default": "bp5",
             },
             {
-                'name': 'full_run',
-                'msg': 'Whill postprocessing be executed?',
-                'type': bool,
-                'default': True,
+                "name": "full_run",
+                "msg": "Whill postprocessing be executed?",
+                "type": bool,
+                "default": True,
             },
             {
-                'name': 'limit',
-                'msg': 'Limit the value of data to track',
-                'type': int,
-                'default': 0,
+                "name": "limit",
+                "msg": "Limit the value of data to track",
+                "type": int,
+                "default": 0,
             },
             {
-                'name': 'db_path',
-                'msg': 'Path where the DB will be stored',
-                'type': str,
-                'default': 'benchmark_metadata.db',
+                "name": "db_path",
+                "msg": "Path where the DB will be stored",
+                "type": str,
+                "default": "benchmark_metadata.db",
             },
             {
-                'name': 'Execution_order',
-                'msg': 'Path where the bp5 will be stored',
-                'type': str,
-                'default': '1',
+                "name": "Execution_order",
+                "msg": "Path where the bp5 will be stored",
+                "type": str,
+                "default": "1",
             },
             {
-                'name': 'run_async',
-                'msg': 'Run in background for parallel execution with consumer',
-                'type': bool,
-                'default': False,
+                "name": "run_async",
+                "msg": "Run in background for parallel execution with consumer",
+                "type": bool,
+                "default": False,
             },
-
         ]
 
     # jarvis pkg config adios2_gray_scott ppn=20 full_run=true engine=hermes db_path=/mnt/nvme/jcernudagarcia/metadata.db out_file=gs.bp nprocs=1
@@ -204,76 +212,85 @@ class Adios2GrayScott(Application):
         :param kwargs: Configuration parameters for this pkg.
         :return: None
         """
-        if self.config['out_file'] is None:
-            adios_dir = os.path.join(self.shared_dir, 'gray-scott-output')
-            self.config['out_file'] = os.path.join(adios_dir,
-                                                 'data/out.bp')
-            Mkdir(adios_dir, PsshExecInfo(hostfile=self.hostfile,
-                                          env=self.env)).run()
+        if self.config["out_file"] is None:
+            adios_dir = os.path.join(self.shared_dir, "gray-scott-output")
+            self.config["out_file"] = os.path.join(adios_dir, "data/out.bp")
+            Mkdir(adios_dir, PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
         settings_json = {
-            'L': self.config['L'],
-            'Du': self.config['Du'],
-            'Dv': self.config['Dv'],
-            'F': self.config['F'],
-            'k': self.config['k'],
-            'dt': self.config['dt'],
-            'plotgap': self.config['plotgap'],
-            'steps': self.config['steps'],
-            'noise': self.config['noise'],
-            'output': self.config['out_file'],
-            'checkpoint': self.config['checkpoint'],
-            'checkpoint_freq': self.config['checkpoint_freq'],
-            'checkpoint_output': self.config['checkpoint_output'],
-            'restart': self.config['restart'],
-            'restart_input': self.config['restart_input'],
-            'adios_span': self.config['adios_span'],
-            'adios_memory_selection': self.config['adios_memory_selection'],
-            'mesh_type': self.config['mesh_type'],
-            'adios_config': f'{self.adios2_xml_path}'
+            "L": self.config["L"],
+            "Du": self.config["Du"],
+            "Dv": self.config["Dv"],
+            "F": self.config["F"],
+            "k": self.config["k"],
+            "dt": self.config["dt"],
+            "plotgap": self.config["plotgap"],
+            "steps": self.config["steps"],
+            "noise": self.config["noise"],
+            "output": self.config["out_file"],
+            "checkpoint": self.config["checkpoint"],
+            "checkpoint_freq": self.config["checkpoint_freq"],
+            "checkpoint_output": self.config["checkpoint_output"],
+            "restart": self.config["restart"],
+            "restart_input": self.config["restart_input"],
+            "adios_span": self.config["adios_span"],
+            "adios_memory_selection": self.config["adios_memory_selection"],
+            "mesh_type": self.config["mesh_type"],
+            "adios_config": f"{self.adios2_xml_path}",
         }
-        output_dir = os.path.dirname(self.config['out_file'])
-        db_dir = os.path.dirname(self.config['db_path'])
-        Mkdir([output_dir, db_dir], PsshExecInfo(hostfile=self.hostfile,
-                                       env=self.env)).run()
+        output_dir = os.path.dirname(self.config["out_file"])
+        db_dir = os.path.dirname(self.config["db_path"])
+        Mkdir(
+            [output_dir, db_dir], PsshExecInfo(hostfile=self.hostfile, env=self.env)
+        ).run()
 
         JsonFile(self.settings_json_path).save(settings_json)
         print(f"Using engine {self.config['engine']}")
-        if self.config['engine'].lower() in ['bp5', 'bp5_derived']:
-            self.copy_template_file(f'{self.pkg_dir}/config/adios2.xml',
-                                self.adios2_xml_path)
-        elif self.config['engine'].lower() == 'sst':
-            self.copy_template_file(f'{self.pkg_dir}/config/sst.xml',
-                                self.adios2_xml_path)
-        elif self.config['engine'].lower() in ['hermes', 'hermes_derived']:
-            self.copy_template_file(f'{self.pkg_dir}/config/hermes.xml',
-                                    self.adios2_xml_path,
-                                    replacements={
-                                        'PPN': self.config['ppn'],
-                                        'VARFILE': self.var_json_path,
-                                        'OPFILE': self.operator_json_path,
-                                        'DBFILE': self.config['db_path'],
-                                        'Order': self.config['Execution_order'],
-                                    })
-            self.copy_template_file(f'{self.pkg_dir}/config/var.yaml',
-                                    self.var_json_path)
-            self.copy_template_file(f'{self.pkg_dir}/config/operator.yaml',
-                                    self.operator_json_path)
-        elif self.config['engine'].lower() in ['iowarp', 'iowarp_derived']:
-            self.copy_template_file(f'{self.pkg_dir}/config/iowarp.xml',
-                                    self.adios2_xml_path,
-                                    replacements={
-                                        'PPN': self.config['ppn'],
-                                        'VARFILE': self.var_json_path,
-                                        'OPFILE': self.operator_json_path,
-                                        'DBFILE': self.config['db_path'],
-                                        'Order': self.config['Execution_order'],
-                                    })
-            self.copy_template_file(f'{self.pkg_dir}/config/var.yaml',
-                                    self.var_json_path)
-            self.copy_template_file(f'{self.pkg_dir}/config/operator.yaml',
-                                    self.operator_json_path)
+        if self.config["engine"].lower() in ["bp5", "bp5_derived"]:
+            self.copy_template_file(
+                f"{self.pkg_dir}/config/adios2.xml", self.adios2_xml_path
+            )
+        elif self.config["engine"].lower() == "sst":
+            self.copy_template_file(
+                f"{self.pkg_dir}/config/sst.xml", self.adios2_xml_path
+            )
+        elif self.config["engine"].lower() in ["hermes", "hermes_derived"]:
+            self.copy_template_file(
+                f"{self.pkg_dir}/config/hermes.xml",
+                self.adios2_xml_path,
+                replacements={
+                    "PPN": self.config["ppn"],
+                    "VARFILE": self.var_json_path,
+                    "OPFILE": self.operator_json_path,
+                    "DBFILE": self.config["db_path"],
+                    "Order": self.config["Execution_order"],
+                },
+            )
+            self.copy_template_file(
+                f"{self.pkg_dir}/config/var.yaml", self.var_json_path
+            )
+            self.copy_template_file(
+                f"{self.pkg_dir}/config/operator.yaml", self.operator_json_path
+            )
+        elif self.config["engine"].lower() in ["iowarp", "iowarp_derived"]:
+            self.copy_template_file(
+                f"{self.pkg_dir}/config/iowarp.xml",
+                self.adios2_xml_path,
+                replacements={
+                    "PPN": self.config["ppn"],
+                    "VARFILE": self.var_json_path,
+                    "OPFILE": self.operator_json_path,
+                    "DBFILE": self.config["db_path"],
+                    "Order": self.config["Execution_order"],
+                },
+            )
+            self.copy_template_file(
+                f"{self.pkg_dir}/config/var.yaml", self.var_json_path
+            )
+            self.copy_template_file(
+                f"{self.pkg_dir}/config/operator.yaml", self.operator_json_path
+            )
         else:
-            raise Exception('Engine not defined')
+            raise Exception("Engine not defined")
 
     def start(self):
         """
@@ -283,27 +300,39 @@ class Adios2GrayScott(Application):
         :return: None
         """
         # print(self.env['HERMES_CLIENT_CONF'])
-        if self.config['engine'].lower() in ['bp5_derived', 'hermes_derived', 'iowarp_derived']:
+        line_callback = self.runtime_line_callback()
+        if self.config["engine"].lower() in [
+            "bp5_derived",
+            "hermes_derived",
+            "iowarp_derived",
+        ]:
             derived = 1
-            self.process = Exec(f'gray-scott {self.settings_json_path} {derived}',
-                 MpiExecInfo(nprocs=self.config['nprocs'],
-                             ppn=self.config['ppn'],
-                             hostfile=self.hostfile,
-                             env=self.mod_env,
-                             exec_async=self.config['run_async']
-                             ))
+            self.process = Exec(
+                f"gray-scott {self.settings_json_path} {derived}",
+                MpiExecInfo(
+                    nprocs=self.config["nprocs"],
+                    ppn=self.config["ppn"],
+                    hostfile=self.hostfile,
+                    env=self.mod_env,
+                    exec_async=self.config["run_async"],
+                    line_callback=line_callback,
+                ),
+            )
             self.process.run()
-        elif self.config['engine'].lower() in ['hermes', 'bp5', 'iowarp', 'sst']:
-
+        elif self.config["engine"].lower() in ["hermes", "bp5", "iowarp", "sst"]:
             derived = 0
-            self.process = Exec(f'gray-scott {self.settings_json_path} {derived}',
-                 MpiExecInfo(nprocs=self.config['nprocs'],
-                             ppn=self.config['ppn'],
-                             hostfile=self.hostfile,
-                             env=self.mod_env,
-                             exec_async=self.config['run_async']))
+            self.process = Exec(
+                f"gray-scott {self.settings_json_path} {derived}",
+                MpiExecInfo(
+                    nprocs=self.config["nprocs"],
+                    ppn=self.config["ppn"],
+                    hostfile=self.hostfile,
+                    env=self.mod_env,
+                    exec_async=self.config["run_async"],
+                    line_callback=line_callback,
+                ),
+            )
             self.process.run()
-
 
     def wait(self):
         """
@@ -322,7 +351,7 @@ class Adios2GrayScott(Application):
         :return: None
         """
         # If running async, wait for completion instead of killing
-        if self.config.get('run_async', False) and self.process:
+        if self.config.get("run_async", False) and self.process:
             print("Waiting for async gray-scott producer to complete...")
             self.process.wait_all()
         elif self.process:
@@ -336,10 +365,11 @@ class Adios2GrayScott(Application):
 
         :return: None
         """
-        output_file = [self.config['out_file'],
-                       self.config['checkpoint_output'],
-                       self.config['db_path']
-                       ]
+        output_file = [
+            self.config["out_file"],
+            self.config["checkpoint_output"],
+            self.config["db_path"],
+        ]
 
-        print(f'Removing {output_file}')
+        print(f"Removing {output_file}")
         Rm(output_file, PsshExecInfo(hostfile=self.hostfile)).run()

--- a/builtin/builtin/adios2_gray_scott/progress.py
+++ b/builtin/builtin/adios2_gray_scott/progress.py
@@ -1,0 +1,194 @@
+"""Progress semantics owned by the builtin ADIOS2 Gray-Scott package."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from jarvis_cd.progress import LineBuffer, ProgressObservation, ProgressState
+
+_RESTART_RE = re.compile(r"^restart:\s+from step\s+(?P<step>\d+)\s*$")
+_STEPS_RE = re.compile(r"^steps:\s+(?P<steps>\d+)\s*$")
+_OUTPUT_RE = re.compile(
+    r"^Simulation at step\s+(?P<step>\d+)\s+"
+    r"writing output step\s+(?P<output_step>\d+)\s*$"
+)
+_COMPLETED_RE = re.compile(
+    r"^Rank\s+0\s+-\s+ET\s+(?P<elapsed_ms>\d+)\s+-\s+milliseconds\s*$"
+)
+
+
+@dataclass
+class Adios2GrayScottProgressAdapter:
+    """Interpret ADIOS2 Gray-Scott simulation lifecycle output."""
+
+    package_name: str = "builtin.adios2_gray_scott"
+    package_id: str = "adios2_gray_scott"
+    total_steps: int | None = None
+    output_every: int | None = None
+    output_path: Path | None = None
+    checkpoint_path: Path | None = None
+    _lines: LineBuffer = field(default_factory=LineBuffer)
+    _restart_step: int = 0
+    _last_step: int = 0
+    _started: bool = False
+    _completed: bool = False
+
+    def observe_progress(self, text: str) -> list[ProgressObservation]:
+        """Return progress based on native Gray-Scott lifecycle messages."""
+        return self._observe(text, finalize=False)
+
+    def finalize_progress(self) -> list[ProgressObservation]:
+        """Flush one final unterminated Gray-Scott output line."""
+        return self._observe("", finalize=True)
+
+    def reset_progress(self) -> None:
+        """Reset parsing when the application output stream is replaced."""
+        self._lines.reset()
+        self._restart_step = 0
+        self._last_step = 0
+        self._started = False
+        self._completed = False
+
+    def _observe(self, text: str, *, finalize: bool) -> list[ProgressObservation]:
+        observations: list[ProgressObservation] = []
+        for line in self._lines.feed(text, finalize=finalize):
+            observation = self._observe_line(line.strip())
+            if observation is not None:
+                observations.append(observation)
+        return observations
+
+    def _observe_line(self, line: str) -> ProgressObservation | None:
+        restart_match = _RESTART_RE.fullmatch(line)
+        if restart_match is not None:
+            self._restart_step = int(restart_match.group("step"))
+            self._last_step = self._restart_step
+            return None
+
+        steps_match = _STEPS_RE.fullmatch(line)
+        if steps_match is not None:
+            observed_total = int(steps_match.group("steps"))
+            if self.total_steps is not None and observed_total != self.total_steps:
+                raise ValueError(
+                    "ADIOS2 Gray-Scott reported a step total that differs from "
+                    "its JARVIS package configuration"
+                )
+            if self._restart_step > observed_total:
+                raise ValueError("Gray-Scott restart timestep exceeds configured total")
+            self.total_steps = observed_total
+            if self._started:
+                return None
+            self._started = True
+            return ProgressObservation(
+                label="simulation",
+                state=ProgressState.RUNNING,
+                current=float(self._restart_step),
+                total=float(observed_total),
+                unit="timestep",
+                message="ADIOS2 Gray-Scott simulation started",
+                metadata={
+                    "application": "gray_scott",
+                    "io_backend": "adios2",
+                    "progress_kind": "simulation_timestep",
+                    "completion_signal": "application_settings_reported",
+                    "restart_step": self._restart_step,
+                },
+            )
+
+        output_match = _OUTPUT_RE.fullmatch(line)
+        if output_match is not None:
+            step = int(output_match.group("step"))
+            output_step = int(output_match.group("output_step"))
+            if step <= self._last_step:
+                return None
+            if self.total_steps is not None and step > self.total_steps:
+                raise ValueError("Gray-Scott output timestep exceeds configured total")
+            if (
+                self.output_every is not None
+                and step // self.output_every != output_step
+            ):
+                raise ValueError("Gray-Scott output sequence contradicts plotgap")
+            self._last_step = step
+            return ProgressObservation(
+                label="simulation",
+                state=ProgressState.RUNNING,
+                current=float(step),
+                total=(
+                    float(self.total_steps) if self.total_steps is not None else None
+                ),
+                unit="timestep",
+                message=f"Gray-Scott completed compute timestep {step}",
+                metadata={
+                    "application": "gray_scott",
+                    "io_backend": "adios2",
+                    "progress_kind": "simulation_timestep",
+                    "completion_signal": "compute_step_completed",
+                    "output_write_state": "started",
+                    "output_step": output_step,
+                },
+            )
+
+        completed_match = _COMPLETED_RE.fullmatch(line)
+        if completed_match is not None:
+            if self._completed:
+                return None
+            self._completed = True
+            current = (
+                self.total_steps if self.total_steps is not None else self._last_step
+            )
+            return ProgressObservation(
+                label="simulation",
+                state=ProgressState.COMPLETED,
+                current=float(current),
+                total=(
+                    float(self.total_steps) if self.total_steps is not None else None
+                ),
+                unit="timestep",
+                message="ADIOS2 Gray-Scott simulation completed",
+                metadata={
+                    "application": "gray_scott",
+                    "io_backend": "adios2",
+                    "progress_kind": "simulation_timestep",
+                    "completion_signal": "writer_closed_and_timing_reported",
+                    "elapsed_milliseconds": int(completed_match.group("elapsed_ms")),
+                },
+            )
+        return None
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> Adios2GrayScottProgressAdapter | None:
+    """Create progress semantics for the builtin ADIOS2 Gray-Scott package."""
+    if package.get("pkg_type") != "builtin.adios2_gray_scott":
+        return None
+    return Adios2GrayScottProgressAdapter(
+        package_id=str(package.get("pkg_id") or "adios2_gray_scott"),
+        total_steps=_positive_int(package.get("steps")),
+        output_every=_positive_int(package.get("plotgap")),
+        output_path=_optional_path(package.get("out_file")),
+        checkpoint_path=_optional_path(package.get("checkpoint_output")),
+    )
+
+
+def _positive_int(value: object) -> int | None:
+    """Return a finite positive integer without accepting booleans."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(parsed) or parsed <= 0 or not parsed.is_integer():
+        return None
+    return int(parsed)
+
+
+def _optional_path(value: object) -> Path | None:
+    """Return a configured non-empty artifact path when one is present."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return Path(value)

--- a/builtin/builtin/gray_scott/artifacts.py
+++ b/builtin/builtin/gray_scott/artifacts.py
@@ -1,0 +1,175 @@
+"""Artifact semantics owned by the builtin Gray-Scott package."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts.provider import ArtifactObservation
+from jarvis_cd.artifacts.schema import (
+    ArtifactLocation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+from jarvis_cd.progress import LineBuffer
+
+_OUTPUT_RE = re.compile(r"^\s*wrote\s+(?P<path>.+?gs_(?P<step>\d+)\.h5)\s*$")
+_ADIOS_STEPS_RE = re.compile(r"^steps:\s+(?P<steps>\d+)\s*$")
+_ADIOS_OUTPUT_RE = re.compile(
+    r"^Simulation at step\s+(?P<step>\d+)\s+"
+    r"writing output step\s+(?P<output_step>\d+)\s*$"
+)
+_ADIOS_COMPLETED_RE = re.compile(
+    r"^Rank\s+0\s+-\s+ET\s+(?P<elapsed_ms>\d+)\s+-\s+milliseconds\s*$"
+)
+
+
+@dataclass
+class GrayScottArtifactAdapter:
+    """Describe Gray-Scott's HDF5 or ADIOS2 timestep collection."""
+
+    output_dir: PurePosixPath | None
+    deploy_mode: str = "default"
+    artifact_id: str = field(default_factory=new_artifact_id)
+    _lines: LineBuffer = field(default_factory=LineBuffer)
+    _member_count: int = 0
+    _latest_step: int = 0
+    _announced: bool = False
+    _finalized: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Return collection revisions from completed HDF5 writes."""
+        return self._observe(text, finalize=False)
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Flush one final unterminated application output line."""
+        return self._observe("", finalize=True)
+
+    def reset_artifacts(self) -> None:
+        """Reset parsing after the application output stream is replaced."""
+        self._lines.reset()
+        self._member_count = 0
+        self._latest_step = 0
+        self._announced = False
+        self._finalized = False
+
+    def _observe(self, text: str, *, finalize: bool) -> list[ArtifactObservation]:
+        observations: list[ArtifactObservation] = []
+        for line in self._lines.feed(text, finalize=finalize):
+            observation = self._observe_line(line)
+            if observation is not None:
+                observations.append(observation)
+        return observations
+
+    def _observe_line(self, line: str) -> ArtifactObservation | None:
+        stripped = line.strip()
+        if (
+            self.deploy_mode != "container"
+            and _ADIOS_STEPS_RE.fullmatch(stripped) is not None
+            and not self._announced
+            and self.output_dir is not None
+        ):
+            self._announced = True
+            return self._observation(ArtifactState.PRODUCING)
+
+        adios_output_match = _ADIOS_OUTPUT_RE.fullmatch(stripped)
+        if adios_output_match is not None:
+            if self.output_dir is None:
+                return None
+            step = int(adios_output_match.group("step"))
+            if step <= self._latest_step:
+                return None
+            self._announced = True
+            self._latest_step = step
+            self._member_count = int(adios_output_match.group("output_step"))
+            return self._observation(ArtifactState.PRODUCING)
+
+        output_match = _OUTPUT_RE.fullmatch(line)
+        if output_match is not None:
+            if self._finalized:
+                raise ValueError(
+                    "Gray-Scott emitted output after finalizing its dataset"
+                )
+            if self.output_dir is None:
+                return None
+            output_path = _absolute_posix_path(output_match.group("path"))
+            if output_path.parent != self.output_dir:
+                raise ValueError(
+                    "Gray-Scott output is outside its configured artifact directory"
+                )
+            step = int(output_match.group("step"))
+            if step <= self._latest_step:
+                return None
+            self._latest_step = step
+            self._member_count += 1
+            self._announced = True
+            return self._observation(ArtifactState.PRODUCING)
+
+        if stripped == "Done." or _ADIOS_COMPLETED_RE.fullmatch(stripped) is not None:
+            if self._finalized or not self._announced:
+                return None
+            self._finalized = True
+            return self._observation(ArtifactState.FINALIZED)
+        return None
+
+    def _observation(self, state: ArtifactState) -> ArtifactObservation:
+        if self.output_dir is None:
+            raise RuntimeError("Gray-Scott artifact location is unavailable")
+        is_hdf5 = self.deploy_mode == "container"
+        return ArtifactObservation(
+            artifact_id=self.artifact_id,
+            logical_name="gray-scott-timesteps",
+            kind="scientific_dataset",
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(self.output_dir),
+            media_type=("application/x-hdf5" if is_hdf5 else "application/x-adios2-bp"),
+            format=("hdf5-time-series" if is_hdf5 else "adios2-bp5"),
+            message=(
+                "Gray-Scott timestep collection finalized"
+                if state is ArtifactState.FINALIZED
+                else "Gray-Scott timestep collection is being produced"
+            ),
+            metadata={
+                "application": "gray_scott",
+                "io_backend": "hdf5" if is_hdf5 else "adios2",
+                "member_pattern": "gs_*.h5" if is_hdf5 else "adios2-steps",
+                "members_observed": self._member_count,
+                "latest_timestep": self._latest_step,
+            },
+        )
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> GrayScottArtifactAdapter | None:
+    """Create artifact semantics for the builtin Gray-Scott package."""
+    if package.get("pkg_type") != "builtin.gray_scott":
+        return None
+    return GrayScottArtifactAdapter(
+        output_dir=_configured_cluster_path(package.get("outdir")),
+        deploy_mode=str(package.get("effective_deploy_mode") or "default").casefold(),
+    )
+
+
+def _configured_cluster_path(value: object) -> PurePosixPath | None:
+    """Return a normalized absolute cluster path from trusted configuration."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    if not PurePosixPath(value).is_absolute():
+        return None
+    return _absolute_posix_path(value)
+
+
+def _absolute_posix_path(value: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if not path.is_absolute() or path.as_posix() != value or ".." in path.parts:
+        raise ValueError("Gray-Scott artifacts require a normalized absolute path")
+    return path

--- a/builtin/builtin/gray_scott/pkg.py
+++ b/builtin/builtin/gray_scott/pkg.py
@@ -2,6 +2,7 @@
 This module provides classes and methods to launch the Gray-Scott application.
 Gray-Scott is a reaction-diffusion simulation.
 """
+
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
@@ -20,88 +21,88 @@ class GrayScott(Application):
     """
 
     def _init(self):
-        self.adios2_xml_path = f'{self.shared_dir}/adios2.xml'
-        self.settings_json_path = f'{self.shared_dir}/settings-files.json'
+        self.adios2_xml_path = f"{self.shared_dir}/adios2.xml"
+        self.settings_json_path = f"{self.shared_dir}/settings-files.json"
 
     def _configure_menu(self):
         return [
             {
-                'name': 'nprocs',
-                'msg': 'Number of MPI processes',
-                'type': int,
-                'default': 4,
+                "name": "nprocs",
+                "msg": "Number of MPI processes",
+                "type": int,
+                "default": 4,
             },
             {
-                'name': 'ppn',
-                'msg': 'Processes per node',
-                'type': int,
-                'default': None,
+                "name": "ppn",
+                "msg": "Processes per node",
+                "type": int,
+                "default": None,
             },
             {
-                'name': 'width',
-                'msg': 'Global grid width (columns)',
-                'type': int,
-                'default': 512,
+                "name": "width",
+                "msg": "Global grid width (columns)",
+                "type": int,
+                "default": 512,
             },
             {
-                'name': 'height',
-                'msg': 'Global grid height (rows)',
-                'type': int,
-                'default': 512,
+                "name": "height",
+                "msg": "Global grid height (rows)",
+                "type": int,
+                "default": 512,
             },
             {
-                'name': 'steps',
-                'msg': 'Total number of time steps',
-                'type': int,
-                'default': 5000,
+                "name": "steps",
+                "msg": "Total number of time steps",
+                "type": int,
+                "default": 5000,
             },
             {
-                'name': 'out_every',
-                'msg': 'HDF5 output interval (steps between writes)',
-                'type': int,
-                'default': 500,
+                "name": "out_every",
+                "msg": "HDF5 output interval (steps between writes)",
+                "type": int,
+                "default": 500,
             },
             {
-                'name': 'outdir',
-                'msg': 'Output directory for HDF5 files',
-                'type': str,
-                'default': '/tmp/gray_scott_out',
+                "name": "outdir",
+                "msg": "Output directory for HDF5 files",
+                "type": str,
+                "default": "/tmp/gray_scott_out",
             },
             {
-                'name': 'F',
-                'msg': 'Feed rate',
-                'type': float,
-                'default': 0.035,
+                "name": "F",
+                "msg": "Feed rate",
+                "type": float,
+                "default": 0.035,
             },
             {
-                'name': 'k',
-                'msg': 'Kill rate',
-                'type': float,
-                'default': 0.060,
+                "name": "k",
+                "msg": "Kill rate",
+                "type": float,
+                "default": 0.060,
             },
             {
-                'name': 'Du',
-                'msg': 'Diffusion coefficient for u',
-                'type': float,
-                'default': 0.16,
+                "name": "Du",
+                "msg": "Diffusion coefficient for u",
+                "type": float,
+                "default": 0.16,
             },
             {
-                'name': 'Dv',
-                'msg': 'Diffusion coefficient for v',
-                'type': float,
-                'default': 0.08,
+                "name": "Dv",
+                "msg": "Diffusion coefficient for v",
+                "type": float,
+                "default": 0.08,
             },
             {
-                'name': 'cuda_arch',
-                'msg': 'CUDA architecture code (80=A100, 90=H100, 70=V100)',
-                'type': int,
-                'default': 80,
+                "name": "cuda_arch",
+                "msg": "CUDA architecture code (80=A100, 90=H100, 70=V100)",
+                "type": int,
+                "default": 80,
             },
             {
-                'name': 'base_image',
-                'msg': 'Base Docker image for build container',
-                'type': str,
-                'default': 'sci-hpc-base',
+                "name": "base_image",
+                "msg": "Base Docker image for build container",
+                "type": str,
+                "default": "sci-hpc-base",
             },
         ]
 
@@ -110,23 +111,29 @@ class GrayScott(Application):
     # ------------------------------------------------------------------
 
     def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+        if self.config.get("deploy_mode") != "container":
             return None
-        cuda_arch = self.config.get('cuda_arch', 80)
-        content = self._read_build_script('build.sh', {
-            'BASE_IMAGE': self.config.get('base_image', 'sci-hpc-base'),
-            'CUDA_ARCH': cuda_arch,
-        })
-        return content, f'cuda-{cuda_arch}'
+        cuda_arch = self.config.get("cuda_arch", 80)
+        content = self._read_build_script(
+            "build.sh",
+            {
+                "BASE_IMAGE": self.config.get("base_image", "sci-hpc-base"),
+                "CUDA_ARCH": cuda_arch,
+            },
+        )
+        return content, f"cuda-{cuda_arch}"
 
     def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+        if self.config.get("deploy_mode") != "container":
             return None
-        suffix = getattr(self, '_build_suffix', '')
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': 'nvidia/cuda:12.6.0-runtime-ubuntu24.04',
-        })
+        suffix = getattr(self, "_build_suffix", "")
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {
+                "BUILD_IMAGE": self.build_image_name(),
+                "DEPLOY_BASE": "nvidia/cuda:12.6.0-runtime-ubuntu24.04",
+            },
+        )
         return content, suffix
 
     # ------------------------------------------------------------------
@@ -145,27 +152,28 @@ class GrayScott(Application):
         """
         super()._configure(**kwargs)
 
-        if self.config.get('deploy_mode') == 'default':
-            output = self.config.get('outdir', f'{self.shared_dir}/gray-scott-output')
-            self.config['outdir'] = output
+        if self.config.get("deploy_mode") == "default":
+            output = self.config.get("outdir", f"{self.shared_dir}/gray-scott-output")
+            self.config["outdir"] = output
             Mkdir(output, PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
 
             settings_json = {
-                'L': self.config.get('width', 512),
-                'Du': self.config.get('Du', 0.16),
-                'Dv': self.config.get('Dv', 0.08),
-                'F': self.config.get('F', 0.035),
-                'k': self.config.get('k', 0.060),
-                'dt': 2.0,
-                'plotgap': self.config.get('out_every', 500),
-                'steps': self.config.get('steps', 5000),
-                'noise': 0.01,
-                'output': output,
-                'adios_config': self.adios2_xml_path
+                "L": self.config.get("width", 512),
+                "Du": self.config.get("Du", 0.16),
+                "Dv": self.config.get("Dv", 0.08),
+                "F": self.config.get("F", 0.035),
+                "k": self.config.get("k", 0.060),
+                "dt": 2.0,
+                "plotgap": self.config.get("out_every", 500),
+                "steps": self.config.get("steps", 5000),
+                "noise": 0.01,
+                "output": output,
+                "adios_config": self.adios2_xml_path,
             }
             JsonFile(self.settings_json_path).save(settings_json)
-            self.copy_template_file(f'{self.pkg_dir}/config/adios2.xml',
-                                    self.adios2_xml_path)
+            self.copy_template_file(
+                f"{self.pkg_dir}/config/adios2.xml", self.adios2_xml_path
+            )
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -178,42 +186,54 @@ class GrayScott(Application):
         Branches on deploy_mode: uses MpiExecInfo with container engine for
         container mode, MpiExecInfo with hostfile and ADIOS2 settings JSON for default mode.
         """
-        if self.config.get('deploy_mode') == 'container':
-            outdir = self.config.get('outdir', '/tmp/gray_scott_out')
+        line_callback = self.runtime_line_callback()
+        if self.config.get("deploy_mode") == "container":
+            outdir = self.config.get("outdir", "/tmp/gray_scott_out")
             Mkdir(outdir).run()
 
-            nprocs = self.config.get('nprocs', 4)
-            inner = ' '.join([
-                '/usr/bin/gray_scott',
-                f'--width {self.config["width"]}',
-                f'--height {self.config["height"]}',
-                f'--steps {self.config["steps"]}',
-                f'--out-every {self.config["out_every"]}',
-                f'--outdir {outdir}',
-                f'--F {self.config["F"]}',
-                f'--k {self.config["k"]}',
-                f'--Du {self.config["Du"]}',
-                f'--Dv {self.config["Dv"]}',
-            ])
-            Exec(inner, MpiExecInfo(
-                nprocs=nprocs,
-                ppn=self.config.get('ppn'),
-                container=self._container_engine,
-                container_image=self.deploy_image_name(),
-                shared_dir=self.shared_dir,
-                private_dir=self.private_dir,
-                gpu=True,
-                env=self.mod_env,
-            )).run()
+            nprocs = self.config.get("nprocs", 4)
+            inner = " ".join(
+                [
+                    "/usr/bin/gray_scott",
+                    f"--width {self.config['width']}",
+                    f"--height {self.config['height']}",
+                    f"--steps {self.config['steps']}",
+                    f"--out-every {self.config['out_every']}",
+                    f"--outdir {outdir}",
+                    f"--F {self.config['F']}",
+                    f"--k {self.config['k']}",
+                    f"--Du {self.config['Du']}",
+                    f"--Dv {self.config['Dv']}",
+                ]
+            )
+            Exec(
+                inner,
+                MpiExecInfo(
+                    nprocs=nprocs,
+                    ppn=self.config.get("ppn"),
+                    container=self._container_engine,
+                    container_image=self.deploy_image_name(),
+                    shared_dir=self.shared_dir,
+                    private_dir=self.private_dir,
+                    gpu=True,
+                    env=self.mod_env,
+                    line_callback=line_callback,
+                ),
+            ).run()
         else:
             start = time.time()
-            Exec(f'gray-scott {self.settings_json_path}',
-                 MpiExecInfo(nprocs=self.config['nprocs'],
-                             ppn=self.config['ppn'],
-                             hostfile=self.hostfile,
-                             env=self.mod_env)).run()
+            Exec(
+                f"gray-scott {self.settings_json_path}",
+                MpiExecInfo(
+                    nprocs=self.config["nprocs"],
+                    ppn=self.config["ppn"],
+                    hostfile=self.hostfile,
+                    env=self.mod_env,
+                    line_callback=line_callback,
+                ),
+            ).run()
             end = time.time()
-            self.log(f'TIME: {end - start:.2f} seconds', color=Color.GREEN)
+            self.log(f"TIME: {end - start:.2f} seconds", color=Color.GREEN)
 
     def stop(self):
         """Stop Gray-Scott (no-op — Gray-Scott runs to completion)."""
@@ -221,6 +241,6 @@ class GrayScott(Application):
 
     def clean(self):
         """Remove Gray-Scott output directory."""
-        output = self.config.get('outdir', '')
+        output = self.config.get("outdir", "")
         if output:
-            Rm(output + '*').run()
+            Rm(output + "*").run()

--- a/builtin/builtin/gray_scott/progress.py
+++ b/builtin/builtin/gray_scott/progress.py
@@ -1,0 +1,260 @@
+"""Progress semantics owned by the builtin Gray-Scott package."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from jarvis_cd.progress import LineBuffer, ProgressObservation, ProgressState
+
+_START_RE = re.compile(
+    r"^Gray-Scott\s+(?P<width>\d+)x(?P<height>\d+)\s+"
+    r"(?P<ranks>\d+)\s+ranks\s+(?P<steps>\d+)\s+steps\s*$"
+)
+_OUTPUT_RE = re.compile(r"^\s*wrote\s+(?P<path>.+?gs_(?P<step>\d+)\.h5)\s*$")
+_ADIOS_STEPS_RE = re.compile(r"^steps:\s+(?P<steps>\d+)\s*$")
+_ADIOS_RESTART_RE = re.compile(r"^restart:\s+from step\s+(?P<step>\d+)\s*$")
+_ADIOS_OUTPUT_RE = re.compile(
+    r"^Simulation at step\s+(?P<step>\d+)\s+"
+    r"writing output step\s+(?P<output_step>\d+)\s*$"
+)
+_ADIOS_COMPLETED_RE = re.compile(
+    r"^Rank\s+0\s+-\s+ET\s+(?P<elapsed_ms>\d+)\s+-\s+milliseconds\s*$"
+)
+
+
+@dataclass
+class GrayScottProgressAdapter:
+    """Interpret completed Gray-Scott timesteps from package-owned stdout."""
+
+    package_name: str = "builtin.gray_scott"
+    package_id: str = "gray_scott"
+    total_steps: int | None = None
+    output_every: int | None = None
+    output_dir: Path | None = None
+    _lines: LineBuffer = field(default_factory=LineBuffer)
+    _last_step: int = 0
+    _restart_step: int = 0
+    _started: bool = False
+    _completed: bool = False
+
+    def observe_progress(self, text: str) -> list[ProgressObservation]:
+        """Return truthful progress observations from complete output lines."""
+        return self._observe(text, finalize=False)
+
+    def finalize_progress(self) -> list[ProgressObservation]:
+        """Flush one final unterminated Gray-Scott output line."""
+        return self._observe("", finalize=True)
+
+    def reset_progress(self) -> None:
+        """Reset parsing when the application output stream is replaced."""
+        self._lines.reset()
+        self._last_step = 0
+        self._restart_step = 0
+        self._started = False
+        self._completed = False
+
+    def _observe(self, text: str, *, finalize: bool) -> list[ProgressObservation]:
+        observations: list[ProgressObservation] = []
+        for line in self._lines.feed(text, finalize=finalize):
+            observation = self._observe_line(line)
+            if observation is not None:
+                observations.append(observation)
+        return observations
+
+    def _observe_line(self, line: str) -> ProgressObservation | None:
+        stripped = line.strip()
+        restart_match = _ADIOS_RESTART_RE.fullmatch(stripped)
+        if restart_match is not None:
+            self._restart_step = int(restart_match.group("step"))
+            self._last_step = self._restart_step
+            return None
+
+        adios_steps_match = _ADIOS_STEPS_RE.fullmatch(stripped)
+        if adios_steps_match is not None:
+            observed_total = int(adios_steps_match.group("steps"))
+            if self.total_steps is not None and observed_total != self.total_steps:
+                raise ValueError(
+                    "Gray-Scott reported a step total that differs from its "
+                    "JARVIS package configuration"
+                )
+            self.total_steps = observed_total
+            if self._started:
+                return None
+            self._started = True
+            return ProgressObservation(
+                label="simulation",
+                state=ProgressState.RUNNING,
+                current=float(self._restart_step),
+                total=float(observed_total),
+                unit="timestep",
+                message="Gray-Scott simulation started",
+                metadata={
+                    "application": "gray_scott",
+                    "io_backend": "adios2",
+                    "progress_kind": "simulation_timestep",
+                    "completion_signal": "application_settings_reported",
+                    "restart_step": self._restart_step,
+                },
+            )
+
+        start_match = _START_RE.fullmatch(stripped)
+        if start_match is not None:
+            observed_total = int(start_match.group("steps"))
+            if self.total_steps is not None and observed_total != self.total_steps:
+                raise ValueError(
+                    "Gray-Scott reported a step total that differs from its "
+                    "JARVIS package configuration"
+                )
+            self.total_steps = observed_total
+            if self._started:
+                return None
+            self._started = True
+            return ProgressObservation(
+                label="simulation",
+                state=ProgressState.RUNNING,
+                current=0.0,
+                total=float(observed_total),
+                unit="timestep",
+                message="Gray-Scott simulation started",
+                metadata={
+                    "application": "gray_scott",
+                    "progress_kind": "simulation_timestep",
+                    "completion_signal": "application_started",
+                    "grid_width": int(start_match.group("width")),
+                    "grid_height": int(start_match.group("height")),
+                    "mpi_ranks": int(start_match.group("ranks")),
+                },
+            )
+
+        adios_output_match = _ADIOS_OUTPUT_RE.fullmatch(stripped)
+        if adios_output_match is not None:
+            step = int(adios_output_match.group("step"))
+            if step <= self._last_step:
+                return None
+            if self.total_steps is not None and step > self.total_steps:
+                raise ValueError("Gray-Scott output timestep exceeds configured total")
+            self._last_step = step
+            return ProgressObservation(
+                label="simulation",
+                state=ProgressState.RUNNING,
+                current=float(step),
+                total=(
+                    float(self.total_steps) if self.total_steps is not None else None
+                ),
+                unit="timestep",
+                message=f"Gray-Scott completed compute timestep {step}",
+                metadata={
+                    "application": "gray_scott",
+                    "io_backend": "adios2",
+                    "progress_kind": "simulation_timestep",
+                    "completion_signal": "compute_step_completed",
+                    "output_write_state": "started",
+                    "output_step": int(adios_output_match.group("output_step")),
+                },
+            )
+
+        output_match = _OUTPUT_RE.fullmatch(line)
+        if output_match is not None:
+            step = int(output_match.group("step"))
+            if step <= self._last_step:
+                return None
+            if self.total_steps is not None and step > self.total_steps:
+                raise ValueError("Gray-Scott output timestep exceeds configured total")
+            self._last_step = step
+            output_path = output_match.group("path")
+            return ProgressObservation(
+                label="simulation",
+                state=ProgressState.RUNNING,
+                current=float(step),
+                total=(
+                    float(self.total_steps) if self.total_steps is not None else None
+                ),
+                unit="timestep",
+                message=f"Gray-Scott completed timestep {step}",
+                metadata={
+                    "application": "gray_scott",
+                    "progress_kind": "simulation_timestep",
+                    "completion_signal": "hdf5_write_returned",
+                    "output_path": output_path,
+                    "output_format": "hdf5",
+                },
+            )
+
+        adios_completed_match = _ADIOS_COMPLETED_RE.fullmatch(stripped)
+        if adios_completed_match is not None:
+            return self._completed_observation(
+                completion_signal="writer_closed_and_timing_reported",
+                elapsed_milliseconds=int(adios_completed_match.group("elapsed_ms")),
+            )
+        if stripped == "Done.":
+            return self._completed_observation(
+                completion_signal="application_reported_done"
+            )
+        return None
+
+    def _completed_observation(
+        self,
+        *,
+        completion_signal: str,
+        elapsed_milliseconds: int | None = None,
+    ) -> ProgressObservation | None:
+        """Return one terminal observation from a real application signal."""
+        if self._completed:
+            return None
+        self._completed = True
+        current = self.total_steps if self.total_steps is not None else self._last_step
+        metadata: dict[str, str | int] = {
+            "application": "gray_scott",
+            "progress_kind": "simulation_timestep",
+            "completion_signal": completion_signal,
+        }
+        if elapsed_milliseconds is not None:
+            metadata["io_backend"] = "adios2"
+            metadata["elapsed_milliseconds"] = elapsed_milliseconds
+        return ProgressObservation(
+            label="simulation",
+            state=ProgressState.COMPLETED,
+            current=float(current),
+            total=(float(self.total_steps) if self.total_steps is not None else None),
+            unit="timestep",
+            message="Gray-Scott simulation completed",
+            metadata=metadata,
+        )
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> GrayScottProgressAdapter | None:
+    """Create progress semantics for the builtin Gray-Scott package."""
+    if package.get("pkg_type") != "builtin.gray_scott":
+        return None
+    return GrayScottProgressAdapter(
+        package_id=str(package.get("pkg_id") or "gray_scott"),
+        total_steps=_positive_int(package.get("steps")),
+        output_every=_positive_int(package.get("out_every")),
+        output_dir=_optional_path(package.get("outdir")),
+    )
+
+
+def _positive_int(value: object) -> int | None:
+    """Return a finite positive integer without accepting booleans."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(parsed) or parsed <= 0 or not parsed.is_integer():
+        return None
+    return int(parsed)
+
+
+def _optional_path(value: object) -> Path | None:
+    """Return a configured non-empty output path when one is present."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return Path(value)

--- a/builtin/builtin/lammps/artifacts.py
+++ b/builtin/builtin/lammps/artifacts.py
@@ -1,0 +1,408 @@
+"""Generated-artifact semantics for the builtin LAMMPS package."""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+from jarvis_cd.artifacts.schema import JsonValue
+
+_MAX_DIRECTORY_ENTRIES = 4096
+_MAX_SCRIPT_BYTES = 1024 * 1024
+_MAX_REPORTED_MEMBERS = 256
+
+
+@dataclass(frozen=True, slots=True)
+class _DiscoveredEntry:
+    """One non-symlink direct child of the configured output directory."""
+
+    name: str
+    is_file: bool
+    is_directory: bool
+    size_bytes: int | None
+
+
+@dataclass
+class LammpsArtifactAdapter:
+    """Discover only known LAMMPS products in its configured output root.
+
+    LAMMPS does not provide a structured artifact stream. The package therefore
+    performs a bounded, non-recursive scan at finalization. It recognizes
+    package-owned logs, dump series, restart/checkpoint series, and concrete
+    outputs declared by static ``write_data`` or ``write_dump`` commands.
+    """
+
+    output_dir: PurePosixPath
+    script_path: Path | None = None
+    _finalized: bool = False
+    _dump_artifact_id: str = field(default_factory=new_artifact_id)
+    _checkpoint_artifact_id: str = field(default_factory=new_artifact_id)
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Return no observations until LAMMPS has finished writing files."""
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Return a bounded manifest of package-owned LAMMPS products."""
+        if self._finalized:
+            return []
+        self._finalized = True
+        entries, truncated = self._discover_entries()
+        declared_outputs = self._declared_output_patterns()
+
+        logs: list[_DiscoveredEntry] = []
+        dumps: list[_DiscoveredEntry] = []
+        checkpoints: list[_DiscoveredEntry] = []
+        outputs: list[_DiscoveredEntry] = []
+        for entry in entries:
+            category = _classify_entry(entry.name, declared_outputs)
+            if category == "log":
+                logs.append(entry)
+            elif category == "dump":
+                dumps.append(entry)
+            elif category == "checkpoint":
+                checkpoints.append(entry)
+            elif category == "output":
+                outputs.append(entry)
+
+        observations: list[ArtifactObservation] = []
+        observations.extend(self._log_observation(entry) for entry in logs)
+        if dumps:
+            observations.append(
+                self._collection_observation(
+                    artifact_id=self._dump_artifact_id,
+                    logical_name="lammps-trajectory-dumps",
+                    kind="scientific_dataset",
+                    role=ArtifactRole.OUTPUT,
+                    format_name="lammps-dump-series",
+                    members=dumps,
+                    truncated=truncated,
+                )
+            )
+        if checkpoints:
+            observations.append(
+                self._collection_observation(
+                    artifact_id=self._checkpoint_artifact_id,
+                    logical_name="lammps-restarts",
+                    kind="checkpoint",
+                    role=ArtifactRole.CHECKPOINT,
+                    format_name="lammps-restart-series",
+                    members=checkpoints,
+                    truncated=truncated,
+                )
+            )
+        observations.extend(self._output_observation(entry) for entry in outputs)
+        return observations
+
+    def reset_artifacts(self) -> None:
+        """Allow final discovery to run again after an execution-stream reset."""
+        self._finalized = False
+
+    def _discover_entries(self) -> tuple[list[_DiscoveredEntry], bool]:
+        """Inspect direct children without following links or walking subtrees."""
+        output_path = Path(self.output_dir.as_posix())
+        try:
+            if not output_path.exists():
+                return [], False
+            if not output_path.is_dir() or output_path.is_symlink():
+                raise RuntimeError(
+                    f"LAMMPS output root is not a real directory: {self.output_dir}"
+                )
+            discovered: list[_DiscoveredEntry] = []
+            truncated = False
+            with os.scandir(output_path) as iterator:
+                for index, entry in enumerate(iterator):
+                    if index >= _MAX_DIRECTORY_ENTRIES:
+                        truncated = True
+                        break
+                    if entry.is_symlink():
+                        continue
+                    is_file = entry.is_file(follow_symlinks=False)
+                    is_directory = entry.is_dir(follow_symlinks=False)
+                    if not is_file and not is_directory:
+                        continue
+                    size_bytes = (
+                        entry.stat(follow_symlinks=False).st_size if is_file else None
+                    )
+                    discovered.append(
+                        _DiscoveredEntry(
+                            name=entry.name,
+                            is_file=is_file,
+                            is_directory=is_directory,
+                            size_bytes=size_bytes,
+                        )
+                    )
+        except OSError as exc:
+            raise RuntimeError(
+                f"cannot inspect LAMMPS output directory {self.output_dir}: {exc}"
+            ) from exc
+        return sorted(discovered, key=lambda item: item.name), truncated
+
+    def _declared_output_patterns(self) -> dict[str, str]:
+        """Read bounded static output directives from the configured input."""
+        if self.script_path is None:
+            return {}
+        try:
+            status = self.script_path.stat()
+            if not self.script_path.is_file() or status.st_size > _MAX_SCRIPT_BYTES:
+                return {}
+            lines = self.script_path.read_text(
+                encoding="utf-8", errors="replace"
+            ).splitlines()
+        except OSError:
+            return {}
+
+        patterns: dict[str, str] = {}
+        for line in lines:
+            try:
+                tokens = shlex.split(line, comments=True, posix=True)
+            except ValueError:
+                continue
+            if not tokens:
+                continue
+            command = tokens[0].casefold()
+            output_tokens: list[tuple[str, str]] = []
+            if command == "write_data" and len(tokens) >= 2:
+                output_tokens.append((tokens[1], "output"))
+            elif command == "write_restart" and len(tokens) >= 2:
+                output_tokens.append((tokens[1], "checkpoint"))
+            elif command == "restart" and len(tokens) >= 3:
+                output_tokens.extend((token, "checkpoint") for token in tokens[2:4])
+            elif command == "dump" and len(tokens) >= 6:
+                output_tokens.append((tokens[5], "dump"))
+            elif command == "write_dump" and len(tokens) >= 4:
+                output_tokens.append((tokens[3], "output"))
+            for output_token, category in output_tokens:
+                if "$" in output_token:
+                    continue
+                normalized = _direct_output_pattern(output_token, self.output_dir)
+                if normalized is not None:
+                    patterns[normalized] = category
+        return patterns
+
+    def _log_observation(self, entry: _DiscoveredEntry) -> ArtifactObservation:
+        """Describe one finalized LAMMPS text log."""
+        return ArtifactObservation(
+            logical_name=entry.name,
+            kind="log",
+            role=ArtifactRole.LOG,
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.SHARED,
+            state=ArtifactState.FINALIZED,
+            location=ArtifactLocation.cluster_path(self.output_dir / entry.name),
+            media_type="text/plain",
+            format="lammps-log",
+            size_bytes=entry.size_bytes,
+            message="LAMMPS application log finalized",
+            metadata={"application": "lammps"},
+        )
+
+    def _collection_observation(
+        self,
+        *,
+        artifact_id: str,
+        logical_name: str,
+        kind: str,
+        role: ArtifactRole,
+        format_name: str,
+        members: list[_DiscoveredEntry],
+        truncated: bool,
+    ) -> ArtifactObservation:
+        """Describe one bounded collection without claiming unscanned members."""
+        names: list[JsonValue] = [
+            entry.name for entry in members[:_MAX_REPORTED_MEMBERS]
+        ]
+        size_bytes = sum(entry.size_bytes or 0 for entry in members if entry.is_file)
+        return ArtifactObservation(
+            artifact_id=artifact_id,
+            logical_name=logical_name,
+            kind=kind,
+            role=role,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=(ArtifactState.INCOMPLETE if truncated else ArtifactState.FINALIZED),
+            location=ArtifactLocation.cluster_path(self.output_dir),
+            format=format_name,
+            size_bytes=size_bytes,
+            message=(
+                "LAMMPS artifact discovery reached its safety bound"
+                if truncated
+                else f"LAMMPS {logical_name} finalized"
+            ),
+            metadata={
+                "application": "lammps",
+                "member_count_observed": len(members),
+                "member_names": names,
+                "member_names_truncated": len(members) > len(names),
+                "discovery_truncated": truncated,
+            },
+        )
+
+    def _output_observation(self, entry: _DiscoveredEntry) -> ArtifactObservation:
+        """Describe one concrete output selected by LAMMPS semantics."""
+        structure = (
+            ArtifactStructure.COLLECTION
+            if entry.is_directory
+            else ArtifactStructure.FILE
+        )
+        format_name, media_type = _output_format(entry.name)
+        return ArtifactObservation(
+            logical_name=entry.name,
+            kind="scientific_dataset",
+            role=ArtifactRole.OUTPUT,
+            structure=structure,
+            ownership=ArtifactOwnership.SHARED,
+            state=ArtifactState.FINALIZED,
+            location=ArtifactLocation.cluster_path(self.output_dir / entry.name),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=entry.size_bytes,
+            message="LAMMPS output finalized",
+            metadata={"application": "lammps"},
+        )
+
+
+def adapter_from_package(package: dict[str, Any]) -> LammpsArtifactAdapter | None:
+    """Create artifact semantics for the builtin LAMMPS package."""
+    if package.get("pkg_type") != "builtin.lammps":
+        return None
+    output_dir = _configured_output_dir(
+        package.get("out"),
+        runtime_cwd=package.get("runtime_cwd"),
+    )
+    deploy_mode = str(package.get("effective_deploy_mode") or "default").casefold()
+    if deploy_mode == "container":
+        allowed_roots = tuple(
+            root
+            for root in (
+                _optional_absolute_path(package.get("shared_dir")),
+                _optional_absolute_path(package.get("private_dir")),
+            )
+            if root is not None
+        )
+        if not any(output_dir.is_relative_to(root) for root in allowed_roots):
+            return None
+    script_base = (
+        output_dir
+        if deploy_mode != "container"
+        else _optional_absolute_path(package.get("runtime_cwd"))
+    )
+    script_path = _configured_script_path(package.get("script"), script_base)
+    return LammpsArtifactAdapter(output_dir=output_dir, script_path=script_path)
+
+
+def _configured_output_dir(
+    value: object,
+    *,
+    runtime_cwd: object,
+) -> PurePosixPath:
+    """Return one normalized absolute POSIX output directory."""
+    raw = os.path.expandvars(str(value or "."))
+    path = PurePosixPath(raw)
+    if not path.is_absolute():
+        if not isinstance(runtime_cwd, str) or not runtime_cwd:
+            raise ValueError(
+                "relative LAMMPS artifact output requires a runtime working directory"
+            )
+        runtime_path = PurePosixPath(runtime_cwd)
+        if not runtime_path.is_absolute():
+            raise ValueError("LAMMPS runtime working directory must be absolute")
+        path = runtime_path / path
+        raw = path.as_posix()
+    if not path.is_absolute() or path.as_posix() != raw or ".." in path.parts:
+        raise ValueError("LAMMPS artifacts require a normalized absolute output path")
+    return path
+
+
+def _configured_script_path(
+    value: object,
+    base_dir: PurePosixPath | None,
+) -> Path | None:
+    """Resolve an input script using the same cwd as the LAMMPS launcher."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    expanded_value = os.path.expandvars(value)
+    host_path = Path(expanded_value)
+    if host_path.is_absolute():
+        return host_path
+    expanded = PurePosixPath(expanded_value)
+    if not expanded.is_absolute():
+        if base_dir is None:
+            return None
+        expanded = base_dir / expanded
+    return Path(expanded.as_posix())
+
+
+def _optional_absolute_path(value: object) -> PurePosixPath | None:
+    """Return one normalized absolute POSIX path when available."""
+    if not isinstance(value, str) or not value:
+        return None
+    path = PurePosixPath(value)
+    if not path.is_absolute() or ".." in path.parts:
+        return None
+    return path
+
+
+def _direct_output_pattern(value: str, output_dir: PurePosixPath) -> str | None:
+    """Return a direct-child pattern only when it stays inside ``output_dir``."""
+    path = PurePosixPath(value)
+    if not path.is_absolute():
+        path = output_dir / path
+    if ".." in path.parts or path.parent != output_dir:
+        return None
+    name = path.name.replace("%", "*")
+    return name if name and "/" not in name else None
+
+
+def _classify_entry(name: str, declared_outputs: dict[str, str]) -> str | None:
+    """Classify only package-specific, high-confidence LAMMPS products."""
+    lowered = name.casefold()
+    if lowered == "log.lammps" or lowered.startswith("log.lammps."):
+        return "log"
+    if (
+        lowered.startswith("restart")
+        or lowered.startswith("checkpoint")
+        or ".restart" in lowered
+    ):
+        return "checkpoint"
+    if (
+        lowered.startswith("dump.")
+        or lowered.endswith(".lammpstrj")
+        or lowered.endswith(".dump")
+    ):
+        return "dump"
+    for pattern, category in declared_outputs.items():
+        if fnmatch.fnmatchcase(name, pattern):
+            return category
+    if lowered.startswith(("output.", "output_", "result.", "result_", "final.")):
+        return "output"
+    return None
+
+
+def _output_format(name: str) -> tuple[str, str | None]:
+    """Return a conservative format and media type for a LAMMPS output."""
+    lowered = name.casefold()
+    if lowered.endswith((".h5", ".hdf5")):
+        return "hdf5", "application/x-hdf5"
+    if lowered.endswith(".bp"):
+        return "adios2-bp", "application/x-adios2"
+    if lowered.endswith((".data", ".dat")) or lowered.startswith("data."):
+        return "lammps-data", "text/plain"
+    return "lammps-output", None
+
+
+__all__ = ["LammpsArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/paraview/artifacts.py
+++ b/builtin/builtin/paraview/artifacts.py
@@ -1,0 +1,284 @@
+"""Generated-artifact semantics for the generic builtin ParaView package."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Any, cast
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+from jarvis_cd.progress import LineBuffer, ProgressState, event_from_progress_line
+from jarvis_cd.progress.schema import JsonValue, ProgressEvent
+
+
+@dataclass
+class _TrackedArtifact:
+    """Stable identity and latest metadata for one reported output path."""
+
+    artifact_id: str
+    location: ArtifactLocation
+    logical_name: str
+    kind: str
+    structure: ArtifactStructure
+    media_type: str | None
+    format_name: str
+    state: ArtifactState
+    metadata: dict[str, JsonValue]
+
+
+@dataclass
+class ParaViewArtifactAdapter:
+    """Translate structured ``pvbatch`` output paths into typed artifacts."""
+
+    package_id: str
+    cwd: PurePosixPath | None = None
+    _lines: LineBuffer = field(default_factory=LineBuffer)
+    _last_sequence: int = 0
+    _tracked: dict[str, _TrackedArtifact] = field(default_factory=dict)
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Return artifact revisions from completed ParaView progress units."""
+        return self._observe(text, finalize=False)
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Flush a final line and finalize every still-available output."""
+        observations = self._observe("", finalize=True)
+        for tracked in self._tracked.values():
+            if tracked.state is ArtifactState.FINALIZED:
+                continue
+            tracked.state = ArtifactState.FINALIZED
+            tracked.metadata = {**tracked.metadata, "finalized_at_execution_end": True}
+            observations.append(self._observation(tracked))
+        return observations
+
+    def reset_artifacts(self) -> None:
+        """Reset parsing and generated-output identity after stream replacement."""
+        self._lines.reset()
+        self._last_sequence = 0
+        self._tracked.clear()
+
+    def _observe(self, text: str, *, finalize: bool) -> list[ArtifactObservation]:
+        observations: list[ArtifactObservation] = []
+        for line in self._lines.feed(text, finalize=finalize):
+            event = event_from_progress_line(line)
+            if event is None:
+                continue
+            observation = self._observe_event(event)
+            if observation is not None:
+                observations.append(observation)
+        return observations
+
+    def _observe_event(self, event: ProgressEvent) -> ArtifactObservation | None:
+        """Validate one package event and translate its optional output path."""
+        if event.package_name != "builtin.paraview":
+            raise ValueError("ParaView artifact package identity does not match")
+        if event.package_id != self.package_id:
+            raise ValueError("ParaView artifact package ID does not match")
+        if event.sequence <= self._last_sequence:
+            raise ValueError("ParaView artifact progress sequences must increase")
+        self._last_sequence = event.sequence
+
+        output_value = event.metadata.get("output_path")
+        if output_value is None:
+            return None
+        if not isinstance(output_value, str) or not output_value.strip():
+            raise ValueError("ParaView output_path must be a non-empty string")
+        path = _resolve_output_path(output_value, self.cwd)
+        key = path.as_posix()
+        tracked = self._tracked.get(key)
+        final = event.state is ProgressState.COMPLETED
+        metadata = _artifact_metadata(event, final=final)
+        if tracked is None:
+            kind, structure, media_type, format_name = _classify_output(path)
+            tracked = _TrackedArtifact(
+                artifact_id=new_artifact_id(),
+                location=ArtifactLocation.cluster_path(path),
+                logical_name=path.name,
+                kind=kind,
+                structure=structure,
+                media_type=media_type,
+                format_name=format_name,
+                state=(ArtifactState.FINALIZED if final else ArtifactState.AVAILABLE),
+                metadata=metadata,
+            )
+            self._tracked[key] = tracked
+        else:
+            if tracked.state is ArtifactState.FINALIZED:
+                raise ValueError("ParaView reported output after artifact finalization")
+            tracked.state = (
+                ArtifactState.FINALIZED if final else ArtifactState.AVAILABLE
+            )
+            tracked.metadata = metadata
+        return self._observation(tracked)
+
+    @staticmethod
+    def _observation(tracked: _TrackedArtifact) -> ArtifactObservation:
+        """Project tracked package state into the generic artifact SPI."""
+        return ArtifactObservation(
+            artifact_id=tracked.artifact_id,
+            logical_name=tracked.logical_name,
+            kind=tracked.kind,
+            role=ArtifactRole.OUTPUT,
+            structure=tracked.structure,
+            ownership=ArtifactOwnership.SHARED,
+            state=tracked.state,
+            location=tracked.location,
+            media_type=tracked.media_type,
+            format=tracked.format_name,
+            message=(
+                "ParaView output finalized"
+                if tracked.state is ArtifactState.FINALIZED
+                else "ParaView completed an output write"
+            ),
+            metadata=tracked.metadata,
+        )
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> ParaViewArtifactAdapter | None:
+    """Create output semantics for ``pvbatch``; ``pvserver`` has no outputs."""
+    if package.get("pkg_type") != "builtin.paraview":
+        return None
+    if package.get("mode", "server") != "batch":
+        return None
+    package_id = package.get("pkg_id")
+    if not isinstance(package_id, str) or not package_id:
+        package_id = "paraview"
+    return ParaViewArtifactAdapter(
+        package_id=package_id,
+        cwd=_configured_cwd(package.get("cwd") or package.get("runtime_cwd")),
+    )
+
+
+def _configured_cwd(value: object) -> PurePosixPath | None:
+    """Return a normalized absolute POSIX working directory when configured."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    path = PurePosixPath(value)
+    if not path.is_absolute() or path.as_posix() != value or ".." in path.parts:
+        raise ValueError("ParaView artifacts require a normalized absolute cwd")
+    return path
+
+
+def _resolve_output_path(value: str, cwd: PurePosixPath | None) -> PurePosixPath:
+    """Resolve one explicit renderer path without granting traversal authority."""
+    if "\\" in value:
+        raise ValueError("ParaView output_path must use POSIX separators")
+    path = PurePosixPath(value)
+    if ".." in path.parts or path.as_posix() != value:
+        raise ValueError("ParaView output_path must be normalized")
+    if not path.is_absolute():
+        if cwd is None:
+            raise ValueError(
+                "relative ParaView output_path requires a configured absolute cwd"
+            )
+        path = cwd / path
+    return path
+
+
+def _artifact_metadata(event: ProgressEvent, *, final: bool) -> dict[str, JsonValue]:
+    """Keep provenance needed to relate an artifact to package progress."""
+    metadata: dict[str, JsonValue] = {
+        "application": "paraview",
+        "progress_sequence": event.sequence,
+        "progress_label": event.label,
+        "generation_stage": "final" if final else "intermediate",
+    }
+    for name in ("timestep", "completion_signal"):
+        value = event.metadata.get(name)
+        if value is not None:
+            metadata[name] = cast(JsonValue, value)
+    if event.current is not None:
+        metadata["completed_units"] = event.current
+    if event.total is not None:
+        metadata["total_units"] = event.total
+    if event.unit is not None:
+        metadata["unit"] = event.unit
+    return metadata
+
+
+def _classify_output(
+    path: PurePosixPath,
+) -> tuple[str, ArtifactStructure, str | None, str]:
+    """Map common ParaView render and dataset suffixes to stable semantics."""
+    suffix = path.suffix.casefold()
+    images = {
+        ".png": ("image/png", "png"),
+        ".jpg": ("image/jpeg", "jpeg"),
+        ".jpeg": ("image/jpeg", "jpeg"),
+        ".tif": ("image/tiff", "tiff"),
+        ".tiff": ("image/tiff", "tiff"),
+        ".bmp": ("image/bmp", "bmp"),
+        ".webp": ("image/webp", "webp"),
+        ".exr": ("image/x-exr", "openexr"),
+    }
+    videos = {
+        ".mp4": ("video/mp4", "mp4"),
+        ".webm": ("video/webm", "webm"),
+        ".avi": ("video/x-msvideo", "avi"),
+        ".mov": ("video/quicktime", "quicktime"),
+        ".mkv": ("video/x-matroska", "matroska"),
+    }
+    if suffix in images:
+        media_type, format_name = images[suffix]
+        return "image", ArtifactStructure.FILE, media_type, format_name
+    if suffix in videos:
+        media_type, format_name = videos[suffix]
+        return "video", ArtifactStructure.FILE, media_type, format_name
+    if suffix == ".bp":
+        return (
+            "scientific_dataset",
+            ArtifactStructure.COLLECTION,
+            "application/x-adios2",
+            "adios2-bp",
+        )
+    if suffix in {".pvd", ".pvtu", ".pvti", ".pvtp", ".pvtr", ".pvts"}:
+        return (
+            "scientific_dataset",
+            ArtifactStructure.COLLECTION,
+            "application/xml",
+            "paraview-data-collection",
+        )
+    if suffix in {".vtk", ".vtu", ".vti", ".vtp", ".vtr", ".vts"}:
+        return (
+            "scientific_dataset",
+            ArtifactStructure.FILE,
+            "application/vnd.vtk",
+            "vtk",
+        )
+    if suffix in {".h5", ".hdf5"}:
+        return (
+            "scientific_dataset",
+            ArtifactStructure.FILE,
+            "application/x-hdf5",
+            "hdf5",
+        )
+    if suffix in {".xdmf", ".xmf"}:
+        return (
+            "scientific_dataset",
+            ArtifactStructure.COLLECTION,
+            "application/xml",
+            "xdmf",
+        )
+    if suffix == ".nc":
+        return (
+            "scientific_dataset",
+            ArtifactStructure.FILE,
+            "application/x-netcdf",
+            "netcdf",
+        )
+    if suffix == ".csv":
+        return "tabular_dataset", ArtifactStructure.FILE, "text/csv", "csv"
+    return "file", ArtifactStructure.FILE, None, "paraview-output"
+
+
+__all__ = ["ParaViewArtifactAdapter", "adapter_from_package"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Jarvis-CD is a unified platform for deploying scientific applications, storage s
 - [Package Development Guide](package_dev_guide.md) — Create new packages, Dockerfile templates, container and spack support
 - [Pipeline Tests](pipeline_tests.md) — Automated testing with grid search and parameter sweeps
 - [Execution Handles](executions.md) — Durable direct and scheduler run identities, status records, and JSON queries
+- [Generated Artifacts](artifacts.md) — Durable output manifests, package providers, lifecycle, and location semantics
 - [Hostfile Configuration](hostfile.md) — Multi-node setup, pattern expansion, IP resolution
 - [Scheduler Integration](scheduler.md) — Submit pipelines as SLURM jobs, automatic hostfile from `$SLURM_JOB_NODELIST`
 - [Resource Graph](resource_graph.md) — Storage and network topology discovery

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -1,0 +1,74 @@
+# Generated artifacts
+
+Every durable execution has a queryable artifact manifest beside its progress
+records. The execution handle remains a stable identity; callers query its
+current outputs while the workload is running and receive the sealed view after
+terminalization.
+
+```python
+handle = pipeline.run(wait=False)
+snapshot = handle.artifacts()
+for artifact in snapshot.artifacts:
+    print(artifact.artifact_id, artifact.logical_name, artifact.state)
+```
+
+The equivalent machine-readable CLI query is:
+
+```bash
+jarvis execution artifacts <execution-id> --pipeline-id <pipeline> +json
+```
+
+## Artifact contract
+
+Each `jarvis.artifact.v1` event has an opaque `art_*` identity, execution and
+package identity, logical name, kind, role, structure, ownership, lifecycle
+state, and optional location, media type, format, size, checksum, message, and
+bounded metadata. A manifest is append-only: later revisions update the same
+artifact identity without rewriting earlier evidence.
+
+Lifecycle and purpose are separate. For example, a checkpoint can be a fully
+`finalized` intermediate artifact. Producing artifacts are sealed as
+`incomplete` or `failed` if execution terminates before the package reports real
+completion. Already `available` output is not promoted to `finalized` merely
+because the process exited.
+
+A `scripted` scheduler record created with `submit=False` is the deliberate
+exception to terminal sealing: JARVIS supports activating that exact script
+later, so its manifest remains appendable until the activated workload reaches
+a real completed, failed, or canceled state.
+
+Locations are transport-neutral references:
+
+- `execution_path` is relative to the owned execution root and is deleted with
+  that execution;
+- `cluster_path` is an absolute server-side reference and is never treated as
+  desktop-local filesystem authority;
+- `external_uri` names an explicitly supported remote provider.
+
+Large ADIOS2/BP and HDF5 time series should normally be one `collection`
+artifact rather than one agent-visible entry per internal file. JARVIS artifact
+IDs deliberately omit site aliases. A relay may qualify an artifact with its
+operator-defined target, for example
+`clio://ares/jarvis/executions/<execution-id>/artifacts/<artifact-id>`, while
+keeping the cluster argument explicit.
+
+## Package providers
+
+Application semantics live beside the package launcher in `artifacts.py`. The
+module exports `adapter_from_package(package)` and may return a provider with
+`observe_artifacts(text)`, `finalize_artifacts()`, and `reset_artifacts()`.
+Providers return typed `ArtifactObservation` values; JARVIS supplies the
+authoritative package/execution identity, sidecar path, sequencing, validation,
+and persistence.
+
+The combined `Pkg.runtime_line_callback()` handles both progress and artifacts.
+Containerized applications may emit validated `JARVIS_ARTIFACT {json}` records
+through stdout instead of opening a host-only sidecar. Package providers must
+constrain discovered paths to configured application outputs and must not crawl
+unbounded directory trees.
+
+JARVIS core automatically records immutable pipeline snapshots, scheduler
+scripts, and owned stdout/stderr streams where those streams exist. Diagnostic
+artifacts are discoverable metadata, not an authorization to download their
+contents; relay or agent-facing content access must apply a separate bounded
+access policy.

--- a/docs/executions.md
+++ b/docs/executions.md
@@ -16,6 +16,7 @@ record = handle.refresh()
 live = pipeline.run(wait=False)
 while not live.refresh().terminal:
     print(live.progress().to_dict())
+    print(live.artifacts().to_dict())
 
 scheduled = pipeline.submit(wait=False)
 print(scheduled.scheduler_provider)   # "slurm"
@@ -43,6 +44,7 @@ Python clients can query an exact ID or list a named pipeline's history:
 record = pipeline.get_execution(handle.execution_id)
 records = pipeline.list_executions()
 progress = handle.progress()
+artifacts = handle.artifacts()
 ```
 
 CLI queries accept `--pipeline-id`, so a handle remains queryable after the
@@ -55,17 +57,21 @@ jarvis ppl submit visualization.yaml --execution-id render-2018-asteroid +json
 jarvis execution get render-2018-asteroid --pipeline-id visualization +json
 jarvis execution list --pipeline-id visualization +json
 jarvis execution progress render-2018-asteroid --pipeline-id visualization +json
+jarvis execution artifacts render-2018-asteroid --pipeline-id visualization +json
 ```
 
 `execution get +json` and `execution list +json` emit clean machine-readable
 JSON. `execution progress +json` returns the latest identity-checked event and
-event count for each package alias without exposing storage paths. `ppl run
-+json` and `ppl submit +json` emit the handle JSON as their final
-line because package and scheduler logs remain visible before it.
+event count for each package alias. `execution artifacts +json` returns the
+current identity-checked artifact manifest. Neither query exposes its internal
+sidecar paths. `ppl run +json` and `ppl submit +json` emit the handle JSON as
+their final line because package and scheduler logs remain visible before it.
 
 During a run, JARVIS binds package shared/private paths to the owned execution
 root. It also exports authoritative `JARVIS_EXECUTION_ID`, `JARVIS_PACKAGE_ID`,
 `JARVIS_PACKAGE_NAME`, `JARVIS_PROGRESS_PATH`, and
-`JARVIS_PROGRESS_TRANSPORT` values before each package starts. Application
-packages may report through the selected sidecar/stdout transport, but cannot
-choose the authoritative execution or sidecar identity.
+`JARVIS_PROGRESS_TRANSPORT`, `JARVIS_ARTIFACT_PATH`, and
+`JARVIS_ARTIFACT_TRANSPORT` values before each package starts. Application
+packages may report through the selected sidecar/stdout transports, but cannot
+choose the authoritative execution or sidecar identity. See
+[Generated artifacts](artifacts.md) for the package contract.

--- a/docs/release.md
+++ b/docs/release.md
@@ -23,16 +23,19 @@ The workflow accepts only a request bound to the repository, intended tag, exact
 current `main` commit, observed setting, and verification time. It rejects future
 records, records older than one hour, unknown fields, and reuse for a different
 tag or commit. Repository variables are an audit transport, not an administrator
-boundary. Publication is separately gated by the protected
-`immutable-release` environment, whose independent reviewer must repeat the
-immutable-release setting check and verify the exact tag and commit before
-approving the deployment.
+boundary. Publication is separately gated by the protected `immutable-release`
+environment. An explicitly listed release administrator must still review the
+waiting deployment and approve the exact tag and commit. Self-review is allowed
+so a designated maintainer can release when a second maintainer is unavailable;
+GitHub still records the approval event and administrators cannot bypass the
+environment gate.
 
 The tag workflow reads the live environment and tag rulesets before building.
-It requires `can_admins_bypass=false`, self-review prevention, explicit admin
-reviewers, a `v*` tag-only deployment policy, admin-only version-tag creation,
-and no-bypass tag update/deletion protection. Do not tag if those controls have
-been removed or changed. Inspect them directly before proceeding:
+It requires `can_admins_bypass=false`, an explicit release-administrator
+reviewer list that includes the initiating maintainer, a `v*` tag-only
+deployment policy, admin-only version-tag creation, and no-bypass tag
+update/deletion protection. Do not tag if those controls have been removed or
+changed. Inspect them directly before proceeding:
 
 ```bash
 gh api repos/grc-iit/jarvis-cd/environments/immutable-release

--- a/jarvis_cd/artifacts/__init__.py
+++ b/jarvis_cd/artifacts/__init__.py
@@ -1,0 +1,63 @@
+"""Generic artifact semantics for JARVIS executions and package providers."""
+
+from .discovery import (
+    load_artifacts_module,
+    package_artifact_context,
+    provider_from_package,
+)
+from .provider import (
+    ArtifactObservation,
+    ArtifactProviderFactory,
+    PackageArtifactProvider,
+)
+from .reporter import (
+    ARTIFACT_LINE_PREFIX,
+    ARTIFACT_PATH_ENV,
+    ARTIFACT_TRANSPORT_ENV,
+    EXECUTION_ID_ENV,
+    PACKAGE_ID_ENV,
+    PACKAGE_NAME_ENV,
+    ArtifactReporter,
+    event_from_artifact_line,
+)
+from .schema import (
+    ARTIFACT_SCHEMA_VERSION,
+    ArtifactEvent,
+    ArtifactLocation,
+    ArtifactLocationKind,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+    validate_artifact_history,
+)
+from .store import ArtifactStore
+
+__all__ = [
+    "ARTIFACT_LINE_PREFIX",
+    "ARTIFACT_PATH_ENV",
+    "ARTIFACT_SCHEMA_VERSION",
+    "ARTIFACT_TRANSPORT_ENV",
+    "EXECUTION_ID_ENV",
+    "PACKAGE_ID_ENV",
+    "PACKAGE_NAME_ENV",
+    "ArtifactEvent",
+    "ArtifactLocation",
+    "ArtifactLocationKind",
+    "ArtifactObservation",
+    "ArtifactOwnership",
+    "ArtifactProviderFactory",
+    "ArtifactReporter",
+    "ArtifactRole",
+    "ArtifactState",
+    "ArtifactStore",
+    "ArtifactStructure",
+    "PackageArtifactProvider",
+    "event_from_artifact_line",
+    "load_artifacts_module",
+    "new_artifact_id",
+    "package_artifact_context",
+    "provider_from_package",
+    "validate_artifact_history",
+]

--- a/jarvis_cd/artifacts/discovery.py
+++ b/jarvis_cd/artifacts/discovery.py
@@ -1,0 +1,132 @@
+"""Package-local artifact discovery for installed and filesystem repositories."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import os
+import sys
+import threading
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING, Any, cast
+
+from .provider import ArtifactProviderFactory, PackageArtifactProvider
+
+_MODULE_LOAD_LOCK = threading.RLock()
+
+if TYPE_CHECKING:
+    from jarvis_cd.core.pkg import Pkg
+
+
+def provider_from_package(package: "Pkg") -> PackageArtifactProvider | None:
+    """Load an optional sibling ``artifacts.py`` for a package instance."""
+    artifacts_path = _package_directory(package) / "artifacts.py"
+    if not artifacts_path.is_file():
+        return None
+    artifacts_module = load_artifacts_module(artifacts_path)
+    module_name = artifacts_module.__name__
+    factory = getattr(artifacts_module, "adapter_from_package", None)
+    if factory is None:
+        raise TypeError(
+            f"package artifact module must export adapter_from_package: {module_name}"
+        )
+    if not callable(factory):
+        raise TypeError(
+            f"package artifact adapter_from_package is not callable: {module_name}"
+        )
+    provider = cast(ArtifactProviderFactory, factory)(package_artifact_context(package))
+    if provider is not None and not isinstance(provider, PackageArtifactProvider):
+        raise TypeError(f"package artifact provider is incomplete: {module_name}")
+    return provider
+
+
+def load_artifacts_module(path: str | Path) -> ModuleType:
+    """Load one package-local artifact module in an isolated namespace."""
+    artifacts_path = Path(path).resolve()
+    if not artifacts_path.is_file():
+        raise FileNotFoundError(
+            f"package artifact module does not exist: {artifacts_path}"
+        )
+    with _MODULE_LOAD_LOCK:
+        return _load_artifacts_module_locked(artifacts_path)
+
+
+def _load_artifacts_module_locked(artifacts_path: Path) -> ModuleType:
+    """Load one resolved provider path while holding the module-cache lock."""
+    digest = hashlib.sha256(str(artifacts_path).encode("utf-8")).hexdigest()[:24]
+    package_name = f"_jarvis_cd_package_artifacts_{digest}"
+    module_name = f"{package_name}.artifacts"
+    cached = sys.modules.get(module_name)
+    if cached is not None:
+        cached_path = Path(str(getattr(cached, "__file__", ""))).resolve()
+        if cached_path != artifacts_path:
+            raise ImportError(
+                f"package artifact module cache collision: {artifacts_path}"
+            )
+        return cached
+
+    package_module = ModuleType(package_name)
+    package_module.__file__ = str(artifacts_path.parent / "__init__.py")
+    package_module.__package__ = package_name
+    package_module.__path__ = [str(artifacts_path.parent)]
+    spec = importlib.util.spec_from_file_location(module_name, artifacts_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load package artifact module: {artifacts_path}")
+    artifacts_module = importlib.util.module_from_spec(spec)
+    sys.modules[package_name] = package_module
+    sys.modules[module_name] = artifacts_module
+    try:
+        spec.loader.exec_module(artifacts_module)
+    except BaseException:
+        sys.modules.pop(module_name, None)
+        sys.modules.pop(package_name, None)
+        raise
+    return artifacts_module
+
+
+def _package_directory(package: "Pkg") -> Path:
+    """Resolve the source directory for a loaded JARVIS package instance."""
+    configured = getattr(package, "pkg_dir", None)
+    if configured:
+        return Path(str(configured)).resolve()
+    module_name = package.__class__.__module__
+    module = sys.modules.get(module_name)
+    module_path = getattr(module, "__file__", None)
+    if not module_path:
+        raise ValueError(
+            f"cannot locate package source directory for {package.pkg_type}"
+        )
+    return Path(str(module_path)).resolve().parent
+
+
+def package_artifact_context(package: "Pkg") -> dict[str, Any]:
+    """Build the generic, non-secret context supplied to a provider factory."""
+    context: dict[str, Any] = dict(package.config)
+    identities: dict[str, object] = {
+        "pkg_type": package.pkg_type,
+        "pkg_id": package.pkg_id,
+        "global_id": package.global_id,
+    }
+    for field_name, value in identities.items():
+        if not isinstance(value, str) or not value:
+            raise ValueError(
+                f"package artifacts require a non-empty {field_name} identity"
+            )
+        context[field_name] = value
+    for field_name in ("shared_dir", "private_dir"):
+        value = getattr(package, field_name, None)
+        if isinstance(value, (str, os.PathLike)):
+            context[field_name] = os.fspath(value)
+    context["runtime_cwd"] = Path.cwd().resolve().as_posix()
+    pipeline = package.pipeline
+    for field_name in ("base_deploy_mode", "install_manager"):
+        value = getattr(pipeline, field_name, None)
+        if value is not None:
+            context[field_name] = value
+    package_mode = context.get("deploy_mode") or context.get("install_method")
+    base_mode = context.get("base_deploy_mode") or context.get("install_manager")
+    effective_mode = package_mode or base_mode
+    if effective_mode:
+        context["effective_deploy_mode"] = effective_mode
+    return context

--- a/jarvis_cd/artifacts/provider.py
+++ b/jarvis_cd/artifacts/provider.py
@@ -1,0 +1,85 @@
+"""Generic package artifact provider protocol."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+from .schema import (
+    JsonValue,
+    ArtifactEvent,
+    ArtifactLocation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactObservation:
+    """Package interpretation of an artifact without authoritative run identity.
+
+    Providers may retain an opaque ``artifact_id`` returned by a reporter when
+    they need to describe later lifecycle revisions. JARVIS supplies package
+    and execution identity when the observation is persisted.
+    """
+
+    logical_name: str
+    kind: str
+    role: ArtifactRole
+    structure: ArtifactStructure
+    ownership: ArtifactOwnership
+    state: ArtifactState = ArtifactState.AVAILABLE
+    artifact_id: str | None = None
+    location: ArtifactLocation | None = None
+    media_type: str | None = None
+    format: str | None = None
+    size_bytes: int | None = None
+    checksum: str | None = None
+    message: str | None = None
+    metadata: Mapping[str, JsonValue] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validate the observation with the persisted schema rules."""
+        ArtifactEvent(
+            package_name="provider",
+            package_id="provider",
+            execution_id="provider",
+            artifact_id=self.artifact_id or new_artifact_id(),
+            logical_name=self.logical_name,
+            kind=self.kind,
+            role=self.role,
+            structure=self.structure,
+            ownership=self.ownership,
+            state=self.state,
+            location=self.location,
+            media_type=self.media_type,
+            format=self.format,
+            size_bytes=self.size_bytes,
+            checksum=self.checksum,
+            message=self.message,
+            metadata=self.metadata,
+        ).to_json()
+
+
+@runtime_checkable
+class PackageArtifactProvider(Protocol):
+    """Minimal artifact contract implemented beside a JARVIS package."""
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Interpret application output and return typed artifact observations."""
+        ...
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Flush final observations after application output ends."""
+        ...
+
+    def reset_artifacts(self) -> None:
+        """Reset provider state when the underlying output stream is replaced."""
+        ...
+
+
+ArtifactProviderFactory = Callable[[dict[str, Any]], PackageArtifactProvider | None]

--- a/jarvis_cd/artifacts/reporter.py
+++ b/jarvis_cd/artifacts/reporter.py
@@ -1,0 +1,223 @@
+"""Dependency-free reporter for generated JARVIS artifacts."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import TextIO
+
+from .schema import (
+    JsonValue,
+    ArtifactEvent,
+    ArtifactLocation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+    validate_artifact_history,
+)
+from .store import ArtifactStore
+
+ARTIFACT_LINE_PREFIX = "JARVIS_ARTIFACT "
+ARTIFACT_PATH_ENV = "JARVIS_ARTIFACT_PATH"
+ARTIFACT_TRANSPORT_ENV = "JARVIS_ARTIFACT_TRANSPORT"
+EXECUTION_ID_ENV = "JARVIS_EXECUTION_ID"
+PACKAGE_NAME_ENV = "JARVIS_PACKAGE_NAME"
+PACKAGE_ID_ENV = "JARVIS_PACKAGE_ID"
+
+
+class ArtifactReporter:
+    """Emit structured artifact lifecycle events to stdout or owned JSONL."""
+
+    def __init__(
+        self,
+        *,
+        package_name: str | None = None,
+        package_id: str | None = None,
+        execution_id: str | None = None,
+        path: str | os.PathLike[str] | None = None,
+        stream: TextIO | None = None,
+    ) -> None:
+        self.package_name = package_name or os.environ.get(PACKAGE_NAME_ENV, "")
+        self.package_id = package_id or os.environ.get(PACKAGE_ID_ENV, "")
+        self.execution_id = execution_id or os.environ.get(EXECUTION_ID_ENV, "")
+        configured_path = (
+            path if path is not None else os.environ.get(ARTIFACT_PATH_ENV)
+        )
+        configured_transport = (
+            None if path is not None else os.environ.get(ARTIFACT_TRANSPORT_ENV)
+        )
+        if configured_transport not in {None, "sidecar", "stdout"}:
+            raise ValueError("JARVIS_ARTIFACT_TRANSPORT must be 'sidecar' or 'stdout'")
+        if configured_transport == "sidecar" and not configured_path:
+            raise ValueError("sidecar artifact transport requires JARVIS_ARTIFACT_PATH")
+        self.transport = configured_transport or (
+            "sidecar" if configured_path else "stdout"
+        )
+        self.path = (
+            Path(configured_path)
+            if configured_path and self.transport == "sidecar"
+            else None
+        )
+        self.stream = stream or sys.stdout
+        events = ArtifactStore(self.path).read_all() if self.path is not None else []
+        if events and (
+            events[0].execution_id,
+            events[0].package_name,
+            events[0].package_id,
+        ) != (self.execution_id, self.package_name, self.package_id):
+            raise ValueError(
+                "existing artifact store identity does not match this reporter"
+            )
+        self._events = list(events)
+        self._current: dict[str, ArtifactEvent] = {}
+        for event in events:
+            self._current[event.artifact_id] = event
+        self.sequence = events[-1].sequence if events else 0
+
+    def emit(
+        self,
+        *,
+        logical_name: str,
+        kind: str,
+        role: ArtifactRole,
+        structure: ArtifactStructure,
+        ownership: ArtifactOwnership,
+        state: ArtifactState = ArtifactState.AVAILABLE,
+        artifact_id: str | None = None,
+        location: ArtifactLocation | str | None = None,
+        media_type: str | None = None,
+        format: str | None = None,
+        size_bytes: int | None = None,
+        checksum: str | None = None,
+        message: str | None = None,
+        metadata: dict[str, JsonValue] | None = None,
+    ) -> ArtifactEvent:
+        """Validate and emit one artifact event, returning the exact event."""
+
+        def build_event(history: tuple[ArtifactEvent, ...]) -> ArtifactEvent:
+            if history and (
+                history[0].execution_id,
+                history[0].package_name,
+                history[0].package_id,
+            ) != (self.execution_id, self.package_name, self.package_id):
+                raise ValueError(
+                    "existing artifact store identity does not match this reporter"
+                )
+            current = {event.artifact_id: event for event in history}
+            resolved_artifact_id = artifact_id
+            if resolved_artifact_id is None:
+                resolved_artifact_id = new_artifact_id()
+                while resolved_artifact_id in current:
+                    resolved_artifact_id = new_artifact_id()
+            previous = current.get(resolved_artifact_id)
+            typed_location = (
+                ArtifactLocation.execution_relative(location)
+                if isinstance(location, str)
+                else location
+            )
+            resolved_media_type = media_type
+            resolved_format = format
+            resolved_size = size_bytes
+            resolved_checksum = checksum
+            if previous is not None:
+                typed_location = typed_location or previous.location
+                resolved_media_type = resolved_media_type or previous.media_type
+                resolved_format = resolved_format or previous.format
+                resolved_size = (
+                    previous.size_bytes if resolved_size is None else resolved_size
+                )
+                resolved_checksum = resolved_checksum or previous.checksum
+            return ArtifactEvent(
+                package_name=self.package_name,
+                package_id=self.package_id,
+                execution_id=self.execution_id,
+                artifact_id=resolved_artifact_id,
+                logical_name=logical_name,
+                kind=kind,
+                role=role,
+                structure=structure,
+                ownership=ownership,
+                state=state,
+                location=typed_location,
+                media_type=resolved_media_type,
+                format=resolved_format,
+                size_bytes=resolved_size,
+                checksum=resolved_checksum,
+                message=message,
+                revision=(previous.revision + 1 if previous is not None else 1),
+                sequence=(history[-1].sequence + 1 if history else 1),
+                metadata=metadata or {},
+            )
+
+        if self.path is not None:
+            event = ArtifactStore(self.path).append_next(build_event)
+        else:
+            event = build_event(tuple(self._events))
+            validate_artifact_history([*self._events, event])
+            self.stream.write(f"{ARTIFACT_LINE_PREFIX}{event.to_json()}\n")
+            self.stream.flush()
+        self.sequence = event.sequence
+        self._events.append(event)
+        self._current[event.artifact_id] = event
+        return event
+
+    def finalize_execution(
+        self,
+        state_for_open: ArtifactState = ArtifactState.INCOMPLETE,
+    ) -> list[ArtifactEvent]:
+        """Seal producing artifacts without changing merely available output."""
+        if state_for_open not in {
+            ArtifactState.FINALIZED,
+            ArtifactState.INCOMPLETE,
+            ArtifactState.FAILED,
+        }:
+            raise ValueError("open artifacts require a terminal sealing state")
+        if self.path is not None:
+            sealed = ArtifactStore(self.path).finalize_open(state_for_open)
+            if sealed:
+                self._events.extend(sealed)
+                self.sequence = sealed[-1].sequence
+                for event in sealed:
+                    self._current[event.artifact_id] = event
+            return sealed
+        producing = [
+            event
+            for event in tuple(self._current.values())
+            if event.state is ArtifactState.PRODUCING
+        ]
+        sealed: list[ArtifactEvent] = []
+        for event in producing:
+            sealed.append(
+                self.emit(
+                    artifact_id=event.artifact_id,
+                    logical_name=event.logical_name,
+                    kind=event.kind,
+                    role=event.role,
+                    structure=event.structure,
+                    ownership=event.ownership,
+                    state=state_for_open,
+                    location=event.location,
+                    media_type=event.media_type,
+                    format=event.format,
+                    size_bytes=event.size_bytes,
+                    checksum=event.checksum,
+                    message=event.message,
+                    metadata=dict(event.metadata),
+                )
+            )
+        return sealed
+
+
+def event_from_artifact_line(line: str) -> ArtifactEvent | None:
+    """Parse one structured stdout or raw JSONL artifact line."""
+    stripped = line.strip()
+    if not stripped:
+        return None
+    if stripped.startswith(ARTIFACT_LINE_PREFIX):
+        stripped = stripped[len(ARTIFACT_LINE_PREFIX) :]
+    elif not stripped.startswith("{"):
+        return None
+    return ArtifactEvent.from_json(stripped)

--- a/jarvis_cd/artifacts/schema.py
+++ b/jarvis_cd/artifacts/schema.py
@@ -1,0 +1,588 @@
+"""Typed, application-independent artifact records for JARVIS executions."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import secrets
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import PurePosixPath
+from typing import Any, Final, Mapping, cast
+from urllib.parse import urlsplit
+
+ARTIFACT_SCHEMA_VERSION: Final = "jarvis.artifact.v1"
+MAX_ARTIFACT_EVENT_BYTES: Final = 64 * 1024
+MAX_IDENTITY_TEXT: Final = 256
+MAX_LOCATION_TEXT: Final = 4096
+MAX_MESSAGE_TEXT: Final = 4096
+_ARTIFACT_ID_PATTERN: Final = re.compile(r"^art_[A-Za-z0-9_-]{22,86}$")
+_CHECKSUM_PATTERN: Final = re.compile(r"^[a-z0-9][a-z0-9_-]*:[A-Fa-f0-9]{16,256}$")
+_MEDIA_TYPE_PATTERN: Final = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*$"
+)
+_URI_SCHEME_PATTERN: Final = re.compile(r"^[a-z][a-z0-9+.-]*$")
+_UNSAFE_URI_SCHEMES: Final = frozenset({"data", "file", "javascript"})
+_EVENT_FIELDS: Final = frozenset(
+    {
+        "schema_version",
+        "package_name",
+        "package_id",
+        "execution_id",
+        "artifact_id",
+        "logical_name",
+        "kind",
+        "role",
+        "structure",
+        "ownership",
+        "state",
+        "location",
+        "media_type",
+        "format",
+        "size_bytes",
+        "checksum",
+        "message",
+        "revision",
+        "sequence",
+        "observed_at_epoch",
+        "metadata",
+    }
+)
+
+
+class ArtifactState(StrEnum):
+    """Lifecycle state of one generated artifact."""
+
+    PRODUCING = "producing"
+    AVAILABLE = "available"
+    FINALIZED = "finalized"
+    INCOMPLETE = "incomplete"
+    FAILED = "failed"
+
+
+class ArtifactRole(StrEnum):
+    """Execution-level purpose of an artifact."""
+
+    INTERMEDIATE = "intermediate"
+    OUTPUT = "output"
+    LOG = "log"
+    CHECKPOINT = "checkpoint"
+    PROVENANCE = "provenance"
+    VALIDATION = "validation"
+
+
+class ArtifactStructure(StrEnum):
+    """Physical shape resolved by one artifact reference."""
+
+    FILE = "file"
+    DIRECTORY = "directory"
+    COLLECTION = "collection"
+    STREAM = "stream"
+
+
+class ArtifactLocationKind(StrEnum):
+    """Namespace used to resolve an artifact location."""
+
+    EXECUTION_PATH = "execution_path"
+    CLUSTER_PATH = "cluster_path"
+    EXTERNAL_URI = "external_uri"
+
+
+class ArtifactOwnership(StrEnum):
+    """Cleanup authority associated with generated artifact content."""
+
+    EXECUTION = "execution"
+    EXTERNAL = "external"
+    SHARED = "shared"
+
+
+JsonScalar = str | int | float | bool | None
+JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactLocation:
+    """Safe, transport-neutral location of an artifact.
+
+    Execution-relative paths are serialized with POSIX separators and cannot
+    escape the execution root. External locations must be non-file URIs, so a
+    manifest never turns an untrusted absolute path into local filesystem
+    authority.
+    """
+
+    kind: ArtifactLocationKind
+    value: str
+
+    def __post_init__(self) -> None:
+        """Validate the location namespace and representation."""
+        if not isinstance(self.kind, ArtifactLocationKind):
+            raise ValueError("artifact location kind must be an ArtifactLocationKind")
+        if not isinstance(self.value, str) or not self.value.strip():
+            raise ValueError("artifact location value must be non-empty")
+        if len(self.value) > MAX_LOCATION_TEXT:
+            raise ValueError("artifact location exceeds maximum length")
+        if any(ord(character) < 32 for character in self.value):
+            raise ValueError("artifact location cannot contain control characters")
+        if self.kind is ArtifactLocationKind.EXECUTION_PATH:
+            _validate_execution_relative_location(self.value)
+        elif self.kind is ArtifactLocationKind.CLUSTER_PATH:
+            _validate_cluster_path(self.value)
+        else:
+            _validate_external_uri(self.value)
+
+    @classmethod
+    def execution_relative(cls, path: str | PurePosixPath) -> "ArtifactLocation":
+        """Create a location resolved relative to an owned execution root."""
+        value = path.as_posix() if isinstance(path, PurePosixPath) else path
+        return cls(ArtifactLocationKind.EXECUTION_PATH, value)
+
+    @classmethod
+    def cluster_path(cls, path: str | PurePosixPath) -> "ArtifactLocation":
+        """Create an opaque absolute path reference on the executing cluster."""
+        value = path.as_posix() if isinstance(path, PurePosixPath) else path
+        return cls(ArtifactLocationKind.CLUSTER_PATH, value)
+
+    @classmethod
+    def external_uri(cls, uri: str) -> "ArtifactLocation":
+        """Create a location resolved by an external non-file URI provider."""
+        return cls(ArtifactLocationKind.EXTERNAL_URI, uri)
+
+    def as_dict(self) -> dict[str, str]:
+        """Serialize this location into the stable artifact schema."""
+        return {"kind": self.kind.value, "value": self.value}
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "ArtifactLocation":
+        """Parse and validate a serialized artifact location."""
+        unknown = set(value) - {"kind", "value"}
+        if unknown:
+            raise ValueError(f"unknown artifact location fields: {sorted(unknown)}")
+        kind = _required_str(value, "kind")
+        try:
+            typed_kind = ArtifactLocationKind(kind)
+        except ValueError as exc:
+            raise ValueError(f"invalid artifact location kind: {kind!r}") from exc
+        return cls(kind=typed_kind, value=_required_str(value, "value"))
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactEvent:
+    """One durable observation in a generated artifact lifecycle."""
+
+    package_name: str
+    package_id: str
+    execution_id: str
+    artifact_id: str
+    logical_name: str
+    kind: str
+    role: ArtifactRole
+    structure: ArtifactStructure
+    ownership: ArtifactOwnership
+    state: ArtifactState = ArtifactState.AVAILABLE
+    location: ArtifactLocation | None = None
+    media_type: str | None = None
+    format: str | None = None
+    size_bytes: int | None = None
+    checksum: str | None = None
+    message: str | None = None
+    revision: int = 1
+    sequence: int = 1
+    observed_at_epoch: float = field(default_factory=time.time)
+    metadata: Mapping[str, JsonValue] = field(default_factory=dict)
+    schema_version: str = ARTIFACT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        """Reject ambiguous, unsafe, or non-JSON artifact observations."""
+        if self.schema_version != ARTIFACT_SCHEMA_VERSION:
+            raise ValueError(f"unsupported artifact schema: {self.schema_version!r}")
+        for enum_name, value, enum_type in (
+            ("role", self.role, ArtifactRole),
+            ("structure", self.structure, ArtifactStructure),
+            ("ownership", self.ownership, ArtifactOwnership),
+            ("state", self.state, ArtifactState),
+        ):
+            if not isinstance(value, enum_type):
+                raise ValueError(
+                    f"artifact {enum_name} must be an {enum_type.__name__}"
+                )
+        for field_name, value in (
+            ("package_name", self.package_name),
+            ("package_id", self.package_id),
+            ("execution_id", self.execution_id),
+            ("logical_name", self.logical_name),
+            ("kind", self.kind),
+        ):
+            _validate_identity_text(field_name, value)
+        if not isinstance(self.artifact_id, str) or not _ARTIFACT_ID_PATTERN.fullmatch(
+            self.artifact_id
+        ):
+            raise ValueError("artifact_id must be an opaque JARVIS artifact identifier")
+        if self.location is not None and not isinstance(
+            self.location, ArtifactLocation
+        ):
+            raise ValueError("artifact location must be an ArtifactLocation")
+        if (
+            self.location is not None
+            and self.location.kind is ArtifactLocationKind.EXECUTION_PATH
+            and self.ownership is not ArtifactOwnership.EXECUTION
+        ):
+            raise ValueError("execution-path artifacts must be owned by the execution")
+        if (
+            self.location is not None
+            and self.location.kind is not ArtifactLocationKind.EXECUTION_PATH
+            and self.ownership is ArtifactOwnership.EXECUTION
+        ):
+            raise ValueError(
+                "execution-owned artifacts must use an execution-relative location"
+            )
+        if self.state in {ArtifactState.AVAILABLE, ArtifactState.FINALIZED} and (
+            self.location is None
+        ):
+            raise ValueError(f"artifact state {self.state.value!r} requires a location")
+        if self.media_type is not None and not _MEDIA_TYPE_PATTERN.fullmatch(
+            self.media_type
+        ):
+            raise ValueError("artifact media_type must be a valid type/subtype")
+        if self.format is not None:
+            _validate_identity_text("format", self.format)
+        if self.size_bytes is not None and (
+            isinstance(self.size_bytes, bool)
+            or not isinstance(self.size_bytes, int)
+            or self.size_bytes < 0
+        ):
+            raise ValueError("artifact size_bytes must be a non-negative integer")
+        if self.checksum is not None and not _CHECKSUM_PATTERN.fullmatch(self.checksum):
+            raise ValueError("artifact checksum must be algorithm:hex-digest")
+        if self.message is not None:
+            if not isinstance(self.message, str) or not self.message.strip():
+                raise ValueError("artifact message must be non-empty when supplied")
+            if len(self.message) > MAX_MESSAGE_TEXT:
+                raise ValueError("artifact message exceeds maximum length")
+        for field_name, value in (
+            ("revision", self.revision),
+            ("sequence", self.sequence),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                raise ValueError(f"artifact {field_name} must be a positive integer")
+        _validate_finite("observed_at_epoch", self.observed_at_epoch)
+        if self.observed_at_epoch < 0:
+            raise ValueError("artifact observed_at_epoch cannot be negative")
+        _canonical_json(dict(self.metadata))
+
+    @property
+    def terminal(self) -> bool:
+        """Return whether no later lifecycle event may alter this artifact."""
+        return self.state in {
+            ArtifactState.FINALIZED,
+            ArtifactState.INCOMPLETE,
+            ArtifactState.FAILED,
+        }
+
+    def as_dict(self) -> dict[str, JsonValue]:
+        """Serialize this event to the stable JARVIS artifact schema."""
+        value: dict[str, JsonValue] = {
+            "schema_version": self.schema_version,
+            "package_name": self.package_name,
+            "package_id": self.package_id,
+            "execution_id": self.execution_id,
+            "artifact_id": self.artifact_id,
+            "logical_name": self.logical_name,
+            "kind": self.kind,
+            "role": self.role.value,
+            "structure": self.structure.value,
+            "ownership": self.ownership.value,
+            "state": self.state.value,
+            "revision": self.revision,
+            "sequence": self.sequence,
+            "observed_at_epoch": self.observed_at_epoch,
+            "metadata": dict(self.metadata),
+        }
+        if self.location is not None:
+            value["location"] = cast(dict[str, JsonValue], self.location.as_dict())
+        for key, item in (
+            ("media_type", self.media_type),
+            ("format", self.format),
+            ("size_bytes", self.size_bytes),
+            ("checksum", self.checksum),
+            ("message", self.message),
+        ):
+            if item is not None:
+                value[key] = item
+        return value
+
+    def to_json(self) -> str:
+        """Return one canonical JSON representation suitable for JSONL."""
+        encoded = _canonical_json(self.as_dict())
+        if len(encoded.encode("utf-8")) > MAX_ARTIFACT_EVENT_BYTES:
+            raise ValueError("artifact event exceeds maximum encoded size")
+        return encoded
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "ArtifactEvent":
+        """Parse and validate a mapping using the stable artifact schema."""
+        unknown = set(value) - _EVENT_FIELDS
+        if unknown:
+            raise ValueError(f"unknown artifact event fields: {sorted(unknown)}")
+        metadata = value.get("metadata", {})
+        if not isinstance(metadata, dict):
+            raise ValueError("artifact metadata must be an object")
+        location_value = value.get("location")
+        if location_value is not None and not isinstance(location_value, dict):
+            raise ValueError("artifact location must be an object")
+        try:
+            role = ArtifactRole(_required_str(value, "role"))
+            structure = ArtifactStructure(_required_str(value, "structure"))
+            ownership = ArtifactOwnership(_required_str(value, "ownership"))
+            state = ArtifactState(_required_str(value, "state"))
+        except ValueError as exc:
+            raise ValueError("invalid artifact role, structure, or state") from exc
+        return cls(
+            schema_version=_required_str(value, "schema_version"),
+            package_name=_required_str(value, "package_name"),
+            package_id=_required_str(value, "package_id"),
+            execution_id=_required_str(value, "execution_id"),
+            artifact_id=_required_str(value, "artifact_id"),
+            logical_name=_required_str(value, "logical_name"),
+            kind=_required_str(value, "kind"),
+            role=role,
+            structure=structure,
+            ownership=ownership,
+            state=state,
+            location=(
+                ArtifactLocation.from_dict(location_value)
+                if location_value is not None
+                else None
+            ),
+            media_type=_optional_str(value, "media_type"),
+            format=_optional_str(value, "format"),
+            size_bytes=_optional_int(value, "size_bytes"),
+            checksum=_optional_str(value, "checksum"),
+            message=_optional_str(value, "message"),
+            revision=_required_int(value, "revision"),
+            sequence=_required_int(value, "sequence"),
+            observed_at_epoch=_required_number(value, "observed_at_epoch"),
+            metadata=cast(dict[str, JsonValue], metadata),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> "ArtifactEvent":
+        """Parse one bounded JSON artifact event."""
+        if len(payload.encode("utf-8")) > MAX_ARTIFACT_EVENT_BYTES:
+            raise ValueError("artifact event exceeds maximum encoded size")
+        try:
+            value = json.loads(payload, object_pairs_hook=_reject_duplicate_keys)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ValueError("artifact event is not valid JSON") from exc
+        if not isinstance(value, dict):
+            raise ValueError("artifact event must be a JSON object")
+        return cls.from_dict(cast(dict[str, Any], value))
+
+
+def new_artifact_id() -> str:
+    """Return a cryptographically random, opaque artifact identifier."""
+    return f"art_{secrets.token_urlsafe(18)}"
+
+
+def validate_artifact_history(events: list[ArtifactEvent]) -> None:
+    """Validate ordering, identity, revisions, and lifecycle transitions."""
+    stream_identity: tuple[str, str, str] | None = None
+    previous_sequence = 0
+    latest: dict[str, ArtifactEvent] = {}
+    for event in events:
+        identity = (event.execution_id, event.package_name, event.package_id)
+        if stream_identity is None:
+            stream_identity = identity
+        elif identity != stream_identity:
+            raise ValueError(
+                "artifact event identity must remain stable within a store"
+            )
+        if event.sequence != previous_sequence + 1:
+            raise ValueError(
+                "artifact event sequences must be contiguous and increasing"
+            )
+        previous_sequence = event.sequence
+        previous = latest.get(event.artifact_id)
+        if previous is None:
+            if event.revision != 1:
+                raise ValueError("a new artifact must begin at revision 1")
+        else:
+            _validate_artifact_revision(previous, event)
+        latest[event.artifact_id] = event
+
+
+def _validate_artifact_revision(
+    previous: ArtifactEvent,
+    event: ArtifactEvent,
+) -> None:
+    if event.revision != previous.revision + 1:
+        raise ValueError("artifact revisions must be contiguous and increasing")
+    for field_name in (
+        "logical_name",
+        "kind",
+        "role",
+        "structure",
+        "ownership",
+    ):
+        if getattr(event, field_name) != getattr(previous, field_name):
+            raise ValueError(f"artifact {field_name} cannot change after registration")
+    for field_name in ("location", "media_type", "format"):
+        before = getattr(previous, field_name)
+        after = getattr(event, field_name)
+        if before is not None and after != before:
+            raise ValueError(f"artifact {field_name} cannot change after being set")
+    if previous.size_bytes is not None:
+        if event.size_bytes is None:
+            raise ValueError("artifact size_bytes cannot be cleared")
+        if event.size_bytes < previous.size_bytes:
+            raise ValueError("artifact size_bytes cannot decrease")
+    if previous.checksum is not None and event.checksum != previous.checksum:
+        raise ValueError("artifact checksum cannot change after being set")
+    allowed = {
+        ArtifactState.PRODUCING: {
+            ArtifactState.PRODUCING,
+            ArtifactState.AVAILABLE,
+            ArtifactState.FINALIZED,
+            ArtifactState.INCOMPLETE,
+            ArtifactState.FAILED,
+        },
+        ArtifactState.AVAILABLE: {
+            ArtifactState.AVAILABLE,
+            ArtifactState.FINALIZED,
+            ArtifactState.INCOMPLETE,
+            ArtifactState.FAILED,
+        },
+        ArtifactState.FINALIZED: set(),
+        ArtifactState.INCOMPLETE: set(),
+        ArtifactState.FAILED: set(),
+    }[previous.state]
+    if event.state not in allowed:
+        raise ValueError(
+            f"artifact state cannot transition from {previous.state.value!r} "
+            f"to {event.state.value!r}"
+        )
+
+
+def _validate_execution_relative_location(value: str) -> None:
+    if "\\" in value:
+        raise ValueError(
+            "execution-relative artifact locations must use '/' separators"
+        )
+    path = PurePosixPath(value)
+    if path.is_absolute() or value.startswith("/"):
+        raise ValueError("execution-relative artifact location cannot be absolute")
+    if value.endswith("/") or "//" in value:
+        raise ValueError("execution-relative artifact location is not normalized")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError("execution-relative artifact location cannot escape its root")
+    if path.parts and ":" in path.parts[0]:
+        raise ValueError("execution-relative artifact location cannot contain a drive")
+    if path.as_posix() != value:
+        raise ValueError("execution-relative artifact location is not normalized")
+
+
+def _validate_external_uri(value: str) -> None:
+    parsed = urlsplit(value)
+    scheme = parsed.scheme.lower()
+    if not scheme or not _URI_SCHEME_PATTERN.fullmatch(scheme):
+        raise ValueError("external artifact location must have a valid URI scheme")
+    if len(scheme) == 1:
+        raise ValueError("external artifact location cannot be a drive path")
+    if scheme in _UNSAFE_URI_SCHEMES:
+        raise ValueError(f"external artifact URI scheme is not allowed: {scheme}")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("external artifact URI cannot contain user information")
+    if scheme in {"gs", "http", "https", "s3"} and not parsed.netloc:
+        raise ValueError("external artifact URI requires an authority")
+
+
+def _validate_cluster_path(value: str) -> None:
+    if "\\" in value:
+        raise ValueError("cluster artifact paths must use '/' separators")
+    path = PurePosixPath(value)
+    if not path.is_absolute() or not value.startswith("/"):
+        raise ValueError("cluster artifact path must be absolute")
+    if value == "/" or value.endswith("/") or "//" in value:
+        raise ValueError("cluster artifact path is not a concrete normalized path")
+    if any(part in {"", ".", ".."} for part in path.parts[1:]):
+        raise ValueError("cluster artifact path cannot contain traversal components")
+    if path.as_posix() != value:
+        raise ValueError("cluster artifact path is not normalized")
+
+
+def _validate_identity_text(field_name: str, value: object) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"artifact {field_name} must be non-empty")
+    if len(value) > MAX_IDENTITY_TEXT:
+        raise ValueError(f"artifact {field_name} exceeds maximum length")
+    if any(ord(character) < 32 for character in value):
+        raise ValueError(f"artifact {field_name} cannot contain control characters")
+
+
+def _canonical_json(value: object) -> str:
+    try:
+        return json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("artifact event must contain finite JSON values") from exc
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON key: {key}")
+        value[key] = item
+    return value
+
+
+def _validate_finite(field_name: str, value: float) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"artifact {field_name} must be numeric")
+    if not math.isfinite(value):
+        raise ValueError(f"artifact {field_name} must be finite")
+
+
+def _required_str(value: Mapping[str, Any], key: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str):
+        raise ValueError(f"artifact {key} must be a string")
+    return item
+
+
+def _optional_str(value: Mapping[str, Any], key: str) -> str | None:
+    item = value.get(key)
+    if item is None:
+        return None
+    if not isinstance(item, str):
+        raise ValueError(f"artifact {key} must be a string")
+    return item
+
+
+def _required_int(value: Mapping[str, Any], key: str) -> int:
+    item = value.get(key)
+    if isinstance(item, bool) or not isinstance(item, int):
+        raise ValueError(f"artifact {key} must be an integer")
+    return item
+
+
+def _optional_int(value: Mapping[str, Any], key: str) -> int | None:
+    item = value.get(key)
+    if item is None:
+        return None
+    if isinstance(item, bool) or not isinstance(item, int):
+        raise ValueError(f"artifact {key} must be an integer")
+    return item
+
+
+def _required_number(value: Mapping[str, Any], key: str) -> float:
+    item = value.get(key)
+    if isinstance(item, bool) or not isinstance(item, (int, float)):
+        raise ValueError(f"artifact {key} must be numeric")
+    return float(item)

--- a/jarvis_cd/artifacts/store.py
+++ b/jarvis_cd/artifacts/store.py
@@ -1,0 +1,400 @@
+"""Durable append-only storage for structured JARVIS artifact manifests."""
+
+from __future__ import annotations
+
+import os
+import stat
+import time
+from contextlib import contextmanager
+from dataclasses import replace
+from pathlib import Path
+from typing import Callable, Final, Iterator
+
+from jarvis_cd.util.private_path import (
+    ensure_private_descriptor,
+    ensure_private_path,
+    reject_private_path_redirection,
+)
+
+from .schema import (
+    MAX_ARTIFACT_EVENT_BYTES,
+    ArtifactEvent,
+    ArtifactState,
+    validate_artifact_history,
+)
+
+MAX_ARTIFACT_STORE_BYTES: Final = 128 * 1024 * 1024
+
+
+class ArtifactStore:
+    """Append and query a bounded, owner-private JSONL artifact manifest."""
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        self.path = Path(path)
+
+    def append(self, event: ArtifactEvent) -> None:
+        """Durably append one lifecycle event under an exclusive store lock."""
+        self._prepare_parent()
+        with _exclusive_store_lock(self.path):
+            if _store_is_sealed(self.path):
+                raise RuntimeError("artifact store is sealed")
+            descriptor = _open_store(self.path, write=True)
+            try:
+                info = _validate_descriptor(self.path, descriptor)
+                existing = _read_events_from_descriptor(descriptor, info.st_size)
+                _commit_events(descriptor, info.st_size, existing, [event])
+            finally:
+                os.close(descriptor)
+
+    def append_next(
+        self,
+        builder: Callable[[tuple[ArtifactEvent, ...]], ArtifactEvent],
+    ) -> ArtifactEvent:
+        """Build and append one event from current history under one lock."""
+        self._prepare_parent()
+        with _exclusive_store_lock(self.path):
+            if _store_is_sealed(self.path):
+                raise RuntimeError("artifact store is sealed")
+            descriptor = _open_store(self.path, write=True)
+            try:
+                info = _validate_descriptor(self.path, descriptor)
+                existing = _read_events_from_descriptor(descriptor, info.st_size)
+                event = builder(tuple(existing))
+                if not isinstance(event, ArtifactEvent):
+                    raise TypeError("artifact event builder returned an invalid value")
+                _commit_events(descriptor, info.st_size, existing, [event])
+                return event
+            finally:
+                os.close(descriptor)
+
+    def read_all(self) -> list[ArtifactEvent]:
+        """Read and validate every complete manifest event in order."""
+        _reject_symlink_tree(self.path)
+        if not self.path.exists():
+            return []
+        _reject_symlink_tree(self.path.parent)
+        with _exclusive_store_lock(self.path):
+            descriptor = _open_store(self.path, write=False)
+            try:
+                info = _validate_descriptor(self.path, descriptor)
+                return _read_events_from_descriptor(descriptor, info.st_size)
+            finally:
+                os.close(descriptor)
+
+    def latest(self, artifact_id: str | None = None) -> ArtifactEvent | None:
+        """Return the latest event globally or for one opaque artifact ID."""
+        events = self.read_all()
+        if artifact_id is None:
+            return events[-1] if events else None
+        return next(
+            (event for event in reversed(events) if event.artifact_id == artifact_id),
+            None,
+        )
+
+    def current(self) -> dict[str, ArtifactEvent]:
+        """Return the current validated event for every registered artifact."""
+        current: dict[str, ArtifactEvent] = {}
+        for event in self.read_all():
+            current[event.artifact_id] = event
+        return current
+
+    def is_sealed(self) -> bool:
+        """Return whether execution terminalization sealed this manifest."""
+        _reject_symlink_tree(self.path.parent)
+        if not self.path.parent.exists():
+            return False
+        with _exclusive_store_lock(self.path):
+            return _store_is_sealed(self.path)
+
+    def finalize_open(
+        self,
+        state_for_open: ArtifactState = ArtifactState.INCOMPLETE,
+    ) -> list[ArtifactEvent]:
+        """Seal every still-producing artifact during execution terminalization.
+
+        ``AVAILABLE`` artifacts remain available. The execution layer seals
+        application output as ``INCOMPLETE``/``FAILED`` unless its authoritative
+        producer explicitly owns completion, such as JARVIS core log streams.
+        """
+        if state_for_open not in {
+            ArtifactState.FINALIZED,
+            ArtifactState.INCOMPLETE,
+            ArtifactState.FAILED,
+        }:
+            raise ValueError("open artifacts require a terminal sealing state")
+        self._prepare_parent()
+        with _exclusive_store_lock(self.path):
+            if _store_is_sealed(self.path):
+                return []
+            descriptor = _open_store(self.path, write=True)
+            try:
+                info = _validate_descriptor(self.path, descriptor)
+                existing = _read_events_from_descriptor(descriptor, info.st_size)
+                current: dict[str, ArtifactEvent] = {}
+                for event in existing:
+                    current[event.artifact_id] = event
+                sequence = existing[-1].sequence if existing else 0
+                sealed: list[ArtifactEvent] = []
+                observed_at = time.time()
+                for event in current.values():
+                    if event.state is not ArtifactState.PRODUCING:
+                        continue
+                    sequence += 1
+                    sealed.append(
+                        replace(
+                            event,
+                            state=state_for_open,
+                            revision=event.revision + 1,
+                            sequence=sequence,
+                            observed_at_epoch=observed_at,
+                        )
+                    )
+                if sealed:
+                    _commit_events(descriptor, info.st_size, existing, sealed)
+                _seal_store(self.path)
+                return sealed
+            finally:
+                os.close(descriptor)
+
+    def _prepare_parent(self) -> None:
+        """Create and protect the manifest parent without following redirects."""
+        _reject_symlink_tree(self.path.parent)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_private_path(self.path.parent, directory=True)
+        _reject_symlink_tree(self.path.parent)
+
+
+def _commit_events(
+    descriptor: int,
+    original_size: int,
+    existing: list[ArtifactEvent],
+    additions: list[ArtifactEvent],
+) -> None:
+    """Validate and commit a locked event batch, rolling back short writes."""
+    if not additions:
+        return
+    combined = [*existing, *additions]
+    validate_artifact_history(combined)
+    payload = b"".join((event.to_json() + "\n").encode("utf-8") for event in additions)
+    if original_size + len(payload) > MAX_ARTIFACT_STORE_BYTES:
+        raise ValueError("artifact store would exceed maximum size")
+    os.lseek(descriptor, 0, os.SEEK_END)
+    try:
+        offset = 0
+        while offset < len(payload):
+            written = os.write(descriptor, payload[offset:])
+            if written <= 0:
+                raise OSError("short write while appending artifact events")
+            offset += written
+        os.fsync(descriptor)
+    except BaseException:
+        os.ftruncate(descriptor, original_size)
+        os.fsync(descriptor)
+        raise
+
+
+def _seal_store(path: Path) -> None:
+    """Create and durably validate an owner-private terminal marker."""
+    marker = _sealed_path(path)
+    _reject_symlink(marker, label="artifact seal")
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(
+            marker,
+            os.O_CREAT | os.O_EXCL | os.O_WRONLY | nofollow,
+            0o600,
+        )
+    except FileExistsError:
+        if not _store_is_sealed(path):
+            raise RuntimeError("artifact seal could not be validated")
+        return
+    try:
+        if os.name != "nt":
+            os.fchmod(descriptor, 0o600)  # type: ignore[attr-defined]
+        ensure_private_descriptor(marker, descriptor, directory=False)
+        payload = b"jarvis.artifact.sealed.v1"
+        if os.write(descriptor, payload) != len(payload):
+            raise OSError("short write while sealing artifact store")
+        os.fsync(descriptor)
+        _validate_descriptor(marker, descriptor)
+    except BaseException:
+        os.close(descriptor)
+        try:
+            marker.unlink()
+        except OSError:
+            pass
+        raise
+    else:
+        os.close(descriptor)
+
+
+def _store_is_sealed(path: Path) -> bool:
+    marker = _sealed_path(path)
+    _reject_symlink(marker, label="artifact seal")
+    try:
+        descriptor = _open_store(marker, write=False)
+    except FileNotFoundError:
+        return False
+    try:
+        information = _validate_descriptor(marker, descriptor)
+        if information.st_size != len(b"jarvis.artifact.sealed.v1"):
+            raise ValueError("artifact seal has invalid content")
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        if os.read(descriptor, information.st_size) != b"jarvis.artifact.sealed.v1":
+            raise ValueError("artifact seal has invalid content")
+        return True
+    finally:
+        os.close(descriptor)
+
+
+def _sealed_path(path: Path) -> Path:
+    return path.with_name(path.name + ".sealed")
+
+
+def _read_events_from_descriptor(descriptor: int, size: int) -> list[ArtifactEvent]:
+    if size > MAX_ARTIFACT_STORE_BYTES:
+        raise ValueError("artifact store exceeds maximum size")
+    _require_complete_framing(descriptor, size)
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    events: list[ArtifactEvent] = []
+    with os.fdopen(os.dup(descriptor), "r", encoding="utf-8", newline="") as stream:
+        for line_number, line in enumerate(stream, start=1):
+            if len(line.encode("utf-8")) > MAX_ARTIFACT_EVENT_BYTES + 1:
+                raise ValueError(f"artifact line {line_number} exceeds maximum size")
+            payload = line.rstrip("\r\n")
+            if not payload:
+                raise ValueError(f"artifact line {line_number} cannot be empty")
+            events.append(ArtifactEvent.from_json(payload))
+    validate_artifact_history(events)
+    return events
+
+
+def _reject_symlink(path: Path, *, label: str) -> None:
+    try:
+        information = path.lstat()
+    except FileNotFoundError:
+        return
+    attributes = getattr(information, "st_file_attributes", 0)
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    if stat.S_ISLNK(information.st_mode) or attributes & reparse_flag:
+        raise ValueError(f"{label} cannot be a symlink or reparse point: {path}")
+
+
+def _reject_symlink_tree(path: Path) -> None:
+    try:
+        reject_private_path_redirection(path)
+    except RuntimeError as exc:
+        raise ValueError(
+            f"artifact path cannot be redirected by a symlink or reparse point: {path}"
+        ) from exc
+
+
+def _open_store(path: Path, *, write: bool) -> int:
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if not write:
+        descriptor = os.open(path, os.O_RDONLY | nofollow)
+    else:
+        try:
+            descriptor = os.open(
+                path,
+                os.O_APPEND | os.O_CREAT | os.O_EXCL | os.O_RDWR | nofollow,
+                0o600,
+            )
+        except FileExistsError:
+            descriptor = os.open(path, os.O_APPEND | os.O_RDWR | nofollow)
+        else:
+            if os.name != "nt":
+                os.fchmod(descriptor, 0o600)  # type: ignore[attr-defined]
+    try:
+        ensure_private_descriptor(path, descriptor, directory=False)
+    except BaseException:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
+def _require_complete_framing(descriptor: int, size: int) -> None:
+    if size == 0:
+        return
+    os.lseek(descriptor, size - 1, os.SEEK_SET)
+    if os.read(descriptor, 1) != b"\n":
+        raise ValueError("artifact store has an incomplete final JSONL record")
+
+
+def _validate_descriptor(path: Path, descriptor: int) -> os.stat_result:
+    information = os.fstat(descriptor)
+    if not stat.S_ISREG(information.st_mode):
+        raise ValueError(f"artifact store must be a regular file: {path}")
+    path_information = path.lstat()
+    if stat.S_ISLNK(path_information.st_mode) or (
+        path_information.st_dev,
+        path_information.st_ino,
+    ) != (information.st_dev, information.st_ino):
+        raise ValueError(f"artifact store changed during secure open: {path}")
+    if os.name != "nt":
+        getuid = getattr(os, "getuid", None)
+        if getuid is not None and information.st_uid != getuid():
+            raise PermissionError(
+                f"artifact store is not owned by current user: {path}"
+            )
+        if stat.S_IMODE(information.st_mode) & 0o077:
+            raise PermissionError(f"artifact store permissions are not private: {path}")
+    return information
+
+
+@contextmanager
+def _exclusive_store_lock(path: Path) -> Iterator[None]:
+    lock_path = path.with_name(path.name + ".lock")
+    _reject_symlink(lock_path, label="artifact lock")
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(
+            lock_path,
+            os.O_CREAT | os.O_EXCL | os.O_RDWR | nofollow,
+            0o600,
+        )
+    except FileExistsError:
+        descriptor = os.open(lock_path, os.O_RDWR | nofollow)
+    try:
+        ensure_private_descriptor(lock_path, descriptor, directory=False)
+        _validate_descriptor(lock_path, descriptor)
+        if os.fstat(descriptor).st_size == 0:
+            os.write(descriptor, b"0")
+            os.fsync(descriptor)
+        _lock_descriptor(descriptor)
+        try:
+            yield
+        finally:
+            _unlock_descriptor(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _lock_descriptor(descriptor: int) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(  # type: ignore[attr-defined]
+            descriptor,
+            fcntl.LOCK_EX,  # type: ignore[attr-defined]
+        )
+
+
+def _unlock_descriptor(descriptor: int) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(  # type: ignore[attr-defined]
+            descriptor,
+            fcntl.LOCK_UN,  # type: ignore[attr-defined]
+        )

--- a/jarvis_cd/core/cli.py
+++ b/jarvis_cd/core/cli.py
@@ -381,6 +381,36 @@ class JarvisCLI(ArgParse):
             ]
         )
 
+        self.add_cmd(
+            "execution artifacts",
+            msg="List generated artifacts for one execution",
+        )
+        self.add_args(
+            [
+                {
+                    "name": "execution_id",
+                    "msg": "JARVIS execution identity",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                },
+                {
+                    "name": "pipeline_id",
+                    "aliases": ["pipeline-id"],
+                    "msg": "Pipeline identity (defaults to current pipeline)",
+                    "type": str,
+                    "required": False,
+                },
+                {
+                    "name": "json",
+                    "msg": "Print the complete artifact snapshot as JSON",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+            ]
+        )
+
         self.add_cmd("ppl update", msg="Update current pipeline")
         self.add_args(
             [
@@ -1503,6 +1533,27 @@ class JarvisCLI(ArgParse):
                 if latest.unit:
                     amount += f" {latest.unit}"
             print(f"  {package.package_id}: {amount}")
+
+    def execution_artifacts(self) -> None:
+        """Print generated artifacts for a named or current pipeline."""
+        self._ensure_initialized()
+        pipeline_id = self.kwargs.get("pipeline_id")
+        pipeline = (
+            Pipeline(pipeline_id) if pipeline_id else self._require_current_pipeline()
+        )
+        snapshot = pipeline.get_execution_artifacts(self.kwargs["execution_id"])
+        if self.kwargs.get("json", False):
+            print(json.dumps(snapshot.to_dict(), separators=(",", ":"), sort_keys=True))
+            return
+        print(
+            f"{snapshot.execution_id}: {snapshot.execution_state} "
+            f"({len(snapshot.artifacts)} artifacts)"
+        )
+        for artifact in snapshot.artifacts:
+            print(
+                f"  {artifact.package_id}/{artifact.logical_name}: "
+                f"{artifact.state.value} {artifact.kind} ({artifact.artifact_id})"
+            )
 
     def ppl_start(self):
         """Start current pipeline"""

--- a/jarvis_cd/core/execution.py
+++ b/jarvis_cd/core/execution.py
@@ -16,6 +16,7 @@ from time import monotonic, sleep
 from typing import Any, Iterator, Literal, Mapping, Optional, cast
 from uuid import uuid4
 
+from jarvis_cd.artifacts import ArtifactEvent, ArtifactState, ArtifactStore
 from jarvis_cd.progress import ProgressEvent, ProgressStore
 from jarvis_cd.util.private_path import (
     ensure_private_descriptor,
@@ -30,6 +31,7 @@ LEGACY_RECORD_SCHEMA = "jarvis.execution.v1"
 RECORD_NAME = ".jarvis-execution.json"
 MAX_RECORD_BYTES = 65_536
 PROGRESS_SNAPSHOT_SCHEMA = "jarvis.execution.progress.v1"
+ARTIFACT_SNAPSHOT_SCHEMA = "jarvis.execution.artifacts.v1"
 DIRECT_LAUNCH_SCHEMA = "jarvis.direct-launch.v1"
 DIRECT_LEASE_NAME = ".jarvis-direct-execution.lease"
 
@@ -113,6 +115,28 @@ class ExecutionProgressSnapshot:
             "execution_state": self.execution_state,
             "terminal": self.terminal,
             "packages": [package.to_dict() for package in self.packages],
+        }
+
+
+@dataclass(frozen=True)
+class ExecutionArtifactSnapshot:
+    """Queryable current artifact manifest for one durable execution."""
+
+    execution_id: str
+    pipeline_id: str
+    execution_state: str
+    terminal: bool
+    artifacts: tuple[ArtifactEvent, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the stable agent-facing artifact snapshot schema."""
+        return {
+            "schema_version": ARTIFACT_SNAPSHOT_SCHEMA,
+            "execution_id": self.execution_id,
+            "pipeline_id": self.pipeline_id,
+            "execution_state": self.execution_state,
+            "terminal": self.terminal,
+            "artifacts": [artifact.as_dict() for artifact in self.artifacts],
         }
 
 
@@ -314,6 +338,13 @@ class ExecutionHandle:
         assert record._record_path is not None
         store = ExecutionStore(record._record_path.parent.parent, self.pipeline_id)
         return store.progress(self.execution_id)
+
+    def artifacts(self) -> ExecutionArtifactSnapshot:
+        """Return the current generated artifacts for this exact execution."""
+        record = self.refresh()
+        assert record._record_path is not None
+        store = ExecutionStore(record._record_path.parent.parent, self.pipeline_id)
+        return store.artifacts(self.execution_id)
 
 
 @dataclass(frozen=True)
@@ -1184,6 +1215,132 @@ class ExecutionStore:
             packages=tuple(snapshots),
         )
 
+    def artifacts(self, execution_id: str) -> ExecutionArtifactSnapshot:
+        """Return the current identity-checked artifact manifest."""
+        record = self.get(execution_id)
+        artifact_files = record.metadata.get("artifact_files", {})
+        if not isinstance(artifact_files, dict):
+            raise RuntimeError("execution artifact index is invalid")
+        execution_root = self.executions_dir / record.execution_id
+        artifact_root = execution_root / "artifacts"
+        if artifact_root.exists() or artifact_root.is_symlink():
+            status = artifact_root.lstat()
+            if not stat.S_ISDIR(status.st_mode) or stat.S_ISLNK(status.st_mode):
+                raise RuntimeError("execution artifact path is not a real directory")
+        latest: list[ArtifactEvent] = []
+        seen_ids: set[str] = set()
+        for artifact_key, entry in sorted(artifact_files.items()):
+            if (
+                not isinstance(artifact_key, str)
+                or not artifact_key
+                or not isinstance(entry, dict)
+                or set(entry) != {"filename", "package_id", "package_name"}
+                or not isinstance(entry.get("filename"), str)
+                or not entry["filename"]
+                or not isinstance(entry.get("package_id"), str)
+                or not entry["package_id"]
+                or not isinstance(entry.get("package_name"), str)
+                or not entry["package_name"]
+            ):
+                raise RuntimeError("execution artifact index is invalid")
+            filename = entry["filename"]
+            package_id = entry["package_id"]
+            package_name = entry["package_name"]
+            relative = Path(filename)
+            if (
+                relative.name != filename
+                or relative.is_absolute()
+                or relative.suffix != ".jsonl"
+            ):
+                raise RuntimeError("execution artifact index contains an invalid path")
+            sidecar = artifact_root / filename
+            try:
+                current = ArtifactStore(sidecar).current()
+            except (OSError, PermissionError, ValueError) as exc:
+                raise RuntimeError(
+                    f"invalid artifact sidecar for package {package_id!r}"
+                ) from exc
+            for event in current.values():
+                if (
+                    event.execution_id != record.execution_id
+                    or event.package_id != package_id
+                    or event.package_name != package_name
+                ):
+                    raise RuntimeError(
+                        f"artifact identity mismatch for package {package_id!r}"
+                    )
+                if event.artifact_id in seen_ids:
+                    raise RuntimeError("artifact ID is duplicated across package manifests")
+                seen_ids.add(event.artifact_id)
+                latest.append(event)
+        return ExecutionArtifactSnapshot(
+            execution_id=record.execution_id,
+            pipeline_id=record.pipeline_id,
+            execution_state=record.state,
+            terminal=record.terminal,
+            artifacts=tuple(
+                sorted(
+                    latest,
+                    key=lambda event: (
+                        event.package_id,
+                        event.logical_name,
+                        event.artifact_id,
+                    ),
+                )
+            ),
+        )
+
+    def finalize_artifacts(
+        self,
+        execution_id: str,
+        *,
+        failed: bool = False,
+    ) -> list[ArtifactEvent]:
+        """Seal every producing artifact before execution terminalization."""
+        validated_id = validate_execution_id(execution_id)
+        record = read_execution_record(
+            self.executions_dir / validated_id,
+            expected_execution_id=validated_id,
+        )
+        artifact_files = record.metadata.get("artifact_files", {})
+        if not isinstance(artifact_files, dict):
+            raise RuntimeError("execution artifact index is invalid")
+        artifact_root = self.executions_dir / record.execution_id / "artifacts"
+        sealed: list[ArtifactEvent] = []
+        for artifact_key, entry in artifact_files.items():
+            if (
+                not isinstance(artifact_key, str)
+                or not artifact_key
+                or not isinstance(entry, dict)
+                or set(entry) != {"filename", "package_id", "package_name"}
+                or not isinstance(entry.get("filename"), str)
+                or not isinstance(entry.get("package_id"), str)
+                or not entry["package_id"]
+                or not isinstance(entry.get("package_name"), str)
+                or not entry["package_name"]
+            ):
+                raise RuntimeError("execution artifact index is invalid")
+            filename = entry["filename"]
+            relative = Path(filename)
+            if relative.name != filename or relative.suffix != ".jsonl":
+                raise RuntimeError("execution artifact index contains an invalid path")
+            sealed.extend(
+                ArtifactStore(artifact_root / filename).finalize_open(
+                    ArtifactState.FINALIZED
+                    if (
+                        artifact_key == "jarvis-core"
+                        and entry["package_id"] == "jarvis-core"
+                        and entry["package_name"] == "jarvis.core"
+                    )
+                    else (
+                        ArtifactState.FAILED
+                        if failed
+                        else ArtifactState.INCOMPLETE
+                    )
+                )
+            )
+        return sealed
+
     def update(
         self,
         execution_id: str,
@@ -1278,6 +1435,15 @@ class ExecutionStore:
                 metadata=merged_metadata,
                 _record_path=execution_root / RECORD_NAME,
             )
+            if (
+                not current.terminal
+                and updated.terminal
+                and updated.state != "scripted"
+            ):
+                self.finalize_artifacts(
+                    validated_id,
+                    failed=updated.state == "failed",
+                )
             _atomic_write_record(execution_root / RECORD_NAME, updated)
             return updated
 

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -19,12 +19,21 @@ from contextlib import ExitStack
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 from uuid import uuid4
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactOwnership,
+    ArtifactReporter,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+)
 from jarvis_cd.core.config import load_class, Jarvis
 from jarvis_cd.core.execution import (
     LEGACY_RECORD_SCHEMA,
     RECORD_NAME,
     RECORD_SCHEMA,
     ExecutionHandle,
+    ExecutionArtifactSnapshot,
     ExecutionProgressSnapshot,
     ExecutionRecord,
     ExecutionStore,
@@ -1214,9 +1223,15 @@ class Pipeline:
             self.save()
             scheduler_spec = dict(self.scheduler)
             scheduler_spec["hostfile"] = str(execution_root / "hostfile.txt")
+            scheduler_spec.setdefault("output", str(execution_root / "stdout.log"))
+            scheduler_spec.setdefault("error", str(execution_root / "stderr.log"))
             snapshot_dir, input_dir, snapshot_sha256 = self._write_execution_snapshot(
                 execution_root,
                 scheduler_spec,
+            )
+            self._register_execution_snapshot_artifacts(
+                store,
+                resolved_execution_id,
             )
             sched = make_scheduler(
                 scheduler_spec,
@@ -1225,6 +1240,75 @@ class Pipeline:
                 pipeline_snapshot_dir=snapshot_dir,
             )
             script_path = sched.write_script()
+            try:
+                script_relative_path = script_path.relative_to(
+                    execution_root
+                ).as_posix()
+            except ValueError:
+                script_relative_path = None
+            if script_relative_path is not None:
+                self._register_execution_file(
+                    store,
+                    resolved_execution_id,
+                    logical_name="scheduler-script",
+                    relative_path=script_relative_path,
+                    kind="script",
+                    role=ArtifactRole.PROVENANCE,
+                    media_type="text/x-shellscript",
+                    format_name="slurm-shell",
+                )
+            if submit:
+                for logical_name, scheduler_key in (
+                    ("stdout", "output"),
+                    ("stderr", "error"),
+                ):
+                    configured_path = Path(str(scheduler_spec[scheduler_key]))
+                    try:
+                        relative_path = configured_path.relative_to(
+                            execution_root
+                        ).as_posix()
+                    except ValueError:
+                        if not configured_path.is_absolute():
+                            configured_path = (Path.cwd() / configured_path).resolve()
+                        if os.name == "nt":
+                            continue
+                        self._core_artifact_reporter(
+                            store,
+                            resolved_execution_id,
+                        ).emit(
+                            logical_name=logical_name,
+                            kind="log",
+                            role=ArtifactRole.LOG,
+                            structure=ArtifactStructure.STREAM,
+                            ownership=ArtifactOwnership.SHARED,
+                            state=ArtifactState.PRODUCING,
+                            location=ArtifactLocation.cluster_path(
+                                configured_path.as_posix()
+                            ),
+                            media_type="text/plain",
+                            format="log",
+                            message=(
+                                "Scheduler output stream; content may grow until "
+                                "execution ends"
+                            ),
+                        )
+                        continue
+                    self._register_execution_file(
+                        store,
+                        resolved_execution_id,
+                        logical_name=logical_name,
+                        relative_path=relative_path,
+                        kind="log",
+                        role=ArtifactRole.LOG,
+                        structure=ArtifactStructure.STREAM,
+                        state=ArtifactState.PRODUCING,
+                        media_type="text/plain",
+                        format_name="log",
+                        message=(
+                            "Scheduler output stream; content may grow until "
+                            "execution ends"
+                        ),
+                    )
         except BaseException as exc:
             try:
                 store.update(
@@ -1461,6 +1545,13 @@ class Pipeline:
     ) -> ExecutionProgressSnapshot:
         """Return validated package progress for one exact execution."""
         return self._execution_store().progress(execution_id)
+
+    def get_execution_artifacts(
+        self,
+        execution_id: str,
+    ) -> ExecutionArtifactSnapshot:
+        """Return generated artifacts for one exact execution."""
+        return self._execution_store().artifacts(execution_id)
 
     def _pipeline_storage_dir(self) -> Path:
         """Return the directory this Pipeline instance is allowed to mutate."""
@@ -2401,7 +2492,7 @@ class Pipeline:
                     ) from e
 
     def _bind_package_execution_environment(self, pkg_def: Dict[str, Any]) -> None:
-        """Bind authoritative per-package progress paths to the active execution."""
+        """Bind authoritative package runtime sidecars to the active execution."""
         execution_root = getattr(self, "_execution_root", None)
         execution_id = getattr(self, "_execution_id", None)
         if execution_root is None or not isinstance(execution_id, str):
@@ -2417,6 +2508,11 @@ class Pipeline:
         if os.name != "nt":
             progress_dir.chmod(0o700)
         progress_path = progress_dir / f"{prefix}-{digest}.jsonl"
+        artifact_dir = Path(execution_root) / "artifacts"
+        artifact_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if os.name != "nt":
+            artifact_dir.chmod(0o700)
+        artifact_path = artifact_dir / f"{prefix}-{digest}.jsonl"
         package_config = pkg_def.get("config", {})
         package_containerized = isinstance(package_config, dict) and (
             package_config.get("deploy_mode") == "container"
@@ -2431,6 +2527,8 @@ class Pipeline:
                 "JARVIS_PACKAGE_NAME": package_name,
                 "JARVIS_PROGRESS_PATH": str(progress_path),
                 "JARVIS_PROGRESS_TRANSPORT": progress_transport,
+                "JARVIS_ARTIFACT_PATH": str(artifact_path),
+                "JARVIS_ARTIFACT_TRANSPORT": progress_transport,
             }
         )
         record = self._execution_store().get(execution_id)
@@ -2439,10 +2537,105 @@ class Pipeline:
             "filename": progress_path.name,
             "package_name": package_name,
         }
+        artifact_files = dict(record.metadata.get("artifact_files", {}))
+        artifact_files[f"package-{prefix}-{digest}"] = {
+            "filename": artifact_path.name,
+            "package_id": package_id,
+            "package_name": package_name,
+        }
         self._execution_store().update(
             execution_id,
-            metadata={"progress_files": progress_files},
+            metadata={
+                "progress_files": progress_files,
+                "artifact_files": artifact_files,
+            },
         )
+
+    def _core_artifact_reporter(
+        self,
+        store: ExecutionStore,
+        execution_id: str,
+    ) -> ArtifactReporter:
+        """Return the JARVIS-owned reporter for execution infrastructure files."""
+        execution_root = store.executions_dir / execution_id
+        artifact_dir = execution_root / "artifacts"
+        artifact_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if os.name != "nt":
+            artifact_dir.chmod(0o700)
+        artifact_path = artifact_dir / "jarvis-core.jsonl"
+        record = store.get(execution_id)
+        artifact_files = dict(record.metadata.get("artifact_files", {}))
+        artifact_files["jarvis-core"] = {
+            "filename": artifact_path.name,
+            "package_id": "jarvis-core",
+            "package_name": "jarvis.core",
+        }
+        store.update(execution_id, metadata={"artifact_files": artifact_files})
+        return ArtifactReporter(
+            package_name="jarvis.core",
+            package_id="jarvis-core",
+            execution_id=execution_id,
+            path=artifact_path,
+        )
+
+    def _register_execution_file(
+        self,
+        store: ExecutionStore,
+        execution_id: str,
+        *,
+        logical_name: str,
+        relative_path: str,
+        kind: str,
+        role: ArtifactRole,
+        structure: ArtifactStructure = ArtifactStructure.FILE,
+        state: ArtifactState = ArtifactState.FINALIZED,
+        media_type: Optional[str] = None,
+        format_name: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> None:
+        """Register one core-owned path without exposing host filesystem authority."""
+        self._core_artifact_reporter(store, execution_id).emit(
+            logical_name=logical_name,
+            kind=kind,
+            role=role,
+            structure=structure,
+            ownership=ArtifactOwnership.EXECUTION,
+            state=state,
+            location=ArtifactLocation.execution_relative(relative_path),
+            media_type=media_type,
+            format=format_name,
+            message=message,
+        )
+
+    def _register_execution_snapshot_artifacts(
+        self,
+        store: ExecutionStore,
+        execution_id: str,
+    ) -> None:
+        """Publish the immutable input and runnable pipeline snapshots."""
+        for logical_name, relative_path, role in (
+            ("pipeline-input", "input/pipeline.yaml", ArtifactRole.PROVENANCE),
+            ("environment-input", "input/environment.yaml", ArtifactRole.PROVENANCE),
+            ("pipeline-runtime", "runtime/pipeline.yaml", ArtifactRole.PROVENANCE),
+            ("environment-runtime", "runtime/environment.yaml", ArtifactRole.PROVENANCE),
+        ):
+            self._register_execution_file(
+                store,
+                execution_id,
+                logical_name=logical_name,
+                relative_path=relative_path,
+                kind="configuration",
+                role=role,
+                media_type="application/yaml",
+                format_name="yaml",
+            )
+
+    def _started_package_instance(self, package_id: str) -> Optional[Any]:
+        """Return the exact instance started for a package alias, if retained."""
+        for instance in reversed(getattr(self, "_started_instances", [])):
+            if str(getattr(instance, "pkg_id", "")) == package_id:
+                return instance
+        return None
 
     def stop(self):
         """Stop all packages in the pipeline"""
@@ -2462,7 +2655,10 @@ class Pipeline:
                     logger.success(f"[{pkg_def['pkg_type']}] [STOP] BEGIN")
 
                     self._bind_package_execution_environment(pkg_def)
-                    pkg_instance = self._load_package_instance(pkg_def, self.env)
+                    package_id = str(pkg_def["pkg_id"])
+                    pkg_instance = self._started_package_instance(package_id)
+                    if pkg_instance is None:
+                        pkg_instance = self._load_package_instance(pkg_def, self.env)
 
                     if hasattr(pkg_instance, "stop"):
                         pkg_instance.stop()
@@ -2495,7 +2691,10 @@ class Pipeline:
                     logger.success(f"[{pkg_def['pkg_type']}] [KILL] BEGIN")
 
                     self._bind_package_execution_environment(pkg_def)
-                    pkg_instance = self._load_package_instance(pkg_def, self.env)
+                    package_id = str(pkg_def["pkg_id"])
+                    pkg_instance = self._started_package_instance(package_id)
+                    if pkg_instance is None:
+                        pkg_instance = self._load_package_instance(pkg_def, self.env)
 
                     if hasattr(pkg_instance, "kill"):
                         pkg_instance.kill()
@@ -2575,6 +2774,8 @@ class Pipeline:
                 "JARVIS_PACKAGE_NAME",
                 "JARVIS_PROGRESS_PATH",
                 "JARVIS_PROGRESS_TRANSPORT",
+                "JARVIS_ARTIFACT_PATH",
+                "JARVIS_ARTIFACT_TRANSPORT",
             )
         }
         snapshot_execution_id = getattr(self, "_execution_id", None)
@@ -2700,9 +2901,30 @@ class Pipeline:
                 execution_root,
                 {},
             )
+            self._register_execution_snapshot_artifacts(
+                store,
+                resolved_execution_id,
+            )
             prepare_direct_execution_lease(execution_root)
             stdout_path = execution_root / "stdout.log"
             stderr_path = execution_root / "stderr.log"
+            for logical_name, path in (
+                ("stdout", stdout_path),
+                ("stderr", stderr_path),
+            ):
+                self._register_execution_file(
+                    store,
+                    resolved_execution_id,
+                    logical_name=logical_name,
+                    relative_path=path.relative_to(execution_root).as_posix(),
+                    kind="log",
+                    role=ArtifactRole.LOG,
+                    structure=ArtifactStructure.STREAM,
+                    state=ArtifactState.AVAILABLE,
+                    media_type="text/plain",
+                    format_name="log",
+                    message="Execution output stream; content may grow until execution ends",
+                )
             direct_launch = {**direct_launch, "phase": "prepared"}
             store.update(
                 resolved_execution_id,
@@ -4309,7 +4531,10 @@ class Pipeline:
             try:
                 logger.success(f"[{pkg_def['pkg_type']}] [STOP] BEGIN")
                 self._bind_package_execution_environment(pkg_def)
-                pkg_instance = self._load_package_instance(pkg_def, self.env)
+                package_id = str(pkg_def["pkg_id"])
+                pkg_instance = self._started_package_instance(package_id)
+                if pkg_instance is None:
+                    pkg_instance = self._load_package_instance(pkg_def, self.env)
                 if hasattr(pkg_instance, "stop"):
                     pkg_instance.stop()
                 logger.success(f"[{pkg_def['pkg_type']}] [STOP] END")

--- a/jarvis_cd/core/pkg.py
+++ b/jarvis_cd/core/pkg.py
@@ -14,6 +14,11 @@ from jarvis_cd.core.config import Jarvis
 from jarvis_cd.util.hostfile import Hostfile
 
 if TYPE_CHECKING:
+    from jarvis_cd.artifacts import (
+        ArtifactObservation,
+        ArtifactReporter,
+        PackageArtifactProvider,
+    )
     from jarvis_cd.progress import (
         PackageProgressProvider,
         ProgressObservation,
@@ -104,6 +109,135 @@ class _PackageProgressLineCallback:
                 message=observation.message,
                 metadata=dict(observation.metadata),
             )
+
+
+class _PackageArtifactLineCallback:
+    """Persist structured or package-interpreted artifact observations."""
+
+    def __init__(
+        self,
+        provider: Optional["PackageArtifactProvider"],
+        reporter: "ArtifactReporter",
+        *,
+        artifact_path: Path,
+        execution_id: str,
+        package_name: str,
+        package_id: str,
+    ) -> None:
+        self._provider = provider
+        self._reporter = reporter
+        self._artifact_path = artifact_path
+        self._expected_identity = (execution_id, package_name, package_id)
+        self._lock = threading.Lock()
+        self._finalized = False
+        self._source: Optional[str] = None
+
+    def __call__(self, stream_name: str, line: str) -> None:
+        """Interpret one stdout line and persist validated artifacts."""
+        if stream_name != "stdout":
+            return
+        with self._lock:
+            if self._finalized:
+                raise RuntimeError("package artifact callback is already finalized")
+            from jarvis_cd.artifacts import (
+                ARTIFACT_LINE_PREFIX,
+                ArtifactStore,
+                event_from_artifact_line,
+            )
+
+            if line.strip().startswith(ARTIFACT_LINE_PREFIX):
+                if self._source == "provider":
+                    raise ValueError(
+                        "package artifacts cannot mix provider and structured sources"
+                    )
+                event = event_from_artifact_line(line)
+                if event is None:
+                    raise ValueError("structured package artifact line was empty")
+                identity = (
+                    event.execution_id,
+                    event.package_name,
+                    event.package_id,
+                )
+                if identity != self._expected_identity:
+                    raise ValueError("structured package artifact identity mismatch")
+                ArtifactStore(self._artifact_path).append(event)
+                self._source = "structured_stdout"
+                return
+            if self._source == "structured_stdout" or self._provider is None:
+                return
+            observations = self._provider.observe_artifacts(line)
+            if observations:
+                self._source = "provider"
+                self._persist(observations)
+
+    def finalize(self) -> None:
+        """Flush a provider's final fragment once after output capture closes."""
+        with self._lock:
+            if self._finalized:
+                return
+            if self._source != "structured_stdout" and self._provider is not None:
+                observations = self._provider.finalize_artifacts()
+                if observations:
+                    self._source = "provider"
+                    self._persist(observations)
+            self._finalized = True
+
+    def _persist(self, observations: list["ArtifactObservation"]) -> None:
+        """Persist observations with JARVIS-owned execution identity."""
+        for observation in observations:
+            self._reporter.emit(
+                logical_name=observation.logical_name,
+                kind=observation.kind,
+                role=observation.role,
+                structure=observation.structure,
+                ownership=observation.ownership,
+                state=observation.state,
+                artifact_id=observation.artifact_id,
+                location=observation.location,
+                media_type=observation.media_type,
+                format=observation.format,
+                size_bytes=observation.size_bytes,
+                checksum=observation.checksum,
+                message=observation.message,
+                metadata=dict(observation.metadata),
+            )
+
+
+class _PackageRuntimeLineCallback:
+    """Fan one application stream into progress and artifact semantics."""
+
+    def __init__(self, *callbacks: Callable[[str, str], None]) -> None:
+        self._callbacks = callbacks
+        self._finalized = False
+        self._lock = threading.Lock()
+
+    def __call__(self, stream_name: str, line: str) -> None:
+        """Deliver one output line to every configured semantic provider."""
+        with self._lock:
+            if self._finalized:
+                raise RuntimeError("package runtime callback is already finalized")
+            for callback in self._callbacks:
+                callback(stream_name, line)
+
+    def finalize(self) -> None:
+        """Finalize every configured provider exactly once."""
+        with self._lock:
+            if self._finalized:
+                return
+            failures: list[Exception] = []
+            for callback in self._callbacks:
+                finalizer = getattr(callback, "finalize", None)
+                if finalizer is not None and callable(finalizer):
+                    try:
+                        finalizer()
+                    except Exception as exc:
+                        failures.append(exc)
+            self._finalized = True
+            if failures:
+                raise ExceptionGroup(
+                    "package runtime callback finalization failed",
+                    failures,
+                )
 
 
 class Pkg:
@@ -255,6 +389,15 @@ class Pkg:
 
         return provider_from_package(self)
 
+    def get_artifact_provider(self) -> Optional["PackageArtifactProvider"]:
+        """Load this package's optional sibling ``artifacts.py`` provider.
+
+        :return: A package artifact provider, or ``None`` when not implemented.
+        """
+        from jarvis_cd.artifacts import provider_from_package
+
+        return provider_from_package(self)
+
     def bind_execution_progress(
         self,
         execution_id: str,
@@ -284,8 +427,33 @@ class Pkg:
         self.env.update(values)
         self.mod_env.update(values)
 
-    def progress_line_callback(self) -> Optional[Callable[[str, str], None]]:
-        """Build a generic stdout-to-sidecar callback for this package.
+    def bind_execution_artifacts(
+        self,
+        execution_id: str,
+        path: str | os.PathLike[str],
+    ) -> None:
+        """Bind package artifact reporting to a JARVIS-owned sidecar.
+
+        :param execution_id: Stable JARVIS execution identifier.
+        :param path: Absolute JSONL path inside the owned execution root.
+        """
+        if not isinstance(execution_id, str) or not execution_id.strip():
+            raise ValueError("execution artifacts require a non-empty execution ID")
+        artifact_path = Path(path)
+        if not artifact_path.is_absolute():
+            raise ValueError("execution artifact path must be absolute")
+        values = {
+            "JARVIS_EXECUTION_ID": execution_id,
+            "JARVIS_ARTIFACT_PATH": str(artifact_path),
+            "JARVIS_PACKAGE_NAME": str(self.pkg_type),
+            "JARVIS_PACKAGE_ID": str(self.pkg_id),
+            "JARVIS_ARTIFACT_TRANSPORT": "sidecar",
+        }
+        self.env.update(values)
+        self.mod_env.update(values)
+
+    def _progress_line_callback(self) -> Optional[Callable[[str, str], None]]:
+        """Build the progress half of the package runtime callback.
 
         Package-local providers interpret application output. Already
         structured ``JARVIS_PROGRESS`` lines are accepted without a provider.
@@ -327,6 +495,59 @@ class Pkg:
             package_name=cast(str, package_name),
             package_id=cast(str, package_id),
         )
+
+    def _artifact_line_callback(self) -> Optional[Callable[[str, str], None]]:
+        """Build the artifact half of the package runtime callback."""
+        execution_id = self.mod_env.get("JARVIS_EXECUTION_ID")
+        artifact_path = self.mod_env.get("JARVIS_ARTIFACT_PATH")
+        package_name = self.mod_env.get("JARVIS_PACKAGE_NAME")
+        package_id = self.mod_env.get("JARVIS_PACKAGE_ID")
+        transport = self.mod_env.get("JARVIS_ARTIFACT_TRANSPORT", "sidecar")
+        if not all(
+            isinstance(value, str) and value
+            for value in (execution_id, artifact_path, package_name, package_id)
+        ):
+            return None
+        if transport not in {"sidecar", "stdout"}:
+            raise ValueError("package artifact transport must be sidecar or stdout")
+        provider = self.get_artifact_provider()
+        if provider is None and transport != "stdout":
+            return None
+
+        from jarvis_cd.artifacts import ArtifactReporter
+
+        reporter = ArtifactReporter(
+            package_name=cast(str, package_name),
+            package_id=cast(str, package_id),
+            execution_id=cast(str, execution_id),
+            path=cast(str, artifact_path),
+        )
+        return _PackageArtifactLineCallback(
+            provider,
+            reporter,
+            artifact_path=Path(cast(str, artifact_path)),
+            execution_id=cast(str, execution_id),
+            package_name=cast(str, package_name),
+            package_id=cast(str, package_id),
+        )
+
+    def runtime_line_callback(self) -> Optional[Callable[[str, str], None]]:
+        """Build one callback for generic progress and artifact semantics."""
+        callbacks = tuple(
+            callback
+            for callback in (
+                self._progress_line_callback(),
+                self._artifact_line_callback(),
+            )
+            if callback is not None
+        )
+        if not callbacks:
+            return None
+        return _PackageRuntimeLineCallback(*callbacks)
+
+    def progress_line_callback(self) -> Optional[Callable[[str, str], None]]:
+        """Return the combined runtime callback under the legacy method name."""
+        return self.runtime_line_callback()
 
     def _init(self):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+  "pyright==1.1.411",
   "pytest==9.1.1",
   "pytest-cov==7.1.0",
   "ruff==0.15.21",
@@ -48,7 +49,7 @@ requires = [
 ]
 
 [tool.setuptools]
-packages = ["jarvis_cd", "jarvis_cd.core", "jarvis_cd.progress", "jarvis_cd.shell", "jarvis_cd.util", "builtin", "builtin.builtin"]
+packages = ["jarvis_cd", "jarvis_cd.artifacts", "jarvis_cd.core", "jarvis_cd.progress", "jarvis_cd.shell", "jarvis_cd.util", "builtin", "builtin.builtin"]
 include-package-data = true
 
 [tool.setuptools.package-data]

--- a/test/unit/core/test_adios2_gray_scott_artifacts.py
+++ b/test/unit/core/test_adios2_gray_scott_artifacts.py
@@ -1,0 +1,125 @@
+"""Tests for builtin ADIOS2 Gray-Scott artifact semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import (
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "adios2_gray_scott"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def test_adios2_gray_scott_exposes_output_and_checkpoint_lifecycles() -> None:
+    """BP output and restart state have distinct stable artifact identities."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_gray_scott",
+            "engine": "bp5",
+            "out_file": "/scratch/run/gs.bp",
+            "checkpoint_output": "/scratch/run/ckpt.bp",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts(
+        "steps: 100\n"
+        "Simulation at step 10 writing output step 1\n"
+        "checkpoint at step 70 create file /scratch/run/ckpt.bp\n"
+        "checkpoint at step 70 create file /scratch/run/ckpt.bp\n"
+        "Rank 0 - ET 2345 - milliseconds\n"
+    )
+
+    outputs = [item for item in observations if item.role is ArtifactRole.OUTPUT]
+    checkpoints = [
+        item for item in observations if item.role is ArtifactRole.CHECKPOINT
+    ]
+    assert len({item.artifact_id for item in outputs}) == 1
+    assert len({item.artifact_id for item in checkpoints}) == 1
+    assert outputs[-1].state is ArtifactState.FINALIZED
+    assert outputs[-1].structure is ArtifactStructure.COLLECTION
+    assert outputs[-1].ownership is ArtifactOwnership.SHARED
+    assert outputs[-1].location is not None
+    assert outputs[-1].location.value == "/scratch/run/gs.bp"
+    assert outputs[-1].format == "adios2-bp5"
+    assert checkpoints[-1].state is ArtifactState.FINALIZED
+    assert checkpoints[-1].ownership is ArtifactOwnership.SHARED
+    assert checkpoints[-1].metadata["checkpoint_timestep"] == 70
+    assert len(checkpoints) == 2
+
+
+def test_adios2_gray_scott_does_not_claim_ephemeral_sst_as_durable() -> None:
+    """An SST stream name is not misrepresented as a persistent cluster path."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_gray_scott",
+            "engine": "sst",
+            "out_file": "/scratch/run/stream.bp",
+            "checkpoint_output": "relative-ckpt.bp",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts(
+        "steps: 100\nSimulation at step 10 writing output step 1\n"
+    )
+
+    assert observations == []
+
+
+def test_adios2_gray_scott_rejects_checkpoint_path_mismatch() -> None:
+    """Native output cannot redirect a declared checkpoint artifact."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_gray_scott",
+            "checkpoint_output": "/scratch/run/ckpt.bp",
+        }
+    )
+    assert adapter is not None
+
+    with pytest.raises(ValueError, match="outside.*configured"):
+        adapter.observe_artifacts(
+            "checkpoint at step 70 create file /scratch/other/ckpt.bp\n"
+        )
+
+
+def test_adios2_gray_scott_resolves_default_relative_checkpoint() -> None:
+    """The default checkpoint path is qualified by the real runtime cwd."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_gray_scott",
+            "engine": "bp5",
+            "out_file": "/scratch/run/gs.bp",
+            "checkpoint_output": "ckpt.bp",
+            "runtime_cwd": "/work/pipeline",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts(
+        "checkpoint at step 70 create file /work/pipeline/ckpt.bp\n"
+        "Rank 0 - ET 2345 - milliseconds\n"
+    )
+
+    checkpoint = next(
+        item for item in observations if item.role is ArtifactRole.CHECKPOINT
+    )
+    assert checkpoint.location is not None
+    assert checkpoint.location.value == "/work/pipeline/ckpt.bp"

--- a/test/unit/core/test_adios2_gray_scott_progress.py
+++ b/test/unit/core/test_adios2_gray_scott_progress.py
@@ -1,0 +1,139 @@
+"""Tests for builtin ADIOS2 Gray-Scott progress semantics."""
+
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.progress import ProgressState, load_progress_module
+
+
+def _progress_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "adios2_gray_scott"
+        / "progress.py"
+    )
+    return load_progress_module(path)
+
+
+def _package_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "adios2_gray_scott"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_adios2_gray_scott_runtime_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load ADIOS2 Gray-Scott package: {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_adios2_gray_scott_tracks_restart_outputs_and_completion() -> None:
+    """Native simulation messages expose restart-aware, durable progress."""
+    module = _progress_module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_gray_scott",
+            "pkg_id": "gray_scott_bp5",
+            "steps": 100,
+            "plotgap": 10,
+            "out_file": "/scratch/run/gs.bp",
+            "checkpoint_output": "/scratch/run/ckpt.bp",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_progress(
+        "restart:          from step 40\n"
+        "steps:            100\n"
+        "Simulation at step 50 writing output step     5\n"
+        "Simulation at step 60 writing output step     6\n"
+        "Rank 0 - ET 1234 - milliseconds\n"
+        "Rank 1 - ET 1235 - milliseconds\n"
+    )
+
+    assert [item.current for item in observations] == [40.0, 50.0, 60.0, 100.0]
+    assert [item.total for item in observations] == [100.0] * 4
+    assert observations[-1].state is ProgressState.COMPLETED
+    assert observations[1].metadata["completion_signal"] == ("compute_step_completed")
+    assert observations[1].metadata["output_write_state"] == "started"
+    assert observations[-1].metadata["completion_signal"] == (
+        "writer_closed_and_timing_reported"
+    )
+
+
+def test_adios2_gray_scott_rejects_untruthful_native_output() -> None:
+    """Conflicting totals and output ordinals fail instead of being normalized."""
+    module = _progress_module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_gray_scott",
+            "steps": 100,
+            "plotgap": 10,
+        }
+    )
+    assert adapter is not None
+
+    with pytest.raises(ValueError, match="differs from.*configuration"):
+        adapter.observe_progress("steps: 200\n")
+
+    with pytest.raises(ValueError, match="contradicts plotgap"):
+        adapter.observe_progress("Simulation at step 20 writing output step 3\n")
+
+
+def test_adios2_gray_scott_factory_is_package_local() -> None:
+    """The ADIOS2 provider cannot claim another package's lifecycle."""
+    module = _progress_module()
+
+    assert module.adapter_from_package({"pkg_type": "builtin.gray_scott"}) is None
+
+
+class _CapturedExec:
+    calls: list[tuple[str, Any]] = []
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.calls.append((command, exec_info))
+
+    def run(self) -> "_CapturedExec":
+        return self
+
+
+def test_adios2_gray_scott_runtime_streams_stdout_to_owned_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ADIOS2 launcher wires its process stream into JARVIS progress."""
+    module = _package_module()
+    package = object.__new__(module.Adios2GrayScott)
+
+    def callback(_stream: str, _line: str) -> None:
+        return None
+
+    package.config = {
+        "engine": "bp5",
+        "nprocs": 2,
+        "ppn": 2,
+        "run_async": False,
+    }
+    package.settings_json_path = "/tmp/settings.json"
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: object())
+    package.mod_env = {}
+    package.runtime_line_callback = lambda: callback
+    _CapturedExec.calls = []
+    monkeypatch.setattr(module, "Exec", _CapturedExec)
+
+    package.start()
+
+    assert len(_CapturedExec.calls) == 1
+    _, exec_info = _CapturedExec.calls[0]
+    assert exec_info.line_callback is callback

--- a/test/unit/core/test_artifact_spi.py
+++ b/test/unit/core/test_artifact_spi.py
@@ -1,0 +1,537 @@
+"""Tests for JARVIS-owned generic generated artifact semantics."""
+
+from __future__ import annotations
+
+import io
+import os
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from jarvis_cd.artifacts import (
+    ARTIFACT_LINE_PREFIX,
+    ArtifactEvent,
+    ArtifactLocation,
+    ArtifactLocationKind,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactReporter,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStore,
+    ArtifactStructure,
+    event_from_artifact_line,
+    new_artifact_id,
+    provider_from_package,
+    validate_artifact_history,
+)
+from jarvis_cd.core.pkg import Pkg
+
+
+def _event(
+    *,
+    artifact_id: str | None = None,
+    sequence: int = 1,
+    revision: int = 1,
+    state: ArtifactState = ArtifactState.AVAILABLE,
+    location: ArtifactLocation | None = None,
+    ownership: ArtifactOwnership = ArtifactOwnership.EXECUTION,
+) -> ArtifactEvent:
+    return ArtifactEvent(
+        package_name="site.application",
+        package_id="simulation_a",
+        execution_id="exec_123",
+        artifact_id=artifact_id or new_artifact_id(),
+        logical_name="simulation-output",
+        kind="dataset",
+        role=ArtifactRole.OUTPUT,
+        structure=ArtifactStructure.COLLECTION,
+        ownership=ownership,
+        state=state,
+        location=location or ArtifactLocation.execution_relative("output/data.bp"),
+        format="adios2-bp5",
+        sequence=sequence,
+        revision=revision,
+        metadata={"source": "application"},
+    )
+
+
+def test_artifact_event_round_trip_preserves_typed_identity() -> None:
+    """The stable schema retains package, artifact, and cleanup identity."""
+    event = _event()
+
+    restored = ArtifactEvent.from_json(event.to_json())
+
+    assert restored == event
+    assert restored.terminal is False
+    assert restored.ownership is ArtifactOwnership.EXECUTION
+    assert restored.location is not None
+    assert restored.location.kind is ArtifactLocationKind.EXECUTION_PATH
+    assert restored.as_dict()["location"] == {
+        "kind": "execution_path",
+        "value": "output/data.bp",
+    }
+
+
+def test_artifact_ids_are_opaque_and_schema_rejects_ambiguous_json() -> None:
+    """IDs carry no path semantics and untrusted JSON fails closed."""
+    first = new_artifact_id()
+    second = new_artifact_id()
+    assert first.startswith("art_")
+    assert first != second
+    assert "simulation" not in first
+
+    with pytest.raises(ValueError, match="opaque"):
+        replace(_event(), artifact_id="output/data.bp")
+
+    payload = _event().as_dict()
+    payload["unexpected"] = True
+    with pytest.raises(ValueError, match="unknown artifact event fields"):
+        ArtifactEvent.from_dict(payload)
+
+    duplicate = (
+        _event()
+        .to_json()
+        .replace(
+            '"package_id":"simulation_a"',
+            '"package_id":"simulation_a","package_id":"other"',
+        )
+    )
+    with pytest.raises(ValueError, match="not valid JSON"):
+        ArtifactEvent.from_json(duplicate)
+
+    with pytest.raises(ValueError, match="finite JSON"):
+        replace(_event(), metadata={"bad": float("nan")})
+    with pytest.raises(ValueError, match="positive integer"):
+        replace(_event(), sequence=cast(Any, 0))
+
+
+def test_artifact_locations_are_explicit_and_non_authorizing() -> None:
+    """Owned paths cannot escape, while cluster paths remain opaque references."""
+    execution_path = ArtifactLocation.execution_relative("frames/step-0001.h5")
+    cluster_path = ArtifactLocation.cluster_path("/mnt/results/run/data.bp")
+    object_uri = ArtifactLocation.external_uri("s3://science/run/data.bp")
+
+    assert execution_path.kind is ArtifactLocationKind.EXECUTION_PATH
+    assert cluster_path.kind is ArtifactLocationKind.CLUSTER_PATH
+    assert object_uri.kind is ArtifactLocationKind.EXTERNAL_URI
+
+    for unsafe in ("../outside", "/absolute", "C:/windows", "a\\b", "a//b"):
+        with pytest.raises(ValueError):
+            ArtifactLocation.execution_relative(unsafe)
+    for unsafe in ("relative/path", "/", "/a/../b", "/a//b", "C:\\output"):
+        with pytest.raises(ValueError):
+            ArtifactLocation.cluster_path(unsafe)
+    for unsafe in (
+        "file:///tmp/output",
+        "data:text/plain,secret",
+        "https://user:password@example.test/output",
+        "https:/missing-authority/output",
+        "C:/windows/path",
+        "no-scheme",
+    ):
+        with pytest.raises(ValueError):
+            ArtifactLocation.external_uri(unsafe)
+
+    with pytest.raises(ValueError, match="owned by the execution"):
+        replace(_event(), ownership=ArtifactOwnership.SHARED)
+    with pytest.raises(ValueError, match="execution-relative"):
+        replace(
+            _event(),
+            location=cluster_path,
+            ownership=ArtifactOwnership.EXECUTION,
+        )
+
+
+def test_available_artifact_requires_a_resolvable_location() -> None:
+    """A manifest cannot claim availability without saying how to resolve it."""
+    with pytest.raises(ValueError, match="requires a location"):
+        replace(_event(), location=None)
+
+    producing = replace(
+        _event(),
+        state=ArtifactState.PRODUCING,
+        location=None,
+    )
+    assert producing.location is None
+
+
+def test_artifact_history_enforces_revisions_and_terminal_lifecycle() -> None:
+    """Immutable identity and forward-only state prevent manifest ambiguity."""
+    artifact_id = new_artifact_id()
+    producing = _event(
+        artifact_id=artifact_id,
+        state=ArtifactState.PRODUCING,
+        location=ArtifactLocation.execution_relative("output/data.bp"),
+    )
+    available = replace(
+        producing,
+        state=ArtifactState.AVAILABLE,
+        revision=2,
+        sequence=2,
+        size_bytes=1024,
+    )
+    finalized = replace(
+        available,
+        state=ArtifactState.FINALIZED,
+        revision=3,
+        sequence=3,
+        checksum="sha256:" + "a" * 64,
+    )
+
+    validate_artifact_history([producing, available, finalized])
+    assert finalized.terminal
+
+    with pytest.raises(ValueError, match="cannot change"):
+        validate_artifact_history(
+            [producing, replace(available, logical_name="renamed")]
+        )
+    with pytest.raises(ValueError, match="cannot decrease"):
+        validate_artifact_history(
+            [
+                producing,
+                available,
+                replace(
+                    finalized,
+                    state=ArtifactState.FINALIZED,
+                    size_bytes=100,
+                ),
+            ]
+        )
+    with pytest.raises(ValueError, match="cannot be cleared"):
+        validate_artifact_history(
+            [
+                producing,
+                available,
+                replace(
+                    finalized,
+                    state=ArtifactState.FINALIZED,
+                    size_bytes=None,
+                ),
+            ]
+        )
+    with pytest.raises(ValueError, match="cannot transition"):
+        validate_artifact_history(
+            [
+                producing,
+                available,
+                finalized,
+                replace(finalized, revision=4, sequence=4),
+            ]
+        )
+    with pytest.raises(ValueError, match="contiguous"):
+        validate_artifact_history([producing, replace(available, sequence=3)])
+
+
+def test_store_is_durable_and_terminalization_seals_only_producing(
+    tmp_path: Path,
+) -> None:
+    """Terminalization never silently promotes available data to finalized."""
+    path = tmp_path / "artifacts.jsonl"
+    store = ArtifactStore(path)
+    producing = _event(
+        state=ArtifactState.PRODUCING,
+        location=ArtifactLocation.cluster_path("/scratch/run/live.bp"),
+        ownership=ArtifactOwnership.SHARED,
+    )
+    available = _event(
+        sequence=2,
+        location=ArtifactLocation.cluster_path("/shared/run/result.bp"),
+        ownership=ArtifactOwnership.SHARED,
+    )
+    available = replace(
+        available,
+        role=ArtifactRole.INTERMEDIATE,
+        logical_name="shared-snapshot",
+    )
+    store.append(producing)
+    store.append(available)
+
+    sealed = store.finalize_open()
+
+    assert len(sealed) == 1
+    assert sealed[0].artifact_id == producing.artifact_id
+    assert sealed[0].state is ArtifactState.INCOMPLETE
+    current = store.current()
+    assert current[producing.artifact_id].state is ArtifactState.INCOMPLETE
+    assert current[available.artifact_id].state is ArtifactState.AVAILABLE
+    assert store.is_sealed()
+    assert store.finalize_open() == []
+    with pytest.raises(RuntimeError, match="sealed"):
+        store.append(
+            _event(
+                artifact_id=new_artifact_id(),
+                sequence=4,
+                location=ArtifactLocation.cluster_path("/scratch/run/too-late.bp"),
+                ownership=ArtifactOwnership.SHARED,
+            )
+        )
+    if os.name != "nt":
+        assert path.stat().st_mode & 0o077 == 0
+
+
+def test_store_rejects_identity_replay_torn_records_and_redirects(
+    tmp_path: Path,
+) -> None:
+    """Mixed identities, replay, partial writes, and symlinks fail closed."""
+    path = tmp_path / "artifacts.jsonl"
+    store = ArtifactStore(path)
+    event = _event()
+    store.append(event)
+    with pytest.raises(ValueError, match="contiguous"):
+        store.append(replace(event, artifact_id=new_artifact_id(), revision=1))
+    with pytest.raises(ValueError, match="identity must remain stable"):
+        store.append(
+            replace(
+                event,
+                artifact_id=new_artifact_id(),
+                execution_id="other",
+                sequence=2,
+            )
+        )
+
+    path.write_text(event.to_json(), encoding="utf-8")
+    if os.name != "nt":
+        path.chmod(0o600)
+    with pytest.raises(ValueError, match="incomplete final JSONL record"):
+        store.read_all()
+
+    if hasattr(os, "symlink"):
+        target = tmp_path / "target.jsonl"
+        target.write_text(event.to_json() + "\n", encoding="utf-8")
+        link = tmp_path / "redirected.jsonl"
+        try:
+            link.symlink_to(target)
+        except OSError:
+            return
+        with pytest.raises(ValueError, match="symlink"):
+            ArtifactStore(link).read_all()
+
+
+def test_reporter_emits_stdout_sidecar_and_seals_open_artifacts(
+    tmp_path: Path,
+) -> None:
+    """One typed event contract works over stdout and durable sidecars."""
+    stream = io.StringIO()
+    stdout_reporter = ArtifactReporter(
+        package_name="site.application",
+        package_id="app_a",
+        execution_id="exec_line",
+        stream=stream,
+    )
+    emitted = stdout_reporter.emit(
+        logical_name="application-log",
+        kind="log",
+        role=ArtifactRole.LOG,
+        structure=ArtifactStructure.STREAM,
+        ownership=ArtifactOwnership.EXECUTION,
+        state=ArtifactState.PRODUCING,
+        location="logs/stdout.log",
+    )
+    sealed = stdout_reporter.finalize_execution()
+
+    lines = stream.getvalue().splitlines()
+    assert all(line.startswith(ARTIFACT_LINE_PREFIX) for line in lines)
+    assert event_from_artifact_line(lines[0]) == emitted
+    assert sealed[0].state is ArtifactState.INCOMPLETE
+    assert event_from_artifact_line(lines[1]) == sealed[0]
+
+    path = tmp_path / "owned" / "artifacts.jsonl"
+    sidecar = ArtifactReporter(
+        package_name="site.application",
+        package_id="app_b",
+        execution_id="exec_file",
+        path=path,
+    )
+    event = sidecar.emit(
+        logical_name="final-image",
+        kind="image",
+        role=ArtifactRole.OUTPUT,
+        structure=ArtifactStructure.FILE,
+        ownership=ArtifactOwnership.EXECUTION,
+        state=ArtifactState.FINALIZED,
+        location="images/final.png",
+        media_type="image/png",
+        size_bytes=42,
+    )
+
+    assert ArtifactStore(path).latest(event.artifact_id) == event
+    assert sidecar.finalize_execution() == []
+
+
+def test_reporter_adopts_only_a_matching_existing_manifest(tmp_path: Path) -> None:
+    """Sequence adoption cannot cross execution or package identity."""
+    path = tmp_path / "artifacts.jsonl"
+    first = _event()
+    ArtifactStore(path).append(first)
+    reporter = ArtifactReporter(
+        package_name="site.application",
+        package_id="simulation_a",
+        execution_id="exec_123",
+        path=path,
+    )
+    second = reporter.emit(
+        logical_name="second-log",
+        kind="log",
+        role=ArtifactRole.LOG,
+        structure=ArtifactStructure.FILE,
+        ownership=ArtifactOwnership.EXECUTION,
+        location="logs/second.log",
+    )
+    assert second.sequence == 2
+
+    with pytest.raises(ValueError, match="does not match this reporter"):
+        ArtifactReporter(
+            package_name="site.application",
+            package_id="simulation_a",
+            execution_id="different",
+            path=path,
+        )
+
+
+def test_multiple_reporters_allocate_sidecar_sequences_under_the_store_lock(
+    tmp_path: Path,
+) -> None:
+    """Reporter caches cannot create duplicate sequences across producers."""
+    path = tmp_path / "artifacts.jsonl"
+    first = ArtifactReporter(
+        package_name="site.application",
+        package_id="simulation",
+        execution_id="exec-concurrent",
+        path=path,
+    )
+    second = ArtifactReporter(
+        package_name="site.application",
+        package_id="simulation",
+        execution_id="exec-concurrent",
+        path=path,
+    )
+
+    first_event = first.emit(
+        logical_name="first",
+        kind="log",
+        role=ArtifactRole.LOG,
+        structure=ArtifactStructure.FILE,
+        ownership=ArtifactOwnership.EXECUTION,
+        location="logs/first.log",
+    )
+    second_event = second.emit(
+        logical_name="second",
+        kind="log",
+        role=ArtifactRole.LOG,
+        structure=ArtifactStructure.FILE,
+        ownership=ArtifactOwnership.EXECUTION,
+        location="logs/second.log",
+    )
+
+    assert (first_event.sequence, second_event.sequence) == (1, 2)
+    assert [event.sequence for event in ArtifactStore(path).read_all()] == [1, 2]
+
+
+def test_observation_has_no_authoritative_execution_identity() -> None:
+    """Package providers describe semantics but cannot select the owning run."""
+    observation = ArtifactObservation(
+        logical_name="checkpoint",
+        kind="checkpoint",
+        role=ArtifactRole.CHECKPOINT,
+        structure=ArtifactStructure.FILE,
+        ownership=ArtifactOwnership.SHARED,
+        location=ArtifactLocation.cluster_path("/shared/checkpoints/latest.h5"),
+    )
+
+    assert "execution_id" not in observation.__dataclass_fields__
+    assert "package_id" not in observation.__dataclass_fields__
+
+
+def test_filesystem_repository_discovers_sibling_artifacts_module(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A registered repository needs no distribution entry point for artifacts."""
+    repository = tmp_path / "artifact_site_repo"
+    package_dir = repository / "demo"
+    package_dir.mkdir(parents=True)
+    (repository / "__init__.py").write_text("", encoding="utf-8")
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    (package_dir / "pkg.py").write_text("class Demo:\n    pass\n", encoding="utf-8")
+    (package_dir / "artifacts.py").write_text(
+        """
+class Provider:
+    def observe_artifacts(self, text): return []
+    def finalize_artifacts(self): return []
+    def reset_artifacts(self): pass
+def adapter_from_package(package):
+    return Provider() if package.get("pkg_type") == "artifact_site_repo.demo" else None
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    module = __import__("artifact_site_repo.demo.pkg", fromlist=["Demo"])
+    package = module.Demo()
+    package.config = {}
+    package.pkg_type = "artifact_site_repo.demo"
+    package.pkg_id = "demo_a"
+    package.global_id = "pipeline.demo_a"
+    package.pipeline = SimpleNamespace()
+
+    provider = provider_from_package(cast(Any, package))
+
+    assert provider is not None
+    assert provider.observe_artifacts("anything") == []
+
+
+def test_package_runtime_callback_persists_artifact_provider_output(
+    tmp_path: Path,
+) -> None:
+    """The combined runtime callback adds authoritative identity and storage."""
+
+    class Provider:
+        def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+            if text.strip() != "wrote result.bp":
+                return []
+            return [
+                ArtifactObservation(
+                    logical_name="result",
+                    kind="scientific_dataset",
+                    role=ArtifactRole.OUTPUT,
+                    structure=ArtifactStructure.COLLECTION,
+                    ownership=ArtifactOwnership.SHARED,
+                    state=ArtifactState.FINALIZED,
+                    location=ArtifactLocation.cluster_path("/scratch/result.bp"),
+                    format="adios2-bp5",
+                )
+            ]
+
+        def finalize_artifacts(self) -> list[ArtifactObservation]:
+            return []
+
+        def reset_artifacts(self) -> None:
+            return None
+
+    package = Pkg.__new__(Pkg)
+    path = (tmp_path / "artifacts.jsonl").resolve()
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec-runtime",
+        "JARVIS_PACKAGE_NAME": "site.application",
+        "JARVIS_PACKAGE_ID": "application-a",
+        "JARVIS_ARTIFACT_PATH": str(path),
+        "JARVIS_ARTIFACT_TRANSPORT": "sidecar",
+    }
+    package.get_progress_provider = lambda: None  # type: ignore[method-assign]
+    package.get_artifact_provider = lambda: Provider()  # type: ignore[method-assign]
+
+    callback = package.runtime_line_callback()
+    assert callback is not None
+    callback("stdout", "wrote result.bp\n")
+    getattr(callback, "finalize")()
+
+    event = ArtifactStore(path).latest()
+    assert event is not None
+    assert event.execution_id == "exec-runtime"
+    assert event.package_name == "site.application"
+    assert event.package_id == "application-a"
+    assert event.state is ArtifactState.FINALIZED

--- a/test/unit/core/test_execution.py
+++ b/test/unit/core/test_execution.py
@@ -17,7 +17,17 @@ import jarvis_cd.core.pipeline as pipeline_module
 import jarvis_cd.shell
 import pytest
 
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactOwnership,
+    ArtifactReporter,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStore,
+    ArtifactStructure,
+)
 from jarvis_cd.core.execution import (
+    ARTIFACT_SNAPSHOT_SCHEMA,
     HANDLE_SCHEMA,
     MAX_RECORD_BYTES,
     PROGRESS_SNAPSHOT_SCHEMA,
@@ -1076,3 +1086,298 @@ def test_slurm_script_installs_durable_exit_finalizer(tmp_path: Path) -> None:
     assert "trap jarvis_finalize_execution EXIT" in rendered
     assert "-m jarvis_cd.core.execution finalize" in rendered
     assert "--execution-id scheduled" in rendered
+
+
+def test_execution_artifacts_aggregate_package_manifests(
+    tmp_path: Path,
+) -> None:
+    """A handle returns current typed outputs without storage sidecar paths."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    record = store.create("artifacts", mode="direct")
+    artifact_root = store.executions_dir / record.execution_id / "artifacts"
+    render_path = artifact_root / "render.jsonl"
+    simulation_path = artifact_root / "simulation.jsonl"
+    ArtifactReporter(
+        package_name="builtin.paraview",
+        package_id="render",
+        execution_id=record.execution_id,
+        path=render_path,
+    ).emit(
+        logical_name="frame-1",
+        kind="image",
+        role=ArtifactRole.OUTPUT,
+        structure=ArtifactStructure.FILE,
+        ownership=ArtifactOwnership.EXECUTION,
+        state=ArtifactState.FINALIZED,
+        location=ArtifactLocation.execution_relative("shared/frame-1.png"),
+        media_type="image/png",
+        format="png",
+    )
+    ArtifactReporter(
+        package_name="builtin.gray_scott",
+        package_id="simulation",
+        execution_id=record.execution_id,
+        path=simulation_path,
+    ).emit(
+        logical_name="timesteps",
+        kind="scientific_dataset",
+        role=ArtifactRole.INTERMEDIATE,
+        structure=ArtifactStructure.COLLECTION,
+        ownership=ArtifactOwnership.SHARED,
+        state=ArtifactState.PRODUCING,
+        location=ArtifactLocation.cluster_path("/scratch/example/gs.bp"),
+        media_type="application/x-adios2-bp",
+        format="adios2-bp5",
+    )
+    store.update(
+        record.execution_id,
+        metadata={
+            "artifact_files": {
+                "render": {
+                    "filename": render_path.name,
+                    "package_id": "render",
+                    "package_name": "builtin.paraview",
+                },
+                "simulation": {
+                    "filename": simulation_path.name,
+                    "package_id": "simulation",
+                    "package_name": "builtin.gray_scott",
+                },
+            }
+        },
+    )
+
+    snapshot = record.handle.artifacts()
+
+    assert snapshot.to_dict()["schema_version"] == ARTIFACT_SNAPSHOT_SCHEMA
+    assert snapshot.execution_id == record.execution_id
+    assert [artifact.package_id for artifact in snapshot.artifacts] == [
+        "render",
+        "simulation",
+    ]
+    assert "filename" not in json.dumps(snapshot.to_dict())
+
+
+@pytest.mark.parametrize(
+    ("failed", "expected_state"),
+    [
+        (False, ArtifactState.INCOMPLETE),
+        (True, ArtifactState.FAILED),
+    ],
+)
+def test_execution_terminalization_seals_producing_artifacts(
+    tmp_path: Path,
+    failed: bool,
+    expected_state: ArtifactState,
+) -> None:
+    """A terminal execution cannot leave a manifest claiming active output."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    record = store.create("seal-artifacts", mode="direct")
+    artifact_path = store.executions_dir / record.execution_id / "artifacts/pkg.jsonl"
+    ArtifactReporter(
+        package_name="builtin.gray_scott",
+        package_id="simulation",
+        execution_id=record.execution_id,
+        path=artifact_path,
+    ).emit(
+        logical_name="timesteps",
+        kind="scientific_dataset",
+        role=ArtifactRole.OUTPUT,
+        structure=ArtifactStructure.COLLECTION,
+        ownership=ArtifactOwnership.SHARED,
+        state=ArtifactState.PRODUCING,
+        location=ArtifactLocation.cluster_path("/scratch/example/gs.bp"),
+    )
+    store.update(
+        record.execution_id,
+        metadata={
+            "artifact_files": {
+                "simulation": {
+                    "filename": artifact_path.name,
+                    "package_id": "simulation",
+                    "package_name": "builtin.gray_scott",
+                }
+            }
+        },
+    )
+
+    sealed = store.finalize_artifacts(record.execution_id, failed=failed)
+
+    assert len(sealed) == 1
+    assert sealed[0].state is expected_state
+    assert store.artifacts(record.execution_id).artifacts[0].state is expected_state
+
+
+def test_pipeline_stop_reuses_the_started_async_package_instance() -> None:
+    """Stopping waits on the process-bearing instance rather than a reload."""
+    pipeline = Pipeline.__new__(Pipeline)
+    pipeline.name = "example"
+    pipeline.packages = [
+        {
+            "pkg_id": "simulation",
+            "pkg_type": "builtin.adios2_gray_scott",
+            "config": {},
+        }
+    ]
+    pipeline.env = {}
+    pipeline._execution_root = None
+    pipeline._execution_id = None
+    pipeline.is_containerized = Mock(return_value=False)
+    started = SimpleNamespace(pkg_id="simulation", stop=Mock())
+    pipeline._started_instances = [started]
+    pipeline._load_package_instance = Mock()
+
+    pipeline.stop()
+
+    started.stop.assert_called_once_with()
+    pipeline._load_package_instance.assert_not_called()
+
+
+def test_terminal_record_update_seals_and_finalizes_core_logs(tmp_path: Path) -> None:
+    """Every terminal transition seals manifests while closing owned logs."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    record = store.create("core-log", mode="direct")
+    artifact_path = store.executions_dir / record.execution_id / "artifacts/core.jsonl"
+    ArtifactReporter(
+        package_name="jarvis.core",
+        package_id="jarvis-core",
+        execution_id=record.execution_id,
+        path=artifact_path,
+    ).emit(
+        logical_name="stdout",
+        kind="log",
+        role=ArtifactRole.LOG,
+        structure=ArtifactStructure.STREAM,
+        ownership=ArtifactOwnership.EXECUTION,
+        state=ArtifactState.PRODUCING,
+        location=ArtifactLocation.execution_relative("stdout.log"),
+    )
+    store.update(
+        record.execution_id,
+        state="running",
+        metadata={
+            "artifact_files": {
+                "jarvis-core": {
+                    "filename": artifact_path.name,
+                    "package_id": "jarvis-core",
+                    "package_name": "jarvis.core",
+                }
+            }
+        },
+    )
+
+    store.update(
+        record.execution_id,
+        state="completed",
+        terminal=True,
+        return_code=0,
+    )
+
+    artifact = store.artifacts(record.execution_id).artifacts[0]
+    assert artifact.state is ArtifactState.FINALIZED
+    assert artifact.terminal is True
+    assert ArtifactStore(artifact_path).is_sealed() is True
+
+
+def test_scheduler_preparation_failure_seals_package_manifest(tmp_path: Path) -> None:
+    """Pre-submit terminal failures cannot leave application output writable."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    record = store.create(
+        "scheduler-failure",
+        mode="scheduler",
+        scheduler_provider="slurm",
+    )
+    artifact_path = store.executions_dir / record.execution_id / "artifacts/app.jsonl"
+    ArtifactReporter(
+        package_name="site.application",
+        package_id="app",
+        execution_id=record.execution_id,
+        path=artifact_path,
+    ).emit(
+        logical_name="partial-output",
+        kind="scientific_dataset",
+        role=ArtifactRole.OUTPUT,
+        structure=ArtifactStructure.COLLECTION,
+        ownership=ArtifactOwnership.SHARED,
+        state=ArtifactState.PRODUCING,
+        location=ArtifactLocation.cluster_path("/scratch/partial.bp"),
+    )
+    store.update(
+        record.execution_id,
+        metadata={
+            "artifact_files": {
+                "app": {
+                    "filename": artifact_path.name,
+                    "package_id": "app",
+                    "package_name": "site.application",
+                }
+            }
+        },
+    )
+
+    store.update(
+        record.execution_id,
+        state="failed",
+        terminal=True,
+        return_code=1,
+        error="scheduler preparation failed",
+    )
+
+    artifact = store.artifacts(record.execution_id).artifacts[0]
+    assert artifact.state is ArtifactState.FAILED
+    assert ArtifactStore(artifact_path).is_sealed() is True
+
+
+def test_package_alias_cannot_overwrite_core_artifact_index(tmp_path: Path) -> None:
+    """Artifact index keys remain separate from operator-selected aliases."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    record = store.create("alias-collision", mode="direct")
+    artifact_root = store.executions_dir / record.execution_id / "artifacts"
+    core_path = artifact_root / "core.jsonl"
+    package_path = artifact_root / "package.jsonl"
+    for package_name, path, logical_name in (
+        ("jarvis.core", core_path, "stdout"),
+        ("site.application", package_path, "result"),
+    ):
+        ArtifactReporter(
+            package_name=package_name,
+            package_id="jarvis-core",
+            execution_id=record.execution_id,
+            path=path,
+        ).emit(
+            logical_name=logical_name,
+            kind="log" if logical_name == "stdout" else "result",
+            role=(
+                ArtifactRole.LOG
+                if logical_name == "stdout"
+                else ArtifactRole.OUTPUT
+            ),
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.EXECUTION,
+            state=ArtifactState.FINALIZED,
+            location=ArtifactLocation.execution_relative(f"{logical_name}.dat"),
+        )
+    store.update(
+        record.execution_id,
+        metadata={
+            "artifact_files": {
+                "jarvis-core": {
+                    "filename": core_path.name,
+                    "package_id": "jarvis-core",
+                    "package_name": "jarvis.core",
+                },
+                "package-operator-alias": {
+                    "filename": package_path.name,
+                    "package_id": "jarvis-core",
+                    "package_name": "site.application",
+                },
+            }
+        },
+    )
+
+    artifacts = store.artifacts(record.execution_id).artifacts
+
+    assert {artifact.package_name for artifact in artifacts} == {
+        "jarvis.core",
+        "site.application",
+    }

--- a/test/unit/core/test_execution_cli.py
+++ b/test/unit/core/test_execution_cli.py
@@ -89,6 +89,33 @@ def test_execution_progress_json_can_query_noncurrent_pipeline(
     constructor.assert_called_once_with("example")
 
 
+def test_execution_artifacts_json_can_query_noncurrent_pipeline(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Agents can discover outputs after the current pipeline changes."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    record = store.create("run-1", mode="direct")
+    snapshot = store.artifacts("run-1")
+    pipeline = SimpleNamespace(
+        get_execution_artifacts=Mock(return_value=snapshot),
+    )
+    cli = JarvisCLI()
+    cli.kwargs = {
+        "execution_id": record.execution_id,
+        "pipeline_id": "example",
+        "json": True,
+    }
+    cli._ensure_initialized = Mock()
+
+    with patch("jarvis_cd.core.cli.Pipeline", return_value=pipeline) as constructor:
+        cli.execution_artifacts()
+
+    assert json.loads(capsys.readouterr().out) == snapshot.to_dict()
+    pipeline.get_execution_artifacts.assert_called_once_with("run-1")
+    constructor.assert_called_once_with("example")
+
+
 def test_json_handle_is_emitted_as_one_final_line(capsys) -> None:
     """Run and submit handlers share the exact handle serialization."""
     handle = ExecutionHandle(
@@ -126,6 +153,7 @@ def test_submit_parser_accepts_execution_id_spellings(option: str) -> None:
         (["execution", "get", "run-1"], "execution_get"),
         (["execution", "list"], "execution_list"),
         (["execution", "progress", "run-1"], "execution_progress"),
+        (["execution", "artifacts", "run-1"], "execution_artifacts"),
     ],
 )
 @pytest.mark.parametrize("option", ["--pipeline-id", "--pipeline_id"])

--- a/test/unit/core/test_gray_scott_artifacts.py
+++ b/test/unit/core/test_gray_scott_artifacts.py
@@ -1,0 +1,104 @@
+"""Tests for builtin Gray-Scott artifact semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import (
+    ArtifactLocationKind,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "gray_scott"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def test_gray_scott_exposes_one_evolving_hdf5_collection() -> None:
+    """A timestep series is one artifact with producing and final revisions."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.gray_scott",
+            "outdir": "/scratch/run/gray-scott",
+        }
+    )
+    assert adapter is not None
+
+    producing = adapter.observe_artifacts(
+        "wrote /scratch/run/gray-scott/gs_000100.h5\n"
+        "wrote /scratch/run/gray-scott/gs_000200.h5\n"
+    )
+    finalized = adapter.observe_artifacts("Done.\n")
+
+    observations = producing + finalized
+    assert len({item.artifact_id for item in observations}) == 1
+    assert [item.state for item in observations] == [
+        ArtifactState.PRODUCING,
+        ArtifactState.PRODUCING,
+        ArtifactState.FINALIZED,
+    ]
+    assert observations[-1].role is ArtifactRole.OUTPUT
+    assert observations[-1].structure is ArtifactStructure.COLLECTION
+    assert observations[-1].ownership is ArtifactOwnership.SHARED
+    assert observations[-1].location is not None
+    assert observations[-1].location.kind is ArtifactLocationKind.CLUSTER_PATH
+    assert observations[-1].location.value == "/scratch/run/gray-scott"
+    assert observations[-1].metadata["members_observed"] == 2
+    assert observations[-1].metadata["latest_timestep"] == 200
+
+
+def test_gray_scott_rejects_output_outside_configured_collection() -> None:
+    """Application output cannot widen configured cluster-path authority."""
+    adapter = _module().adapter_from_package(
+        {"pkg_type": "builtin.gray_scott", "outdir": "/scratch/owned"}
+    )
+    assert adapter is not None
+
+    with pytest.raises(ValueError, match="outside.*configured"):
+        adapter.observe_artifacts("wrote /scratch/other/gs_000100.h5\n")
+
+
+def test_gray_scott_relative_output_is_not_exposed_as_cluster_authority() -> None:
+    """A relative package path is not silently resolved on the desktop host."""
+    adapter = _module().adapter_from_package(
+        {"pkg_type": "builtin.gray_scott", "outdir": "relative/output"}
+    )
+    assert adapter is not None
+
+    assert adapter.observe_artifacts("wrote relative/output/gs_000100.h5\n") == []
+
+
+def test_gray_scott_default_mode_exposes_adios_collection() -> None:
+    """The package's default ADIOS2 branch has the same artifact lifecycle."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.gray_scott",
+            "effective_deploy_mode": "default",
+            "outdir": "/scratch/run/gray-scott.bp",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts(
+        "steps: 100\n"
+        "Simulation at step 10 writing output step 1\n"
+        "Rank 0 - ET 123 - milliseconds\n"
+    )
+
+    assert observations[-1].state is ArtifactState.FINALIZED
+    assert observations[-1].format == "adios2-bp5"
+    assert observations[-1].metadata["io_backend"] == "adios2"

--- a/test/unit/core/test_gray_scott_progress.py
+++ b/test/unit/core/test_gray_scott_progress.py
@@ -1,0 +1,193 @@
+"""Tests for builtin Gray-Scott progress semantics."""
+
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.progress import ProgressState, load_progress_module
+
+
+def _progress_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "gray_scott"
+        / "progress.py"
+    )
+    return load_progress_module(path)
+
+
+def _package_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "gray_scott"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_gray_scott_runtime_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load Gray-Scott package: {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_gray_scott_tracks_completed_outputs_and_terminal_state() -> None:
+    """Only completed writes and the application's done marker advance progress."""
+    module = _progress_module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.gray_scott",
+            "pkg_id": "reaction_diffusion",
+            "steps": 1000,
+            "out_every": 250,
+            "outdir": "/scratch/run/gray-scott",
+        }
+    )
+    assert adapter is not None
+
+    first = adapter.observe_progress(
+        "Gray-Scott 512x256  4 ranks  1000 steps\n"
+        "  wrote /scratch/run/gray-scott/gs_000250.h5\n"
+        "  wrote /scratch/run/gray-scott/gs_000500"
+    )
+    second = adapter.observe_progress(".h5\nDone.\n")
+
+    observations = first + second
+    assert [item.current for item in observations] == [0.0, 250.0, 500.0, 1000.0]
+    assert [item.total for item in observations] == [1000.0] * 4
+    assert observations[-1].state is ProgressState.COMPLETED
+    assert observations[1].metadata["completion_signal"] == "hdf5_write_returned"
+    assert observations[1].metadata["output_format"] == "hdf5"
+    assert observations[1].metadata["output_path"] == (
+        "/scratch/run/gray-scott/gs_000250.h5"
+    )
+
+
+def test_gray_scott_rejects_identity_mismatch_and_impossible_timestep() -> None:
+    """Package configuration remains authoritative over observed output."""
+    module = _progress_module()
+    adapter = module.adapter_from_package(
+        {"pkg_type": "builtin.gray_scott", "steps": 100}
+    )
+    assert adapter is not None
+
+    with pytest.raises(ValueError, match="differs from.*configuration"):
+        adapter.observe_progress("Gray-Scott 32x32  1 ranks  200 steps\n")
+
+    with pytest.raises(ValueError, match="timestep exceeds"):
+        adapter.observe_progress("wrote /tmp/gs_000101.h5\n")
+
+
+def test_gray_scott_does_not_invent_a_total() -> None:
+    """Malformed or absent totals leave progress explicitly indeterminate."""
+    module = _progress_module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.gray_scott",
+            "steps": float("inf"),
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_progress("wrote /tmp/gs_000010.h5\nDone.")
+    observations += adapter.finalize_progress()
+
+    assert [item.current for item in observations] == [10.0, 10.0]
+    assert all(item.total is None for item in observations)
+    assert observations[-1].state is ProgressState.COMPLETED
+
+
+def test_gray_scott_provider_is_package_local() -> None:
+    """The factory cannot claim output from an unrelated package."""
+    module = _progress_module()
+
+    assert module.adapter_from_package({"pkg_type": "builtin.paraview"}) is None
+
+
+def test_gray_scott_default_adios_mode_uses_native_terminal_signal() -> None:
+    """The non-container launcher also reports progress through its ADIOS2 app."""
+    module = _progress_module()
+    adapter = module.adapter_from_package(
+        {"pkg_type": "builtin.gray_scott", "steps": 100, "out_every": 10}
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_progress(
+        "restart: from step 40\n"
+        "steps: 100\n"
+        "Simulation at step 50 writing output step 5\n"
+        "Rank 0 - ET 900 - milliseconds\n"
+    )
+
+    assert [item.current for item in observations] == [40.0, 50.0, 100.0]
+    assert observations[-1].state is ProgressState.COMPLETED
+    assert observations[-1].metadata["completion_signal"] == (
+        "writer_closed_and_timing_reported"
+    )
+
+
+class _CapturedExec:
+    calls: list[tuple[str, Any]] = []
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.calls.append((command, exec_info))
+
+    def run(self) -> "_CapturedExec":
+        return self
+
+
+class _CapturedMkdir:
+    def __init__(self, _path: object, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    def run(self) -> "_CapturedMkdir":
+        return self
+
+
+def test_gray_scott_runtime_streams_stdout_to_owned_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The package launcher wires its execution stream into JARVIS progress."""
+    module = _package_module()
+    package = object.__new__(module.GrayScott)
+
+    def callback(_stream: str, _line: str) -> None:
+        return None
+
+    package.config = {
+        "deploy_mode": "container",
+        "nprocs": 2,
+        "ppn": 2,
+        "width": 64,
+        "height": 64,
+        "steps": 100,
+        "out_every": 10,
+        "outdir": "/tmp/gray_scott_test",
+        "F": 0.035,
+        "k": 0.06,
+        "Du": 0.16,
+        "Dv": 0.08,
+    }
+    package.mod_env = {}
+    package.shared_dir = "/tmp/shared"
+    package.private_dir = "/tmp/private"
+    package.pipeline = SimpleNamespace(container_engine="apptainer")
+    package.runtime_line_callback = lambda: callback
+    package.deploy_image_name = lambda: "gray-scott:test"
+    _CapturedExec.calls = []
+    monkeypatch.setattr(module, "Exec", _CapturedExec)
+    monkeypatch.setattr(module, "Mkdir", _CapturedMkdir)
+
+    package.start()
+
+    assert len(_CapturedExec.calls) == 1
+    _, exec_info = _CapturedExec.calls[0]
+    assert exec_info.line_callback is callback

--- a/test/unit/core/test_lammps_artifacts.py
+++ b/test/unit/core/test_lammps_artifacts.py
@@ -1,0 +1,175 @@
+"""Tests for builtin LAMMPS generated-artifact semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import (
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "lammps"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def test_lammps_finalization_discovers_only_bounded_known_outputs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The provider does not crawl or register unrelated output-root content."""
+    script = tmp_path / "in.simulation"
+    script.write_text(
+        "write_data atoms.snapshot\n"
+        "write_restart state.chk\n"
+        "write_dump all custom viz.bp id type x y z\n"
+        "write_data /outside/foreign.data\n",
+        encoding="utf-8",
+    )
+    for name, payload in {
+        "log.lammps": "thermo output\n",
+        "dump.0.lammpstrj": "frame zero\n",
+        "dump.100.lammpstrj": "frame one\n",
+        "restart.100": "restart\n",
+        "state.chk": "checkpoint\n",
+        "atoms.snapshot": "atoms\n",
+        "foreign.data": "not package-declared here\n",
+        "notes.txt": "unrelated\n",
+    }.items():
+        (tmp_path / name).write_text(payload, encoding="utf-8")
+    (tmp_path / "viz.bp").mkdir()
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "dump.999.lammpstrj").write_text("nested\n", encoding="utf-8")
+
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.lammps",
+            "out": "/scratch/run",
+            "script": str(script),
+        }
+    )
+    assert adapter is not None
+    monkeypatch.setattr(module, "Path", lambda _value: tmp_path)
+
+    assert adapter.observe_artifacts("LAMMPS stdout is not filesystem truth\n") == []
+    observations = adapter.finalize_artifacts()
+
+    assert adapter.finalize_artifacts() == []
+    assert {item.ownership for item in observations} == {ArtifactOwnership.SHARED}
+    logical_names = {item.logical_name for item in observations}
+    assert "log.lammps" in logical_names
+    assert "atoms.snapshot" in logical_names
+    assert "viz.bp" in logical_names
+    assert "foreign.data" not in logical_names
+    assert "notes.txt" not in logical_names
+
+    dumps = next(
+        item for item in observations if item.logical_name == "lammps-trajectory-dumps"
+    )
+    assert dumps.role is ArtifactRole.OUTPUT
+    assert dumps.structure is ArtifactStructure.COLLECTION
+    assert dumps.state is ArtifactState.FINALIZED
+    assert dumps.metadata["member_count_observed"] == 2
+    assert "nested/dump.999.lammpstrj" not in dumps.metadata["member_names"]
+
+    checkpoints = next(
+        item for item in observations if item.logical_name == "lammps-restarts"
+    )
+    assert checkpoints.role is ArtifactRole.CHECKPOINT
+    assert checkpoints.metadata["member_count_observed"] == 2
+    assert set(checkpoints.metadata["member_names"]) == {
+        "restart.100",
+        "state.chk",
+    }
+    viz = next(item for item in observations if item.logical_name == "viz.bp")
+    assert viz.structure is ArtifactStructure.COLLECTION
+    assert viz.format == "adios2-bp"
+
+
+def test_lammps_discovery_reports_safety_bound_as_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A bounded scan cannot silently claim a complete collection manifest."""
+    for index in range(3):
+        (tmp_path / f"dump.{index}.lammpstrj").write_text(str(index), encoding="utf-8")
+    module = _module()
+    adapter = module.adapter_from_package(
+        {"pkg_type": "builtin.lammps", "out": "/scratch/bounded"}
+    )
+    assert adapter is not None
+    monkeypatch.setattr(module, "Path", lambda _value: tmp_path)
+    monkeypatch.setattr(module, "_MAX_DIRECTORY_ENTRIES", 2)
+
+    observations = adapter.finalize_artifacts()
+
+    assert len(observations) == 1
+    assert observations[0].state is ArtifactState.INCOMPLETE
+    assert observations[0].metadata["discovery_truncated"] is True
+
+
+def test_lammps_factory_rejects_unscoped_output_authority() -> None:
+    """Relative output is resolved only with JARVIS-owned runtime context."""
+    module = _module()
+    assert module.adapter_from_package({"pkg_type": "builtin.paraview"}) is None
+    with pytest.raises(ValueError, match="runtime working directory"):
+        module.adapter_from_package(
+            {"pkg_type": "builtin.lammps", "out": "relative/output"}
+        )
+
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.lammps",
+            "out": "relative/output",
+            "script": "in.lj",
+            "runtime_cwd": "/work",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.output_dir.as_posix() == "/work/relative/output"
+    assert adapter.script_path == Path("/work/relative/output/in.lj")
+
+
+def test_container_lammps_reports_only_host_visible_output() -> None:
+    """Container-private paths are not claimed as durable cluster artifacts."""
+    module = _module()
+    hidden = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.lammps",
+            "out": "/tmp/lammps_out",
+            "effective_deploy_mode": "container",
+            "shared_dir": "/shared/execution",
+            "private_dir": "/private/execution",
+            "runtime_cwd": "/work",
+        }
+    )
+    visible = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.lammps",
+            "out": "/shared/execution/lammps",
+            "effective_deploy_mode": "container",
+            "shared_dir": "/shared/execution",
+            "private_dir": "/private/execution",
+            "runtime_cwd": "/work",
+        }
+    )
+
+    assert hidden is None
+    assert visible is not None

--- a/test/unit/core/test_paraview_artifacts.py
+++ b/test/unit/core/test_paraview_artifacts.py
@@ -1,0 +1,177 @@
+"""Tests for generic builtin ParaView generated-artifact semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import (
+    ArtifactOwnership,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+from jarvis_cd.progress import PROGRESS_LINE_PREFIX, ProgressEvent, ProgressState
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "paraview"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def _line(
+    *,
+    sequence: int,
+    output_path: str | None,
+    state: ProgressState = ProgressState.RUNNING,
+    current: float = 1,
+    total: float | None = 2,
+) -> str:
+    metadata: dict[str, str | float | bool] = {
+        "progress_kind": "pvbatch_completed_unit",
+        "renderer": "paraview",
+        "completion_signal": "render_returned",
+        "completed_after_render": True,
+        "timestep": current - 1,
+    }
+    if output_path is not None:
+        metadata["output_path"] = output_path
+    event = ProgressEvent(
+        package_name="builtin.paraview",
+        package_id="asteroid_render",
+        execution_id="exec_asteroid",
+        label="frame",
+        state=state,
+        current=current,
+        total=total,
+        unit="frame",
+        sequence=sequence,
+        metadata=metadata,
+    )
+    return f"{PROGRESS_LINE_PREFIX}{event.to_json()}\n"
+
+
+def test_paraview_translates_progress_output_paths_and_finalizes_revisions() -> None:
+    """Distinct render paths become typed, queryable output artifacts."""
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.paraview",
+            "pkg_id": "asteroid_render",
+            "mode": "batch",
+            "cwd": "/scratch/render",
+        }
+    )
+    assert adapter is not None
+
+    first = adapter.observe_artifacts(
+        _line(sequence=1, output_path="frames/frame-0001.png")
+    )
+    final = adapter.observe_artifacts(
+        _line(
+            sequence=2,
+            output_path="/scratch/render/asteroid.mp4",
+            state=ProgressState.COMPLETED,
+            current=2,
+        )
+    )
+    sealed = adapter.finalize_artifacts()
+
+    assert len(first) == 1
+    assert first[0].state is ArtifactState.AVAILABLE
+    assert first[0].ownership is ArtifactOwnership.SHARED
+    assert first[0].location is not None
+    assert first[0].location.value == "/scratch/render/frames/frame-0001.png"
+    assert first[0].kind == "image"
+    assert first[0].media_type == "image/png"
+    assert first[0].metadata["generation_stage"] == "intermediate"
+
+    assert len(final) == 1
+    assert final[0].state is ArtifactState.FINALIZED
+    assert final[0].kind == "video"
+    assert final[0].format == "mp4"
+    assert final[0].metadata["generation_stage"] == "final"
+
+    assert len(sealed) == 1
+    assert sealed[0].artifact_id == first[0].artifact_id
+    assert sealed[0].state is ArtifactState.FINALIZED
+    assert sealed[0].metadata["finalized_at_execution_end"] is True
+    assert adapter.finalize_artifacts() == []
+
+
+def test_paraview_dataset_mapping_and_stable_path_identity() -> None:
+    """Repeated reports revise one ADIOS collection rather than duplicating it."""
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.paraview",
+            "pkg_id": "asteroid_render",
+            "mode": "batch",
+            "cwd": "/scratch/render",
+        }
+    )
+    assert adapter is not None
+
+    producing = adapter.observe_artifacts(
+        _line(sequence=1, output_path="processed.bp")
+    )[0]
+    finalized = adapter.observe_artifacts(
+        _line(
+            sequence=2,
+            output_path="processed.bp",
+            state=ProgressState.COMPLETED,
+            current=2,
+        )
+    )[0]
+
+    assert producing.artifact_id == finalized.artifact_id
+    assert finalized.structure is ArtifactStructure.COLLECTION
+    assert finalized.kind == "scientific_dataset"
+    assert finalized.format == "adios2-bp"
+    with pytest.raises(ValueError, match="after artifact finalization"):
+        adapter.observe_artifacts(
+            _line(sequence=3, output_path="processed.bp", current=2)
+        )
+
+
+def test_paraview_server_and_progress_without_output_claim_no_artifacts() -> None:
+    """A server readiness/progress event is not fabricated into an output."""
+    module = _module()
+    assert (
+        module.adapter_from_package({"pkg_type": "builtin.paraview", "mode": "server"})
+        is None
+    )
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.paraview",
+            "pkg_id": "asteroid_render",
+            "mode": "batch",
+            "cwd": "/scratch/render",
+        }
+    )
+    assert adapter is not None
+    assert adapter.observe_artifacts(_line(sequence=1, output_path=None)) == []
+
+
+def test_paraview_rejects_output_path_traversal() -> None:
+    """Structured metadata cannot escape path normalization checks."""
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.paraview",
+            "pkg_id": "asteroid_render",
+            "mode": "batch",
+            "cwd": "/scratch/render",
+        }
+    )
+    assert adapter is not None
+    with pytest.raises(ValueError, match="normalized"):
+        adapter.observe_artifacts(_line(sequence=1, output_path="../outside/frame.png"))

--- a/test/unit/test_release_workflow.py
+++ b/test/unit/test_release_workflow.py
@@ -37,11 +37,16 @@ def test_exact_release_request_gates_artifact_build() -> None:
     assert 'gh api "repos/$REPOSITORY/immutable-releases"' not in WORKFLOW
     assert "Verify protected release controls" in WORKFLOW
     assert ".can_admins_bypass == false" in WORKFLOW
+    assert ".prevent_self_review == false" in WORKFLOW
+    assert '"JaimeCernuda",' in WORKFLOW
     assert '"type": "tag"' in WORKFLOW
     assert "Restrict immutable version tag creation" in WORKFLOW
     assert "tag actor is not an approved release administrator" in WORKFLOW
     assert "collaborators/$release_admin/permission" in WORKFLOW
     assert '.permission == "admin" and .role_name == "admin"' in WORKFLOW
+    assert "test/unit/core/test_artifact_spi.py" in WORKFLOW
+    assert "'schema_version': 'jarvis.artifact.v1'" in WORKFLOW
+    assert "jarvis execution artifacts" in WORKFLOW
     build_block = WORKFLOW[build_index : WORKFLOW.index("  release:")]
     assert "    needs: release-preflight" in build_block
     assert "release_request" in build_block

--- a/uv.lock
+++ b/uv.lock
@@ -393,6 +393,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -409,6 +410,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = "==1.1.411" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "ruff", specifier = "==0.15.21" },
@@ -504,6 +506,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/55/9de666ad975d6ccd77d799ea0add55ee2347aa81286ce21b2a97c070746b/nh3-0.3.6-cp38-abi3-win32.whl", hash = "sha256:5276ef17bdba9ad8040575c74072008b13aae429436e9d0429e718bb5f90f4da", size = 609081, upload-time = "2026-06-22T00:46:57.665Z" },
     { url = "https://files.pythonhosted.org/packages/82/fa/2b5d684e3edf1e81bfd02d298c78c3e3da77ca1d8a2be3183a79544a7548/nh3-0.3.6-cp38-abi3-win_amd64.whl", hash = "sha256:f338ac7d594c067679f1e99b4f5ec3906842979560f9d8f15d6bdfa39a353b10", size = 624461, upload-time = "2026-06-22T00:46:59.163Z" },
     { url = "https://files.pythonhosted.org/packages/7b/e5/7cafee2f0413ca4cb0ef3bd111e94d408a48810008b283ad8aee00dd1809/nh3-0.3.6-cp38-abi3-win_arm64.whl", hash = "sha256:69f365963f63a1e9bff53bdbb3c542c7c2efed3e163c9d5d83a772a2ac468c21", size = 603060, upload-time = "2026-06-22T00:47:00.596Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
 ]
 
 [[package]]
@@ -757,6 +768,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]
@@ -1078,6 +1102,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- adds durable `jarvis.artifact.v1` events, locked append-only manifests, opaque artifact IDs, lifecycle sealing, and safe execution/cluster/external locations
- adds `ExecutionHandle.artifacts()`, pipeline/store queries, and `jarvis execution artifacts ... +json`
- records execution snapshots, scheduler scripts, and stdout/stderr as core artifacts
- adds package-owned progress and artifact semantics for Gray-Scott and ADIOS2 Gray-Scott, plus artifact providers for LAMMPS and ParaView
- adds typed/linted CI coverage, installed-wheel provider validation, artifact documentation, and an explicit package-data manifest
- changes the immutable release environment contract to allow a listed maintainer to self-approve while keeping admin bypass disabled and preserving the manual approval event

## Why

Durable execution IDs and progress made running work queryable, but agents still lacked a stable, machine-readable way to discover intermediate and final scientific outputs. This adds that missing runtime contract without embedding site aliases or exposing raw desktop-local path assumptions.

## Production behavior

Artifact identities are execution-scoped and cluster-neutral. Application providers supply semantics but cannot choose execution identity or manifest storage. Terminal transitions seal manifests; core logs finalize, unfinished application output becomes incomplete/failed, shared cluster paths are never cleanup-owned, concurrent reporters allocate sequences under the store lock, and async packages retain their process-bearing instance through stop/wait.

## Validation

- `uv lock --check`
- `uv run --frozen pytest -q test/unit` — 1087 passed, 3 subtests passed
- focused artifact/scheduler suite — 135 passed
- Ruff checks and formatting checks pass for the runtime contracts
- Pyright — 0 errors, 0 warnings
- `uv build` and `twine check` pass
- isolated Python 3.11 wheel smoke from outside the checkout verifies all six packaged progress/artifact provider files and the CLI