### PR TITLE
fix: resume immutable draft releases safely

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,7 @@ jobs:
             test/unit/core/test_paraview_artifacts.py \
             test/unit/core/test_scheduler_submission.py \
             test/unit/core/test_pipeline_hostfile.py \
+            test/unit/test_release_draft.py \
             test/unit/test_release_request.py \
             test/unit/test_release_workflow.py
 
@@ -493,9 +494,10 @@ jobs:
           trap 'rm -rf "$release_tmp"' EXIT
           release_json="$release_tmp/release.json"
           release_error="$release_tmp/release.error"
+          release_pages_json="$release_tmp/release-pages.json"
           release_body="JARVIS-CD $TAG_NAME immutable release."
 
-          fetch_release() {
+          fetch_published_release() {
             gh api "repos/$REPOSITORY/releases/tags/$TAG_NAME" >"$release_json"
             jq -e \
               --arg tag "$TAG_NAME" \
@@ -505,13 +507,56 @@ jobs:
                 and .body == $body
                 and .prerelease == false
                 and .author.login == "github-actions[bot]"
+                and (.id | type == "number" and . > 0)
+                and (.assets | type == "array")
               ' "$release_json" >/dev/null
           }
 
+          find_draft_release() {
+            if ! gh api --paginate --slurp \
+              "repos/$REPOSITORY/releases?per_page=100" \
+              >"$release_pages_json"; then
+              return 1
+            fi
+            python ci/release_draft.py \
+              --tag "$TAG_NAME" \
+              --title "$TAG_NAME" \
+              --body "$release_body" \
+              --author "github-actions[bot]" \
+              <"$release_pages_json" >"$release_json"
+          }
+
+          find_existing_release() {
+            if fetch_published_release 2>"$release_error"; then
+              return 0
+            fi
+            if ! grep -Fq 'HTTP 404' "$release_error"; then
+              cat "$release_error" >&2
+              return 1
+            fi
+            find_draft_release
+          }
+
+          refresh_exact_release() {
+            find_existing_release
+            test "$(jq -r .id "$release_json")" = "$release_id"
+          }
+
           load_and_verify_assets() {
-            local allow_missing="$1" id name declared_digest downloaded
+            local allow_missing="$1" id name declared_digest state size
+            local downloaded encoded_name
             declare -gA asset_ids=()
-            while IFS=$'\t' read -r id name declared_digest; do
+            jq -e '
+              [.assets[].name] as $names
+              | [.assets[].id] as $ids
+              | ($names | length) == ($names | unique | length)
+                and ($ids | length) == ($ids | unique | length)
+            ' "$release_json" >/dev/null
+            while IFS=$'\t' read -r id name declared_digest state size; do
+              if [ "$declared_digest" = - ]; then
+                declared_digest=""
+              fi
+              [[ "$id" =~ ^[1-9][0-9]*$ ]]
               [[ "$name" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]*$ ]]
               if [[ ! -v "expected_sha[$name]" ]]; then
                 echo "unexpected release asset: $name" >&2
@@ -521,6 +566,23 @@ jobs:
                 echo "duplicate release asset: $name" >&2
                 return 1
               fi
+              if [ "$state" = starter ]; then
+                if [ "$allow_missing" != true ] || \
+                   [ -n "$declared_digest" ] || \
+                   [ "$size" != 0 ]; then
+                  echo "unsafe starter release asset: $name" >&2
+                  return 1
+                fi
+                gh api \
+                  --method DELETE \
+                  -H 'X-GitHub-Api-Version: 2022-11-28' \
+                  "repos/$REPOSITORY/releases/assets/$id"
+                continue
+              fi
+              if [ "$state" != uploaded ]; then
+                echo "unexpected release asset state: $name: $state" >&2
+                return 1
+              fi
               if [ -n "$declared_digest" ] && \
                  [ "$declared_digest" != "sha256:${expected_sha[$name]}" ]; then
                 echo "release asset digest mismatch: $name" >&2
@@ -528,14 +590,36 @@ jobs:
               fi
               asset_ids["$name"]="$id"
             done < <(
-              jq -r '.assets[] | [.id, .name, (.digest // "")] | @tsv' \
+              jq -r '
+                .assets[]
+                | [
+                    .id,
+                    .name,
+                    (.digest // "-"),
+                    (.state // ""),
+                    (.size // -1)
+                  ]
+                | @tsv
+              ' \
                 "$release_json"
             )
 
             for name in "${artifacts[@]}"; do
               if [[ ! -v "asset_ids[$name]" ]]; then
                 if [ "$allow_missing" = true ]; then
-                  gh release upload "$TAG_NAME" "dist/$name" --repo "$REPOSITORY"
+                  encoded_name="$(jq -rn --arg value "$name" '$value | @uri')"
+                  gh api \
+                    --method POST \
+                    -H 'Content-Type: application/octet-stream' \
+                    -H 'X-GitHub-Api-Version: 2022-11-28' \
+                    --input "dist/$name" \
+                    "https://uploads.github.com/repos/$REPOSITORY/releases/$release_id/assets?name=$encoded_name" \
+                    >"$release_tmp/upload-$name.json"
+                  jq -e --arg name "$name" '
+                    .name == $name
+                    and .state == "uploaded"
+                    and (.id | type == "number" and . > 0)
+                  ' "$release_tmp/upload-$name.json" >/dev/null
                   continue
                 fi
                 echo "missing release asset: $name" >&2
@@ -550,9 +634,9 @@ jobs:
             done
           }
 
-          if fetch_release 2>"$release_error"; then
-            :
-          elif grep -Fq 'HTTP 404' "$release_error"; then
+          lookup_status=0
+          find_existing_release || lookup_status=$?
+          if [ "$lookup_status" -eq 3 ]; then
             gh release create "$TAG_NAME" \
               --repo "$REPOSITORY" \
               --verify-tag \
@@ -560,31 +644,37 @@ jobs:
               --notes "$release_body" \
               --latest \
               --draft
-            fetch_release
-          else
-            cat "$release_error" >&2
-            exit 1
+            find_draft_release
+          elif [ "$lookup_status" -ne 0 ]; then
+            exit "$lookup_status"
           fi
+          release_id="$(jq -er '.id | select(type == "number" and . > 0)' \
+            "$release_json")"
 
           draft="$(jq -r .draft "$release_json")"
           immutable="$(jq -r .immutable "$release_json")"
           if [ "$draft" = true ]; then
             test "$immutable" = false
             load_and_verify_assets true
-            fetch_release
+            refresh_exact_release
             load_and_verify_assets false
             test "$(resolve_remote_tag)" = "$GITHUB_SHA"
-            gh release edit "$TAG_NAME" \
-              --repo "$REPOSITORY" \
-              --draft=false \
-              --latest
+            gh api \
+              --method PATCH \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              -F draft=false \
+              -f make_latest=true \
+              "repos/$REPOSITORY/releases/$release_id" \
+              >"$release_tmp/published.json"
           else
             test "$immutable" = true
             load_and_verify_assets false
           fi
 
           test "$(resolve_remote_tag)" = "$GITHUB_SHA"
-          fetch_release
+          fetch_published_release
+          test "$(jq -r .id "$release_json")" = "$release_id"
           test "$(jq -r .draft "$release_json")" = false
           test "$(jq -r .immutable "$release_json")" = true
           test "$(gh api "repos/$REPOSITORY/releases/latest" --jq .tag_name)" = \

--- a/ci/release_draft.py
+++ b/ci/release_draft.py
@@ -1,0 +1,120 @@
+"""Select one exact GitHub draft release from a paginated API response."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from typing import Any, cast
+
+MAX_RELEASE_LIST_BYTES = 64 * 1024 * 1024
+
+
+class ReleaseDraftError(ValueError):
+    """Raised when a draft release cannot be resumed safely."""
+
+
+class ReleaseDraftNotFound(ReleaseDraftError):
+    """Raised when no draft exists for the requested tag."""
+
+
+def _release_pages(raw: str) -> list[list[dict[str, Any]]]:
+    """Parse the exact nested array emitted by ``gh api --paginate --slurp``."""
+    if len(raw.encode("utf-8")) > MAX_RELEASE_LIST_BYTES:
+        raise ReleaseDraftError("release list exceeds its byte limit")
+    try:
+        document = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ReleaseDraftError("release list is not valid JSON") from exc
+    if not isinstance(document, list) or not document:
+        raise ReleaseDraftError("release list must contain at least one API page")
+
+    pages: list[list[dict[str, Any]]] = []
+    for page in document:
+        if not isinstance(page, list):
+            raise ReleaseDraftError("release list pages must be JSON arrays")
+        releases: list[dict[str, Any]] = []
+        for release in page:
+            if not isinstance(release, dict):
+                raise ReleaseDraftError("release list entries must be JSON objects")
+            releases.append(cast(dict[str, Any], release))
+        pages.append(releases)
+    return pages
+
+
+def select_exact_draft(
+    raw: str,
+    *,
+    tag: str,
+    title: str,
+    body: str,
+    author: str,
+) -> dict[str, Any]:
+    """Return the only draft for ``tag`` after validating immutable metadata."""
+    candidates = [
+        release
+        for page in _release_pages(raw)
+        for release in page
+        if release.get("tag_name") == tag
+    ]
+    if not candidates:
+        raise ReleaseDraftNotFound(f"no draft release exists for tag {tag}")
+    if len(candidates) != 1:
+        raise ReleaseDraftError(f"multiple releases exist for tag {tag}")
+
+    release = candidates[0]
+    expected = {
+        "tag_name": tag,
+        "name": title,
+        "body": body,
+        "draft": True,
+        "prerelease": False,
+        "immutable": False,
+    }
+    for field, value in expected.items():
+        if release.get(field) != value:
+            raise ReleaseDraftError(f"draft release {field} does not match")
+    release_author = release.get("author")
+    if not isinstance(release_author, dict) or release_author.get("login") != author:
+        raise ReleaseDraftError("draft release author does not match")
+    release_id = release.get("id")
+    if type(release_id) is not int or release_id <= 0:
+        raise ReleaseDraftError("draft release id is not a positive integer")
+    if not isinstance(release.get("assets"), list):
+        raise ReleaseDraftError("draft release assets must be a JSON array")
+    return release
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--body", required=True)
+    parser.add_argument("--author", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Select and print the exact draft, returning 3 when it does not exist."""
+    parser = _parser()
+    arguments = parser.parse_args(argv)
+    raw = sys.stdin.read(MAX_RELEASE_LIST_BYTES + 1)
+    try:
+        release = select_exact_draft(
+            raw,
+            tag=arguments.tag,
+            title=arguments.title,
+            body=arguments.body,
+            author=arguments.author,
+        )
+    except ReleaseDraftNotFound:
+        return 3
+    except ReleaseDraftError as exc:
+        parser.error(str(exc))
+    print(json.dumps(release, ensure_ascii=True, separators=(",", ":"), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/release.md
+++ b/docs/release.md
@@ -97,7 +97,15 @@ git push origin "refs/tags/$tag"
 
 The workflow fails if the tag is not on `main`, artifact metadata differs from
 the tag, the remote tag moves, the published release is not immutable, or GitHub
-cannot verify the release attestation. After it completes, verify independently:
+cannot verify the release attestation. A rerun may resume a draft only when the
+paginated release list contains exactly one record for the tag and its title,
+body, author, draft state, prerelease state, and immutability state all match the
+workflow request. Duplicate or drifted records abort publication, and existing
+assets are compared byte for byte rather than overwritten. Draft assets and the
+publish transition are addressed by the validated release ID, not resolved from
+the tag a second time. The only automatic repair is deletion of an unambiguous
+zero-byte `starter` asset left by an interrupted GitHub upload; other asset-state
+or metadata drift aborts the release. After it completes, verify independently:
 
 ```bash
 gh release verify "v${version}" --repo grc-iit/jarvis-cd

--- a/test/unit/test_release_draft.py
+++ b/test/unit/test_release_draft.py
@@ -1,0 +1,119 @@
+"""Tests for fail-closed GitHub draft release discovery."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Callable
+from io import StringIO
+from typing import Any
+
+import pytest
+
+from ci.release_draft import (
+    ReleaseDraftError,
+    ReleaseDraftNotFound,
+    main,
+    select_exact_draft,
+)
+
+TAG = "v1.2.0"
+TITLE = TAG
+BODY = f"JARVIS-CD {TAG} immutable release."
+AUTHOR = "github-actions[bot]"
+
+
+def _draft(**overrides: Any) -> dict[str, Any]:
+    release: dict[str, Any] = {
+        "id": 123,
+        "tag_name": TAG,
+        "name": TITLE,
+        "body": BODY,
+        "draft": True,
+        "prerelease": False,
+        "immutable": False,
+        "author": {"login": AUTHOR},
+        "assets": [],
+    }
+    release.update(overrides)
+    return release
+
+
+def _select(pages: object) -> dict[str, Any]:
+    return select_exact_draft(
+        json.dumps(pages),
+        tag=TAG,
+        title=TITLE,
+        body=BODY,
+        author=AUTHOR,
+    )
+
+
+def test_exact_draft_is_selected_across_paginated_results() -> None:
+    draft = _draft()
+
+    assert (
+        _select([[{"id": 1, "tag_name": "v1.1.0", "draft": False}], [draft]]) == draft
+    )
+
+
+def test_missing_and_duplicate_tag_drafts_are_rejected() -> None:
+    with pytest.raises(ReleaseDraftNotFound, match="no draft"):
+        _select([[]])
+    with pytest.raises(ReleaseDraftError, match="draft"):
+        _select([[{"id": 1, "tag_name": TAG, "draft": False}]])
+
+    with pytest.raises(ReleaseDraftError, match="multiple releases"):
+        _select([[_draft(id=1)], [_draft(id=2)]])
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda value: value.update(name="wrong"), "name"),
+        (lambda value: value.update(body="wrong"), "body"),
+        (lambda value: value.update(prerelease=True), "prerelease"),
+        (lambda value: value.update(immutable=True), "immutable"),
+        (lambda value: value.update(author={"login": "someone"}), "author"),
+        (lambda value: value.update(id=0), "positive integer"),
+        (lambda value: value.update(assets={}), "assets"),
+    ],
+)
+def test_draft_metadata_drift_is_rejected(
+    mutate: Callable[[dict[str, Any]], object],
+    message: str,
+) -> None:
+    draft = _draft()
+    mutate(draft)
+
+    with pytest.raises(ReleaseDraftError, match=message):
+        _select([[draft]])
+
+
+@pytest.mark.parametrize("document", [[], {}, [[None]]])
+def test_malformed_paginated_responses_are_rejected(document: object) -> None:
+    expected = "at least one API page" if document == [] else "release list|entries"
+    with pytest.raises(ReleaseDraftError, match=expected):
+        _select(document)
+
+
+def test_cli_uses_status_three_only_for_an_absent_tag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "stdin", StringIO("[[]]"))
+
+    assert (
+        main(
+            [
+                "--tag",
+                TAG,
+                "--title",
+                TITLE,
+                "--body",
+                BODY,
+                "--author",
+                AUTHOR,
+            ]
+        )
+        == 3
+    )

--- a/test/unit/test_release_workflow.py
+++ b/test/unit/test_release_workflow.py
@@ -2,14 +2,287 @@
 
 from __future__ import annotations
 
+import hashlib
+import os
 import re
+import shutil
+import subprocess
 from pathlib import Path
+
+import yaml
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = (REPOSITORY_ROOT / ".github" / "workflows" / "release.yml").read_text(
     encoding="utf-8"
 )
+COMMIT = "a" * 40
+TAG = "v1.2.0"
+
+
+def _publish_script() -> str:
+    workflow = yaml.safe_load(WORKFLOW)
+    steps = workflow["jobs"]["release"]["steps"]
+    return next(
+        step["run"] for step in steps if step.get("name") == "Publish immutable release"
+    )
+
+
+def _bash_path(path: Path) -> str:
+    if os.name != "nt":
+        return str(path)
+    result = subprocess.run(
+        ["wsl.exe", "wslpath", "-a", "-u", str(path).replace("\\", "/")],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _prepare_release_tree(root: Path) -> tuple[Path, dict[str, bytes]]:
+    dist = root / "dist"
+    state = root / "state"
+    assets = state / "assets"
+    dist.mkdir(parents=True)
+    assets.mkdir(parents=True)
+    payloads = {
+        "jarvis_cd-1.2.0-py3-none-any.whl": b"wheel\n",
+        "jarvis_cd-1.2.0.tar.gz": b"sdist\n",
+        "release-metadata.json": b'{"schema_version":"1.0"}\n',
+        "runtime-requirements.txt": b"dependency==1.0\n",
+    }
+    for name, payload in payloads.items():
+        (dist / name).write_bytes(payload)
+    checksums = "".join(
+        f"{hashlib.sha256(payload).hexdigest()} *{name}\n"
+        for name, payload in payloads.items()
+    ).encode()
+    payloads["SHA256SUMS"] = checksums
+    (dist / "SHA256SUMS").write_bytes(checksums)
+    first_name = "jarvis_cd-1.2.0-py3-none-any.whl"
+    shutil.copyfile(dist / first_name, assets / first_name)
+    starter = state / "starter"
+    starter.mkdir()
+    (starter / "jarvis_cd-1.2.0.tar.gz").touch()
+    return state, payloads
+
+
+def _release_shell_stub() -> str:
+    return r"""
+asset_id() {
+  case "$1" in
+    SHA256SUMS) printf '1001\n' ;;
+    jarvis_cd-1.2.0-py3-none-any.whl) printf '1002\n' ;;
+    jarvis_cd-1.2.0.tar.gz) printf '1003\n' ;;
+    release-metadata.json) printf '1004\n' ;;
+    runtime-requirements.txt) printf '1005\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+emit_release() {
+  local draft="$1" immutable="$2" assets_json='[]' file name id digest size
+  for file in "$STATE"/assets/*; do
+    [ -e "$file" ] || continue
+    name="$(basename "$file")"
+    id="$(asset_id "$name")"
+    digest="sha256:$(sha256sum "$file" | cut -d' ' -f1)"
+    size="$(wc -c <"$file")"
+    assets_json="$(jq -cn \
+      --argjson current "$assets_json" \
+      --argjson id "$id" \
+      --arg name "$name" \
+      --arg digest "$digest" \
+      --argjson size "$size" \
+      '$current + [{id: $id, name: $name, digest: $digest, state: "uploaded", size: $size}]')"
+  done
+  for file in "$STATE"/starter/*; do
+    [ -e "$file" ] || continue
+    name="$(basename "$file")"
+    id="$(asset_id "$name")"
+    assets_json="$(jq -cn \
+      --argjson current "$assets_json" \
+      --argjson id "$id" \
+      --arg name "$name" \
+      '$current + [{id: $id, name: $name, digest: null, state: "starter", size: 0}]')"
+  done
+  jq -cn \
+    --arg tag "$TAG_NAME" \
+    --arg body "JARVIS-CD $TAG_NAME immutable release." \
+    --argjson draft "$draft" \
+    --argjson immutable "$immutable" \
+    --argjson assets "$assets_json" '
+      {
+        id: 123,
+        tag_name: $tag,
+        name: $tag,
+        body: $body,
+        draft: $draft,
+        prerelease: false,
+        immutable: $immutable,
+        author: {login: "github-actions[bot]"},
+        assets: $assets
+      }
+    '
+}
+
+python() {
+  touch "$STATE/python-called"
+  [ "$1" = "ci/release_draft.py" ]
+  jq -cer \
+    --arg tag "$TAG_NAME" \
+    --arg body "JARVIS-CD $TAG_NAME immutable release." '
+      [.[][] | select(.tag_name == $tag)] as $matches
+      | if (
+          ($matches | length) == 1
+          and $matches[0].name == $tag
+          and $matches[0].body == $body
+          and $matches[0].draft == true
+          and $matches[0].prerelease == false
+          and $matches[0].immutable == false
+          and $matches[0].author.login == "github-actions[bot]"
+        ) then $matches[0] else error("unsafe draft fixture") end
+    '
+}
+
+gh() {
+  local group="$1" operation="${2:-}" method=GET input='' endpoint='' id name file
+  local content_type=false api_version=false accept_json=false
+  local draft_field='' latest_field=''
+  shift
+  if [ "$group" = release ]; then
+    shift
+    if [ "$operation" = verify ] && [ -f "$STATE/published" ]; then
+      return 0
+    fi
+    echo "unexpected gh release operation: $operation" >&2
+    return 64
+  fi
+  [ "$group" = api ] || return 64
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --method) method="$2"; shift 2 ;;
+      --input) input="$2"; shift 2 ;;
+      -H)
+        case "$2" in
+          'Content-Type: application/octet-stream') content_type=true ;;
+          'X-GitHub-Api-Version: 2022-11-28') api_version=true ;;
+          'Accept: application/vnd.github+json') accept_json=true ;;
+          'Accept: application/octet-stream') ;;
+          *) return 64 ;;
+        esac
+        shift 2
+        ;;
+      -F) draft_field="$2"; shift 2 ;;
+      -f) latest_field="$2"; shift 2 ;;
+      --jq) shift 2 ;;
+      --paginate|--slurp) shift ;;
+      *) endpoint="$1"; shift ;;
+    esac
+  done
+  case "$endpoint" in
+    repos/*/git/ref/tags/*)
+      printf '%s\tcommit\n' "$GITHUB_SHA"
+      ;;
+    repos/*/releases/tags/*)
+      if [ ! -f "$STATE/published" ]; then
+        echo 'gh: Not Found (HTTP 404)' >&2
+        return 1
+      fi
+      emit_release false true
+      ;;
+    *'/releases?per_page=100')
+      if [ -f "$STATE/fail-pagination" ]; then
+        echo 'pagination failed' >&2
+        return 1
+      fi
+      release="$(emit_release true false)"
+      jq -cn --argjson release "$release" '[[$release]]'
+      ;;
+    repos/*/releases/assets/*)
+      id="${endpoint##*/}"
+      if [ "$method" = DELETE ]; then
+        [ "$api_version" = true ]
+        for file in "$STATE"/starter/*; do
+          [ -e "$file" ] || continue
+          if [ "$(asset_id "$(basename "$file")")" = "$id" ]; then
+            printf '%s\n' "$(basename "$file")" >>"$STATE/delete-log"
+            rm "$file"
+            return 0
+          fi
+        done
+        return 1
+      fi
+      [ "$method" = GET ]
+      for file in "$STATE"/assets/*; do
+        [ -e "$file" ] || continue
+        if [ "$(asset_id "$(basename "$file")")" = "$id" ]; then
+          cat "$file"
+          return 0
+        fi
+      done
+      return 1
+      ;;
+    https://uploads.github.com/*/releases/123/assets?name=*)
+      [ "$method" = POST ]
+      [ -n "$input" ]
+      [ "$content_type" = true ]
+      [ "$api_version" = true ]
+      name="${endpoint##*name=}"
+      cp "$input" "$STATE/assets/$name"
+      printf '%s\n' "$name" >>"$STATE/upload-log"
+      id="$(asset_id "$name")"
+      jq -cn --argjson id "$id" --arg name "$name" \
+        '{id: $id, name: $name, state: "uploaded"}'
+      ;;
+    repos/*/releases/latest)
+      [ -f "$STATE/published" ]
+      printf '%s\n' "$TAG_NAME"
+      ;;
+    repos/*/releases/123)
+      [ "$method" = PATCH ]
+      [ "$accept_json" = true ]
+      [ "$api_version" = true ]
+      [ "$draft_field" = draft=false ]
+      [ "$latest_field" = make_latest=true ]
+      touch "$STATE/published"
+      printf 'publish\n' >>"$STATE/publish-log"
+      emit_release false true
+      ;;
+    *)
+      echo "unexpected gh api endpoint: $endpoint" >&2
+      return 64
+      ;;
+  esac
+}
+"""
+
+
+def _run_publish_script(root: Path) -> subprocess.CompletedProcess[str]:
+    root_for_bash = _bash_path(root)
+    script = f"""
+set -euo pipefail
+export GITHUB_SHA={COMMIT}
+export REPOSITORY=grc-iit/jarvis-cd
+export TAG_NAME={TAG}
+TEST_ROOT='{root_for_bash}'
+STATE="$TEST_ROOT/state"
+cd "$TEST_ROOT"
+{_release_shell_stub()}
+{_publish_script()}
+"""
+    result = subprocess.run(
+        ["bash"],
+        input=script.encode(),
+        capture_output=True,
+    )
+    return subprocess.CompletedProcess(
+        args=result.args,
+        returncode=result.returncode,
+        stdout=result.stdout.decode(errors="replace"),
+        stderr=result.stderr.decode(errors="replace"),
+    )
 
 
 def test_external_actions_are_immutable_commit_pins() -> None:
@@ -60,6 +333,19 @@ def test_release_resume_is_exact_byte_and_fail_closed() -> None:
     """Reruns may resume exact releases but cannot overwrite or accept drift."""
     assert "load_and_verify_assets true" in WORKFLOW
     assert WORKFLOW.count("load_and_verify_assets false") >= 3
+    assert "gh api --paginate --slurp" in WORKFLOW
+    assert "python ci/release_draft.py" in WORKFLOW
+    assert "find_existing_release || lookup_status=$?" in WORKFLOW
+    assert 'if [ "$lookup_status" -eq 3 ]' in WORKFLOW
+    assert "if ! gh api --paginate --slurp" in WORKFLOW
+    assert "find_draft_release" in WORKFLOW
+    assert "releases/$release_id/assets?name=$encoded_name" in WORKFLOW
+    assert '"repos/$REPOSITORY/releases/$release_id"' in WORKFLOW
+    assert "gh release upload" not in WORKFLOW
+    assert "gh release edit" not in WORKFLOW
+    assert 'if [ "$state" = starter ]' in WORKFLOW
+    assert '"repos/$REPOSITORY/releases/assets/$id"' in WORKFLOW
+    assert "unsafe starter release asset" in WORKFLOW
     assert "cmp --silent" in WORKFLOW
     assert "release asset digest mismatch" in WORKFLOW
     assert "unexpected release asset" in WORKFLOW
@@ -71,6 +357,53 @@ def test_release_resume_is_exact_byte_and_fail_closed() -> None:
     assert '--notes "$release_body"' in WORKFLOW
     assert "--generate-notes" not in WORKFLOW
     assert "--clobber" not in WORKFLOW
+
+
+def test_release_shell_resumes_exact_partial_draft_and_fails_closed(
+    tmp_path: Path,
+) -> None:
+    """The executable recovery path is ID-bound, idempotent, and fail-closed."""
+    resume_root = tmp_path / "resume"
+    state, payloads = _prepare_release_tree(resume_root)
+
+    first = _run_publish_script(resume_root)
+
+    assert first.returncode == 0, f"stdout:\n{first.stdout}\nstderr:\n{first.stderr}"
+    assert (state / "published").is_file()
+    assert (state / "publish-log").read_text(encoding="utf-8").splitlines() == [
+        "publish"
+    ]
+    assert (state / "delete-log").read_text(encoding="utf-8").splitlines() == [
+        "jarvis_cd-1.2.0.tar.gz"
+    ]
+    assert not any((state / "starter").iterdir())
+    uploaded = (state / "upload-log").read_text(encoding="utf-8").splitlines()
+    assert sorted(uploaded) == sorted(
+        set(payloads) - {"jarvis_cd-1.2.0-py3-none-any.whl"}
+    )
+    for name, payload in payloads.items():
+        assert (state / "assets" / name).read_bytes() == payload
+
+    second = _run_publish_script(resume_root)
+
+    assert second.returncode == 0, f"stdout:\n{second.stdout}\nstderr:\n{second.stderr}"
+    assert (state / "publish-log").read_text(encoding="utf-8").splitlines() == [
+        "publish"
+    ]
+    assert (state / "upload-log").read_text(encoding="utf-8").splitlines() == uploaded
+    assert (state / "delete-log").read_text(encoding="utf-8").splitlines() == [
+        "jarvis_cd-1.2.0.tar.gz"
+    ]
+
+    failure_root = tmp_path / "pagination-failure"
+    failure_state, _ = _prepare_release_tree(failure_root)
+    (failure_state / "fail-pagination").touch()
+
+    failed = _run_publish_script(failure_root)
+
+    assert failed.returncode != 0
+    assert not (failure_state / "python-called").exists()
+    assert not (failure_state / "published").exists()
 
 
 def test_final_release_requires_exact_tag_attestation_and_immutability() -> None:


### PR DESCRIPTION
## Summary

- recover an exact bot-authored draft when GitHub's tag endpoint hides drafts
- bind asset upload, verification, and publication to the validated release ID
- fail closed on pagination, duplicate/drifted drafts, and unsafe asset states
- add executable interrupted-upload and idempotent-rerun coverage

## Validation

- 174 release-contract tests passed
- Ruff and Pyright passed
- workflow YAML, Bash syntax, lock, and diff checks passed
- hostile re-review found no remaining defects

The mandatory `gh release verify` gate remains unchanged. GitHub has not generated a tag-level attestation for the already-public immutable v1.2.0 release, although its artifact provenance attestations verify.