### PR TITLE
feat: harden durable execution release contracts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,9 @@ jobs:
           uv run --frozen pyright \
             jarvis_cd/artifacts \
             jarvis_cd/core/execution.py \
+            jarvis_cd/core/scheduler.py \
+            jarvis_cd/progress \
+            ci/live_ares_gray_scott_probe.py \
             builtin/builtin/lammps/artifacts.py \
             builtin/builtin/paraview/artifacts.py \
             builtin/builtin/gray_scott/progress.py \
@@ -89,12 +92,18 @@ jobs:
             jarvis_cd/core/pipeline.py \
             jarvis_cd/core/pkg.py \
             jarvis_cd/core/cli.py \
+            jarvis_cd/core/scheduler.py \
+            jarvis_cd/progress \
+            ci/live_ares_gray_scott_probe.py \
             builtin/builtin/lammps/artifacts.py \
             builtin/builtin/paraview/artifacts.py \
             builtin/builtin/gray_scott \
             builtin/builtin/adios2_gray_scott
           uv run --frozen ruff format --check \
             jarvis_cd/artifacts \
+            jarvis_cd/core/scheduler.py \
+            jarvis_cd/progress \
+            ci/live_ares_gray_scott_probe.py \
             builtin/builtin/lammps/artifacts.py \
             builtin/builtin/paraview/artifacts.py \
             builtin/builtin/gray_scott/progress.py \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,15 +176,23 @@ jobs:
           uv lock --check
           uv run --frozen pytest -q \
             test/unit/core/test_artifact_spi.py \
+            test/unit/core/test_progress_spi.py \
             test/unit/core/test_execution.py \
             test/unit/core/test_gray_scott_artifacts.py \
+            test/unit/core/test_gray_scott_progress.py \
             test/unit/core/test_adios2_gray_scott_artifacts.py \
+            test/unit/core/test_adios2_gray_scott_progress.py \
+            test/unit/core/test_pipeline_coverage.py \
+            test/unit/ci/test_live_ares_gray_scott_probe.py \
+            test/unit/shell/test_local_exec.py \
+            test/unit/shell/test_mpi_exec.py \
             test/unit/core/test_lammps_artifacts.py \
             test/unit/core/test_lammps_progress.py \
             test/unit/core/test_lammps_package_runtime.py \
             test/unit/core/test_paraview_artifacts.py \
             test/unit/core/test_scheduler_submission.py \
             test/unit/core/test_pipeline_hostfile.py \
+            test/unit/util/test_pkg_argparse.py \
             test/unit/test_release_draft.py \
             test/unit/test_release_request.py \
             test/unit/test_release_workflow.py

--- a/builtin/builtin/adios2_gray_scott/artifacts.py
+++ b/builtin/builtin/adios2_gray_scott/artifacts.py
@@ -47,7 +47,10 @@ class Adios2GrayScottArtifactAdapter:
     _latest_step: int = 0
     _checkpoint_announced: bool = False
     _latest_checkpoint_step: int = 0
-    _finalized: bool = False
+    _terminal: bool = False
+    _pending_elapsed_milliseconds: int | None = None
+    _completion_signal: str | None = None
+    _return_code: int | None = None
 
     def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
         """Return artifact revisions from native Gray-Scott output."""
@@ -55,7 +58,35 @@ class Adios2GrayScottArtifactAdapter:
 
     def finalize_artifacts(self) -> list[ArtifactObservation]:
         """Flush one final unterminated application output line."""
-        return self._observe("", finalize=True)
+        observations = self._observe("", finalize=True)
+        if self._pending_elapsed_milliseconds is not None and not self._terminal:
+            self._terminal = True
+            self._completion_signal = "writer_closed_and_timing_reported"
+            observations.extend(self._terminal_observations(ArtifactState.FINALIZED))
+        return observations
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Finalize durable outputs from the producer's owned process status."""
+        observations = self._observe("", finalize=True)
+        if self._terminal or not (self._output_announced or self._checkpoint_announced):
+            return observations
+
+        self._terminal = True
+        self._return_code = return_code
+        if return_code == 0:
+            self._completion_signal = (
+                "writer_closed_and_timing_reported"
+                if self._pending_elapsed_milliseconds is not None
+                else "process_exit_zero_after_final_output"
+            )
+            terminal_state = ArtifactState.FINALIZED
+        else:
+            self._completion_signal = "process_exit_nonzero"
+            terminal_state = ArtifactState.INCOMPLETE
+        observations.extend(self._terminal_observations(terminal_state))
+        return observations
 
     def reset_artifacts(self) -> None:
         """Reset parsing after the application output stream is replaced."""
@@ -65,7 +96,10 @@ class Adios2GrayScottArtifactAdapter:
         self._latest_step = 0
         self._checkpoint_announced = False
         self._latest_checkpoint_step = 0
-        self._finalized = False
+        self._terminal = False
+        self._pending_elapsed_milliseconds = None
+        self._completion_signal = None
+        self._return_code = None
 
     def _observe(self, text: str, *, finalize: bool) -> list[ArtifactObservation]:
         observations: list[ArtifactObservation] = []
@@ -74,7 +108,7 @@ class Adios2GrayScottArtifactAdapter:
         return observations
 
     def _observe_line(self, line: str) -> list[ArtifactObservation]:
-        if self._finalized:
+        if self._terminal:
             return []
 
         if _STEPS_RE.fullmatch(line) is not None:
@@ -114,30 +148,21 @@ class Adios2GrayScottArtifactAdapter:
         completed_match = _COMPLETED_RE.fullmatch(line)
         if completed_match is None:
             return []
-        self._finalized = True
-        elapsed_ms = int(completed_match.group("elapsed_ms"))
+        self._pending_elapsed_milliseconds = int(completed_match.group("elapsed_ms"))
+        return []
+
+    def _terminal_observations(self, state: ArtifactState) -> list[ArtifactObservation]:
+        """Return terminal revisions for every artifact seen in this run."""
         observations: list[ArtifactObservation] = []
         if self._output_announced:
-            observations.append(
-                self._output_observation(
-                    ArtifactState.FINALIZED,
-                    elapsed_milliseconds=elapsed_ms,
-                )
-            )
+            observations.append(self._output_observation(state))
         if self._checkpoint_announced:
-            observations.append(
-                self._checkpoint_observation(
-                    ArtifactState.FINALIZED,
-                    elapsed_milliseconds=elapsed_ms,
-                )
-            )
+            observations.append(self._checkpoint_observation(state))
         return observations
 
     def _output_observation(
         self,
         state: ArtifactState,
-        *,
-        elapsed_milliseconds: int | None = None,
     ) -> ArtifactObservation:
         if self.output_path is None:
             raise RuntimeError("ADIOS2 Gray-Scott output location is unavailable")
@@ -148,9 +173,13 @@ class Adios2GrayScottArtifactAdapter:
             "output_steps_observed": self._output_steps,
             "latest_timestep": self._latest_step,
         }
-        if elapsed_milliseconds is not None:
-            metadata["elapsed_milliseconds"] = elapsed_milliseconds
-            metadata["completion_signal"] = "writer_closed_and_timing_reported"
+        self._add_terminal_metadata(metadata, state)
+        if state is ArtifactState.FINALIZED:
+            message = "Gray-Scott ADIOS2 output finalized"
+        elif state is ArtifactState.INCOMPLETE:
+            message = "Gray-Scott ADIOS2 output is incomplete after process failure"
+        else:
+            message = "Gray-Scott ADIOS2 output is being produced"
         return ArtifactObservation(
             artifact_id=self.output_artifact_id,
             logical_name="gray-scott-simulation-output",
@@ -162,19 +191,13 @@ class Adios2GrayScottArtifactAdapter:
             location=ArtifactLocation.cluster_path(self.output_path),
             media_type="application/x-adios2-bp",
             format=_output_format(self.engine),
-            message=(
-                "Gray-Scott ADIOS2 output finalized"
-                if state is ArtifactState.FINALIZED
-                else "Gray-Scott ADIOS2 output is being produced"
-            ),
+            message=message,
             metadata=metadata,
         )
 
     def _checkpoint_observation(
         self,
         state: ArtifactState,
-        *,
-        elapsed_milliseconds: int | None = None,
     ) -> ArtifactObservation:
         if self.checkpoint_path is None:
             raise RuntimeError("ADIOS2 Gray-Scott checkpoint location is unavailable")
@@ -183,9 +206,15 @@ class Adios2GrayScottArtifactAdapter:
             "io_backend": "adios2",
             "checkpoint_timestep": self._latest_checkpoint_step,
         }
-        if elapsed_milliseconds is not None:
-            metadata["elapsed_milliseconds"] = elapsed_milliseconds
-            metadata["completion_signal"] = "application_completed_after_checkpoint"
+        self._add_terminal_metadata(metadata, state)
+        if state is ArtifactState.FINALIZED:
+            message = "Gray-Scott restart checkpoint finalized"
+        elif state is ArtifactState.INCOMPLETE:
+            message = (
+                "Gray-Scott restart checkpoint is incomplete after process failure"
+            )
+        else:
+            message = "Gray-Scott is writing a restart checkpoint"
         return ArtifactObservation(
             artifact_id=self.checkpoint_artifact_id,
             logical_name="gray-scott-restart-checkpoint",
@@ -197,13 +226,31 @@ class Adios2GrayScottArtifactAdapter:
             location=ArtifactLocation.cluster_path(self.checkpoint_path),
             media_type="application/x-adios2-bp",
             format="adios2-bp5",
-            message=(
-                "Gray-Scott restart checkpoint finalized"
-                if state is ArtifactState.FINALIZED
-                else "Gray-Scott is writing a restart checkpoint"
-            ),
+            message=message,
             metadata=metadata,
         )
+
+    def _add_terminal_metadata(
+        self,
+        metadata: dict[str, str | int],
+        state: ArtifactState,
+    ) -> None:
+        """Attach process-aware metadata only to terminal revisions."""
+        if state not in {ArtifactState.FINALIZED, ArtifactState.INCOMPLETE}:
+            return
+        if self._completion_signal is not None:
+            metadata["completion_signal"] = self._completion_signal
+        if self._pending_elapsed_milliseconds is not None:
+            metadata["elapsed_milliseconds"] = self._pending_elapsed_milliseconds
+        if (
+            self._completion_signal == "process_exit_nonzero"
+            and self._pending_elapsed_milliseconds is not None
+        ):
+            metadata["application_completion_signal"] = (
+                "writer_closed_and_timing_reported"
+            )
+        if self._return_code is not None:
+            metadata["return_code"] = self._return_code
 
 
 def adapter_from_package(

--- a/builtin/builtin/adios2_gray_scott/pkg.py
+++ b/builtin/builtin/adios2_gray_scott/pkg.py
@@ -9,6 +9,8 @@ from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
 from jarvis_cd.util.config_parser import JsonFile
 import os
+import shlex
+from typing import Any
 
 
 class Adios2GrayScott(Application):
@@ -46,6 +48,12 @@ class Adios2GrayScott(Application):
                 "msg": "Processes per node",
                 "type": int,
                 "default": 16,
+            },
+            {
+                "name": "executable",
+                "msg": "ADIOS2 Gray-Scott producer executable or absolute path",
+                "type": str,
+                "default": "adios2-gray-scott",
             },
             {
                 "name": "L",
@@ -92,7 +100,7 @@ class Adios2GrayScott(Application):
             {
                 "name": "plotgap",
                 "msg": "Number of steps between output",
-                "type": float,
+                "type": int,
                 "default": 10,
             },
             {
@@ -301,6 +309,10 @@ class Adios2GrayScott(Application):
         """
         # print(self.env['HERMES_CLIENT_CONF'])
         line_callback = self.runtime_line_callback()
+        executable = self.config.get("executable", "adios2-gray-scott")
+        if not isinstance(executable, str) or not executable.strip():
+            raise ValueError("ADIOS2 Gray-Scott executable must be a non-empty string")
+        command = f"{shlex.quote(executable)} {shlex.quote(self.settings_json_path)}"
         if self.config["engine"].lower() in [
             "bp5_derived",
             "hermes_derived",
@@ -308,7 +320,7 @@ class Adios2GrayScott(Application):
         ]:
             derived = 1
             self.process = Exec(
-                f"gray-scott {self.settings_json_path} {derived}",
+                f"{command} {derived}",
                 MpiExecInfo(
                     nprocs=self.config["nprocs"],
                     ppn=self.config["ppn"],
@@ -318,11 +330,13 @@ class Adios2GrayScott(Application):
                     line_callback=line_callback,
                 ),
             )
-            self.process.run()
+            result = self.process.run()
+            if not self.config["run_async"]:
+                self._raise_for_exec_failure(result, operation="ADIOS2 Gray-Scott")
         elif self.config["engine"].lower() in ["hermes", "bp5", "iowarp", "sst"]:
             derived = 0
             self.process = Exec(
-                f"gray-scott {self.settings_json_path} {derived}",
+                f"{command} {derived}",
                 MpiExecInfo(
                     nprocs=self.config["nprocs"],
                     ppn=self.config["ppn"],
@@ -332,7 +346,9 @@ class Adios2GrayScott(Application):
                     line_callback=line_callback,
                 ),
             )
-            self.process.run()
+            result = self.process.run()
+            if not self.config["run_async"]:
+                self._raise_for_exec_failure(result, operation="ADIOS2 Gray-Scott")
 
     def wait(self):
         """
@@ -342,6 +358,10 @@ class Adios2GrayScott(Application):
         """
         if self.process:
             self.process.wait_all()
+            self._raise_for_exec_failure(
+                self.process,
+                operation="ADIOS2 Gray-Scott async producer",
+            )
 
     def stop(self):
         """
@@ -354,9 +374,29 @@ class Adios2GrayScott(Application):
         if self.config.get("run_async", False) and self.process:
             print("Waiting for async gray-scott producer to complete...")
             self.process.wait_all()
+            self._raise_for_exec_failure(
+                self.process,
+                operation="ADIOS2 Gray-Scott async producer",
+            )
         elif self.process:
             self.process.kill_all()
-        pass
+
+    @staticmethod
+    def _raise_for_exec_failure(result: Any, *, operation: str) -> None:
+        """Raise when an execution has no status or any host exits nonzero."""
+        exit_codes = getattr(result, "exit_code", None)
+        if not isinstance(exit_codes, dict) or not exit_codes:
+            raise RuntimeError(f"{operation} returned no process exit status")
+        failures = {
+            str(host): code
+            for host, code in exit_codes.items()
+            if isinstance(code, bool) or not isinstance(code, int) or code != 0
+        }
+        if failures:
+            details = ", ".join(
+                f"{host}={code!r}" for host, code in sorted(failures.items())
+            )
+            raise RuntimeError(f"{operation} failed with exit status: {details}")
 
     def clean(self):
         """

--- a/builtin/builtin/adios2_gray_scott/progress.py
+++ b/builtin/builtin/adios2_gray_scott/progress.py
@@ -36,6 +36,8 @@ class Adios2GrayScottProgressAdapter:
     _last_step: int = 0
     _started: bool = False
     _completed: bool = False
+    _failed: bool = False
+    _pending_elapsed_milliseconds: int | None = None
 
     def observe_progress(self, text: str) -> list[ProgressObservation]:
         """Return progress based on native Gray-Scott lifecycle messages."""
@@ -43,7 +45,33 @@ class Adios2GrayScottProgressAdapter:
 
     def finalize_progress(self) -> list[ProgressObservation]:
         """Flush one final unterminated Gray-Scott output line."""
-        return self._observe("", finalize=True)
+        observations = self._observe("", finalize=True)
+        completed = self._pending_completed_observation()
+        if completed is not None:
+            observations.append(completed)
+        return observations
+
+    def finalize_progress_for_exit(self, return_code: int) -> list[ProgressObservation]:
+        """Finalize progress from the authoritative producer process status."""
+        observations = self._observe("", finalize=True)
+        if return_code != 0:
+            failed = self._failed_observation(return_code)
+            if failed is not None:
+                observations.append(failed)
+            return observations
+
+        completed = self._pending_completed_observation()
+        if completed is None and (
+            self._started
+            and self.total_steps is not None
+            and self._last_step == self.total_steps
+        ):
+            completed = self._completed_observation(
+                completion_signal="process_exit_zero_after_final_output"
+            )
+        if completed is not None:
+            observations.append(completed)
+        return observations
 
     def reset_progress(self) -> None:
         """Reset parsing when the application output stream is replaced."""
@@ -52,6 +80,8 @@ class Adios2GrayScottProgressAdapter:
         self._last_step = 0
         self._started = False
         self._completed = False
+        self._failed = False
+        self._pending_elapsed_milliseconds = None
 
     def _observe(self, text: str, *, finalize: bool) -> list[ProgressObservation]:
         observations: list[ProgressObservation] = []
@@ -62,6 +92,9 @@ class Adios2GrayScottProgressAdapter:
         return observations
 
     def _observe_line(self, line: str) -> ProgressObservation | None:
+        if self._completed or self._failed:
+            return None
+
         restart_match = _RESTART_RE.fullmatch(line)
         if restart_match is not None:
             self._restart_step = int(restart_match.group("step"))
@@ -133,30 +166,77 @@ class Adios2GrayScottProgressAdapter:
 
         completed_match = _COMPLETED_RE.fullmatch(line)
         if completed_match is not None:
-            if self._completed:
-                return None
-            self._completed = True
-            current = (
-                self.total_steps if self.total_steps is not None else self._last_step
-            )
-            return ProgressObservation(
-                label="simulation",
-                state=ProgressState.COMPLETED,
-                current=float(current),
-                total=(
-                    float(self.total_steps) if self.total_steps is not None else None
-                ),
-                unit="timestep",
-                message="ADIOS2 Gray-Scott simulation completed",
-                metadata={
-                    "application": "gray_scott",
-                    "io_backend": "adios2",
-                    "progress_kind": "simulation_timestep",
-                    "completion_signal": "writer_closed_and_timing_reported",
-                    "elapsed_milliseconds": int(completed_match.group("elapsed_ms")),
-                },
+            self._pending_elapsed_milliseconds = int(
+                completed_match.group("elapsed_ms")
             )
         return None
+
+    def _pending_completed_observation(self) -> ProgressObservation | None:
+        """Commit a deferred writer-close marker for legacy callers."""
+        if self._pending_elapsed_milliseconds is None:
+            return None
+        return self._completed_observation(
+            completion_signal="writer_closed_and_timing_reported",
+            elapsed_milliseconds=self._pending_elapsed_milliseconds,
+        )
+
+    def _completed_observation(
+        self,
+        *,
+        completion_signal: str,
+        elapsed_milliseconds: int | None = None,
+    ) -> ProgressObservation | None:
+        """Return one terminal success after its process status is accepted."""
+        if self._completed or self._failed:
+            return None
+        self._completed = True
+        current = self.total_steps if self.total_steps is not None else self._last_step
+        metadata: dict[str, str | int] = {
+            "application": "gray_scott",
+            "io_backend": "adios2",
+            "progress_kind": "simulation_timestep",
+            "completion_signal": completion_signal,
+        }
+        if elapsed_milliseconds is not None:
+            metadata["elapsed_milliseconds"] = elapsed_milliseconds
+        return ProgressObservation(
+            label="simulation",
+            state=ProgressState.COMPLETED,
+            current=float(current),
+            total=(float(self.total_steps) if self.total_steps is not None else None),
+            unit="timestep",
+            message="ADIOS2 Gray-Scott simulation completed",
+            metadata=metadata,
+        )
+
+    def _failed_observation(self, return_code: int) -> ProgressObservation | None:
+        """Return one terminal failure from an authoritative process status."""
+        if self._completed or self._failed:
+            return None
+        self._failed = True
+        metadata: dict[str, str | int] = {
+            "application": "gray_scott",
+            "io_backend": "adios2",
+            "progress_kind": "simulation_timestep",
+            "completion_signal": "process_exit_nonzero",
+            "return_code": return_code,
+        }
+        if self._pending_elapsed_milliseconds is not None:
+            metadata["application_completion_signal"] = (
+                "writer_closed_and_timing_reported"
+            )
+            metadata["elapsed_milliseconds"] = self._pending_elapsed_milliseconds
+        return ProgressObservation(
+            label="simulation",
+            state=ProgressState.FAILED,
+            current=float(self._last_step),
+            total=(float(self.total_steps) if self.total_steps is not None else None),
+            unit="timestep",
+            message=(
+                f"ADIOS2 Gray-Scott simulation failed with exit status {return_code}"
+            ),
+            metadata=metadata,
+        )
 
 
 def adapter_from_package(

--- a/builtin/builtin/gray_scott/README.md
+++ b/builtin/builtin/gray_scott/README.md
@@ -1,154 +1,70 @@
-Gray-Scott is a 3D 7-Point stencil code
+# IOWarp Gray-Scott
 
-# Installation
+`builtin.gray_scott` runs the direct Gray-Scott application maintained in
+[`iowarp/clio-core`](https://github.com/iowarp/clio-core), under
+`external/iowarp-gray-scott`. It does not require Coeus or Hermes.
+
+## Install
+
+The Clio Core Spack repository exposes the project as `iowarp`. Enable ADIOS2
+when installing the direct application:
 
 ```bash
-scspkg create gray-scott
-cd `scspkg pkg src gray-scott`
-git clone https://github.com/pnorbert/adiosvm
-cd adiosvm/Tutorial/gs-mpiio
-mkdir build
-pushd build
-cmake ../ -DCMAKE_BUILD_TYPE=Release
-make -j8
-export GRAY_SCOTT_PATH=`pwd`
-scspkg env set gray_scott GRAY_SCOTT_PATH="${GRAY_SCOTT_PATH}"
-scspkg env prepend gray_scott PATH "${GRAY_SCOTT_PATH}"
-module load gray_scott
-spack load mpi adios2
+git clone https://github.com/iowarp/clio-core.git
+spack repo add clio-core/installers/spack
+spack install iowarp@main+adios2
+spack load iowarp@main+adios2
 ```
 
-# Gray Scott
+You can also build `external/iowarp-gray-scott` directly with CMake. The
+resulting executable is named `gray-scott`.
 
-## 1. Setup Environment
+## Run with JARVIS
 
-Create the environment variables needed by Gray Scott
+The executable can be selected explicitly, which is recommended for durable
+and live-validated runs:
+
 ```bash
-module load gray_scott
-spack load mpi
-```````````
-
-## 1. Create a Resource Graph
-
-If you haven't already, create a resource graph. This only needs to be done
-once throughout the lifetime of Jarvis. No need to repeat if you have already
-done this for a different pipeline.
-
-If you are running distributed tests, set path to the hostfile you are  using.
-```bash
-jarvis hostfile set /path/to/hostfile
+jarvis ppl create gray-scott-test
+jarvis ppl append builtin.gray_scott \
+  executable=/absolute/path/to/gray-scott \
+  nprocs=1 ppn=1 width=32 height=32 \
+  steps=20 out_every=10 \
+  outdir=/shared/results/gray-scott.bp
+jarvis ppl run
 ```
 
-Next, collect the resources from each of those pkgs. Walkthrough will give
-a command line tutorial on how to build the hostfile.
-```bash
-jarvis resource-graph build +walkthrough
+The package writes the complete settings schema expected by Clio Core,
+including checkpoint and ADIOS2 memory-selection defaults. Its file-backed
+default uses BP5. If `outdir` is omitted, JARVIS writes under this package's
+pipeline-shared directory rather than temporary host storage.
+
+## Durable progress and artifacts
+
+For an owned execution, JARVIS records simulation-timestep progress and one
+evolving artifact named `gray-scott-timesteps`. The artifact is a shared
+cluster-path collection with media type `application/x-adios2-bp` and format
+`adios2-bp5`. A successful process exit after the final observed timestep
+finalizes both progress and the artifact; a nonzero exit never makes that
+claim.
+
+When `checkpoint=true`, JARVIS also reports
+`gray-scott-restart-checkpoint` at the configured `checkpoint_output` path.
+The direct Clio Core writer does not emit a checkpoint-completion message, so
+JARVIS snapshots that exact path before launch and reports it only if it was
+created or changed by the owned process. A zero exit finalizes the checkpoint;
+a nonzero exit records a changed checkpoint as incomplete. Package cleanup
+removes the exact main-output and checkpoint paths, including independently
+configured locations, without wildcard deletion.
+
+Use the execution handle or reopen the execution later:
+
+```python
+handle = pipeline.run()
+record = handle.refresh()
+progress = handle.progress()
+artifacts = handle.artifacts()
 ```
 
-## 2. Create a Pipeline
-
-The Jarvis pipeline will store all configuration data needed by Gray Scott.
-
-```bash
-jarvis pipeline create gray-scott-test
-```
-
-## 3. Save Environment
-
-Store the current environment in the pipeline.
-```bash
-jarvis pipeline env build
-```
-
-## 4. Add pkgs to the Pipeline
-
-Create a Jarvis pipeline with Gray Scott
-```bash
-jarvis pipeline append gray_scott
-```
-
-## 5. Run Experiment
-
-Run the experiment
-```bash
-jarvis pipeline run
-```
-
-## 6. Clean Data
-
-Clean data produced by Gray Scott
-```bash
-jarvis pipeline clean
-```
-
-# Gray Scott With Hermes
-
-## 1. Setup Environment
-
-Create the environment variables needed by Hermes + Gray Scott
-```bash
-# On personal
-spack install hermes@master adios2
-spack load hermes adios2
-# On Ares
-module load hermes/master-feow7up adios2/2.9.0-mmkelnu
-# export GRAY_SCOTT_PATH=${HOME}/adiosvm/Tutorial/gs-mpiio/build
-export PATH="${GRAY_SCOTT_PATH}:$PATH"
-```
-
-## 2. Create a Resource Graph
-
-If you haven't already, create a resource graph. This only needs to be done
-once throughout the lifetime of Jarvis. No need to repeat if you have already
-done this for a different pipeline.
-
-If you are running distributed tests, set path to the hostfile you are  using.
-```bash
-jarvis hostfile set /path/to/hostfile.txt
-```
-
-Next, collect the resources from each of those pkgs. Walkthrough will give
-a command line tutorial on how to build the hostfile.
-```bash
-jarvis resource-graph build +walkthrough
-```
-
-## 3. Create a Pipeline
-
-The Jarvis pipeline will store all configuration data needed by Hermes
-and Gray Scott.
-
-```bash
-jarvis pipeline create gs-hermes
-```
-
-## 3. Save Environment
-
-Store the current environment in the pipeline.
-```bash
-jarvis pipeline env build
-```
-
-## 4. Add pkgs to the Pipeline
-
-Create a Jarvis pipeline with Hermes, the Hermes MPI-IO interceptor,
-and gray-scott
-```bash
-jarvis pipeline append hermes --sleep=10 --output_dir=${HOME}/gray-scott
-jarvis pipeline append hermes_api +mpi
-jarvis pipeline append gray_scott
-```
-
-## 5. Run the Experiment
-
-Run the experiment
-```bash
-jarvis pipeline run
-```
-
-## 6. Clean Data
-
-To clean data produced by Hermes + Gray-Scott:
-```bash
-jarvis pipeline clean
-```
+Coeus-specific engines and adapter experiments belong to the Coeus package and
+repository rather than this direct application package.

--- a/builtin/builtin/gray_scott/artifacts.py
+++ b/builtin/builtin/gray_scott/artifacts.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import os
 import re
+import stat
 from dataclasses import dataclass, field
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from jarvis_cd.artifacts.provider import ArtifactObservation
@@ -28,19 +30,71 @@ _ADIOS_COMPLETED_RE = re.compile(
     r"^Rank\s+0\s+-\s+ET\s+(?P<elapsed_ms>\d+)\s+-\s+milliseconds\s*$"
 )
 
+_PathStat = tuple[str, int, int, int, int, int]
+_PathFingerprint = tuple[_PathStat, tuple[_PathStat, ...]]
+
+
+def _path_fingerprint(path: PurePosixPath) -> _PathFingerprint | None:
+    """Return metadata-only evidence that a configured path changed.
+
+    The direct Clio Core writer does not print a checkpoint-completion line.
+    Snapshotting the configured BP path before and after the owned process lets
+    JARVIS report only a checkpoint that appeared or changed during that run,
+    without reading or hashing potentially large scientific data files.
+    """
+    concrete = Path(path.as_posix())
+    try:
+        root_stat = concrete.lstat()
+        children: list[_PathStat] = []
+        if stat.S_ISDIR(root_stat.st_mode):
+            for child in concrete.iterdir():
+                child_stat = child.lstat()
+                children.append(_stat_signature(child.name, child_stat))
+    except OSError:
+        return None
+    return (
+        _stat_signature(".", root_stat),
+        tuple(sorted(children, key=lambda item: item[0])),
+    )
+
+
+def _stat_signature(name: str, value: os.stat_result) -> _PathStat:
+    """Return stable filesystem metadata without reading artifact contents."""
+    return (
+        name,
+        int(value.st_mode),
+        int(value.st_ino),
+        int(value.st_size),
+        int(value.st_mtime_ns),
+        int(value.st_ctime_ns),
+    )
+
 
 @dataclass
 class GrayScottArtifactAdapter:
     """Describe Gray-Scott's HDF5 or ADIOS2 timestep collection."""
 
     output_dir: PurePosixPath | None
+    checkpoint_path: PurePosixPath | None = None
     deploy_mode: str = "default"
     artifact_id: str = field(default_factory=new_artifact_id)
+    checkpoint_artifact_id: str = field(default_factory=new_artifact_id)
     _lines: LineBuffer = field(default_factory=LineBuffer)
     _member_count: int = 0
     _latest_step: int = 0
     _announced: bool = False
-    _finalized: bool = False
+    _terminal: bool = False
+    _completion_signal: str | None = None
+    _pending_completion_signal: str | None = None
+    _pending_elapsed_milliseconds: int | None = None
+    _return_code: int | None = None
+    _checkpoint_baseline: _PathFingerprint | None = field(init=False, default=None)
+    _checkpoint_detected: bool = False
+
+    def __post_init__(self) -> None:
+        """Snapshot a configured checkpoint before the owned process starts."""
+        if self.checkpoint_path is not None:
+            self._checkpoint_baseline = _path_fingerprint(self.checkpoint_path)
 
     def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
         """Return collection revisions from completed HDF5 writes."""
@@ -48,7 +102,40 @@ class GrayScottArtifactAdapter:
 
     def finalize_artifacts(self) -> list[ArtifactObservation]:
         """Flush one final unterminated application output line."""
-        return self._observe("", finalize=True)
+        observations = self._observe("", finalize=True)
+        finalized = self._pending_finalized_observation()
+        if finalized is not None:
+            observations.append(finalized)
+        return observations
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Finalize direct outputs from an owned process and filesystem state."""
+        observations = self._observe("", finalize=True)
+        if self._terminal:
+            return observations
+
+        self._checkpoint_detected = self._checkpoint_changed_during_process()
+        if not self._announced and not self._checkpoint_detected:
+            return observations
+
+        self._terminal = True
+        self._return_code = return_code
+        if return_code == 0:
+            self._completion_signal = (
+                self._pending_completion_signal
+                or "process_exit_zero_after_final_output"
+            )
+            terminal_state = ArtifactState.FINALIZED
+        else:
+            self._completion_signal = "process_exit_nonzero"
+            terminal_state = ArtifactState.INCOMPLETE
+        if self._announced:
+            observations.append(self._observation(terminal_state))
+        if self._checkpoint_detected:
+            observations.append(self._checkpoint_observation(terminal_state))
+        return observations
 
     def reset_artifacts(self) -> None:
         """Reset parsing after the application output stream is replaced."""
@@ -56,7 +143,17 @@ class GrayScottArtifactAdapter:
         self._member_count = 0
         self._latest_step = 0
         self._announced = False
-        self._finalized = False
+        self._terminal = False
+        self._completion_signal = None
+        self._pending_completion_signal = None
+        self._pending_elapsed_milliseconds = None
+        self._return_code = None
+        self._checkpoint_detected = False
+        self._checkpoint_baseline = (
+            None
+            if self.checkpoint_path is None
+            else _path_fingerprint(self.checkpoint_path)
+        )
 
     def _observe(self, text: str, *, finalize: bool) -> list[ArtifactObservation]:
         observations: list[ArtifactObservation] = []
@@ -91,7 +188,7 @@ class GrayScottArtifactAdapter:
 
         output_match = _OUTPUT_RE.fullmatch(line)
         if output_match is not None:
-            if self._finalized:
+            if self._terminal:
                 raise ValueError(
                     "Gray-Scott emitted output after finalizing its dataset"
                 )
@@ -111,16 +208,63 @@ class GrayScottArtifactAdapter:
             return self._observation(ArtifactState.PRODUCING)
 
         if stripped == "Done." or _ADIOS_COMPLETED_RE.fullmatch(stripped) is not None:
-            if self._finalized or not self._announced:
+            if self._terminal or not self._announced:
                 return None
-            self._finalized = True
-            return self._observation(ArtifactState.FINALIZED)
+            self._pending_completion_signal = (
+                "application_reported_done"
+                if stripped == "Done."
+                else "writer_closed_and_timing_reported"
+            )
+            completed_match = _ADIOS_COMPLETED_RE.fullmatch(stripped)
+            if completed_match is not None:
+                self._pending_elapsed_milliseconds = int(
+                    completed_match.group("elapsed_ms")
+                )
         return None
+
+    def _pending_finalized_observation(self) -> ArtifactObservation | None:
+        """Commit a deferred application success marker for legacy callers."""
+        if (
+            self._terminal
+            or not self._announced
+            or self._pending_completion_signal is None
+        ):
+            return None
+        self._terminal = True
+        self._completion_signal = self._pending_completion_signal
+        return self._observation(ArtifactState.FINALIZED)
 
     def _observation(self, state: ArtifactState) -> ArtifactObservation:
         if self.output_dir is None:
             raise RuntimeError("Gray-Scott artifact location is unavailable")
         is_hdf5 = self.deploy_mode == "container"
+        metadata: dict[str, str | int] = {
+            "application": "gray_scott",
+            "io_backend": "hdf5" if is_hdf5 else "adios2",
+            "member_pattern": "gs_*.h5" if is_hdf5 else "adios2-steps",
+            "members_observed": self._member_count,
+            "latest_timestep": self._latest_step,
+        }
+        if self._completion_signal is not None:
+            metadata["completion_signal"] = self._completion_signal
+        if self._pending_elapsed_milliseconds is not None:
+            metadata["elapsed_milliseconds"] = self._pending_elapsed_milliseconds
+        if (
+            self._completion_signal == "process_exit_nonzero"
+            and self._pending_completion_signal is not None
+        ):
+            metadata["application_completion_signal"] = self._pending_completion_signal
+        if self._return_code is not None:
+            metadata["return_code"] = self._return_code
+
+        if state is ArtifactState.FINALIZED:
+            message = "Gray-Scott timestep collection finalized"
+        elif state is ArtifactState.INCOMPLETE:
+            message = (
+                "Gray-Scott timestep collection is incomplete after process failure"
+            )
+        else:
+            message = "Gray-Scott timestep collection is being produced"
         return ArtifactObservation(
             artifact_id=self.artifact_id,
             logical_name="gray-scott-timesteps",
@@ -132,18 +276,54 @@ class GrayScottArtifactAdapter:
             location=ArtifactLocation.cluster_path(self.output_dir),
             media_type=("application/x-hdf5" if is_hdf5 else "application/x-adios2-bp"),
             format=("hdf5-time-series" if is_hdf5 else "adios2-bp5"),
-            message=(
-                "Gray-Scott timestep collection finalized"
-                if state is ArtifactState.FINALIZED
-                else "Gray-Scott timestep collection is being produced"
-            ),
-            metadata={
-                "application": "gray_scott",
-                "io_backend": "hdf5" if is_hdf5 else "adios2",
-                "member_pattern": "gs_*.h5" if is_hdf5 else "adios2-steps",
-                "members_observed": self._member_count,
-                "latest_timestep": self._latest_step,
-            },
+            message=message,
+            metadata=metadata,
+        )
+
+    def _checkpoint_changed_during_process(self) -> bool:
+        """Return whether the configured checkpoint became durable this run."""
+        if self.checkpoint_path is None:
+            return False
+        current = _path_fingerprint(self.checkpoint_path)
+        return current is not None and current != self._checkpoint_baseline
+
+    def _checkpoint_observation(
+        self,
+        state: ArtifactState,
+    ) -> ArtifactObservation:
+        """Describe the checkpoint observed at owned-process completion."""
+        if self.checkpoint_path is None:
+            raise RuntimeError("Gray-Scott checkpoint location is unavailable")
+        metadata: dict[str, str | int | bool] = {
+            "application": "gray_scott",
+            "io_backend": "adios2",
+            "detection_signal": "configured_path_created_or_changed_during_process",
+            "physical_path_observed": True,
+        }
+        if self._latest_step > 0:
+            metadata["latest_output_timestep_observed"] = self._latest_step
+        if self._completion_signal is not None:
+            metadata["completion_signal"] = self._completion_signal
+        if self._return_code is not None:
+            metadata["return_code"] = self._return_code
+        message = (
+            "Gray-Scott restart checkpoint finalized"
+            if state is ArtifactState.FINALIZED
+            else "Gray-Scott restart checkpoint is incomplete after process failure"
+        )
+        return ArtifactObservation(
+            artifact_id=self.checkpoint_artifact_id,
+            logical_name="gray-scott-restart-checkpoint",
+            kind="restart_checkpoint",
+            role=ArtifactRole.CHECKPOINT,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(self.checkpoint_path),
+            media_type="application/x-adios2-bp",
+            format="adios2-bp5",
+            message=message,
+            metadata=metadata,
         )
 
 
@@ -153,9 +333,14 @@ def adapter_from_package(
     """Create artifact semantics for the builtin Gray-Scott package."""
     if package.get("pkg_type") != "builtin.gray_scott":
         return None
+    deploy_mode = str(package.get("effective_deploy_mode") or "default").casefold()
+    checkpoint_path = None
+    if deploy_mode != "container" and package.get("checkpoint") is True:
+        checkpoint_path = _configured_cluster_path(package.get("checkpoint_output"))
     return GrayScottArtifactAdapter(
         output_dir=_configured_cluster_path(package.get("outdir")),
-        deploy_mode=str(package.get("effective_deploy_mode") or "default").casefold(),
+        checkpoint_path=checkpoint_path,
+        deploy_mode=deploy_mode,
     )
 
 

--- a/builtin/builtin/gray_scott/config/adios2.xml
+++ b/builtin/builtin/gray_scott/config/adios2.xml
@@ -6,14 +6,11 @@
         ============================================-->
 
     <io name="SimulationOutput">
-        <engine type="FileStream">
-            <!-- SST engine parameters -->
-            <parameter key="RendezvousReaderCount" value="0"/>
-            <parameter key="QueueLimit" value="1"/>
-            <parameter key="QueueFullPolicy" value="Discard"/>
-            <!-- BP4/SST engine parameters -->
-            <parameter key="OpenTimeoutSecs" value="10.0"/>
-        </engine>
+        <engine type="BP5"/>
+    </io>
+
+    <io name="SimulationCheckpoint">
+        <engine type="BP5"/>
     </io>
 
     <!--===========================================

--- a/builtin/builtin/gray_scott/pkg.py
+++ b/builtin/builtin/gray_scott/pkg.py
@@ -3,12 +3,38 @@ This module provides classes and methods to launch the Gray-Scott application.
 Gray-Scott is a reaction-diffusion simulation.
 """
 
+import shlex
+import time
+from pathlib import PurePosixPath
+from typing import Any
+
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
-from jarvis_cd.shell.process import Mkdir, Rm
+from jarvis_cd.shell.process import Mkdir
 from jarvis_cd.util.config_parser import JsonFile
 from jarvis_cd.util.logger import Color
-import time
+
+
+def _absolute_dataset_path(
+    value: str,
+    *,
+    field_name: str,
+    context: str = "",
+) -> str:
+    """Validate one normalized absolute dataset path for execution or cleanup."""
+    path = value.strip()
+    parsed = PurePosixPath(path)
+    label = " ".join(part for part in (field_name, context, "path") if part)
+    if (
+        not path
+        or not parsed.is_absolute()
+        or len(parsed.parts) == 1
+        or parsed.as_posix() != path
+        or ".." in parsed.parts
+        or any(ord(character) < 32 or ord(character) == 127 for character in path)
+    ):
+        raise ValueError(f"Gray-Scott refuses unsafe {label}: {value!r}")
+    return path
 
 
 class GrayScott(Application):
@@ -20,11 +46,13 @@ class GrayScott(Application):
     gray-scott binary via MPI with ADIOS2 I/O.
     """
 
-    def _init(self):
+    config: dict[str, Any]
+
+    def _init(self) -> None:
         self.adios2_xml_path = f"{self.shared_dir}/adios2.xml"
         self.settings_json_path = f"{self.shared_dir}/settings-files.json"
 
-    def _configure_menu(self):
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
             {
                 "name": "nprocs",
@@ -37,6 +65,12 @@ class GrayScott(Application):
                 "msg": "Processes per node",
                 "type": int,
                 "default": None,
+            },
+            {
+                "name": "executable",
+                "msg": "IOWarp Gray-Scott executable or absolute path",
+                "type": str,
+                "default": "gray-scott",
             },
             {
                 "name": "width",
@@ -58,15 +92,52 @@ class GrayScott(Application):
             },
             {
                 "name": "out_every",
-                "msg": "HDF5 output interval (steps between writes)",
+                "msg": "Output interval (simulation steps between writes)",
                 "type": int,
                 "default": 500,
             },
             {
                 "name": "outdir",
-                "msg": "Output directory for HDF5 files",
+                "msg": "Output dataset path (default: package shared directory)",
                 "type": str,
-                "default": "/tmp/gray_scott_out",
+                "default": "",
+            },
+            {
+                "name": "checkpoint",
+                "msg": "Enable ADIOS2 restart checkpoints",
+                "type": bool,
+                "default": False,
+            },
+            {
+                "name": "checkpoint_freq",
+                "msg": "Checkpoint frequency in output intervals",
+                "type": int,
+                "default": 2000,
+            },
+            {
+                "name": "checkpoint_output",
+                "msg": "ADIOS2 checkpoint dataset path",
+                "type": str,
+                "default": "",
+            },
+            {
+                "name": "adios_span",
+                "msg": "Use the ADIOS2 span write API",
+                "type": bool,
+                "default": False,
+            },
+            {
+                "name": "adios_memory_selection",
+                "msg": "Use ADIOS2 memory selections for ghost cells",
+                "type": bool,
+                "default": False,
+            },
+            {
+                "name": "mesh_type",
+                "msg": "ADIOS2 visualization mesh schema",
+                "type": str,
+                "default": "image",
+                "choices": ["image"],
             },
             {
                 "name": "F",
@@ -110,7 +181,7 @@ class GrayScott(Application):
     # Container Dockerfile generators
     # ------------------------------------------------------------------
 
-    def _build_phase(self):
+    def _build_phase(self) -> Any:
         if self.config.get("deploy_mode") != "container":
             return None
         cuda_arch = self.config.get("cuda_arch", 80)
@@ -123,10 +194,10 @@ class GrayScott(Application):
         )
         return content, f"cuda-{cuda_arch}"
 
-    def _build_deploy_phase(self):
+    def _build_deploy_phase(self) -> Any:
         if self.config.get("deploy_mode") != "container":
             return None
-        suffix = getattr(self, "_build_suffix", "")
+        suffix = str(getattr(self, "_build_suffix", ""))
         content = self._read_dockerfile(
             "Dockerfile.deploy",
             {
@@ -140,7 +211,7 @@ class GrayScott(Application):
     # Configuration
     # ------------------------------------------------------------------
 
-    def _configure(self, **kwargs):
+    def _configure(self, **kwargs: Any) -> None:
         """
         Configure Gray-Scott.
 
@@ -153,33 +224,115 @@ class GrayScott(Application):
         super()._configure(**kwargs)
 
         if self.config.get("deploy_mode") == "default":
-            output = self.config.get("outdir", f"{self.shared_dir}/gray-scott-output")
-            self.config["outdir"] = output
-            Mkdir(output, PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+            width = self.config.get("width", 512)
+            height = self.config.get("height", 512)
+            steps = self.config.get("steps", 5000)
+            out_every = self.config.get("out_every", 500)
+            for name, value in (
+                ("width", width),
+                ("height", height),
+                ("steps", steps),
+                ("out_every", out_every),
+            ):
+                if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                    raise ValueError(f"Gray-Scott {name} must be a positive integer")
+            if width != height:
+                raise ValueError(
+                    "Direct IOWarp Gray-Scott requires width and height to match"
+                )
+            if steps % out_every != 0:
+                raise ValueError(
+                    "Direct IOWarp Gray-Scott requires steps to be divisible by "
+                    "out_every"
+                )
+            checkpoint_freq = self.config.get("checkpoint_freq", 2000)
+            if self.config.get("checkpoint", False) and (
+                isinstance(checkpoint_freq, bool)
+                or not isinstance(checkpoint_freq, int)
+                or checkpoint_freq <= 0
+            ):
+                raise ValueError(
+                    "Gray-Scott checkpoint_freq must be a positive integer when "
+                    "checkpointing is enabled"
+                )
+            output = self._resolve_output_path()
+            checkpoint_output = self.config.get("checkpoint_output")
+            if not isinstance(checkpoint_output, str) or not checkpoint_output.strip():
+                checkpoint_output = f"{output}.checkpoint.bp"
+            else:
+                checkpoint_output = checkpoint_output.strip()
+            checkpoint_output = _absolute_dataset_path(
+                checkpoint_output,
+                field_name="checkpoint_output",
+            )
+            self.config["checkpoint_output"] = checkpoint_output
+            directories = [output]
+            if self.config.get("checkpoint", False):
+                checkpoint_parent = PurePosixPath(checkpoint_output).parent.as_posix()
+                if checkpoint_parent != "/" and checkpoint_parent not in directories:
+                    directories.append(checkpoint_parent)
+            mkdir_result = Mkdir(
+                directories,
+                PsshExecInfo(hostfile=self.hostfile, env=self.env),
+            ).run()
+            self._raise_for_exec_failure(
+                mkdir_result,
+                operation="Gray-Scott output setup",
+            )
 
             settings_json = {
-                "L": self.config.get("width", 512),
+                "L": width,
                 "Du": self.config.get("Du", 0.16),
                 "Dv": self.config.get("Dv", 0.08),
                 "F": self.config.get("F", 0.035),
                 "k": self.config.get("k", 0.060),
                 "dt": 2.0,
-                "plotgap": self.config.get("out_every", 500),
-                "steps": self.config.get("steps", 5000),
+                "plotgap": out_every,
+                "steps": steps,
                 "noise": 0.01,
                 "output": output,
+                "checkpoint": self.config.get("checkpoint", False),
+                "checkpoint_freq": checkpoint_freq,
+                "checkpoint_output": checkpoint_output,
                 "adios_config": self.adios2_xml_path,
+                "adios_span": self.config.get("adios_span", False),
+                "adios_memory_selection": self.config.get(
+                    "adios_memory_selection", False
+                ),
+                "mesh_type": self.config.get("mesh_type", "image"),
             }
             JsonFile(self.settings_json_path).save(settings_json)
             self.copy_template_file(
                 f"{self.pkg_dir}/config/adios2.xml", self.adios2_xml_path
             )
+        else:
+            self._resolve_output_path()
+
+    def _resolve_output_path(self) -> str:
+        """Resolve an omitted output to durable package-shared storage."""
+        output = self.config.get("outdir")
+        if not isinstance(output, str) or not output.strip():
+            if not isinstance(self.shared_dir, str) or not self.shared_dir.strip():
+                raise RuntimeError(
+                    "Gray-Scott requires its package shared directory before "
+                    "resolving the default output path"
+                )
+            shared_dir = _absolute_dataset_path(
+                self.shared_dir,
+                field_name="package shared directory",
+            )
+            output = (PurePosixPath(shared_dir) / "gray-scott-output").as_posix()
+        else:
+            output = output.strip()
+        output = _absolute_dataset_path(output, field_name="outdir")
+        self.config["outdir"] = output
+        return output
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
-    def start(self):
+    def start(self) -> None:
         """
         Launch Gray-Scott.
 
@@ -188,8 +341,14 @@ class GrayScott(Application):
         """
         line_callback = self.runtime_line_callback()
         if self.config.get("deploy_mode") == "container":
-            outdir = self.config.get("outdir", "/tmp/gray_scott_out")
-            Mkdir(outdir).run()
+            outdir = self.config.get("outdir")
+            if not isinstance(outdir, str) or not outdir:
+                raise RuntimeError("Gray-Scott output path was not configured")
+            mkdir_result = Mkdir(outdir).run()
+            self._raise_for_exec_failure(
+                mkdir_result,
+                operation="Gray-Scott output setup",
+            )
 
             nprocs = self.config.get("nprocs", 4)
             inner = " ".join(
@@ -199,14 +358,14 @@ class GrayScott(Application):
                     f"--height {self.config['height']}",
                     f"--steps {self.config['steps']}",
                     f"--out-every {self.config['out_every']}",
-                    f"--outdir {outdir}",
+                    f"--outdir {shlex.quote(outdir)}",
                     f"--F {self.config['F']}",
                     f"--k {self.config['k']}",
                     f"--Du {self.config['Du']}",
                     f"--Dv {self.config['Dv']}",
                 ]
             )
-            Exec(
+            result = Exec(
                 inner,
                 MpiExecInfo(
                     nprocs=nprocs,
@@ -220,10 +379,19 @@ class GrayScott(Application):
                     line_callback=line_callback,
                 ),
             ).run()
+            self._raise_for_exec_failure(result, operation="container Gray-Scott")
         else:
             start = time.time()
-            Exec(
-                f"gray-scott {self.settings_json_path}",
+            executable = self.config.get("executable", "gray-scott")
+            if not isinstance(executable, str) or not executable.strip():
+                raise ValueError("Gray-Scott executable must be a non-empty string")
+            result = Exec(
+                " ".join(
+                    [
+                        shlex.quote(executable.strip()),
+                        shlex.quote(self.settings_json_path),
+                    ]
+                ),
                 MpiExecInfo(
                     nprocs=self.config["nprocs"],
                     ppn=self.config["ppn"],
@@ -232,15 +400,70 @@ class GrayScott(Application):
                     line_callback=line_callback,
                 ),
             ).run()
+            self._raise_for_exec_failure(result, operation="IOWarp Gray-Scott")
             end = time.time()
             self.log(f"TIME: {end - start:.2f} seconds", color=Color.GREEN)
 
-    def stop(self):
+    @staticmethod
+    def _raise_for_exec_failure(result: Any, *, operation: str) -> None:
+        """Raise with bounded stderr when an execution exits unsuccessfully."""
+        exit_codes = getattr(result, "exit_code", None)
+        if not isinstance(exit_codes, dict) or not exit_codes:
+            raise RuntimeError(f"{operation} returned no process exit status")
+        failures = {
+            str(host): code
+            for host, code in exit_codes.items()
+            if isinstance(code, bool) or not isinstance(code, int) or code != 0
+        }
+        if failures:
+            details = ", ".join(
+                f"{host}={code!r}" for host, code in sorted(failures.items())
+            )
+            diagnostic = ""
+            stderr_by_host = getattr(result, "stderr", None)
+            if isinstance(stderr_by_host, dict):
+                messages: list[str] = []
+                for host in sorted(failures):
+                    stderr = stderr_by_host.get(host)
+                    if isinstance(stderr, str) and stderr.strip():
+                        messages.append(f"{host}: {' '.join(stderr.split())}")
+                if messages:
+                    bounded = "; ".join(messages)
+                    if len(bounded) > 4096:
+                        bounded = bounded[:4093] + "..."
+                    diagnostic = f"; stderr: {bounded}"
+            raise RuntimeError(
+                f"{operation} failed with exit status: {details}{diagnostic}"
+            )
+
+    def stop(self) -> None:
         """Stop Gray-Scott (no-op — Gray-Scott runs to completion)."""
         pass
 
-    def clean(self):
-        """Remove Gray-Scott output directory."""
-        output = self.config.get("outdir", "")
-        if output:
-            Rm(output + "*").run()
+    def clean(self) -> None:
+        """Remove only the configured output and checkpoint datasets."""
+        paths = self._cleanup_paths()
+        if not paths:
+            return
+        command = "rm -rf -- " + " ".join(shlex.quote(path) for path in paths)
+        result = Exec(
+            command,
+            PsshExecInfo(hostfile=self.hostfile, env=self.env),
+        ).run()
+        self._raise_for_exec_failure(result, operation="Gray-Scott cleanup")
+
+    def _cleanup_paths(self) -> list[str]:
+        """Return de-duplicated, exact paths safe for package cleanup."""
+        paths: list[str] = []
+        for field_name in ("outdir", "checkpoint_output"):
+            configured = self.config.get(field_name)
+            if not isinstance(configured, str) or not configured.strip():
+                continue
+            path = _absolute_dataset_path(
+                configured,
+                field_name=field_name,
+                context="cleanup",
+            )
+            if path not in paths:
+                paths.append(path)
+        return paths

--- a/builtin/builtin/gray_scott/progress.py
+++ b/builtin/builtin/gray_scott/progress.py
@@ -40,6 +40,9 @@ class GrayScottProgressAdapter:
     _restart_step: int = 0
     _started: bool = False
     _completed: bool = False
+    _failed: bool = False
+    _pending_completion_signal: str | None = None
+    _pending_elapsed_milliseconds: int | None = None
 
     def observe_progress(self, text: str) -> list[ProgressObservation]:
         """Return truthful progress observations from complete output lines."""
@@ -47,7 +50,33 @@ class GrayScottProgressAdapter:
 
     def finalize_progress(self) -> list[ProgressObservation]:
         """Flush one final unterminated Gray-Scott output line."""
-        return self._observe("", finalize=True)
+        observations = self._observe("", finalize=True)
+        completed = self._pending_completed_observation()
+        if completed is not None:
+            observations.append(completed)
+        return observations
+
+    def finalize_progress_for_exit(self, return_code: int) -> list[ProgressObservation]:
+        """Finalize direct IOWarp runs from JARVIS's owned process result."""
+        observations = self._observe("", finalize=True)
+        if return_code != 0:
+            failed = self._failed_observation(return_code)
+            if failed is not None:
+                observations.append(failed)
+            return observations
+
+        completed = self._pending_completed_observation()
+        if completed is None and (
+            self._started
+            and self.total_steps is not None
+            and self._last_step == self.total_steps
+        ):
+            completed = self._completed_observation(
+                completion_signal="process_exit_zero_after_final_output"
+            )
+        if completed is not None:
+            observations.append(completed)
+        return observations
 
     def reset_progress(self) -> None:
         """Reset parsing when the application output stream is replaced."""
@@ -56,6 +85,9 @@ class GrayScottProgressAdapter:
         self._restart_step = 0
         self._started = False
         self._completed = False
+        self._failed = False
+        self._pending_completion_signal = None
+        self._pending_elapsed_milliseconds = None
 
     def _observe(self, text: str, *, finalize: bool) -> list[ProgressObservation]:
         observations: list[ProgressObservation] = []
@@ -67,6 +99,9 @@ class GrayScottProgressAdapter:
 
     def _observe_line(self, line: str) -> ProgressObservation | None:
         stripped = line.strip()
+        if self._completed or self._failed:
+            return None
+
         restart_match = _ADIOS_RESTART_RE.fullmatch(stripped)
         if restart_match is not None:
             self._restart_step = int(restart_match.group("step"))
@@ -186,15 +221,35 @@ class GrayScottProgressAdapter:
 
         adios_completed_match = _ADIOS_COMPLETED_RE.fullmatch(stripped)
         if adios_completed_match is not None:
-            return self._completed_observation(
-                completion_signal="writer_closed_and_timing_reported",
+            self._remember_completion(
+                "writer_closed_and_timing_reported",
                 elapsed_milliseconds=int(adios_completed_match.group("elapsed_ms")),
             )
+            return None
         if stripped == "Done.":
-            return self._completed_observation(
-                completion_signal="application_reported_done"
-            )
+            self._remember_completion("application_reported_done")
         return None
+
+    def _remember_completion(
+        self,
+        completion_signal: str,
+        *,
+        elapsed_milliseconds: int | None = None,
+    ) -> None:
+        """Hold an application success marker until process exit is known."""
+        if self._pending_completion_signal is not None:
+            return
+        self._pending_completion_signal = completion_signal
+        self._pending_elapsed_milliseconds = elapsed_milliseconds
+
+    def _pending_completed_observation(self) -> ProgressObservation | None:
+        """Commit a deferred application success marker for legacy callers."""
+        if self._pending_completion_signal is None:
+            return None
+        return self._completed_observation(
+            completion_signal=self._pending_completion_signal,
+            elapsed_milliseconds=self._pending_elapsed_milliseconds,
+        )
 
     def _completed_observation(
         self,
@@ -203,7 +258,7 @@ class GrayScottProgressAdapter:
         elapsed_milliseconds: int | None = None,
     ) -> ProgressObservation | None:
         """Return one terminal observation from a real application signal."""
-        if self._completed:
+        if self._completed or self._failed:
             return None
         self._completed = True
         current = self.total_steps if self.total_steps is not None else self._last_step
@@ -222,6 +277,29 @@ class GrayScottProgressAdapter:
             total=(float(self.total_steps) if self.total_steps is not None else None),
             unit="timestep",
             message="Gray-Scott simulation completed",
+            metadata=metadata,
+        )
+
+    def _failed_observation(self, return_code: int) -> ProgressObservation | None:
+        """Return one terminal failure from an authoritative process status."""
+        if self._completed or self._failed:
+            return None
+        self._failed = True
+        metadata: dict[str, str | int] = {
+            "application": "gray_scott",
+            "progress_kind": "simulation_timestep",
+            "completion_signal": "process_exit_nonzero",
+            "return_code": return_code,
+        }
+        if self._pending_completion_signal is not None:
+            metadata["application_completion_signal"] = self._pending_completion_signal
+        return ProgressObservation(
+            label="simulation",
+            state=ProgressState.FAILED,
+            current=float(self._last_step),
+            total=(float(self.total_steps) if self.total_steps is not None else None),
+            unit="timestep",
+            message=f"Gray-Scott simulation failed with exit status {return_code}",
             metadata=metadata,
         )
 

--- a/ci/live_ares_gray_scott_probe.py
+++ b/ci/live_ares_gray_scott_probe.py
@@ -1,0 +1,1412 @@
+#!/usr/bin/env python3
+"""Run a released-wheel Gray-Scott acceptance probe on Ares.
+
+The outer process installs the supplied wheel into an isolated virtual
+environment below a caller-supplied shared root.  The installed child then uses
+the public JARVIS Python API to submit ``builtin.gray_scott`` against the exact
+``clio-core/external/iowarp-gray-scott`` executable through the explicit Slurm
+scheduler provider. Every valid invocation writes a machine-readable report,
+including failure paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from uuid import uuid4
+
+
+REPORT_SCHEMA = "jarvis.live-validation.gray-scott.v1"
+PACKAGE_ID = "gray_scott_bp5"
+OUTPUT_LOGICAL_NAME = "gray-scott-timesteps"
+CHECKPOINT_LOGICAL_NAME = "gray-scott-restart-checkpoint"
+EXPECTED_STEPS = 20
+EXPECTED_PLOTGAP = 10
+_SAFE_SPEC = re.compile(r"^[A-Za-z0-9@%+~_./:=^,-]{1,512}$")
+_SAFE_SCHEDULER_TOKEN = re.compile(r"^[A-Za-z0-9_.:@/+,-]{1,255}$")
+_SAFE_VERSION = re.compile(r"^[A-Za-z0-9][A-Za-z0-9.!+_-]{0,127}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def utc_now() -> str:
+    """Return the current time as a stable UTC ISO-8601 timestamp."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest of one regular file."""
+    status = path.stat(follow_symlinks=False)
+    if not stat.S_ISREG(status.st_mode):
+        raise ValueError(f"expected a regular file: {path}")
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def atomic_write_json(path: Path, document: Mapping[str, Any]) -> None:
+    """Durably replace ``path`` with one private JSON report."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        text=True,
+    )
+    temporary_path = Path(temporary_name)
+    descriptor_owned = True
+    try:
+        try:
+            stream = os.fdopen(descriptor, "w", encoding="utf-8", newline="\n")
+        except BaseException:
+            os.close(descriptor)
+            descriptor_owned = False
+            raise
+        descriptor_owned = False
+        with stream:
+            json.dump(
+                document,
+                stream,
+                allow_nan=False,
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary_path.chmod(0o600)
+        os.replace(temporary_path, path)
+        if os.name != "nt":
+            directory = os.open(
+                path.parent,
+                os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+            )
+            try:
+                os.fsync(directory)
+            finally:
+                os.close(directory)
+    finally:
+        if descriptor_owned:
+            os.close(descriptor)
+        temporary_path.unlink(missing_ok=True)
+
+
+def add_assertion(
+    assertions: list[dict[str, Any]],
+    name: str,
+    *,
+    passed: bool,
+    expected: Any,
+    actual: Any,
+    detail: str | None = None,
+) -> None:
+    """Append one explicit, JSON-safe acceptance assertion."""
+    result: dict[str, Any] = {
+        "name": name,
+        "passed": bool(passed),
+        "expected": expected,
+        "actual": actual,
+    }
+    if detail is not None:
+        result["detail"] = detail
+    assertions.append(result)
+
+
+def _assert_expected_release_artifact(
+    args: argparse.Namespace,
+    report: dict[str, Any],
+    *,
+    installed_version: str | None = None,
+) -> None:
+    """Bind the acceptance report to the requested wheel and distribution."""
+    assertions = report.get("assertions")
+    if not isinstance(assertions, list):
+        raise RuntimeError("live report assertions field is not a list")
+
+    actual_digest = sha256_file(args.wheel)
+    add_assertion(
+        assertions,
+        "release_artifact.wheel_sha256",
+        passed=actual_digest == args.expected_wheel_sha256,
+        expected=args.expected_wheel_sha256,
+        actual=actual_digest,
+        detail="exact bytes installed by the acceptance probe",
+    )
+    if installed_version is not None:
+        add_assertion(
+            assertions,
+            "release_artifact.installed_version",
+            passed=installed_version == args.expected_version,
+            expected=args.expected_version,
+            actual=installed_version,
+            detail="importlib metadata from the isolated installed environment",
+        )
+
+    failed = [item["name"] for item in assertions if item.get("passed") is False]
+    if failed:
+        raise AssertionError(
+            "release artifact provenance assertions failed: " + ", ".join(failed)
+        )
+
+
+def evaluate_semantics(
+    *,
+    record: Mapping[str, Any],
+    progress: Mapping[str, Any],
+    artifacts: Mapping[str, Any],
+    output_path: Path,
+    checkpoint_path: Path,
+    bpls_output: Mapping[str, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Evaluate the exact durable Gray-Scott acceptance contract."""
+    assertions: list[dict[str, Any]] = []
+    _assert_equal(assertions, "execution.state", record.get("state"), "completed")
+    _assert_equal(assertions, "execution.terminal", record.get("terminal"), True)
+    _assert_equal(assertions, "execution.return_code", record.get("return_code"), 0)
+    _assert_equal(
+        assertions,
+        "execution.scheduler_provider",
+        record.get("scheduler_provider"),
+        "slurm",
+    )
+    native_id = record.get("scheduler_native_id")
+    add_assertion(
+        assertions,
+        "execution.scheduler_native_id",
+        passed=isinstance(native_id, str) and native_id.isdigit(),
+        expected="non-empty decimal Slurm job ID",
+        actual=native_id,
+    )
+
+    package = _single_by_key(progress.get("packages"), "package_id", PACKAGE_ID)
+    add_assertion(
+        assertions,
+        "progress.package_present_once",
+        passed=package is not None,
+        expected=PACKAGE_ID,
+        actual=None if package is None else package.get("package_id"),
+    )
+    if package is not None:
+        _assert_equal(assertions, "progress.event_count", package.get("event_count"), 4)
+        latest = package.get("latest")
+        latest = latest if isinstance(latest, Mapping) else {}
+        for key, expected in (
+            ("state", "completed"),
+            ("current", float(EXPECTED_STEPS)),
+            ("total", float(EXPECTED_STEPS)),
+            ("unit", "timestep"),
+        ):
+            _assert_equal(
+                assertions, f"progress.latest.{key}", latest.get(key), expected
+            )
+        metadata = latest.get("metadata")
+        metadata = metadata if isinstance(metadata, Mapping) else {}
+        _assert_equal(
+            assertions,
+            "progress.completion_signal",
+            metadata.get("completion_signal"),
+            "process_exit_zero_after_final_output",
+        )
+
+    current_artifacts = artifacts.get("artifacts")
+    package_artifacts = (
+        [
+            item
+            for item in current_artifacts
+            if isinstance(item, Mapping) and item.get("package_id") == PACKAGE_ID
+        ]
+        if isinstance(current_artifacts, list)
+        else []
+    )
+    _assert_equal(
+        assertions,
+        "artifacts.package_logical_names",
+        sorted(str(item.get("logical_name")) for item in package_artifacts),
+        sorted([OUTPUT_LOGICAL_NAME, CHECKPOINT_LOGICAL_NAME]),
+    )
+    output = _single_by_key(current_artifacts, "logical_name", OUTPUT_LOGICAL_NAME)
+    _assert_artifact(
+        assertions,
+        artifact=output,
+        assertion_prefix="artifacts.output",
+        logical_name=OUTPUT_LOGICAL_NAME,
+        expected_path=output_path,
+        expected_kind="scientific_dataset",
+        expected_role="output",
+        expected_revision=4,
+        expected_metadata={
+            "application": "gray_scott",
+            "io_backend": "adios2",
+            "member_pattern": "adios2-steps",
+            "members_observed": 2,
+            "latest_timestep": EXPECTED_STEPS,
+            "completion_signal": "process_exit_zero_after_final_output",
+        },
+    )
+    checkpoint = _single_by_key(
+        current_artifacts,
+        "logical_name",
+        CHECKPOINT_LOGICAL_NAME,
+    )
+    _assert_artifact(
+        assertions,
+        artifact=checkpoint,
+        assertion_prefix="artifacts.checkpoint",
+        logical_name=CHECKPOINT_LOGICAL_NAME,
+        expected_path=checkpoint_path,
+        expected_kind="restart_checkpoint",
+        expected_role="checkpoint",
+        expected_revision=1,
+        expected_metadata={
+            "application": "gray_scott",
+            "io_backend": "adios2",
+            "detection_signal": "configured_path_created_or_changed_during_process",
+            "physical_path_observed": True,
+            "latest_output_timestep_observed": EXPECTED_STEPS,
+            "completion_signal": "process_exit_zero_after_final_output",
+            "return_code": 0,
+        },
+    )
+
+    _assert_bpls(assertions, bpls_output)
+    return assertions
+
+
+def _assert_equal(
+    assertions: list[dict[str, Any]], name: str, actual: Any, expected: Any
+) -> None:
+    """Append one exact-equality assertion."""
+    add_assertion(
+        assertions,
+        name,
+        passed=actual == expected,
+        expected=expected,
+        actual=actual,
+    )
+
+
+def _single_by_key(
+    values: object,
+    key: str,
+    expected: str,
+) -> Mapping[str, Any] | None:
+    """Return one matching mapping, rejecting missing or duplicate values."""
+    if not isinstance(values, list):
+        return None
+    matches = [
+        item
+        for item in values
+        if isinstance(item, Mapping) and item.get(key) == expected
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _assert_artifact(
+    assertions: list[dict[str, Any]],
+    *,
+    artifact: Mapping[str, Any] | None,
+    assertion_prefix: str,
+    logical_name: str,
+    expected_path: Path,
+    expected_kind: str,
+    expected_role: str,
+    expected_revision: int,
+    expected_metadata: Mapping[str, Any],
+) -> None:
+    """Assert one exact package artifact without depending on opaque IDs."""
+    add_assertion(
+        assertions,
+        f"{assertion_prefix}.present_once",
+        passed=artifact is not None,
+        expected=logical_name,
+        actual=None if artifact is None else artifact.get("logical_name"),
+    )
+    if artifact is None:
+        return
+    for key, expected in (
+        ("package_id", PACKAGE_ID),
+        ("state", "finalized"),
+        ("kind", expected_kind),
+        ("role", expected_role),
+        ("structure", "collection"),
+        ("ownership", "shared"),
+        ("media_type", "application/x-adios2-bp"),
+        ("format", "adios2-bp5"),
+        ("revision", expected_revision),
+    ):
+        _assert_equal(
+            assertions, f"{assertion_prefix}.{key}", artifact.get(key), expected
+        )
+    artifact_id = artifact.get("artifact_id")
+    add_assertion(
+        assertions,
+        f"{assertion_prefix}.artifact_id",
+        passed=isinstance(artifact_id, str)
+        and re.fullmatch(r"art_[A-Za-z0-9_-]{22,86}", artifact_id) is not None,
+        expected="opaque art_* identifier",
+        actual=artifact_id,
+    )
+    location = artifact.get("location")
+    location = location if isinstance(location, Mapping) else {}
+    _assert_equal(
+        assertions,
+        f"{assertion_prefix}.location.kind",
+        location.get("kind"),
+        "cluster_path",
+    )
+    _assert_equal(
+        assertions,
+        f"{assertion_prefix}.location.value",
+        location.get("value"),
+        expected_path.as_posix(),
+    )
+    metadata = artifact.get("metadata")
+    metadata = metadata if isinstance(metadata, Mapping) else {}
+    for key, expected in expected_metadata.items():
+        _assert_equal(
+            assertions,
+            f"{assertion_prefix}.metadata.{key}",
+            metadata.get(key),
+            expected,
+        )
+
+
+def _assert_bpls(
+    assertions: list[dict[str, Any]],
+    results: Mapping[str, Mapping[str, Any]],
+) -> None:
+    """Assert physical ADIOS2 datasets independently of JARVIS metadata."""
+    for name in (
+        "output_list",
+        "output_steps",
+        "checkpoint_list",
+        "checkpoint_steps",
+    ):
+        result = results.get(name, {})
+        _assert_equal(
+            assertions, f"bpls.{name}.return_code", result.get("return_code"), 0
+        )
+    output_listing = str(results.get("output_list", {}).get("stdout", ""))
+    output_steps = str(results.get("output_steps", {}).get("stdout", ""))
+    checkpoint_listing = str(results.get("checkpoint_list", {}).get("stdout", ""))
+    checkpoint_steps = str(results.get("checkpoint_steps", {}).get("stdout", ""))
+    for variable in ("U", "V", "step"):
+        add_assertion(
+            assertions,
+            f"bpls.output.variable.{variable}",
+            passed=re.search(rf"\b{re.escape(variable)}\b", output_listing) is not None,
+            expected=f"variable {variable}",
+            actual=output_listing,
+        )
+    for expected_step in (10, 20):
+        add_assertion(
+            assertions,
+            f"bpls.output.step.{expected_step}",
+            passed=re.search(rf"\b{expected_step}\b", output_steps) is not None,
+            expected=f"physical output contains timestep {expected_step}",
+            actual=output_steps,
+        )
+    for variable in ("U", "V", "step"):
+        add_assertion(
+            assertions,
+            f"bpls.checkpoint.variable.{variable}",
+            passed=re.search(rf"\b{re.escape(variable)}\b", checkpoint_listing)
+            is not None,
+            expected=f"checkpoint variable {variable}",
+            actual=checkpoint_listing,
+        )
+    add_assertion(
+        assertions,
+        "bpls.checkpoint.step.20",
+        passed=re.search(r"\b20\b", checkpoint_steps) is not None,
+        expected="latest restart checkpoint contains timestep 20",
+        actual=checkpoint_steps,
+    )
+
+
+def _new_report(args: argparse.Namespace) -> dict[str, Any]:
+    """Create a report document before any external side effect."""
+    return {
+        "schema_version": REPORT_SCHEMA,
+        "started_at": utc_now(),
+        "finished_at": None,
+        "success": False,
+        "phase": "initializing",
+        "inputs": {
+            "wheel": str(args.wheel),
+            "expected_version": args.expected_version,
+            "expected_wheel_sha256": args.expected_wheel_sha256,
+            "root": str(args.root),
+            "report": str(args.report),
+            "partition": args.partition,
+            "account": args.account,
+            "clio_core_root": str(args.clio_core_root),
+            "executable": str(args.executable),
+            "spack": str(args.spack),
+            "spack_spec": args.spack_spec,
+            "bpls": str(args.bpls) if args.bpls is not None else None,
+            "timeout_seconds": args.timeout_seconds,
+            "poll_seconds": args.poll_seconds,
+            "cancel_on_timeout": args.cancel_on_timeout,
+        },
+        "provenance": {},
+        "acceptance_contract": {
+            "package": "builtin.gray_scott",
+            "application": "clio-core/external/iowarp-gray-scott",
+            "grid": [32, 32, 32],
+            "steps": EXPECTED_STEPS,
+            "output_every": EXPECTED_PLOTGAP,
+            "expected_output_steps": [10, 20],
+            "progress_terminal_signal": "process_exit_zero_after_final_output",
+            "artifact_logical_name": OUTPUT_LOGICAL_NAME,
+            "checkpoint_artifact_logical_name": CHECKPOINT_LOGICAL_NAME,
+            "artifact_state": "finalized",
+            "artifact_format": "adios2-bp5",
+            "artifact_completion_signal": "process_exit_zero_after_final_output",
+        },
+        "execution": {},
+        "queries": {},
+        "physical_validation": {},
+        "assertions": [],
+        "commands": [],
+        "error": None,
+    }
+
+
+def _record_command(
+    report: dict[str, Any],
+    argv: Sequence[str],
+    result: subprocess.CompletedProcess[str],
+) -> None:
+    """Append bounded subprocess evidence to the report."""
+    report["commands"].append(
+        {
+            "argv": list(argv),
+            "return_code": result.returncode,
+            "stdout": result.stdout[-32_768:],
+            "stderr": result.stderr[-32_768:],
+        }
+    )
+
+
+def _run_command(
+    report: dict[str, Any],
+    argv: Sequence[str],
+    *,
+    cwd: Path | None = None,
+    env: Mapping[str, str] | None = None,
+    check: bool = True,
+    timeout: float = 120.0,
+) -> subprocess.CompletedProcess[str]:
+    """Run one argv command and retain bounded diagnostics."""
+    result = subprocess.run(
+        list(argv),
+        cwd=cwd,
+        env=dict(env) if env is not None else None,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=timeout,
+    )
+    _record_command(report, argv, result)
+    if check and result.returncode != 0:
+        raise RuntimeError(
+            f"command failed with exit {result.returncode}: "
+            + " ".join(str(item) for item in argv)
+        )
+    return result
+
+
+def _validate_arguments(args: argparse.Namespace) -> None:
+    """Reject unsafe or ambiguous live inputs before installation/submission."""
+    for name in (
+        "wheel",
+        "root",
+        "report",
+        "clio_core_root",
+        "executable",
+        "spack",
+    ):
+        value = getattr(args, name)
+        if not isinstance(value, Path) or not value.is_absolute():
+            raise ValueError(f"--{name.replace('_', '-')} must be an absolute path")
+    if args.bpls is not None and not args.bpls.is_absolute():
+        raise ValueError("--bpls must be an absolute path")
+    if not args.wheel.name.endswith(".whl") or not args.wheel.is_file():
+        raise ValueError(f"--wheel must name an existing .whl file: {args.wheel}")
+    if (
+        not isinstance(args.expected_version, str)
+        or _SAFE_VERSION.fullmatch(args.expected_version) is None
+    ):
+        raise ValueError("--expected-version must be one valid version token")
+    if (
+        not isinstance(args.expected_wheel_sha256, str)
+        or _SHA256.fullmatch(args.expected_wheel_sha256) is None
+    ):
+        raise ValueError("--expected-wheel-sha256 must be 64 lowercase hex digits")
+    if args.executable.name != "gray-scott":
+        raise ValueError("--executable must name the clio-core gray-scott binary")
+    if not args.executable.is_relative_to(args.clio_core_root):
+        raise ValueError("--executable must belong to the selected clio-core checkout")
+    if not args.executable.is_file() or not os.access(args.executable, os.X_OK):
+        raise ValueError(
+            f"--executable must be an executable regular file: {args.executable}"
+        )
+    if not (args.clio_core_root / ".git").is_dir():
+        raise ValueError(
+            f"--clio-core-root is not a git checkout: {args.clio_core_root}"
+        )
+    if not args.spack.is_file() or not os.access(args.spack, os.X_OK):
+        raise ValueError(f"--spack must be executable: {args.spack}")
+    if _SAFE_SPEC.fullmatch(args.spack_spec) is None or args.spack_spec.startswith("-"):
+        raise ValueError("--spack-spec contains unsupported characters")
+    for name in ("partition", "account"):
+        value = getattr(args, name)
+        if value is not None and _SAFE_SCHEDULER_TOKEN.fullmatch(value) is None:
+            raise ValueError(f"--{name} must be one printable scheduler token")
+    if args.timeout_seconds <= 0 or args.poll_seconds <= 0:
+        raise ValueError("poll and timeout values must be positive")
+    if args.poll_seconds > args.timeout_seconds:
+        raise ValueError("--poll-seconds cannot exceed --timeout-seconds")
+
+
+def _venv_python(venv: Path) -> Path:
+    """Return the Python entry point for a platform-specific virtualenv."""
+    return venv / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def _assert_fresh_install_root(root: Path) -> None:
+    """Refuse to replace state that may belong to another acceptance run."""
+    reserved = (
+        ".jarvis-live-probe-venv",
+        "jarvis-root",
+        "outputs",
+        "private",
+        "shared",
+    )
+    existing = [name for name in reserved if (root / name).exists()]
+    if existing:
+        raise RuntimeError(
+            "live acceptance root already contains owned state: " + ", ".join(existing)
+        )
+
+
+def _bootstrap_installed_child(
+    args: argparse.Namespace,
+    report: dict[str, Any],
+) -> int:
+    """Install the exact wheel and re-execute this probe from that environment."""
+    _assert_fresh_install_root(args.root)
+    report["phase"] = "installing_wheel"
+    report["provenance"]["wheel"] = {
+        "path": str(args.wheel),
+        "sha256": sha256_file(args.wheel),
+        "size_bytes": args.wheel.stat().st_size,
+    }
+    _assert_expected_release_artifact(args, report)
+    atomic_write_json(args.report, report)
+    venv = args.root / ".jarvis-live-probe-venv"
+    uv = args.uv or shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv is required to install the acceptance wheel")
+    _run_command(report, [uv, "venv", "--clear", str(venv)], cwd=args.root)
+    python = _venv_python(venv)
+    _run_command(
+        report,
+        [
+            uv,
+            "pip",
+            "install",
+            "--python",
+            str(python),
+            "--reinstall",
+            "--no-cache",
+            str(args.wheel),
+        ],
+        cwd=args.root,
+        timeout=300.0,
+    )
+    child_argv = [
+        str(python),
+        str(Path(__file__).resolve()),
+        *sys.argv[1:],
+        "--installed-child",
+    ]
+    child_env = dict(os.environ)
+    child_env.pop("PYTHONPATH", None)
+    child_env["PATH"] = os.pathsep.join([str(python.parent), child_env.get("PATH", "")])
+    result = subprocess.run(
+        child_argv,
+        cwd=args.root,
+        env=child_env,
+        text=True,
+        check=False,
+    )
+    if not args.report.is_file():
+        raise RuntimeError(
+            f"installed probe exited {result.returncode} without writing its report"
+        )
+    return result.returncode
+
+
+def _installed_distribution_provenance() -> dict[str, Any]:
+    """Return installed distribution and import-path evidence."""
+    import jarvis_cd
+
+    distribution = importlib.metadata.distribution("jarvis_cd")
+    direct_url: Any = None
+    direct_url_text = distribution.read_text("direct_url.json")
+    if direct_url_text:
+        direct_url = json.loads(direct_url_text)
+    return {
+        "distribution_name": distribution.metadata["Name"],
+        "version": distribution.version,
+        "module_path": str(Path(jarvis_cd.__file__).resolve()),
+        "python_executable": sys.executable,
+        "python_executable_resolved": str(Path(sys.executable).resolve()),
+        "python_prefix": str(Path(sys.prefix).resolve()),
+        "python_base_prefix": str(Path(sys.base_prefix).resolve()),
+        "direct_url": direct_url,
+    }
+
+
+def _git_provenance(report: dict[str, Any], repository: Path) -> dict[str, Any]:
+    """Return exact clio-core source identity and worktree state."""
+    source_relative = "external/iowarp-gray-scott"
+    commit = _run_command(
+        report,
+        ["git", "-C", str(repository), "rev-parse", "HEAD"],
+    ).stdout.strip()
+    status = _run_command(
+        report,
+        ["git", "-C", str(repository), "status", "--porcelain=v1"],
+    ).stdout
+    source_status = _run_command(
+        report,
+        [
+            "git",
+            "-C",
+            str(repository),
+            "status",
+            "--porcelain=v1",
+            "--",
+            source_relative,
+        ],
+    ).stdout
+    source_tree = _run_command(
+        report,
+        [
+            "git",
+            "-C",
+            str(repository),
+            "rev-parse",
+            f"HEAD:{source_relative}",
+        ],
+    ).stdout.strip()
+    remote = _run_command(
+        report,
+        ["git", "-C", str(repository), "remote", "get-url", "origin"],
+        check=False,
+    ).stdout.strip()
+    return {
+        "path": str(repository),
+        "commit": commit,
+        "dirty": bool(status.strip()),
+        "status_porcelain": status.splitlines(),
+        "origin": remote or None,
+        "gray_scott_source": {
+            "relative_path": source_relative,
+            "git_tree": source_tree,
+            "dirty": bool(source_status.strip()),
+            "status_porcelain": source_status.splitlines(),
+        },
+    }
+
+
+def _spack_provenance(report: dict[str, Any], spack: Path, spec: str) -> dict[str, Any]:
+    """Return the selected installed Spack spec and its machine digest."""
+    format_string = "{hash:32}|{name}|{version}|{prefix}"
+    result = _run_command(
+        report,
+        [str(spack), "find", "--format", format_string, spec],
+    )
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if len(lines) != 1:
+        raise RuntimeError(
+            f"Spack spec must resolve to exactly one installation: {spec}"
+        )
+    fields = lines[0].split("|", 3)
+    if len(fields) != 4:
+        raise RuntimeError("Spack returned malformed concrete-spec provenance")
+    dag_hash, name, version, prefix_text = fields
+    prefix = Path(prefix_text)
+    if not re.fullmatch(r"[a-z0-9]{32}", dag_hash) or not prefix.is_absolute():
+        raise RuntimeError("Spack returned invalid concrete hash or prefix")
+    if not prefix.is_dir():
+        raise RuntimeError(f"Spack installation prefix does not exist: {prefix}")
+
+    json_result = _run_command(
+        report,
+        [str(spack), "find", "--json", f"/{dag_hash}"],
+        check=False,
+    )
+    parsed: Any = None
+    json_sha256: str | None = None
+    if json_result.stdout.strip():
+        try:
+            parsed = json.loads(json_result.stdout)
+        except json.JSONDecodeError as error:
+            raise RuntimeError("Spack emitted malformed JSON provenance") from error
+        canonical = json.dumps(
+            parsed, allow_nan=False, separators=(",", ":"), sort_keys=True
+        )
+        json_sha256 = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return {
+        "requested": spec,
+        "name": name,
+        "version": version,
+        "dag_hash": dag_hash,
+        "prefix": str(prefix),
+        "resolved": parsed,
+        "spec_hashes": sorted(_spack_hashes(parsed)),
+        "resolved_json_sha256": json_sha256,
+        "json_command_return_code": json_result.returncode,
+    }
+
+
+def _spack_hashes(value: object) -> set[str]:
+    """Collect concrete DAG hashes from arbitrarily nested Spack JSON."""
+    hashes: set[str] = set()
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if key in {"hash", "full_hash", "dag_hash"} and isinstance(item, str):
+                if item:
+                    hashes.add(item)
+            else:
+                hashes.update(_spack_hashes(item))
+    elif isinstance(value, list):
+        for item in value:
+            hashes.update(_spack_hashes(item))
+    return hashes
+
+
+def _runtime_linkage(
+    report: dict[str, Any], executable: Path, adios_prefix: Path
+) -> dict[str, Any]:
+    """Verify the binary links to ADIOS2 from the selected Spack prefix."""
+    result = _run_command(report, ["ldd", str(executable)])
+    libraries, missing = _parse_ldd_output(result.stdout)
+    if missing:
+        raise RuntimeError(f"Gray-Scott has unresolved shared libraries: {missing}")
+    adios_paths = [
+        Path(path).resolve()
+        for name, path in libraries.items()
+        if name.startswith("libadios2")
+    ]
+    if not adios_paths or any(
+        not path.is_relative_to(adios_prefix.resolve()) for path in adios_paths
+    ):
+        raise RuntimeError(
+            "Gray-Scott is not linked to ADIOS2 from the selected Spack prefix"
+        )
+    mpi_paths = [
+        Path(path).resolve()
+        for name, path in libraries.items()
+        if name.startswith("libmpi.so")
+    ]
+    if len(mpi_paths) != 1:
+        raise RuntimeError("Gray-Scott must resolve exactly one MPI runtime")
+    mpi_prefix = mpi_paths[0].parent.parent
+    mpi_executable = mpi_prefix / "bin" / "mpiexec"
+    if not mpi_executable.is_file():
+        raise RuntimeError(f"matching MPI launcher does not exist: {mpi_executable}")
+    return {
+        "libraries": libraries,
+        "adios2_libraries": [str(path) for path in adios_paths],
+        "mpi_library": str(mpi_paths[0]),
+        "mpi_prefix": str(mpi_prefix),
+        "mpi_executable": str(mpi_executable),
+    }
+
+
+def _parse_ldd_output(text: str) -> tuple[dict[str, str], list[str]]:
+    """Parse the stable ``name => path`` subset of Linux ``ldd`` output."""
+    libraries: dict[str, str] = {}
+    missing: list[str] = []
+    for line in text.splitlines():
+        match = re.match(r"^\s*(?P<name>\S+)\s+=>\s+(?P<path>\S+)", line)
+        if match is None:
+            continue
+        name = match.group("name")
+        path = match.group("path")
+        if path == "not":
+            missing.append(name)
+            continue
+        libraries[name] = path
+    return libraries, missing
+
+
+def _spack_environment(
+    *,
+    base: Mapping[str, str],
+    executable: Path,
+    adios_prefix: Path,
+    mpi_prefix: Path,
+) -> dict[str, str]:
+    """Build a bounded runtime environment from verified concrete prefixes."""
+    environment = dict(base)
+    path_parts = [
+        str(Path(sys.executable).parent),
+        str(executable.parent),
+        str(mpi_prefix / "bin"),
+        str(adios_prefix / "bin"),
+        base.get("PATH", ""),
+    ]
+    library_parts = [
+        str(adios_prefix / "lib"),
+        str(mpi_prefix / "lib"),
+        base.get("LD_LIBRARY_PATH", ""),
+    ]
+    environment["PATH"] = os.pathsep.join(part for part in path_parts if part)
+    environment["LD_LIBRARY_PATH"] = os.pathsep.join(
+        part for part in library_parts if part
+    )
+    return environment
+
+
+def _pipeline_environment(environment: Mapping[str, str]) -> dict[str, str]:
+    """Select non-secret compiler/runtime variables needed inside Slurm."""
+    allowed = {
+        "ACLOCAL_PATH",
+        "CMAKE_PREFIX_PATH",
+        "CPATH",
+        "CPLUS_INCLUDE_PATH",
+        "C_INCLUDE_PATH",
+        "INFOPATH",
+        "LD_LIBRARY_PATH",
+        "LIBRARY_PATH",
+        "MANPATH",
+        "MODULEPATH",
+        "PATH",
+        "PKG_CONFIG_PATH",
+        "PYTHONPATH",
+        "SPACK_ROOT",
+    }
+    prefixes = ("OMPI_", "OPAL_", "PMIX_", "PRTE_", "UCX_", "FI_")
+    return {
+        key: value
+        for key, value in environment.items()
+        if key in allowed or key.startswith(prefixes)
+    }
+
+
+def _assert_installed_import(provenance: Mapping[str, Any], venv: Path) -> None:
+    """Prove JARVIS was imported through the probe virtual environment."""
+    resolved_venv = venv.resolve()
+    module_path = provenance.get("module_path")
+    if not isinstance(module_path, str) or not Path(
+        module_path
+    ).resolve().is_relative_to(resolved_venv):
+        raise RuntimeError(
+            f"installed-wheel isolation failed for module_path: {module_path}"
+        )
+
+    python_prefix = provenance.get("python_prefix")
+    if (
+        not isinstance(python_prefix, str)
+        or Path(python_prefix).resolve() != resolved_venv
+    ):
+        raise RuntimeError(
+            f"installed-wheel isolation failed for python_prefix: {python_prefix}"
+        )
+
+    python_executable = provenance.get("python_executable")
+    if not isinstance(python_executable, str) or not Path(
+        python_executable
+    ).absolute().is_relative_to(resolved_venv):
+        raise RuntimeError(
+            "installed-wheel isolation failed for python_executable entry point: "
+            f"{python_executable}"
+        )
+
+
+def _assert_installed_package_source(
+    pipeline_provenance: Mapping[str, Any],
+    venv: Path,
+) -> None:
+    """Prove the selected built-in package came from the installed wheel."""
+    package = pipeline_provenance.get("package")
+    source = package.get("source_path") if isinstance(package, Mapping) else None
+    if not isinstance(source, str) or not Path(source).resolve().is_relative_to(
+        venv.resolve()
+    ):
+        raise RuntimeError(
+            f"installed-wheel isolation failed for package source_path: {source}"
+        )
+
+
+def _configured_pipeline(
+    args: argparse.Namespace,
+    report: dict[str, Any],
+    environment: Mapping[str, str],
+    output_path: Path,
+    mpi_executable: Path,
+    run_id: str,
+) -> Any:
+    """Create and persist the exact one-package JARVIS pipeline."""
+    from jarvis_cd.core.config import Jarvis
+    from jarvis_cd.core.pipeline import Pipeline
+
+    jarvis_root = args.root / "jarvis-root"
+    Jarvis._instance = None
+    jarvis = Jarvis.get_instance(str(jarvis_root))
+    jarvis.initialize(
+        config_dir=str(jarvis_root / "config"),
+        private_dir=str(args.root / "private"),
+        shared_dir=str(args.root / "shared"),
+        force=True,
+    )
+    pipeline = Pipeline()
+    pipeline.create(run_id)
+    scheduler: dict[str, Any] = {
+        "name": "slurm",
+        "job_name": run_id,
+        "nodes": 1,
+        "ntasks": 1,
+        "ntasks_per_node": 1,
+        "time": "00:10:00",
+        "partition": args.partition,
+    }
+    if args.account is not None:
+        scheduler["account"] = args.account
+    pipeline.scheduler = scheduler
+    pipeline.mpi_cmd = str(mpi_executable)
+    pipeline.env = _pipeline_environment(environment)
+    config_args = [
+        "nprocs=1",
+        "ppn=1",
+        f"executable={args.executable}",
+        "width=32",
+        "height=32",
+        f"steps={EXPECTED_STEPS}",
+        f"out_every={EXPECTED_PLOTGAP}",
+        f"outdir={output_path}",
+        "checkpoint=true",
+        "checkpoint_freq=1",
+        f"checkpoint_output={output_path}.checkpoint.bp",
+        "adios_span=false",
+        "adios_memory_selection=false",
+        "mesh_type=image",
+    ]
+    pipeline.append(
+        "builtin.gray_scott",
+        package_alias=PACKAGE_ID,
+        config_args=config_args,
+    )
+    package = pipeline.packages[-1]
+    package_instance = pipeline._load_package_instance(package, pipeline.env)
+    package_module = sys.modules.get(type(package_instance).__module__)
+    package_source = getattr(package_module, "__file__", None)
+    if not isinstance(package_source, str):
+        raise RuntimeError("could not resolve the selected Gray-Scott package source")
+    package_source = str(Path(package_source).resolve())
+    expected_config = {
+        "nprocs": 1,
+        "ppn": 1,
+        "executable": str(args.executable),
+        "width": 32,
+        "height": 32,
+        "steps": EXPECTED_STEPS,
+        "out_every": EXPECTED_PLOTGAP,
+        "outdir": str(output_path),
+        "checkpoint": True,
+        "checkpoint_freq": 1,
+        "checkpoint_output": f"{output_path}.checkpoint.bp",
+        "adios_span": False,
+        "adios_memory_selection": False,
+        "mesh_type": "image",
+    }
+    actual_config = package.get("config", {})
+    mismatches = {
+        key: {"expected": expected, "actual": actual_config.get(key)}
+        for key, expected in expected_config.items()
+        if actual_config.get(key) != expected
+    }
+    if mismatches:
+        raise RuntimeError(
+            f"installed wheel rejected the live package contract: {mismatches}"
+        )
+    pipeline.save()
+    report["pipeline"] = {
+        "pipeline_id": run_id,
+        "jarvis_root": str(jarvis.jarvis_root),
+        "repositories": list(jarvis.repos.get("repos", [])),
+        "scheduler": scheduler,
+        "mpi_executable": str(mpi_executable),
+        "base_deploy_mode": pipeline.base_deploy_mode,
+        "package": {
+            "pkg_type": package.get("pkg_type"),
+            "pkg_id": package.get("pkg_id"),
+            "source_path": package_source,
+            "config": {key: actual_config.get(key) for key in expected_config},
+            "effective_deploy_mode": pipeline.base_deploy_mode or "default",
+        },
+        "environment_keys": sorted(pipeline.env),
+    }
+    return pipeline
+
+
+def _poll_execution(
+    args: argparse.Namespace,
+    report: dict[str, Any],
+    pipeline: Any,
+    execution_id: str,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Query durable execution, progress, and artifacts until terminal."""
+    deadline = time.monotonic() + args.timeout_seconds
+    states: list[dict[str, Any]] = []
+    previous_state: tuple[Any, ...] | None = None
+    while True:
+        record = pipeline.get_execution(execution_id).to_dict()
+        progress = pipeline.get_execution_progress(execution_id).to_dict()
+        artifacts = pipeline.get_execution_artifacts(execution_id).to_dict()
+        current_state = (
+            record.get("state"),
+            record.get("terminal"),
+            tuple(
+                (item.get("package_id"), item.get("event_count"))
+                for item in progress.get("packages", [])
+                if isinstance(item, Mapping)
+            ),
+            tuple(
+                (item.get("logical_name"), item.get("revision"), item.get("state"))
+                for item in artifacts.get("artifacts", [])
+                if isinstance(item, Mapping)
+            ),
+        )
+        if current_state != previous_state:
+            states.append(
+                {
+                    "observed_at": utc_now(),
+                    "record_state": record.get("state"),
+                    "terminal": record.get("terminal"),
+                    "progress": progress,
+                    "artifacts": artifacts,
+                }
+            )
+            previous_state = current_state
+            report["queries"]["timeline"] = states
+            atomic_write_json(args.report, report)
+        if record.get("terminal") is True:
+            return record, progress, artifacts
+        if time.monotonic() >= deadline:
+            if args.cancel_on_timeout:
+                native_id = record.get("scheduler_native_id")
+                if isinstance(native_id, str) and native_id.isdigit():
+                    _run_command(report, ["scancel", native_id], check=False)
+            raise TimeoutError(
+                f"execution {execution_id} did not become terminal in "
+                f"{args.timeout_seconds} seconds"
+            )
+        time.sleep(args.poll_seconds)
+
+
+def _run_bpls(
+    report: dict[str, Any],
+    bpls: Path,
+    output_path: Path,
+    checkpoint_path: Path,
+) -> dict[str, dict[str, Any]]:
+    """Inspect physical output and restart datasets with ``bpls``."""
+    commands = {
+        "output_list": [str(bpls), "-l", str(output_path)],
+        "output_steps": [str(bpls), "-d", str(output_path), "step"],
+        "checkpoint_list": [str(bpls), "-l", str(checkpoint_path)],
+        "checkpoint_steps": [str(bpls), "-d", str(checkpoint_path), "step"],
+    }
+    results: dict[str, dict[str, Any]] = {}
+    for name, argv in commands.items():
+        completed = _run_command(report, argv, check=False)
+        results[name] = {
+            "argv": argv,
+            "return_code": completed.returncode,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+        }
+    return results
+
+
+def _execution_log_evidence(submission: Mapping[str, Any]) -> dict[str, Any]:
+    """Return bounded scheduler stdout/stderr evidence and full-file digests."""
+    root_value = submission.get("execution_root_path")
+    if not isinstance(root_value, str) or not root_value:
+        raise RuntimeError("scheduler submission did not retain its execution root")
+    execution_root = Path(root_value)
+    evidence: dict[str, Any] = {}
+    for name in ("stdout.log", "stderr.log"):
+        path = execution_root / name
+        status = path.stat(follow_symlinks=False)
+        if not stat.S_ISREG(status.st_mode):
+            raise RuntimeError(f"scheduler log is not a regular file: {path}")
+        with path.open("rb") as stream:
+            if status.st_size > 65_536:
+                stream.seek(status.st_size - 65_536)
+            tail = stream.read().decode("utf-8", errors="replace")
+        evidence[name] = {
+            "path": str(path),
+            "size_bytes": status.st_size,
+            "sha256": sha256_file(path),
+            "tail": tail,
+        }
+    return evidence
+
+
+def _run_installed_probe(args: argparse.Namespace, report: dict[str, Any]) -> None:
+    """Run provenance, Slurm execution, queries, and physical validation."""
+    report["phase"] = "collecting_provenance"
+    venv = args.root / ".jarvis-live-probe-venv"
+    installed = _installed_distribution_provenance()
+    _assert_installed_import(installed, venv)
+    report["provenance"]["installed_jarvis"] = installed
+    report["provenance"]["wheel"] = {
+        "path": str(args.wheel),
+        "sha256": sha256_file(args.wheel),
+        "size_bytes": args.wheel.stat().st_size,
+    }
+    _assert_expected_release_artifact(
+        args,
+        report,
+        installed_version=str(installed["version"]),
+    )
+    report["provenance"]["clio_core"] = _git_provenance(report, args.clio_core_root)
+    report["provenance"]["binary"] = {
+        "path": str(args.executable),
+        "sha256": sha256_file(args.executable),
+        "size_bytes": args.executable.stat().st_size,
+    }
+    spack_provenance = _spack_provenance(
+        report,
+        args.spack,
+        args.spack_spec,
+    )
+    report["provenance"]["spack_adios2"] = spack_provenance
+    adios_prefix = Path(spack_provenance["prefix"])
+    linkage = _runtime_linkage(report, args.executable, adios_prefix)
+    report["provenance"]["binary"]["runtime_linkage"] = linkage
+    mpi_prefix = Path(linkage["mpi_prefix"])
+    mpi_executable = Path(linkage["mpi_executable"])
+    environment = _spack_environment(
+        base=os.environ,
+        executable=args.executable,
+        adios_prefix=adios_prefix,
+        mpi_prefix=mpi_prefix,
+    )
+    os.environ.update(environment)
+    bpls = args.bpls or adios_prefix / "bin" / "bpls"
+    if not bpls.is_absolute() or not bpls.is_file():
+        raise RuntimeError("bpls was not resolved from the selected Spack environment")
+    bpls = bpls.resolve()
+    if not bpls.is_relative_to(adios_prefix.resolve()):
+        raise RuntimeError("bpls does not belong to the selected Spack ADIOS2 prefix")
+    if not os.access(bpls, os.X_OK):
+        raise RuntimeError(f"bpls is not executable: {bpls}")
+    report["provenance"]["bpls"] = {
+        "path": str(bpls),
+        "sha256": sha256_file(bpls),
+        "size_bytes": bpls.stat().st_size,
+    }
+
+    run_id = "ares-gray-scott-" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_id += "-" + uuid4().hex[:8]
+    output_root = args.root / "outputs" / run_id
+    output_root.mkdir(parents=True, exist_ok=False)
+    output_path = output_root / "gray-scott.bp"
+    checkpoint_path = Path(f"{output_path}.checkpoint.bp")
+
+    report["phase"] = "configuring_pipeline"
+    pipeline = _configured_pipeline(
+        args,
+        report,
+        environment,
+        output_path,
+        mpi_executable,
+        run_id,
+    )
+    _assert_installed_package_source(report["pipeline"], venv)
+    atomic_write_json(args.report, report)
+
+    report["phase"] = "submitting"
+    handle = pipeline.submit(submit=True, wait=False)
+    report["execution"]["handle"] = handle.to_dict()
+    report["execution"]["submission"] = dict(pipeline.last_submission or {})
+    atomic_write_json(args.report, report)
+
+    report["phase"] = "polling"
+    record, progress, artifacts = _poll_execution(
+        args,
+        report,
+        pipeline,
+        handle.execution_id,
+    )
+    report["queries"].update(
+        {"record": record, "progress": progress, "artifacts": artifacts}
+    )
+    report["execution"]["logs"] = _execution_log_evidence(
+        report["execution"]["submission"]
+    )
+    report["phase"] = "physical_validation"
+    bpls_output = _run_bpls(
+        report,
+        bpls,
+        output_path,
+        checkpoint_path,
+    )
+    report["physical_validation"] = bpls_output
+    report["assertions"].extend(
+        evaluate_semantics(
+            record=record,
+            progress=progress,
+            artifacts=artifacts,
+            output_path=output_path,
+            checkpoint_path=checkpoint_path,
+            bpls_output=bpls_output,
+        )
+    )
+    failures = [item for item in report["assertions"] if not item["passed"]]
+    if failures:
+        names = ", ".join(str(item["name"]) for item in failures)
+        raise AssertionError(f"live acceptance assertions failed: {names}")
+    report["phase"] = "complete"
+    report["success"] = True
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Build the live probe command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--wheel", type=Path, required=True)
+    parser.add_argument("--expected-version")
+    parser.add_argument("--expected-wheel-sha256", type=str.lower)
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--report", type=Path)
+    parser.add_argument("--partition", required=True)
+    parser.add_argument("--account")
+    parser.add_argument(
+        "--clio-core-root", type=Path, default=Path.home() / "clio-core"
+    )
+    parser.add_argument(
+        "--executable",
+        type=Path,
+        default=(
+            Path.home() / "clio-core/external/iowarp-gray-scott/install/bin/gray-scott"
+        ),
+    )
+    parser.add_argument("--spack", type=Path, default=Path.home() / "spack/bin/spack")
+    parser.add_argument("--spack-spec", default="adios2")
+    parser.add_argument("--bpls", type=Path)
+    parser.add_argument("--uv")
+    parser.add_argument("--timeout-seconds", type=float, default=600.0)
+    parser.add_argument("--poll-seconds", type=float, default=1.0)
+    parser.add_argument("--cancel-on-timeout", action="store_true")
+    parser.add_argument(
+        "--installed-child", action="store_true", help=argparse.SUPPRESS
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the probe and return zero only for a fully passing report."""
+    args = _parser().parse_args(argv)
+    args.wheel = args.wheel.expanduser().resolve()
+    args.root = args.root.expanduser().resolve()
+    args.root.mkdir(parents=True, exist_ok=True)
+    args.report = (
+        args.report.expanduser().resolve()
+        if args.report is not None
+        else args.root / "live-ares-gray-scott-report.json"
+    )
+    args.clio_core_root = args.clio_core_root.expanduser().resolve()
+    args.executable = args.executable.expanduser().resolve()
+    args.spack = args.spack.expanduser().resolve()
+    if args.bpls is not None:
+        args.bpls = args.bpls.expanduser().resolve()
+    report = _new_report(args)
+    if args.installed_child and args.report.is_file():
+        try:
+            bootstrap = json.loads(args.report.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            bootstrap = None
+        if isinstance(bootstrap, Mapping):
+            report["bootstrap"] = {
+                "started_at": bootstrap.get("started_at"),
+                "phase": bootstrap.get("phase"),
+                "commands": bootstrap.get("commands", []),
+                "wheel": bootstrap.get("provenance", {}).get("wheel")
+                if isinstance(bootstrap.get("provenance"), Mapping)
+                else None,
+            }
+    if not args.installed_child:
+        try:
+            _validate_arguments(args)
+            atomic_write_json(args.report, report)
+            return _bootstrap_installed_child(args, report)
+        except BaseException as error:
+            report["success"] = False
+            report["error"] = {
+                "type": type(error).__name__,
+                "message": str(error),
+                "traceback": traceback.format_exc(),
+            }
+            report["finished_at"] = utc_now()
+            try:
+                atomic_write_json(args.report, report)
+            except BaseException as report_error:
+                print(
+                    f"could not write live report {args.report}: {report_error}",
+                    file=sys.stderr,
+                )
+            return 1
+
+    exit_code = 1
+    try:
+        _validate_arguments(args)
+        atomic_write_json(args.report, report)
+        _run_installed_probe(args, report)
+        exit_code = 0
+    except BaseException as error:
+        report["success"] = False
+        report["error"] = {
+            "type": type(error).__name__,
+            "message": str(error),
+            "traceback": traceback.format_exc(),
+        }
+    finally:
+        report["finished_at"] = utc_now()
+        try:
+            atomic_write_json(args.report, report)
+        except BaseException as report_error:
+            print(
+                f"could not write live report {args.report}: {report_error}",
+                file=sys.stderr,
+            )
+            exit_code = 1
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -16,6 +16,12 @@ job script, and (by default) hands it off to the scheduler's submit command
 2. Writes it to that execution's private `hostfile.txt`
 3. Runs the execution's isolated `runtime/pipeline.yaml` working copy
 
+The generated script invokes JARVIS through the same Python interpreter that
+created the submission and binds the submitting `JARVIS_ROOT`. This preserves
+the submitting configuration boundary on compute nodes; an unrelated `jarvis`
+executable or a different user's default built-in checkout on the allocation's
+`PATH` cannot replace it.
+
 Changing or deleting the named pipeline after submission cannot change an
 already queued execution. Each execution directory contains:
 

--- a/jarvis_cd/artifacts/__init__.py
+++ b/jarvis_cd/artifacts/__init__.py
@@ -9,6 +9,7 @@ from .provider import (
     ArtifactObservation,
     ArtifactProviderFactory,
     PackageArtifactProvider,
+    ProcessExitArtifactProvider,
 )
 from .reporter import (
     ARTIFACT_LINE_PREFIX,
@@ -22,6 +23,7 @@ from .reporter import (
 )
 from .schema import (
     ARTIFACT_SCHEMA_VERSION,
+    PROCESS_EXIT_RECONCILIATION_KEY,
     ArtifactEvent,
     ArtifactLocation,
     ArtifactLocationKind,
@@ -42,6 +44,7 @@ __all__ = [
     "EXECUTION_ID_ENV",
     "PACKAGE_ID_ENV",
     "PACKAGE_NAME_ENV",
+    "PROCESS_EXIT_RECONCILIATION_KEY",
     "ArtifactEvent",
     "ArtifactLocation",
     "ArtifactLocationKind",
@@ -54,6 +57,7 @@ __all__ = [
     "ArtifactStore",
     "ArtifactStructure",
     "PackageArtifactProvider",
+    "ProcessExitArtifactProvider",
     "event_from_artifact_line",
     "load_artifacts_module",
     "new_artifact_id",

--- a/jarvis_cd/artifacts/provider.py
+++ b/jarvis_cd/artifacts/provider.py
@@ -82,4 +82,15 @@ class PackageArtifactProvider(Protocol):
         ...
 
 
+@runtime_checkable
+class ProcessExitArtifactProvider(Protocol):
+    """Optional provider extension for JARVIS-owned process completion."""
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Finalize observations using the authoritative process return code."""
+        ...
+
+
 ArtifactProviderFactory = Callable[[dict[str, Any]], PackageArtifactProvider | None]

--- a/jarvis_cd/artifacts/schema.py
+++ b/jarvis_cd/artifacts/schema.py
@@ -25,6 +25,7 @@ _MEDIA_TYPE_PATTERN: Final = re.compile(
 )
 _URI_SCHEME_PATTERN: Final = re.compile(r"^[a-z][a-z0-9+.-]*$")
 _UNSAFE_URI_SCHEMES: Final = frozenset({"data", "file", "javascript"})
+PROCESS_EXIT_RECONCILIATION_KEY: Final = "jarvis_process_exit"
 _EVENT_FIELDS: Final = frozenset(
     {
         "schema_version",
@@ -273,7 +274,11 @@ class ArtifactEvent:
 
     @property
     def terminal(self) -> bool:
-        """Return whether no later lifecycle event may alter this artifact."""
+        """Return whether the producer declared this artifact terminal.
+
+        JARVIS may append one authoritative ``FINALIZED`` to ``INCOMPLETE``
+        correction if the owning package process subsequently exits nonzero.
+        """
         return self.state in {
             ArtifactState.FINALIZED,
             ArtifactState.INCOMPLETE,
@@ -453,7 +458,11 @@ def _validate_artifact_revision(
             ArtifactState.INCOMPLETE,
             ArtifactState.FAILED,
         },
-        ArtifactState.FINALIZED: set(),
+        ArtifactState.FINALIZED: (
+            {ArtifactState.INCOMPLETE}
+            if _is_process_exit_reconciliation(previous, event)
+            else set()
+        ),
         ArtifactState.INCOMPLETE: set(),
         ArtifactState.FAILED: set(),
     }[previous.state]
@@ -462,6 +471,37 @@ def _validate_artifact_revision(
             f"artifact state cannot transition from {previous.state.value!r} "
             f"to {event.state.value!r}"
         )
+
+
+def _is_process_exit_reconciliation(
+    previous: ArtifactEvent,
+    event: ArtifactEvent,
+) -> bool:
+    """Recognize the sole JARVIS-owned correction to a finalized artifact."""
+    if (
+        previous.state is not ArtifactState.FINALIZED
+        or event.state is not ArtifactState.INCOMPLETE
+    ):
+        return False
+    details = event.metadata.get(PROCESS_EXIT_RECONCILIATION_KEY)
+    if not isinstance(details, dict) or set(details) != {
+        "reported_state",
+        "return_code",
+        "source",
+    }:
+        return False
+    return_code = details.get("return_code")
+    if (
+        isinstance(return_code, bool)
+        or not isinstance(return_code, int)
+        or return_code == 0
+        or details.get("reported_state") != ArtifactState.FINALIZED.value
+        or details.get("source") != "jarvis_process_owner"
+    ):
+        return False
+    expected_metadata = dict(previous.metadata)
+    expected_metadata[PROCESS_EXIT_RECONCILIATION_KEY] = dict(details)
+    return dict(event.metadata) == expected_metadata
 
 
 def _validate_execution_relative_location(value: str) -> None:

--- a/jarvis_cd/artifacts/store.py
+++ b/jarvis_cd/artifacts/store.py
@@ -18,6 +18,7 @@ from jarvis_cd.util.private_path import (
 
 from .schema import (
     MAX_ARTIFACT_EVENT_BYTES,
+    PROCESS_EXIT_RECONCILIATION_KEY,
     ArtifactEvent,
     ArtifactState,
     validate_artifact_history,
@@ -97,6 +98,62 @@ class ArtifactStore:
         for event in self.read_all():
             current[event.artifact_id] = event
         return current
+
+    def reconcile_process_exit(self, return_code: int) -> list[ArtifactEvent]:
+        """Correct false finalized claims after a nonzero package process exit.
+
+        The correction is committed as one locked batch, retaining each opaque
+        artifact ID and advancing both its revision and the manifest sequence.
+        Available, producing, and already-incomplete/failed artifacts are left
+        untouched because their lifecycle remains meaningful after failure.
+        """
+        if isinstance(return_code, bool) or not isinstance(return_code, int):
+            raise TypeError("process return code must be an integer")
+        if return_code == 0:
+            return []
+        self._prepare_parent()
+        with _exclusive_store_lock(self.path):
+            if _store_is_sealed(self.path):
+                raise RuntimeError("artifact store is sealed")
+            descriptor = _open_store(self.path, write=True)
+            try:
+                info = _validate_descriptor(self.path, descriptor)
+                existing = _read_events_from_descriptor(descriptor, info.st_size)
+                current: dict[str, ArtifactEvent] = {}
+                for event in existing:
+                    current[event.artifact_id] = event
+                sequence = existing[-1].sequence if existing else 0
+                observed_at = time.time()
+                reconciled: list[ArtifactEvent] = []
+                for event in current.values():
+                    if event.state is not ArtifactState.FINALIZED:
+                        continue
+                    sequence += 1
+                    metadata = dict(event.metadata)
+                    metadata[PROCESS_EXIT_RECONCILIATION_KEY] = {
+                        "reported_state": ArtifactState.FINALIZED.value,
+                        "return_code": return_code,
+                        "source": "jarvis_process_owner",
+                    }
+                    reconciled.append(
+                        replace(
+                            event,
+                            state=ArtifactState.INCOMPLETE,
+                            message=(
+                                "JARVIS corrected a finalized artifact after the "
+                                f"package process exited with code {return_code}"
+                            ),
+                            revision=event.revision + 1,
+                            sequence=sequence,
+                            observed_at_epoch=observed_at,
+                            metadata=metadata,
+                        )
+                    )
+                if reconciled:
+                    _commit_events(descriptor, info.st_size, existing, reconciled)
+                return reconciled
+            finally:
+                os.close(descriptor)
 
     def is_sealed(self) -> bool:
         """Return whether execution terminalization sealed this manifest."""

--- a/jarvis_cd/core/config.py
+++ b/jarvis_cd/core/config.py
@@ -6,6 +6,9 @@ from jarvis_cd.core.execution import validate_pipeline_id
 from jarvis_cd.util.hostfile import Hostfile
 
 
+_JARVIS_ROOT_ENVIRONMENT = "JARVIS_ROOT"
+
+
 def load_class(import_str: str, path: str, class_name: str):
     """
     Loads a class from a python file.
@@ -76,10 +79,20 @@ class Jarvis:
             return
 
         # Set up jarvis root directory
-        if jarvis_root is None:
+        configured_root = jarvis_root
+        if configured_root is None:
+            configured_root = os.environ.get(_JARVIS_ROOT_ENVIRONMENT)
+        if configured_root is None:
             self.jarvis_root = Path.home() / ".ppi-jarvis"
         else:
-            self.jarvis_root = Path(jarvis_root)
+            if not configured_root or any(
+                ord(character) < 32 or ord(character) == 127
+                for character in configured_root
+            ):
+                raise ValueError(
+                    f"{_JARVIS_ROOT_ENVIRONMENT} must be a non-empty printable path"
+                )
+            self.jarvis_root = Path(configured_root).expanduser().resolve()
 
         self.config_file = self.jarvis_root / "jarvis_config.yaml"
         self.repos_file = self.jarvis_root / "repos.yaml"

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -16,8 +16,9 @@ import sys
 import tempfile
 import yaml
 from contextlib import ExitStack
+from copy import deepcopy
 from pathlib import Path
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Mapping, Optional
 from uuid import uuid4
 from jarvis_cd.artifacts import (
     ArtifactLocation,
@@ -77,6 +78,41 @@ def _bounded_scheduler_stderr(result: Any, limit: int = 4096) -> Optional[str]:
     if len(diagnostic) <= limit:
         return diagnostic
     return "[truncated]\n" + diagnostic[-limit:]
+
+
+def _executor_status_error(
+    result: Any,
+    *,
+    operation: str,
+    limit: int = 4096,
+) -> Optional[RuntimeError]:
+    """Return an error when an executor omitted or failed a host status."""
+    exit_codes = getattr(result, "exit_code", None)
+    if not isinstance(exit_codes, Mapping) or not exit_codes:
+        return RuntimeError(f"{operation} returned no per-host exit status")
+
+    stderr = getattr(result, "stderr", {})
+    stderr_by_host = stderr if isinstance(stderr, Mapping) else {}
+    failures: list[str] = []
+    for raw_host, code in exit_codes.items():
+        host = str(raw_host)
+        if isinstance(code, bool) or not isinstance(code, int):
+            detail = f"{host}=invalid exit status {code!r}"
+        elif code != 0:
+            detail = f"{host}=exit {code}"
+        else:
+            continue
+        diagnostic = str(stderr_by_host.get(raw_host, "") or "").strip()
+        if diagnostic:
+            detail += f" stderr={diagnostic!r}"
+        failures.append(detail)
+
+    if not failures:
+        return None
+    message = f"{operation} failed: " + "; ".join(failures)
+    if len(message) > limit:
+        message = "[truncated]\n" + message[-limit:]
+    return RuntimeError(message)
 
 
 def _bounded_execution_error(error: BaseException, limit: int = 16_384) -> str:
@@ -1130,8 +1166,8 @@ class Pipeline:
         """Write the scheduler job script and (optionally) submit it.
 
         :param submit: when True, exec the scheduler's submit command
-            (e.g. ``sbatch``); when False, only write the script and
-            return its path so the caller can inspect it.
+            (e.g. ``sbatch``); when False, only write the script without
+            submitting it. The returned handle exposes it as ``script_path``.
         :param wait: when True (and submit is True), ask the scheduler
             to block until the job finishes. SLURM maps this to
             ``sbatch --wait``; backends without an equivalent ignore it.
@@ -1238,6 +1274,7 @@ class Pipeline:
                 execution_root,
                 pipeline_name=self.name,
                 pipeline_snapshot_dir=snapshot_dir,
+                jarvis_root=getattr(self.jarvis, "jarvis_root", None),
             )
             script_path = sched.write_script()
             try:
@@ -1664,6 +1701,15 @@ class Pipeline:
         provider = submission.get("provider")
         native_id = submission.get("scheduler_job_id")
         cluster = submission.get("scheduler_cluster")
+        submission_projection = dict(submission)
+        if cluster is None and current.cluster is not None:
+            cluster = current.cluster
+            submission["scheduler_cluster"] = cluster
+            submission["cluster_identity_source"] = "scheduler_runtime_environment"
+            submission_projection["scheduler_cluster"] = cluster
+            submission_projection["cluster_identity_source"] = (
+                "scheduler_runtime_environment"
+            )
         store.update(
             execution_id,
             state=canonical_state,
@@ -1679,7 +1725,7 @@ class Pipeline:
             return_code=return_code,
             error=scheduler_error,
             metadata={
-                "submission": dict(submission),
+                "submission": submission_projection,
                 "script_path": submission.get("script_path"),
             },
         )
@@ -2617,7 +2663,11 @@ class Pipeline:
             ("pipeline-input", "input/pipeline.yaml", ArtifactRole.PROVENANCE),
             ("environment-input", "input/environment.yaml", ArtifactRole.PROVENANCE),
             ("pipeline-runtime", "runtime/pipeline.yaml", ArtifactRole.PROVENANCE),
-            ("environment-runtime", "runtime/environment.yaml", ArtifactRole.PROVENANCE),
+            (
+                "environment-runtime",
+                "runtime/environment.yaml",
+                ArtifactRole.PROVENANCE,
+            ),
         ):
             self._register_execution_file(
                 store,
@@ -2637,7 +2687,7 @@ class Pipeline:
                 return instance
         return None
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop all packages in the pipeline"""
         from jarvis_cd.util.logger import logger
 
@@ -2649,6 +2699,7 @@ class Pipeline:
             self._stop_containerized_pipeline()
         else:
             # Standard deployment mode - stop each package individually
+            failures: list[Exception] = []
             for pkg_def in reversed(self.packages):
                 try:
                     # Print BEGIN message
@@ -2672,6 +2723,9 @@ class Pipeline:
 
                 except Exception as e:
                     logger.error(f"Error stopping package {pkg_def['pkg_id']}: {e}")
+                    failures.append(e)
+            if failures:
+                raise ExceptionGroup("pipeline package stop failed", failures)
 
     def kill(self):
         """Force kill all packages in the pipeline"""
@@ -3141,20 +3195,25 @@ class Pipeline:
             # Load package instance
             pkg_instance = self._load_package_instance(package_entry, self.env)
 
+            argparse = pkg_instance.get_argparse()
             try:
                 # Use PkgArgParse to parse and convert arguments
-                argparse = pkg_instance.get_argparse()
                 # Parse arguments - prepend 'configure' command
                 argparse.parse(["configure"] + config_args)
-                converted_args = argparse.kwargs
+                converted_args = argparse.kwargs.copy()
 
                 # Update package configuration with converted values
                 package_entry["config"].update(converted_args)
-            except Exception as e:
-                print(f"Warning: Error parsing configuration arguments: {e}")
-                # Show available configuration options
-                argparse = pkg_instance.get_argparse()
-                argparse.print_help("configure")
+            except SystemExit as exc:
+                detail = getattr(argparse, "error_message", None)
+                suffix = f": {detail}" if detail else ""
+                raise ValueError(
+                    f"Invalid configuration arguments for package {pkg_id}{suffix}"
+                ) from exc
+            except Exception as exc:
+                raise ValueError(
+                    f"Failed to parse configuration for package {pkg_id}: {exc}"
+                ) from exc
 
         # Validate that all required parameters have values (after applying config_args)
         self._validate_required_config(package_spec, package_entry["config"])
@@ -3224,12 +3283,13 @@ class Pipeline:
             except Exception as e:
                 logger.error(f"Error cleaning package {pkg_def['pkg_id']}: {e}")
 
-    def configure_package(self, pkg_id: str, config_args: List[str]):
+    def configure_package(self, pkg_id: str, config_args: List[str]) -> None:
         """
         Configure a specific package in the pipeline.
 
         :param pkg_id: Package ID to configure
         :param config_args: Configuration arguments as command-line args (e.g., ['--nprocs', '4', 'block=32m'])
+        :raises ValueError: If an argument is unknown or package configuration fails
         """
         # Find package in pipeline
         pkg_def = None
@@ -3241,47 +3301,52 @@ class Pipeline:
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
 
-        # Load package instance
+        original_config = deepcopy(pkg_def["config"])
+
+        # Loading historically aliases the package instance's config to the
+        # pipeline definition and may add defaults. Detach it so configuration
+        # is transactional until the package completes successfully.
         pkg_instance = self._load_package_instance(pkg_def, self.env)
+        working_config = deepcopy(pkg_instance.config)
+        pkg_instance.config = working_config
+        pkg_def["config"] = original_config
 
+        argparse = pkg_instance.get_argparse()
         try:
-            # Use PkgArgParse to parse and convert arguments
-            argparse = pkg_instance.get_argparse()
-
-            # Get defaults by parsing with no user args
-            argparse.parse(["configure"])
-            defaults = argparse.kwargs.copy()
-
-            # Parse with user args
             argparse.parse(["configure"] + config_args)
-            converted_args = argparse.kwargs
-
-            # Only keep args the user explicitly provided (differ from defaults)
+            converted_args = argparse.kwargs.copy()
+            explicit_names = set(argparse.provided_args)
+            missing = sorted(explicit_names - set(converted_args))
+            if missing:
+                raise ValueError(
+                    "configuration parser did not return explicit parameters: "
+                    + ", ".join(missing)
+                )
             explicit_args = {
-                k: v
-                for k, v in converted_args.items()
-                if k not in defaults or defaults[k] != v
+                name: converted_args[name] for name in sorted(explicit_names)
             }
 
-            # Update package configuration with only explicit values
-            pkg_def["config"].update(explicit_args)
+            if not hasattr(pkg_instance, "configure"):
+                raise ValueError(f"Package {pkg_id} has no configure method")
 
-            # Configure the package instance
-            if hasattr(pkg_instance, "configure"):
-                pkg_instance.configure(**explicit_args)
-                print(f"Configured package {pkg_id} successfully")
-            else:
-                print(f"Package {pkg_id} has no configure method")
-
-            # Save updated pipeline
+            # Package configuration may create files or validate cross-field state.
+            # Do not mutate the durable pipeline definition until it succeeds.
+            pkg_instance.configure(**explicit_args)
+            pkg_def["config"] = deepcopy(pkg_instance.config)
             self.save()
-            print(f"Saved configuration for {pkg_id}")
+        except SystemExit as exc:
+            pkg_def["config"] = original_config
+            detail = getattr(argparse, "error_message", None)
+            suffix = f": {detail}" if detail else ""
+            raise ValueError(
+                f"Invalid configuration arguments for package {pkg_id}{suffix}"
+            ) from exc
+        except Exception as exc:
+            pkg_def["config"] = original_config
+            raise ValueError(f"Failed to configure package {pkg_id}: {exc}") from exc
 
-        except Exception as e:
-            print(f"Error configuring package {pkg_id}: {e}")
-            # Show available configuration options
-            argparse = pkg_instance.get_argparse()
-            argparse.print_help("configure")
+        print(f"Configured package {pkg_id} successfully")
+        print(f"Saved configuration for {pkg_id}")
 
     def show_package_readme(self, pkg_id: str):
         """
@@ -4515,7 +4580,7 @@ class Pipeline:
         except OSError:
             pass
 
-    def _stop_containerized_pipeline(self):
+    def _stop_containerized_pipeline(self) -> None:
         """
         Stop containerized pipeline:
         1. Stop each package via its stop() method
@@ -4527,6 +4592,7 @@ class Pipeline:
         logger.info("Stopping containerized pipeline")
 
         # Stop packages in reverse order (same as non-containerized)
+        failures: list[Exception] = []
         for pkg_def in reversed(self.packages):
             try:
                 logger.success(f"[{pkg_def['pkg_type']}] [STOP] BEGIN")
@@ -4540,6 +4606,7 @@ class Pipeline:
                 logger.success(f"[{pkg_def['pkg_type']}] [STOP] END")
             except Exception as e:
                 logger.error(f"Error stopping package {pkg_def['pkg_id']}: {e}")
+                failures.append(e)
 
         # Bring down the containers
         engine = self.container_engine.lower()
@@ -4558,10 +4625,23 @@ class Pipeline:
         else:
             exec_info = PsshExecInfo(hostfile=hostfile)
 
-        Exec(stop_cmd, exec_info).run()
-        logger.success("Containers stopped")
+        try:
+            result = Exec(stop_cmd, exec_info).run()
+            status_error = _executor_status_error(
+                result,
+                operation="container stop",
+            )
+            if status_error is not None:
+                raise status_error
+            logger.success("Containers stopped")
+        except Exception as exc:
+            logger.error(f"Error stopping pipeline containers: {exc}")
+            failures.append(exc)
 
-    def _kill_containerized_pipeline(self):
+        if failures:
+            raise ExceptionGroup("containerized pipeline stop failed", failures)
+
+    def _kill_containerized_pipeline(self) -> None:
         """
         Force-kill containerized pipeline:
         1. Kill each package
@@ -4573,6 +4653,7 @@ class Pipeline:
         logger.info("Force-killing containerized pipeline")
 
         # Kill packages
+        failures: list[Exception] = []
         for pkg_def in self.packages:
             try:
                 logger.success(f"[{pkg_def['pkg_type']}] [KILL] BEGIN")
@@ -4583,6 +4664,7 @@ class Pipeline:
                 logger.success(f"[{pkg_def['pkg_type']}] [KILL] END")
             except Exception as e:
                 logger.error(f"Error killing package {pkg_def['pkg_id']}: {e}")
+                failures.append(e)
 
         # Force-remove containers
         engine = self.container_engine.lower()
@@ -4601,5 +4683,18 @@ class Pipeline:
         else:
             exec_info = PsshExecInfo(hostfile=hostfile)
 
-        Exec(kill_cmd, exec_info).run()
-        logger.success("Containers force-killed")
+        try:
+            result = Exec(kill_cmd, exec_info).run()
+            status_error = _executor_status_error(
+                result,
+                operation="container force-kill",
+            )
+            if status_error is not None:
+                raise status_error
+            logger.success("Containers force-killed")
+        except Exception as exc:
+            logger.error(f"Error force-killing pipeline containers: {exc}")
+            failures.append(exc)
+
+        if failures:
+            raise ExceptionGroup("containerized pipeline force-kill failed", failures)

--- a/jarvis_cd/core/pkg.py
+++ b/jarvis_cd/core/pkg.py
@@ -87,15 +87,42 @@ class _PackageProgressLineCallback:
 
     def finalize(self) -> None:
         """Flush the provider's final fragment once after output capture closes."""
+        self.finalize_process(None)
+
+    def finalize_process(self, return_code: int | None) -> None:
+        """Finalize using an optional JARVIS-owned process return code."""
         with self._lock:
             if self._finalized:
                 return
             if self._source != "structured_stdout" and self._provider is not None:
-                observations = self._provider.finalize_progress()
+                from jarvis_cd.progress import ProcessExitProgressProvider
+
+                if return_code is not None and isinstance(
+                    self._provider,
+                    ProcessExitProgressProvider,
+                ):
+                    observations = self._provider.finalize_progress_for_exit(
+                        return_code
+                    )
+                else:
+                    observations = self._provider.finalize_progress()
                 if observations:
                     self._source = "provider"
                     self._persist(observations)
+            if return_code is not None and return_code != 0:
+                from jarvis_cd.progress import ProgressStore
+
+                ProgressStore(self._progress_path).reconcile_process_exit(return_code)
             self._finalized = True
+
+    def reconcile_process_exit(self, return_code: int) -> None:
+        """Correct any terminal success after the effective process failure."""
+        if return_code == 0:
+            return
+        from jarvis_cd.progress import ProgressStore
+
+        with self._lock:
+            ProgressStore(self._progress_path).reconcile_process_exit(return_code)
 
     def _persist(self, observations: list["ProgressObservation"]) -> None:
         """Persist typed observations with JARVIS-owned identity and sequence."""
@@ -172,15 +199,42 @@ class _PackageArtifactLineCallback:
 
     def finalize(self) -> None:
         """Flush a provider's final fragment once after output capture closes."""
+        self.finalize_process(None)
+
+    def finalize_process(self, return_code: int | None) -> None:
+        """Finalize using an optional JARVIS-owned process return code."""
         with self._lock:
             if self._finalized:
                 return
             if self._source != "structured_stdout" and self._provider is not None:
-                observations = self._provider.finalize_artifacts()
+                from jarvis_cd.artifacts import ProcessExitArtifactProvider
+
+                if return_code is not None and isinstance(
+                    self._provider,
+                    ProcessExitArtifactProvider,
+                ):
+                    observations = self._provider.finalize_artifacts_for_exit(
+                        return_code
+                    )
+                else:
+                    observations = self._provider.finalize_artifacts()
                 if observations:
                     self._source = "provider"
                     self._persist(observations)
+            if return_code is not None and return_code != 0:
+                from jarvis_cd.artifacts import ArtifactStore
+
+                ArtifactStore(self._artifact_path).reconcile_process_exit(return_code)
             self._finalized = True
+
+    def reconcile_process_exit(self, return_code: int) -> None:
+        """Correct any terminal success after the effective process failure."""
+        if return_code == 0:
+            return
+        from jarvis_cd.artifacts import ArtifactStore
+
+        with self._lock:
+            ArtifactStore(self._artifact_path).reconcile_process_exit(return_code)
 
     def _persist(self, observations: list["ArtifactObservation"]) -> None:
         """Persist observations with JARVIS-owned execution identity."""
@@ -221,21 +275,49 @@ class _PackageRuntimeLineCallback:
 
     def finalize(self) -> None:
         """Finalize every configured provider exactly once."""
+        self.finalize_process(None)
+
+    def finalize_process(self, return_code: int | None) -> None:
+        """Finalize providers with an optional owned process return code."""
         with self._lock:
             if self._finalized:
                 return
             failures: list[Exception] = []
             for callback in self._callbacks:
+                process_finalizer = getattr(callback, "finalize_process", None)
                 finalizer = getattr(callback, "finalize", None)
-                if finalizer is not None and callable(finalizer):
+                if callable(process_finalizer) or callable(finalizer):
                     try:
-                        finalizer()
+                        if return_code is not None and callable(process_finalizer):
+                            cast(Callable[[int], None], process_finalizer)(return_code)
+                        elif callable(finalizer):
+                            cast(Callable[[], None], finalizer)()
                     except Exception as exc:
                         failures.append(exc)
             self._finalized = True
             if failures:
                 raise ExceptionGroup(
                     "package runtime callback finalization failed",
+                    failures,
+                )
+
+    def reconcile_process_exit(self, return_code: int) -> None:
+        """Correct every semantic stream using the effective process failure."""
+        if return_code == 0:
+            return
+        with self._lock:
+            failures: list[Exception] = []
+            for callback in self._callbacks:
+                reconciler = getattr(callback, "reconcile_process_exit", None)
+                if not callable(reconciler):
+                    continue
+                try:
+                    cast(Callable[[int], None], reconciler)(return_code)
+                except Exception as exc:
+                    failures.append(exc)
+            if failures:
+                raise ExceptionGroup(
+                    "package runtime callback reconciliation failed",
                     failures,
                 )
 

--- a/jarvis_cd/core/scheduler.py
+++ b/jarvis_cd/core/scheduler.py
@@ -46,6 +46,7 @@ def make_scheduler(
     pipeline_yaml: Optional[str] = None,
     pipeline_name: Optional[str] = None,
     pipeline_snapshot_dir: Optional[Path] = None,
+    jarvis_root: Optional[Path] = None,
 ) -> "Scheduler":
     """Factory: build a Scheduler from a parsed YAML dict.
 
@@ -59,6 +60,8 @@ def make_scheduler(
     :param pipeline_snapshot_dir: immutable execution-scoped pipeline input
         directory. When provided, the scheduler runs that snapshot rather than
         reloading mutable named-pipeline state.
+    :param jarvis_root: configuration root whose repository selection must be
+        retained by a scheduled snapshot.
     """
     name = (spec or {}).get("name")
     if not name:
@@ -75,6 +78,7 @@ def make_scheduler(
         pipeline_yaml=pipeline_yaml,
         pipeline_name=pipeline_name,
         pipeline_snapshot_dir=pipeline_snapshot_dir,
+        jarvis_root=jarvis_root,
     )
 
 
@@ -95,6 +99,7 @@ class Scheduler:
         pipeline_yaml: Optional[str] = None,
         pipeline_name: Optional[str] = None,
         pipeline_snapshot_dir: Optional[Path] = None,
+        jarvis_root: Optional[Path] = None,
     ):
         self.spec = dict(spec or {})
         self.shared_dir = Path(pipeline_shared_dir)
@@ -103,6 +108,7 @@ class Scheduler:
         self.pipeline_snapshot_dir = (
             Path(pipeline_snapshot_dir) if pipeline_snapshot_dir is not None else None
         )
+        self.jarvis_root = Path(jarvis_root) if jarvis_root is not None else None
 
         default_hostfile = str(self.shared_dir / "hostfile.txt")
         hostfile = self.spec.get("hostfile") or default_hostfile
@@ -191,19 +197,28 @@ class Scheduler:
         supplied, falling back to ``jarvis ppl run`` against the
         currently-loaded pipeline otherwise.
         """
+        jarvis_cli = f"{shlex.quote(sys.executable)} -m jarvis_cd.core.cli"
         if self.pipeline_snapshot_dir is not None:
             snapshot = self.pipeline_snapshot_dir
             snapshot_yaml = snapshot / "pipeline.yaml"
+            environment = [
+                "env",
+                "JARVIS_PIPELINE_SNAPSHOT_DIR=" + shlex.quote(str(snapshot)),
+            ]
+            if self.jarvis_root is not None:
+                environment.append("JARVIS_ROOT=" + shlex.quote(str(self.jarvis_root)))
             return (
-                "env JARVIS_PIPELINE_SNAPSHOT_DIR="
-                f"{shlex.quote(str(snapshot))} "
-                f"jarvis ppl run yaml {shlex.quote(str(snapshot_yaml))}"
+                " ".join(environment)
+                + f" {jarvis_cli} ppl run yaml {shlex.quote(str(snapshot_yaml))}"
             )
         if self.pipeline_yaml:
-            return f"jarvis ppl run yaml {shlex.quote(self.pipeline_yaml)}"
+            return f"{jarvis_cli} ppl run yaml {shlex.quote(self.pipeline_yaml)}"
         if self.pipeline_name:
-            return f"jarvis cd {shlex.quote(self.pipeline_name)} && jarvis ppl run"
-        return "jarvis ppl run"
+            return (
+                f"{jarvis_cli} cd {shlex.quote(self.pipeline_name)} && "
+                f"{jarvis_cli} ppl run"
+            )
+        return f"{jarvis_cli} ppl run"
 
     def _execution_lifecycle_block(self) -> str:
         """Render an EXIT trap that durably finalizes scheduler script state."""

--- a/jarvis_cd/progress/__init__.py
+++ b/jarvis_cd/progress/__init__.py
@@ -9,6 +9,7 @@ from .provider import (
     LineBuffer,
     PackageProgressProvider,
     PackageScopeFilter,
+    ProcessExitProgressProvider,
     ProgressObservation,
     ProgressProviderFactory,
     RelayProgressAdapter,
@@ -24,7 +25,12 @@ from .reporter import (
     ProgressReporter,
     event_from_progress_line,
 )
-from .schema import PROGRESS_SCHEMA_VERSION, ProgressEvent, ProgressState
+from .schema import (
+    PROCESS_EXIT_RECONCILIATION_KEY,
+    PROGRESS_SCHEMA_VERSION,
+    ProgressEvent,
+    ProgressState,
+)
 from .store import ProgressStore
 
 __all__ = [
@@ -36,8 +42,10 @@ __all__ = [
     "PROGRESS_PATH_ENV",
     "PROGRESS_SCHEMA_VERSION",
     "PROGRESS_TRANSPORT_ENV",
+    "PROCESS_EXIT_RECONCILIATION_KEY",
     "PackageProgressProvider",
     "PackageScopeFilter",
+    "ProcessExitProgressProvider",
     "ProgressEvent",
     "ProgressObservation",
     "ProgressProviderFactory",

--- a/jarvis_cd/progress/provider.py
+++ b/jarvis_cd/progress/provider.py
@@ -62,6 +62,15 @@ class PackageProgressProvider(Protocol):
 
 
 @runtime_checkable
+class ProcessExitProgressProvider(Protocol):
+    """Optional provider extension for JARVIS-owned process completion."""
+
+    def finalize_progress_for_exit(self, return_code: int) -> list[ProgressObservation]:
+        """Finalize observations using the authoritative process return code."""
+        ...
+
+
+@runtime_checkable
 class RelayProgressAdapter(Protocol):
     """Legacy clio-relay adapter contract kept outside the JARVIS core SPI."""
 

--- a/jarvis_cd/progress/schema.py
+++ b/jarvis_cd/progress/schema.py
@@ -10,6 +10,7 @@ from enum import StrEnum
 from typing import Any, Final, Mapping, cast
 
 PROGRESS_SCHEMA_VERSION: Final = "jarvis.progress.v1"
+PROCESS_EXIT_RECONCILIATION_KEY: Final = "jarvis_process_exit"
 MAX_PROGRESS_EVENT_BYTES: Final = 64 * 1024
 MAX_IDENTITY_TEXT: Final = 256
 MAX_MESSAGE_TEXT: Final = 4096

--- a/jarvis_cd/progress/store.py
+++ b/jarvis_cd/progress/store.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 import os
 import stat
+import time
 from contextlib import contextmanager
+from dataclasses import replace
 from pathlib import Path
 from typing import Final, Iterator
 
-from .schema import MAX_PROGRESS_EVENT_BYTES, ProgressEvent
+from .schema import (
+    MAX_PROGRESS_EVENT_BYTES,
+    PROCESS_EXIT_RECONCILIATION_KEY,
+    ProgressEvent,
+    ProgressState,
+)
 from jarvis_cd.util.private_path import (
     ensure_private_descriptor,
     ensure_private_path,
@@ -109,6 +116,70 @@ class ProgressStore:
         """Return the most recent valid event, if one exists."""
         events = self.read_all()
         return events[-1] if events else None
+
+    def reconcile_process_exit(self, return_code: int) -> ProgressEvent | None:
+        """Correct a false completion after a nonzero package process exit.
+
+        The package's quantitative progress and identity remain intact. JARVIS
+        appends a machine-readable failed event with the next sequence while
+        holding the same lock used by ordinary progress writes.
+        """
+        if isinstance(return_code, bool) or not isinstance(return_code, int):
+            raise TypeError("process return code must be an integer")
+        if return_code == 0:
+            return None
+        _reject_symlink_tree(self.path.parent)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_private_path(self.path.parent, directory=True)
+        _reject_symlink_tree(self.path.parent)
+        with _exclusive_store_lock(self.path):
+            descriptor = _open_store(self.path, write=True)
+            try:
+                info = _validate_descriptor(self.path, descriptor)
+                previous = _latest_event(descriptor, info.st_size)
+                if previous is None or previous.state is not ProgressState.COMPLETED:
+                    return None
+                metadata = dict(previous.metadata)
+                metadata[PROCESS_EXIT_RECONCILIATION_KEY] = {
+                    "reported_state": ProgressState.COMPLETED.value,
+                    "return_code": return_code,
+                    "source": "jarvis_process_owner",
+                }
+                event = replace(
+                    previous,
+                    state=ProgressState.FAILED,
+                    message=(
+                        "JARVIS corrected completed progress after the package "
+                        f"process exited with code {return_code}"
+                    ),
+                    sequence=previous.sequence + 1,
+                    observed_at_epoch=time.time(),
+                    metadata=metadata,
+                )
+                payload = (event.to_json() + "\n").encode("utf-8")
+                if info.st_size + len(payload) > MAX_PROGRESS_STORE_BYTES:
+                    raise ValueError("progress store would exceed maximum size")
+                if _stream_identity(event) != _stream_identity(previous):
+                    raise ValueError(
+                        "progress event identity must remain stable within a store"
+                    )
+                try:
+                    offset = 0
+                    while offset < len(payload):
+                        written = os.write(descriptor, payload[offset:])
+                        if written <= 0:
+                            raise OSError(
+                                "short write while appending progress reconciliation"
+                            )
+                        offset += written
+                    os.fsync(descriptor)
+                except BaseException:
+                    os.ftruncate(descriptor, info.st_size)
+                    os.fsync(descriptor)
+                    raise
+                return event
+            finally:
+                os.close(descriptor)
 
 
 def _reject_symlink(path: Path, *, label: str) -> None:

--- a/jarvis_cd/shell/core_exec.py
+++ b/jarvis_cd/shell/core_exec.py
@@ -8,10 +8,31 @@ import time
 import os
 import signal
 from abc import ABC, abstractmethod
-from typing import Dict
+from typing import Callable, Dict, cast
 
 from .exec_info import ExecInfo, ExecType
 from .windows_job import WindowsJob, spawn_windows_job_process
+
+
+def _callback_failure_detail(error: Exception, limit: int = 4096) -> str:
+    """Return a bounded diagnostic including nested exception-group causes."""
+    details = [str(error) or type(error).__name__]
+    pending: list[BaseException] = list(
+        error.exceptions if isinstance(error, BaseExceptionGroup) else []
+    )
+    causes: list[str] = []
+    while pending and len(causes) < 16:
+        current = pending.pop(0)
+        if isinstance(current, BaseExceptionGroup):
+            pending[0:0] = list(current.exceptions)
+            continue
+        causes.append(str(current) or type(current).__name__)
+    if causes:
+        details.append("causes: " + "; ".join(causes))
+    detail = ": ".join(details)
+    if len(detail) > limit:
+        return detail[: limit - 3] + "..."
+    return detail
 
 
 class CoreExec(ABC):
@@ -63,7 +84,16 @@ class CoreExec(ABC):
             self.exit_code[hostname] = exit_code
 
             self._join_output_threads(hostname)
-            self._finalize_output_callback()
+            semantic_return_code = exit_code
+            if semantic_return_code == 0 and self._output_callback_failure.is_set():
+                semantic_return_code = 1
+            self._finalize_output_callback(semantic_return_code)
+            if semantic_return_code == 0 and self._output_callback_failure.is_set():
+                semantic_return_code = 1
+            if semantic_return_code != 0:
+                self._reconcile_output_callback(semantic_return_code)
+            exit_code = semantic_return_code
+            self.exit_code[hostname] = exit_code
 
             if self.output_callback_errors:
                 existing = self.stderr.get(hostname, "")
@@ -72,9 +102,6 @@ class CoreExec(ABC):
                     f"{existing}{separator}{''.join(self.output_callback_errors)}"
                 )
                 self.output_callback_errors.clear()
-                if exit_code == 0:
-                    exit_code = 1
-                    self.exit_code[hostname] = exit_code
 
             windows_job = self.windows_jobs.get(hostname)
             if windows_job is not None:
@@ -131,11 +158,14 @@ class CoreExec(ABC):
         should_terminate = False
         with self._output_callback_lock:
             if self._output_callback_failure.is_set():
+                if not terminate:
+                    detail = _callback_failure_detail(exc)
+                    self.output_callback_errors.append(
+                        f"Output line callback failed for {output_type}: {detail}\n"
+                    )
                 return
             self._output_callback_failure.set()
-            detail = str(exc)
-            if len(detail) > 4096:
-                detail = detail[:4093] + "..."
+            detail = _callback_failure_detail(exc)
             self.output_callback_errors.append(
                 f"Output line callback failed for {output_type}: {detail}\n"
             )
@@ -153,23 +183,39 @@ class CoreExec(ABC):
                         f"Could not terminate process after callback failure: {detail}\n"
                     )
 
-    def _finalize_output_callback(self) -> None:
-        """Finalize a stateful output callback once after both streams close."""
+    def _finalize_output_callback(self, return_code: int) -> None:
+        """Finalize a stateful callback with the owned process return code."""
         callback = getattr(getattr(self, "exec_info", None), "line_callback", None)
+        process_finalizer = getattr(callback, "finalize_process", None)
         finalizer = getattr(callback, "finalize", None)
-        if finalizer is None or not callable(finalizer):
+        if not callable(process_finalizer) and not callable(finalizer):
             return
         with self._output_callback_lock:
-            if (
-                self._output_callback_finalized
-                or self._output_callback_failure.is_set()
-            ):
+            if self._output_callback_finalized:
                 return
             self._output_callback_finalized = True
         try:
-            finalizer()
+            if callable(process_finalizer):
+                cast(Callable[[int], None], process_finalizer)(return_code)
+            elif callable(finalizer):
+                cast(Callable[[], None], finalizer)()
         except Exception as exc:
             self._record_output_callback_failure("finalization", exc, terminate=False)
+
+    def _reconcile_output_callback(self, return_code: int) -> None:
+        """Correct semantic success using the effective nonzero return code."""
+        callback = getattr(getattr(self, "exec_info", None), "line_callback", None)
+        reconciler = getattr(callback, "reconcile_process_exit", None)
+        if not callable(reconciler):
+            return
+        try:
+            cast(Callable[[int], None], reconciler)(return_code)
+        except Exception as exc:
+            self._record_output_callback_failure(
+                "reconciliation",
+                exc,
+                terminate=False,
+            )
 
     def wait_all(self) -> Dict[str, int]:
         """
@@ -461,6 +507,10 @@ class MpiVersion(LocalExec):
             exec_async=False,
             dry_run=False,
             container="none",
+            # MPI detection is an internal probe, not the application process.
+            # Reusing an application callback here would finalize its durable
+            # progress/artifact providers before the real MPI stream starts.
+            line_callback=None,
         )
 
         # If the hostfile points to remote nodes, run via SSH on the

--- a/jarvis_cd/util/argparse.py
+++ b/jarvis_cd/util/argparse.py
@@ -1,4 +1,3 @@
-import re
 import ast
 from typing import Dict, List, Any, Optional
 
@@ -9,64 +8,69 @@ class ArgParse:
         self.commands = {}
         self.command_args = {}
         self.kwargs = {}
+        self.provided_args = set()
+        self.error_message = None
+        self.strict_unknown_args = False
         self.remainder = []
         self.current_menu = None
         self.current_command = None
-        
+
     def add_menu(self, name: str, msg: str = ""):
         """Add a menu to the parser"""
-        self.menus[name] = {
-            'name': name,
-            'msg': msg,
-            'commands': []
-        }
-        
-    def add_cmd(self, name: str, msg: str = "", keep_remainder: bool = False, aliases: Optional[List[str]] = None):
+        self.menus[name] = {"name": name, "msg": msg, "commands": []}
+
+    def add_cmd(
+        self,
+        name: str,
+        msg: str = "",
+        keep_remainder: bool = False,
+        aliases: Optional[List[str]] = None,
+    ):
         """Add a command to a menu"""
         if aliases is None:
             aliases = []
-            
+
         # Extract menu name from command name
         parts = name.split()
-        menu_name = ' '.join(parts[:-1]) if len(parts) > 1 else ''
+        menu_name = " ".join(parts[:-1]) if len(parts) > 1 else ""
         cmd_name = parts[-1] if parts else name
-        
+
         self.commands[name] = {
-            'name': name,
-            'menu': menu_name,
-            'cmd_name': cmd_name,
-            'msg': msg,
-            'keep_remainder': keep_remainder,
-            'aliases': aliases,
-            'args': []
+            "name": name,
+            "menu": menu_name,
+            "cmd_name": cmd_name,
+            "msg": msg,
+            "keep_remainder": keep_remainder,
+            "aliases": aliases,
+            "args": [],
         }
-        
+
         # Add to menu's command list
         if menu_name in self.menus:
-            self.menus[menu_name]['commands'].append(name)
-            
+            self.menus[menu_name]["commands"].append(name)
+
         # Add aliases to commands dict
         for alias in aliases:
             self.commands[alias] = self.commands[name]
-            
+
     def add_args(self, args_list: List[Dict[str, Any]]):
         """Add arguments to the most recently added command"""
         if not self.commands:
             raise ValueError("No command to add arguments to")
-            
+
         # Get the last added command (excluding aliases)
         last_cmd = None
         for cmd_name, cmd_info in reversed(list(self.commands.items())):
             # Check if this is not an alias by seeing if it equals itself
-            if cmd_name == cmd_info['name']:
+            if cmd_name == cmd_info["name"]:
                 last_cmd = cmd_name
                 break
-                
+
         if last_cmd is None:
             last_cmd = list(self.commands.keys())[-1]
-                
+
         self.command_args[last_cmd] = args_list
-        
+
     def _parse_list_value(self, value: str, arg_spec: Dict[str, Any]) -> List[Any]:
         """Parse a list value from string representation"""
         try:
@@ -75,53 +79,63 @@ class ArgParse:
                 value = value[1:-1]
             elif value.startswith("'") and value.endswith("'"):
                 value = value[1:-1]
-                
+
             # Handle Python-like list notation: "[item1, item2]" or "[(item1, item2), (item3, item4)]"
-            if value.startswith('[') and value.endswith(']'):
+            if value.startswith("[") and value.endswith("]"):
                 parsed = ast.literal_eval(value)
                 return self._convert_list_items(parsed, arg_spec)
             else:
                 # Handle single item that should be added to list
-                return self._convert_list_items([self._parse_single_item(value, arg_spec)], arg_spec)
+                return self._convert_list_items(
+                    [self._parse_single_item(value, arg_spec)], arg_spec
+                )
         except (ValueError, SyntaxError):
             # Fallback: try to parse as single item
             return [self._parse_single_item(value, arg_spec)]
-            
+
     def _parse_single_item(self, value: str, arg_spec: Dict[str, Any]) -> Any:
         """Parse a single item for a list"""
-        args_def = arg_spec.get('args', [])
-        
+        args_def = arg_spec.get("args", [])
+
         if not args_def:
             return value
-        
+
         # Remove surrounding quotes if present
         if value.startswith('"') and value.endswith('"'):
             value = value[1:-1]
         elif value.startswith("'") and value.endswith("'"):
             value = value[1:-1]
-            
+
         # Handle tuple-like notation: "(item1, item2)"
-        if value.startswith('(') and value.endswith(')'):
+        if value.startswith("(") and value.endswith(")"):
             try:
                 parsed = ast.literal_eval(value)
                 if isinstance(parsed, tuple):
                     result = {}
                     for i, arg_def in enumerate(args_def):
                         if i < len(parsed):
-                            result[arg_def['name']] = self._cast_value(parsed[i], arg_def.get('type', str))
+                            result[arg_def["name"]] = self._cast_value(
+                                parsed[i], arg_def.get("type", str)
+                            )
                     return result
             except (ValueError, SyntaxError):
                 pass
-                
+
         # Handle single value
         if len(args_def) == 1:
-            return {args_def[0]['name']: self._cast_value(value, args_def[0].get('type', str))}
-            
+            return {
+                args_def[0]["name"]: self._cast_value(
+                    value, args_def[0].get("type", str)
+                )
+            }
+
         return value
-        
-    def _convert_list_items(self, items: List[Any], arg_spec: Dict[str, Any]) -> List[Any]:
+
+    def _convert_list_items(
+        self, items: List[Any], arg_spec: Dict[str, Any]
+    ) -> List[Any]:
         """Convert list items according to the argument specification"""
-        args_def = arg_spec.get('args', [])
+        args_def = arg_spec.get("args", [])
         result = []
 
         for item in items:
@@ -130,18 +144,28 @@ class ArgParse:
                 item_dict = {}
                 for i, arg_def in enumerate(args_def):
                     if i < len(item):
-                        item_dict[arg_def['name']] = self._cast_value(item[i], arg_def.get('type', str))
+                        item_dict[arg_def["name"]] = self._cast_value(
+                            item[i], arg_def.get("type", str)
+                        )
                 result.append(item_dict)
             elif isinstance(item, dict) and args_def:
                 # Convert dict values based on args definition
                 item_dict = {}
                 for arg_def in args_def:
-                    arg_name = arg_def['name']
+                    arg_name = arg_def["name"]
                     if arg_name in item:
-                        item_dict[arg_name] = self._cast_value(item[arg_name], arg_def.get('type', str))
+                        item_dict[arg_name] = self._cast_value(
+                            item[arg_name], arg_def.get("type", str)
+                        )
                     else:
                         # Keep other keys as-is
-                        item_dict.update({k: v for k, v in item.items() if k not in [a['name'] for a in args_def]})
+                        item_dict.update(
+                            {
+                                k: v
+                                for k, v in item.items()
+                                if k not in [a["name"] for a in args_def]
+                            }
+                        )
                 result.append(item_dict)
             elif isinstance(item, dict):
                 result.append(item)
@@ -149,13 +173,15 @@ class ArgParse:
                 # Single value - if there's exactly one arg_def, convert it
                 if args_def and len(args_def) == 1:
                     arg_def = args_def[0]
-                    result.append(self._cast_value(item, arg_def.get('type', str)))
+                    result.append(self._cast_value(item, arg_def.get("type", str)))
                 else:
                     result.append(item)
 
         return result
-        
-    def _cast_value(self, value: Any, value_type: type, arg_spec: Dict[str, Any] = None) -> Any:
+
+    def _cast_value(
+        self, value: Any, value_type: type, arg_spec: Dict[str, Any] = None
+    ) -> Any:
         """
         Cast a value to the specified type.
 
@@ -165,36 +191,38 @@ class ArgParse:
         :param value_type: Target type
         :param arg_spec: Full argument specification (optional, used for nested list/dict conversions)
         """
-        if value_type == bool:
+        if value_type is bool:
             if isinstance(value, bool):
                 return value
             elif isinstance(value, str):
-                return value.lower() in ('true', '1', 'yes', 'on')
+                return value.lower() in ("true", "1", "yes", "on")
             else:
                 return bool(value)
-        elif value_type == int:
+        elif value_type is int:
             return int(value)
-        elif value_type == float:
+        elif value_type is float:
             return float(value)
-        elif value_type == str:
+        elif value_type is str:
             return str(value)
-        elif value_type == list:
+        elif value_type is list:
             if isinstance(value, list):
                 # If arg_spec provided with nested args, convert list items
-                if arg_spec and 'args' in arg_spec:
+                if arg_spec and "args" in arg_spec:
                     return self._convert_list_items(value, arg_spec)
                 return value
             return [value]
-        elif value_type == dict:
+        elif value_type is dict:
             if isinstance(value, dict):
                 # If arg_spec provided with nested args, convert dict values
-                if arg_spec and 'args' in arg_spec:
+                if arg_spec and "args" in arg_spec:
                     converted = {}
-                    args_def = arg_spec.get('args', [])
+                    args_def = arg_spec.get("args", [])
                     for arg_def in args_def:
-                        arg_name = arg_def['name']
+                        arg_name = arg_def["name"]
                         if arg_name in value:
-                            converted[arg_name] = self._cast_value(value[arg_name], arg_def.get('type', str), arg_def)
+                            converted[arg_name] = self._cast_value(
+                                value[arg_name], arg_def.get("type", str), arg_def
+                            )
                     # Keep other keys as-is
                     for k, v in value.items():
                         if k not in converted:
@@ -204,18 +232,25 @@ class ArgParse:
             # Try to parse as dict
             if isinstance(value, str):
                 # Try Python literal syntax first (JSON-like format)
-                if (value.startswith('{') and value.endswith('}')) or (value.startswith('[') and value.endswith(']')):
+                if (value.startswith("{") and value.endswith("}")) or (
+                    value.startswith("[") and value.endswith("]")
+                ):
                     try:
                         import ast
+
                         result = ast.literal_eval(value)
                         # Apply type conversions if arg_spec has args
-                        if isinstance(result, dict) and arg_spec and 'args' in arg_spec:
+                        if isinstance(result, dict) and arg_spec and "args" in arg_spec:
                             converted = {}
-                            args_def = arg_spec.get('args', [])
+                            args_def = arg_spec.get("args", [])
                             for arg_def in args_def:
-                                arg_name = arg_def['name']
+                                arg_name = arg_def["name"]
                                 if arg_name in result:
-                                    converted[arg_name] = self._cast_value(result[arg_name], arg_def.get('type', str), arg_def)
+                                    converted[arg_name] = self._cast_value(
+                                        result[arg_name],
+                                        arg_def.get("type", str),
+                                        arg_def,
+                                    )
                             # Keep other keys as-is
                             for k, v in result.items():
                                 if k not in converted:
@@ -226,20 +261,22 @@ class ArgParse:
                         pass
 
                 # Try key:value,key2:value2 format (only if not JSON-like)
-                if ':' in value and ',' in value and not value.startswith('{'):
+                if ":" in value and "," in value and not value.startswith("{"):
                     try:
                         result = {}
-                        pairs = value.split(',')
+                        pairs = value.split(",")
                         for pair in pairs:
-                            if ':' in pair:
-                                k, v = pair.split(':', 1)
+                            if ":" in pair:
+                                k, v = pair.split(":", 1)
                                 k = k.strip()
                                 v = v.strip()
                                 # Apply type conversion if arg_spec has args
-                                if arg_spec and 'args' in arg_spec:
-                                    for arg_def in arg_spec['args']:
-                                        if arg_def['name'] == k:
-                                            v = self._cast_value(v, arg_def.get('type', str), arg_def)
+                                if arg_spec and "args" in arg_spec:
+                                    for arg_def in arg_spec["args"]:
+                                        if arg_def["name"] == k:
+                                            v = self._cast_value(
+                                                v, arg_def.get("type", str), arg_def
+                                            )
                                             break
                                 result[k] = v
                         if result:
@@ -260,47 +297,53 @@ class ArgParse:
                 return value_type(value)
             except (ValueError, TypeError):
                 return value
-            
+
     def _find_command(self, args: List[str]) -> tuple[Optional[str], int]:
         """Find the best matching command and return it with the number of args consumed"""
         best_match = None
         best_length = 0
-        
+
         for cmd_name in self.commands.keys():
             # Skip aliases, only check primary command names
-            if cmd_name in self.commands and 'aliases' in self.commands[cmd_name] and cmd_name in self.commands[cmd_name]['aliases']:
+            if (
+                cmd_name in self.commands
+                and "aliases" in self.commands[cmd_name]
+                and cmd_name in self.commands[cmd_name]["aliases"]
+            ):
                 continue
-                
+
             cmd_parts = cmd_name.split()
             if len(cmd_parts) <= len(args):
-                if args[:len(cmd_parts)] == cmd_parts:
+                if args[: len(cmd_parts)] == cmd_parts:
                     if len(cmd_parts) > best_length:
                         best_match = cmd_name
                         best_length = len(cmd_parts)
-        
+
         # Check aliases
         for cmd_name, cmd_info in self.commands.items():
-            if 'aliases' in cmd_info:
-                for alias in cmd_info['aliases']:
+            if "aliases" in cmd_info:
+                for alias in cmd_info["aliases"]:
                     alias_parts = alias.split()
                     if len(alias_parts) <= len(args):
-                        if args[:len(alias_parts)] == alias_parts:
+                        if args[: len(alias_parts)] == alias_parts:
                             if len(alias_parts) > best_length:
                                 best_match = cmd_name
                                 best_length = len(alias_parts)
-                        
+
         return best_match, best_length
-        
-    def _get_argument_info(self, cmd_name: str, arg_name: str) -> Optional[Dict[str, Any]]:
+
+    def _get_argument_info(
+        self, cmd_name: str, arg_name: str
+    ) -> Optional[Dict[str, Any]]:
         """Get argument information for a command"""
         if cmd_name not in self.command_args:
             return None
 
         for arg_spec in self.command_args[cmd_name]:
-            if arg_spec['name'] == arg_name:
+            if arg_spec["name"] == arg_name:
                 return arg_spec
             # Check aliases
-            if 'aliases' in arg_spec and arg_name in arg_spec['aliases']:
+            if "aliases" in arg_spec and arg_name in arg_spec["aliases"]:
                 return arg_spec
 
         return None
@@ -308,43 +351,49 @@ class ArgParse:
     def _print_param_error(self, error_msg: str, cmd_name: str):
         """Print parameter error with usage menu and exit"""
         import sys
+
+        self.error_message = error_msg
         print(f"Error: {error_msg}")
         print()
         self.print_command_help(cmd_name)
         sys.exit(1)
-        
+
     def parse(self, args: List[str]) -> Dict[str, Any]:
         """Parse the argument list"""
         self.kwargs = {}
+        self.provided_args = set()
+        self.error_message = None
         self.remainder = []
         self.current_menu = None
         self.current_command = None
 
         # Check for help request
-        if args and (args[0] in ['--help', '-h', 'help']):
+        if args and (args[0] in ["--help", "-h", "help"]):
             if len(args) > 1:
                 # Help for specific command/menu
-                self.print_help(' '.join(args[1:]))
+                self.print_help(" ".join(args[1:]))
             else:
                 # General help
                 self.print_help()
             return {}
 
         if not args:
-            self.current_command = ''
-            return self._handle_command('')
+            self.current_command = ""
+            return self._handle_command("")
 
         # Find matching command
         cmd_name, consumed = self._find_command(args)
 
         if cmd_name is None:
             # Check for multi-word menus first (e.g., "ppl env")
-            for i in range(min(3, len(args)), 0, -1):  # Check up to 3 words, longest first
-                potential_menu = ' '.join(args[:i])
+            for i in range(
+                min(3, len(args)), 0, -1
+            ):  # Check up to 3 words, longest first
+                potential_menu = " ".join(args[:i])
                 if potential_menu in self.menus:
                     # Check if there's a help flag in the remaining args
                     remaining_args = args[i:]
-                    if '--help' in remaining_args or '-h' in remaining_args:
+                    if "--help" in remaining_args or "-h" in remaining_args:
                         self.print_menu_help(potential_menu)
                         return {}
                     # If no help flag, treat as menu navigation
@@ -352,26 +401,27 @@ class ArgParse:
                     return {}
 
             # Check if there's an empty command defined (default command)
-            if '' in self.commands:
-                cmd_name = ''
+            if "" in self.commands:
+                cmd_name = ""
                 consumed = 0
             elif self.commands or self.menus:
                 # Unknown command - exit with error if there are menus or commands defined (but no default)
                 import sys
+
                 print(f"Error: Unknown command '{' '.join(args)}'")
                 print()
                 self.print_help()
                 sys.exit(1)
             else:
                 # Default to empty command (if nothing is defined)
-                cmd_name = ''
+                cmd_name = ""
                 consumed = 0
 
         self.current_command = cmd_name
         remaining_args = args[consumed:]
 
         # Check for help in remaining args
-        if '--help' in remaining_args or '-h' in remaining_args:
+        if "--help" in remaining_args or "-h" in remaining_args:
             self.print_command_help(cmd_name)
             return {}
 
@@ -379,38 +429,38 @@ class ArgParse:
             return self._parse_command_args(cmd_name, remaining_args)
         except ValueError as e:
             self._print_param_error(str(e), cmd_name)
-        
+
     def _parse_command_args(self, cmd_name: str, args: List[str]) -> Dict[str, Any]:
         """Parse arguments for a specific command"""
         if cmd_name not in self.command_args:
             # If no args defined, treat all as remainder
-            if cmd_name in self.commands and self.commands[cmd_name]['keep_remainder']:
+            if cmd_name in self.commands and self.commands[cmd_name]["keep_remainder"]:
                 self.remainder = args
             return self._handle_command(cmd_name)
 
         arg_specs = self.command_args[cmd_name]
-        keep_remainder = self.commands[cmd_name]['keep_remainder']
+        keep_remainder = self.commands[cmd_name]["keep_remainder"]
 
         # Initialize defaults
         for arg_spec in arg_specs:
-            if 'default' in arg_spec:
-                self.kwargs[arg_spec['name']] = arg_spec['default']
+            if "default" in arg_spec:
+                self.kwargs[arg_spec["name"]] = arg_spec["default"]
 
         # Separate positional and keyword args by class and rank
         positional_args = []
         for arg_spec in arg_specs:
-            if arg_spec.get('pos', False):
+            if arg_spec.get("pos", False):
                 positional_args.append(arg_spec)
 
         # Sort positional args by class and rank
         # Arguments with a class should be sorted by (class, rank)
         # Arguments without a class should come after classed arguments
         def sort_key(x):
-            class_name = x.get('class', '')
-            rank = x.get('rank', 0)
+            class_name = x.get("class", "")
+            rank = x.get("rank", 0)
             # If no class, put it at the end with a high sort value
             if not class_name:
-                return ('zzz_no_class', rank)
+                return ("zzz_no_class", rank)
             return (class_name, rank)
 
         positional_args.sort(key=sort_key)
@@ -423,10 +473,14 @@ class ArgParse:
 
             # Handle key=value format (for any argument, not just --)
             # Only treat as key=value if key looks like a valid argument name (alphanumeric + underscore, no spaces)
-            if '=' in arg and not arg.startswith('-'):
-                key, value = arg.split('=', 1)
+            if "=" in arg and not arg.startswith("-"):
+                key, value = arg.split("=", 1)
                 # Check if key looks like an argument name (no spaces, alphanumeric/underscore)
-                if key and not ' ' in key and key.replace('_', '').replace('-', '').isalnum():
+                if (
+                    key
+                    and " " not in key
+                    and key.replace("_", "").replace("-", "").isalnum()
+                ):
                     # Remove surrounding quotes if present
                     if value.startswith('"') and value.endswith('"'):
                         value = value[1:-1]
@@ -435,25 +489,35 @@ class ArgParse:
 
                     arg_spec = self._get_argument_info(cmd_name, key)
                     if arg_spec:
-                        if arg_spec.get('type') == list:
-                            self.kwargs[arg_spec['name']] = self._parse_list_value(value, arg_spec)
+                        if arg_spec.get("type") is list:
+                            self.kwargs[arg_spec["name"]] = self._parse_list_value(
+                                value, arg_spec
+                            )
                         else:
-                            self.kwargs[arg_spec['name']] = self._cast_value(value, arg_spec.get('type', str), arg_spec)
+                            self.kwargs[arg_spec["name"]] = self._cast_value(
+                                value, arg_spec.get("type", str), arg_spec
+                            )
+                        self.provided_args.add(arg_spec["name"])
                         i += 1
                         continue
                     # If not a known arg, fall through to positional handling
 
-            if arg.startswith('--'):
+            if arg.startswith("--"):
                 # Long option
-                if '=' in arg:
+                if "=" in arg:
                     # --key=value format
-                    key, value = arg[2:].split('=', 1)
+                    key, value = arg[2:].split("=", 1)
                     arg_spec = self._get_argument_info(cmd_name, key)
                     if arg_spec:
-                        if arg_spec.get('type') == list:
-                            self.kwargs[arg_spec['name']] = self._parse_list_value(value, arg_spec)
+                        if arg_spec.get("type") is list:
+                            self.kwargs[arg_spec["name"]] = self._parse_list_value(
+                                value, arg_spec
+                            )
                         else:
-                            self.kwargs[arg_spec['name']] = self._cast_value(value, arg_spec.get('type', str), arg_spec)
+                            self.kwargs[arg_spec["name"]] = self._cast_value(
+                                value, arg_spec.get("type", str), arg_spec
+                            )
+                        self.provided_args.add(arg_spec["name"])
                     elif keep_remainder:
                         # Unknown argument but keep_remainder is True - add to remainder
                         self.remainder.append(arg)
@@ -468,24 +532,33 @@ class ArgParse:
                     if arg_spec:
                         if i + 1 < len(args):
                             value = args[i + 1]
-                            if arg_spec.get('type') == list:
+                            if arg_spec.get("type") is list:
                                 # Append mode for lists without =
-                                if arg_spec['name'] not in self.kwargs:
-                                    self.kwargs[arg_spec['name']] = []
-                                elif not isinstance(self.kwargs[arg_spec['name']], list):
-                                    self.kwargs[arg_spec['name']] = [self.kwargs[arg_spec['name']]]
+                                if arg_spec["name"] not in self.kwargs:
+                                    self.kwargs[arg_spec["name"]] = []
+                                elif not isinstance(
+                                    self.kwargs[arg_spec["name"]], list
+                                ):
+                                    self.kwargs[arg_spec["name"]] = [
+                                        self.kwargs[arg_spec["name"]]
+                                    ]
                                 parsed_item = self._parse_single_item(value, arg_spec)
-                                self.kwargs[arg_spec['name']].append(parsed_item)
+                                self.kwargs[arg_spec["name"]].append(parsed_item)
                             else:
-                                self.kwargs[arg_spec['name']] = self._cast_value(value, arg_spec.get('type', str), arg_spec)
+                                self.kwargs[arg_spec["name"]] = self._cast_value(
+                                    value, arg_spec.get("type", str), arg_spec
+                                )
+                            self.provided_args.add(arg_spec["name"])
                             i += 2
                         else:
                             # Missing value for argument
-                            self._print_param_error(f"Argument '{key}' requires a value", cmd_name)
+                            self._print_param_error(
+                                f"Argument '{key}' requires a value", cmd_name
+                            )
                     elif keep_remainder:
                         # Unknown argument but keep_remainder is True - add to remainder
                         # Check if next arg looks like a value (doesn't start with -)
-                        if i + 1 < len(args) and not args[i + 1].startswith('-'):
+                        if i + 1 < len(args) and not args[i + 1].startswith("-"):
                             self.remainder.append(arg)
                             self.remainder.append(args[i + 1])
                             i += 2
@@ -495,19 +568,23 @@ class ArgParse:
                     else:
                         # Unknown argument
                         self._print_param_error(f"Unknown argument '{key}'", cmd_name)
-            elif arg.startswith('+') and len(arg) > 1:
+            elif arg.startswith("+") and len(arg) > 1:
                 # +arg format for boolean true
                 key = arg[1:]
                 arg_spec = self._get_argument_info(cmd_name, key)
-                if arg_spec and arg_spec.get('type') == bool:
-                    self.kwargs[arg_spec['name']] = True
+                if arg_spec and arg_spec.get("type") is bool:
+                    self.kwargs[arg_spec["name"]] = True
+                    self.provided_args.add(arg_spec["name"])
                     i += 1
                     continue
                 else:
                     # If not a boolean arg, treat as positional
                     if pos_index < len(positional_args):
                         arg_spec = positional_args[pos_index]
-                        self.kwargs[arg_spec['name']] = self._cast_value(arg, arg_spec.get('type', str), arg_spec)
+                        self.kwargs[arg_spec["name"]] = self._cast_value(
+                            arg, arg_spec.get("type", str), arg_spec
+                        )
+                        self.provided_args.add(arg_spec["name"])
                         pos_index += 1
                         i += 1
                     else:
@@ -515,37 +592,56 @@ class ArgParse:
                         if keep_remainder:
                             self.remainder.extend(args[i:])
                             break
+                        if self.strict_unknown_args:
+                            self._print_param_error(
+                                f"Unknown argument '{arg}'", cmd_name
+                            )
                         i += 1
-            elif arg.startswith('-') and len(arg) > 1 and not arg[1:].isdigit():
+            elif arg.startswith("-") and len(arg) > 1 and not arg[1:].isdigit():
                 # Check for -arg format for boolean false first
                 key = arg[1:]
                 arg_spec = self._get_argument_info(cmd_name, key)
-                if arg_spec and arg_spec.get('type') == bool:
-                    self.kwargs[arg_spec['name']] = False
+                if arg_spec and arg_spec.get("type") is bool:
+                    self.kwargs[arg_spec["name"]] = False
+                    self.provided_args.add(arg_spec["name"])
                     i += 1
                     continue
 
                 # Short option with value
                 if arg_spec and i + 1 < len(args):
                     value = args[i + 1]
-                    if arg_spec.get('type') == list:
+                    if arg_spec.get("type") is list:
                         # Append mode for lists
-                        if arg_spec['name'] not in self.kwargs:
-                            self.kwargs[arg_spec['name']] = []
-                        elif not isinstance(self.kwargs[arg_spec['name']], list):
-                            self.kwargs[arg_spec['name']] = [self.kwargs[arg_spec['name']]]
+                        if arg_spec["name"] not in self.kwargs:
+                            self.kwargs[arg_spec["name"]] = []
+                        elif not isinstance(self.kwargs[arg_spec["name"]], list):
+                            self.kwargs[arg_spec["name"]] = [
+                                self.kwargs[arg_spec["name"]]
+                            ]
                         parsed_item = self._parse_single_item(value, arg_spec)
-                        self.kwargs[arg_spec['name']].append(parsed_item)
+                        self.kwargs[arg_spec["name"]].append(parsed_item)
                     else:
-                        self.kwargs[arg_spec['name']] = self._cast_value(value, arg_spec.get('type', str), arg_spec)
+                        self.kwargs[arg_spec["name"]] = self._cast_value(
+                            value, arg_spec.get("type", str), arg_spec
+                        )
+                    self.provided_args.add(arg_spec["name"])
                     i += 2
+                elif arg_spec:
+                    self._print_param_error(
+                        f"Argument '{key}' requires a value", cmd_name
+                    )
+                elif self.strict_unknown_args:
+                    self._print_param_error(f"Unknown argument '{key}'", cmd_name)
                 else:
                     i += 1
             else:
                 # Positional argument
                 if pos_index < len(positional_args):
                     arg_spec = positional_args[pos_index]
-                    self.kwargs[arg_spec['name']] = self._cast_value(arg, arg_spec.get('type', str), arg_spec)
+                    self.kwargs[arg_spec["name"]] = self._cast_value(
+                        arg, arg_spec.get("type", str), arg_spec
+                    )
+                    self.provided_args.add(arg_spec["name"])
                     pos_index += 1
                     i += 1
                 else:
@@ -553,30 +649,41 @@ class ArgParse:
                     if keep_remainder:
                         self.remainder.extend(args[i:])
                         break
+                    if self.strict_unknown_args:
+                        self._print_param_error(f"Unknown argument '{arg}'", cmd_name)
                     i += 1
 
         # Check required args
         for arg_spec in arg_specs:
-            if arg_spec.get('required', False) and arg_spec['name'] not in self.kwargs:
-                self._print_param_error(f"Required argument '{arg_spec['name']}' not provided", cmd_name)
+            if arg_spec.get("required", False) and arg_spec["name"] not in self.kwargs:
+                self._print_param_error(
+                    f"Required argument '{arg_spec['name']}' not provided", cmd_name
+                )
 
         # Validate choices
         for arg_spec in arg_specs:
-            if 'choices' in arg_spec and arg_spec['choices'] and arg_spec['name'] in self.kwargs:
-                value = self.kwargs[arg_spec['name']]
-                if value not in arg_spec['choices']:
-                    self._print_param_error(f"Argument '{arg_spec['name']}' must be one of {arg_spec['choices']}, got: {value}", cmd_name)
+            if (
+                "choices" in arg_spec
+                and arg_spec["choices"]
+                and arg_spec["name"] in self.kwargs
+            ):
+                value = self.kwargs[arg_spec["name"]]
+                if value not in arg_spec["choices"]:
+                    self._print_param_error(
+                        f"Argument '{arg_spec['name']}' must be one of {arg_spec['choices']}, got: {value}",
+                        cmd_name,
+                    )
 
         return self._handle_command(cmd_name)
-        
+
     def _handle_command(self, cmd_name: str) -> Dict[str, Any]:
         """Handle command execution"""
         # Call the appropriate method if it exists
-        method_name = cmd_name.replace(' ', '_').replace('-', '_') or 'main_menu'
+        method_name = cmd_name.replace(" ", "_").replace("-", "_") or "main_menu"
         if hasattr(self, method_name):
             getattr(self, method_name)()
         return self.kwargs
-        
+
     def print_help(self, target: str = ""):
         """Print help information"""
         if target:
@@ -590,134 +697,151 @@ class ArgParse:
         else:
             # General help - show all top-level menus and commands
             self.print_general_help()
-            
+
     def print_general_help(self):
         """Print general help showing all available menus and commands"""
         print("Usage: [command] [options]")
         print()
 
         # Show top-level menus and their commands
-        top_level_menus = [name for name, menu in self.menus.items() if name and ' ' not in name]
+        top_level_menus = [
+            name for name, menu in self.menus.items() if name and " " not in name
+        ]
         if top_level_menus:
             print("Available menus:")
             for menu_name in sorted(top_level_menus):
                 menu = self.menus[menu_name]
-                msg = menu.get('msg', '')
+                msg = menu.get("msg", "")
                 print(f"  {menu_name:<15} {msg}")
 
                 # Show commands under this menu
-                if menu['commands']:
-                    for cmd_name in menu['commands']:
+                if menu["commands"]:
+                    for cmd_name in menu["commands"]:
                         if cmd_name in self.commands:
                             cmd = self.commands[cmd_name]
                             # Show command with indentation
-                            display_name = cmd['cmd_name']
-                            cmd_msg = cmd.get('msg', '')
+                            display_name = cmd["cmd_name"]
+                            cmd_msg = cmd.get("msg", "")
                             print(f"    {display_name:<13} {cmd_msg}")
             print()
 
         # Show top-level commands (commands with no menu or empty menu)
-        top_level_commands = [name for name, cmd in self.commands.items()
-                            if cmd['menu'] == '' and name == cmd['name']]  # Exclude aliases
+        top_level_commands = [
+            name
+            for name, cmd in self.commands.items()
+            if cmd["menu"] == "" and name == cmd["name"]
+        ]  # Exclude aliases
         if top_level_commands:
             print("Available commands:")
             for cmd_name in sorted(top_level_commands):
                 cmd = self.commands[cmd_name]
-                msg = cmd.get('msg', '')
-                aliases_str = f" (aliases: {', '.join(cmd['aliases'])})" if cmd['aliases'] else ""
+                msg = cmd.get("msg", "")
+                aliases_str = (
+                    f" (aliases: {', '.join(cmd['aliases'])})" if cmd["aliases"] else ""
+                )
                 print(f"  {cmd_name:<15} {msg}{aliases_str}")
             print()
 
-        print("Use 'help [menu|command]' or '[menu|command] --help' for more information")
-        
+        print(
+            "Use 'help [menu|command]' or '[menu|command] --help' for more information"
+        )
+
     def print_menu_help(self, menu_name: str):
         """Print help for a specific menu"""
         if menu_name not in self.menus:
             print(f"Menu '{menu_name}' not found")
             return
-            
+
         menu = self.menus[menu_name]
         print(f"Menu: {menu_name}")
-        if menu.get('msg'):
+        if menu.get("msg"):
             print(f"Description: {menu['msg']}")
         print()
-        
-        if menu['commands']:
+
+        if menu["commands"]:
             print("Available commands:")
-            for cmd_name in menu['commands']:
+            for cmd_name in menu["commands"]:
                 if cmd_name in self.commands:
                     cmd = self.commands[cmd_name]
                     # Extract just the command part (after the menu name)
-                    display_name = cmd['cmd_name']
-                    msg = cmd.get('msg', '')
-                    aliases_str = f" (aliases: {', '.join(cmd['aliases'])})" if cmd['aliases'] else ""
+                    display_name = cmd["cmd_name"]
+                    msg = cmd.get("msg", "")
+                    aliases_str = (
+                        f" (aliases: {', '.join(cmd['aliases'])})"
+                        if cmd["aliases"]
+                        else ""
+                    )
                     print(f"  {display_name:<15} {msg}{aliases_str}")
         else:
             print("No commands available in this menu")
-            
+
     def print_command_help(self, cmd_name: str):
         """Print help for a specific command"""
         if cmd_name not in self.commands:
             print(f"Command '{cmd_name}' not found")
             return
-            
+
         cmd = self.commands[cmd_name]
         print(f"Command: {cmd_name}")
-        if cmd.get('msg'):
+        if cmd.get("msg"):
             print(f"Description: {cmd['msg']}")
-        
-        if cmd['aliases']:
+
+        if cmd["aliases"]:
             print(f"Aliases: {', '.join(cmd['aliases'])}")
         print()
-        
+
         # Show arguments if any
         if cmd_name in self.command_args:
             args = self.command_args[cmd_name]
             if args:
                 print("Arguments:")
-                
+
                 # Separate positional and optional arguments
-                positional = [arg for arg in args if arg.get('pos', False)]
-                optional = [arg for arg in args if not arg.get('pos', False)]
-                
+                positional = [arg for arg in args if arg.get("pos", False)]
+                optional = [arg for arg in args if not arg.get("pos", False)]
+
                 if positional:
                     print("  Positional arguments:")
-                    for arg in sorted(positional, key=lambda x: (x.get('class', ''), x.get('rank', 0))):
+                    for arg in sorted(
+                        positional, key=lambda x: (x.get("class", ""), x.get("rank", 0))
+                    ):
                         self._print_argument_help(arg, "    ")
-                        
+
                 if optional:
                     print("  Optional arguments:")
                     for arg in optional:
                         self._print_argument_help(arg, "    ")
         else:
             print("No arguments defined for this command")
-            
+
     def _print_argument_help(self, arg: Dict[str, Any], indent: str = ""):
         """Print help for a single argument"""
-        name = arg['name']
-        msg = arg.get('msg', 'No description')
-        arg_type = arg.get('type', str).__name__
-        default = arg.get('default')
-        required = arg.get('required', False)
-        choices = arg.get('choices')
-        aliases = arg.get('aliases', [])
-        
+        name = arg["name"]
+        msg = arg.get("msg", "No description")
+        arg_type = arg.get("type", str).__name__
+        default = arg.get("default")
+        required = arg.get("required", False)
+        choices = arg.get("choices")
+        aliases = arg.get("aliases", [])
+
         # Build argument display
-        if arg.get('pos', False):
+        if arg.get("pos", False):
             arg_display = f"{name}"
         else:
             arg_display = f"--{name}"
             if aliases:
-                alias_display = ', '.join([f"-{a}" if len(a) == 1 else f"--{a}" for a in aliases])
+                alias_display = ", ".join(
+                    [f"-{a}" if len(a) == 1 else f"--{a}" for a in aliases]
+                )
                 arg_display += f", {alias_display}"
-            
+
             # Add +/- syntax for boolean arguments
-            if arg.get('type') == bool:
+            if arg.get("type") is bool:
                 arg_display += f", +{name}, -{name}"
-                
+
         print(f"{indent}{arg_display}")
         print(f"{indent}  {msg}")
-        
+
         details = []
         if required:
             details.append("required")
@@ -726,7 +850,7 @@ class ArgParse:
         if choices:
             details.append(f"choices: {choices}")
         details.append(f"type: {arg_type}")
-        
+
         if details:
             print(f"{indent}  ({', '.join(details)})")
 
@@ -739,6 +863,8 @@ class ArgParse:
         :return: Parsed arguments with proper types
         """
         self.kwargs = {}
+        self.provided_args = set()
+        self.error_message = None
         self.remainder = []  # No remainder support for dict parsing
         self.current_menu = None
         self.current_command = cmd_name
@@ -758,8 +884,8 @@ class ArgParse:
 
             # Initialize defaults
             for arg_spec in arg_specs:
-                if 'default' in arg_spec:
-                    self.kwargs[arg_spec['name']] = arg_spec['default']
+                if "default" in arg_spec:
+                    self.kwargs[arg_spec["name"]] = arg_spec["default"]
 
             # Process each argument from the dictionary
             for arg_name, arg_value in arg_dict.items():
@@ -769,31 +895,52 @@ class ArgParse:
                 if arg_spec is None:
                     # Unknown argument - still include it but without type conversion
                     self.kwargs[arg_name] = arg_value
+                    self.provided_args.add(arg_name)
                     continue
 
+                self.provided_args.add(arg_spec["name"])
+
                 # Convert value to proper type
-                if arg_spec.get('type') == list:
+                if arg_spec.get("type") is list:
                     # Handle list arguments
                     if isinstance(arg_value, list):
-                        self.kwargs[arg_spec['name']] = self._convert_list_items(arg_value, arg_spec)
+                        self.kwargs[arg_spec["name"]] = self._convert_list_items(
+                            arg_value, arg_spec
+                        )
                     else:
                         # Single value for list - wrap in list
-                        self.kwargs[arg_spec['name']] = [self._parse_single_item(str(arg_value), arg_spec)]
+                        self.kwargs[arg_spec["name"]] = [
+                            self._parse_single_item(str(arg_value), arg_spec)
+                        ]
                 else:
                     # Handle scalar arguments
-                    self.kwargs[arg_spec['name']] = self._cast_value(arg_value, arg_spec.get('type', str), arg_spec)
+                    self.kwargs[arg_spec["name"]] = self._cast_value(
+                        arg_value, arg_spec.get("type", str), arg_spec
+                    )
 
             # Check required arguments
             for arg_spec in arg_specs:
-                if arg_spec.get('required', False) and arg_spec['name'] not in self.kwargs:
-                    self._print_param_error(f"Required argument '{arg_spec['name']}' not provided", cmd_name)
+                if (
+                    arg_spec.get("required", False)
+                    and arg_spec["name"] not in self.kwargs
+                ):
+                    self._print_param_error(
+                        f"Required argument '{arg_spec['name']}' not provided", cmd_name
+                    )
 
             # Validate choices
             for arg_spec in arg_specs:
-                if 'choices' in arg_spec and arg_spec['choices'] and arg_spec['name'] in self.kwargs:
-                    value = self.kwargs[arg_spec['name']]
-                    if value not in arg_spec['choices']:
-                        self._print_param_error(f"Argument '{arg_spec['name']}' must be one of {arg_spec['choices']}, got: {value}", cmd_name)
+                if (
+                    "choices" in arg_spec
+                    and arg_spec["choices"]
+                    and arg_spec["name"] in self.kwargs
+                ):
+                    value = self.kwargs[arg_spec["name"]]
+                    if value not in arg_spec["choices"]:
+                        self._print_param_error(
+                            f"Argument '{arg_spec['name']}' must be one of {arg_spec['choices']}, got: {value}",
+                            cmd_name,
+                        )
 
             return self._handle_command(cmd_name)
         except (ValueError, TypeError) as e:

--- a/jarvis_cd/util/pkg_argparse.py
+++ b/jarvis_cd/util/pkg_argparse.py
@@ -11,6 +11,7 @@ Supported types in configure_menu:
 - SizeType: Size specifications (e.g., "1k", "2M", "10G")
 - Custom types: Any type with a constructor that accepts string values
 """
+
 from .argparse import ArgParse
 from typing import List, Dict, Any
 
@@ -39,14 +40,13 @@ class PkgArgParse(ArgParse):
         :param configure_menu: List of argument specifications from configure_menu()
         """
         super().__init__()
+        self.strict_unknown_args = True
 
         self.pkg_name = pkg_name
 
         # Add the configure command
         self.add_cmd(
-            'configure',
-            msg=f'Configure {pkg_name} package',
-            keep_remainder=False
+            "configure", msg=f"Configure {pkg_name} package", keep_remainder=False
         )
 
         # Add arguments from configure_menu
@@ -59,7 +59,7 @@ class PkgArgParse(ArgParse):
 
         :param cmd_name: Command name (always 'configure' for packages)
         """
-        if cmd_name and cmd_name != 'configure':
+        if cmd_name and cmd_name != "configure":
             print(f"Unknown command: {cmd_name}")
             print("Only 'configure' command is available for packages")
             return
@@ -71,4 +71,4 @@ class PkgArgParse(ArgParse):
         print()
 
         # Print the configure command help
-        self.print_command_help('configure')
+        self.print_command_help("configure")

--- a/test/unit/ci/test_live_ares_gray_scott_probe.py
+++ b/test/unit/ci/test_live_ares_gray_scott_probe.py
@@ -1,0 +1,435 @@
+"""Focused tests for the machine-readable Ares Gray-Scott live probe."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def _probe_module() -> ModuleType:
+    """Load the standalone CI probe without requiring an editable install."""
+    path = Path(__file__).resolve().parents[3] / "ci" / "live_ares_gray_scott_probe.py"
+    spec = spec_from_file_location("test_live_ares_gray_scott_probe_module", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load live probe: {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+PROBE = _probe_module()
+REPORT_SCHEMA = PROBE.REPORT_SCHEMA
+add_assertion = PROBE.add_assertion
+atomic_write_json = PROBE.atomic_write_json
+evaluate_semantics = PROBE.evaluate_semantics
+sha256_file = PROBE.sha256_file
+spack_hashes = PROBE._spack_hashes
+parse_ldd_output = PROBE._parse_ldd_output
+assert_installed_import = PROBE._assert_installed_import
+assert_installed_package_source = PROBE._assert_installed_package_source
+assert_fresh_install_root = PROBE._assert_fresh_install_root
+configured_pipeline = PROBE._configured_pipeline
+assert_expected_release_artifact = PROBE._assert_expected_release_artifact
+
+
+def _record() -> dict[str, Any]:
+    return {
+        "state": "completed",
+        "terminal": True,
+        "return_code": 0,
+        "scheduler_provider": "slurm",
+        "scheduler_native_id": "12345",
+    }
+
+
+def _progress() -> dict[str, Any]:
+    return {
+        "packages": [
+            {
+                "package_id": "gray_scott_bp5",
+                "event_count": 4,
+                "latest": {
+                    "state": "completed",
+                    "current": 20.0,
+                    "total": 20.0,
+                    "unit": "timestep",
+                    "metadata": {
+                        "completion_signal": "process_exit_zero_after_final_output"
+                    },
+                },
+            }
+        ]
+    }
+
+
+def _artifact(
+    *,
+    artifact_id: str,
+    logical_name: str,
+    kind: str,
+    role: str,
+    revision: int,
+    path: Path,
+    metadata: dict[str, object],
+) -> dict[str, Any]:
+    return {
+        "artifact_id": artifact_id,
+        "logical_name": logical_name,
+        "package_id": "gray_scott_bp5",
+        "state": "finalized",
+        "kind": kind,
+        "role": role,
+        "structure": "collection",
+        "ownership": "shared",
+        "media_type": "application/x-adios2-bp",
+        "format": "adios2-bp5",
+        "revision": revision,
+        "location": {"kind": "cluster_path", "value": path.as_posix()},
+        "metadata": metadata,
+    }
+
+
+def _artifacts(output_path: Path, checkpoint_path: Path) -> dict[str, Any]:
+    return {
+        "artifacts": [
+            _artifact(
+                artifact_id="art_0123456789abcdef0123456789abcdef",
+                logical_name="gray-scott-timesteps",
+                kind="scientific_dataset",
+                role="output",
+                revision=4,
+                path=output_path,
+                metadata={
+                    "application": "gray_scott",
+                    "io_backend": "adios2",
+                    "member_pattern": "adios2-steps",
+                    "members_observed": 2,
+                    "latest_timestep": 20,
+                    "completion_signal": "process_exit_zero_after_final_output",
+                },
+            ),
+            _artifact(
+                artifact_id="art_fedcba9876543210fedcba9876543210",
+                logical_name="gray-scott-restart-checkpoint",
+                kind="restart_checkpoint",
+                role="checkpoint",
+                revision=1,
+                path=checkpoint_path,
+                metadata={
+                    "application": "gray_scott",
+                    "io_backend": "adios2",
+                    "detection_signal": (
+                        "configured_path_created_or_changed_during_process"
+                    ),
+                    "physical_path_observed": True,
+                    "latest_output_timestep_observed": 20,
+                    "completion_signal": "process_exit_zero_after_final_output",
+                    "return_code": 0,
+                },
+            ),
+        ]
+    }
+
+
+def _bpls() -> dict[str, dict[str, object]]:
+    return {
+        "output_list": {"return_code": 0, "stdout": "double U\ndouble V\nint step\n"},
+        "output_steps": {"return_code": 0, "stdout": "step: 10 20\n"},
+        "checkpoint_list": {
+            "return_code": 0,
+            "stdout": "double U\ndouble V\nint step\n",
+        },
+        "checkpoint_steps": {"return_code": 0, "stdout": "step: 20\n"},
+    }
+
+
+def test_digest_and_atomic_report_are_deterministic(tmp_path: Path) -> None:
+    """Provenance hashes and reports use exact bytes and valid JSON."""
+    artifact = tmp_path / "artifact.whl"
+    artifact.write_bytes(b"jarvis-wheel")
+    assert sha256_file(artifact) == (
+        "a2698bbe900f78e274e491b58c8f0afaad67482b93bccd4b5105e77d9101cb66"
+    )
+
+    report = tmp_path / "reports" / "live.json"
+    atomic_write_json(report, {"schema_version": REPORT_SCHEMA, "success": True})
+    assert json.loads(report.read_text(encoding="utf-8")) == {
+        "schema_version": REPORT_SCHEMA,
+        "success": True,
+    }
+
+
+def test_release_artifact_assertions_bind_digest_and_version(tmp_path: Path) -> None:
+    """A passing report names the exact wheel bytes and installed version."""
+    wheel = tmp_path / "jarvis_cd-1.2.1-py3-none-any.whl"
+    wheel.write_bytes(b"released-wheel")
+    expected_digest = sha256_file(wheel)
+    args = SimpleNamespace(
+        wheel=wheel,
+        expected_version="1.2.1",
+        expected_wheel_sha256=expected_digest,
+    )
+    report: dict[str, Any] = {"assertions": []}
+
+    assert_expected_release_artifact(
+        args,
+        report,
+        installed_version="1.2.1",
+    )
+
+    assert [item["name"] for item in report["assertions"]] == [
+        "release_artifact.wheel_sha256",
+        "release_artifact.installed_version",
+    ]
+    assert all(item["passed"] is True for item in report["assertions"])
+
+
+def test_release_artifact_assertions_reject_wrong_digest(tmp_path: Path) -> None:
+    """The probe fails before submission when wheel bytes do not match."""
+    wheel = tmp_path / "jarvis_cd-1.2.1-py3-none-any.whl"
+    wheel.write_bytes(b"different-wheel")
+    args = SimpleNamespace(
+        wheel=wheel,
+        expected_version="1.2.1",
+        expected_wheel_sha256="0" * 64,
+    )
+    report: dict[str, Any] = {"assertions": []}
+
+    with pytest.raises(AssertionError, match="wheel_sha256"):
+        assert_expected_release_artifact(args, report)
+
+    assert report["assertions"][0]["passed"] is False
+
+
+def test_assertion_helper_preserves_machine_readable_evidence() -> None:
+    """Each acceptance decision retains expected and actual values."""
+    assertions: list[dict[str, object]] = []
+    add_assertion(
+        assertions,
+        "example",
+        passed=False,
+        expected=20,
+        actual=10,
+        detail="the final timestep was missing",
+    )
+    assert assertions == [
+        {
+            "name": "example",
+            "passed": False,
+            "expected": 20,
+            "actual": 10,
+            "detail": "the final timestep was missing",
+        }
+    ]
+
+
+def test_spack_hash_discovery_covers_nested_json() -> None:
+    """The report records concrete IDs emitted by common Spack schemas."""
+    assert spack_hashes(
+        [
+            {"name": "adios2", "hash": "27nopqaa"},
+            {"deps": [{"full_hash": "og56sxz"}]},
+        ]
+    ) == {"27nopqaa", "og56sxz"}
+
+
+def test_ldd_parser_retains_exact_runtime_paths_and_missing_libraries() -> None:
+    """Binary provenance distinguishes resolved paths from missing libraries."""
+    libraries, missing = parse_ldd_output(
+        "libadios2_cxx_mpi.so.2.10 => /spack/adios2/lib/libadios2.so (0x1)\n"
+        "libmpi.so.40 => /spack/openmpi/lib/libmpi.so.40 (0x2)\n"
+        "liboptional.so => not found\n"
+    )
+    assert libraries == {
+        "libadios2_cxx_mpi.so.2.10": "/spack/adios2/lib/libadios2.so",
+        "libmpi.so.40": "/spack/openmpi/lib/libmpi.so.40",
+    }
+    assert missing == ["liboptional.so"]
+
+
+def test_installed_import_accepts_uv_managed_python_symlink(tmp_path: Path) -> None:
+    """A uv venv remains isolated when its interpreter target lives outside it."""
+    venv = tmp_path / ".venv"
+    provenance = {
+        "module_path": str(venv / "lib/python3.12/site-packages/jarvis_cd/__init__.py"),
+        "python_executable": str(venv / "bin/python"),
+        "python_executable_resolved": "/opt/uv/python/cpython-3.12/bin/python3.12",
+        "python_prefix": str(venv),
+        "python_base_prefix": "/opt/uv/python/cpython-3.12",
+    }
+
+    assert_installed_import(provenance, venv)
+
+
+def test_installed_import_rejects_non_venv_prefix(tmp_path: Path) -> None:
+    """An import through a different Python prefix fails the release gate."""
+    venv = tmp_path / ".venv"
+    provenance = {
+        "module_path": str(venv / "lib/python3.12/site-packages/jarvis_cd/__init__.py"),
+        "python_executable": str(venv / "bin/python"),
+        "python_prefix": str(tmp_path / "different-prefix"),
+    }
+
+    with pytest.raises(RuntimeError, match="python_prefix"):
+        assert_installed_import(provenance, venv)
+
+
+def test_installed_package_source_rejects_stale_user_checkout(tmp_path: Path) -> None:
+    """A global built-in repository cannot satisfy an installed-wheel probe."""
+    venv = tmp_path / ".venv"
+    with pytest.raises(RuntimeError, match="package source_path"):
+        assert_installed_package_source(
+            {"package": {"source_path": "/home/operator/.ppi-jarvis/builtin/pkg.py"}},
+            venv,
+        )
+
+
+def test_installed_package_source_accepts_wheel_package(tmp_path: Path) -> None:
+    """A built-in module below the isolated site-packages prefix is accepted."""
+    venv = tmp_path / ".venv"
+    assert_installed_package_source(
+        {
+            "package": {
+                "source_path": str(
+                    venv
+                    / "lib/python3.12/site-packages/builtin/builtin/gray_scott/pkg.py"
+                )
+            }
+        },
+        venv,
+    )
+
+
+def test_live_probe_refuses_to_replace_an_existing_venv(tmp_path: Path) -> None:
+    """Concurrent or repeated acceptance runs require distinct owned roots."""
+    (tmp_path / ".jarvis-live-probe-venv").mkdir()
+
+    with pytest.raises(RuntimeError, match="already contains owned state"):
+        assert_fresh_install_root(tmp_path)
+
+
+def test_live_pipeline_uses_base_default_instead_of_private_package_argument(
+    tmp_path: Path,
+) -> None:
+    """The direct probe configures only the package's public argument contract."""
+    args = argparse.Namespace(
+        root=tmp_path / "probe",
+        partition="compute",
+        account=None,
+        executable=Path("/opt/iowarp/bin/gray-scott"),
+    )
+    report: dict[str, Any] = {}
+
+    pipeline = configured_pipeline(
+        args,
+        report,
+        environment={},
+        output_path=tmp_path / "gray-scott.bp",
+        mpi_executable=Path("/opt/mpi/bin/mpiexec"),
+        run_id="gray-scott-contract-test",
+    )
+
+    assert pipeline.base_deploy_mode is None
+    assert "deploy_mode" not in pipeline.packages[-1]["config"]
+    assert report["pipeline"]["package"]["effective_deploy_mode"] == "default"
+    assert report["pipeline"]["package"]["config"]["checkpoint"] is True
+    assert report["pipeline"]["package"]["config"]["checkpoint_freq"] == 1
+    source_path = Path(report["pipeline"]["package"]["source_path"])
+    assert source_path.parts[-4:] == ("builtin", "builtin", "gray_scott", "pkg.py")
+
+
+def test_exact_gray_scott_contract_passes() -> None:
+    """The expected progress, artifacts, and physical datasets all pass."""
+    output_path = Path("/mnt/common/probe/gray-scott.bp")
+    checkpoint_path = Path(f"{output_path}.checkpoint.bp")
+    assertions = evaluate_semantics(
+        record=_record(),
+        progress=_progress(),
+        artifacts=_artifacts(output_path, checkpoint_path),
+        output_path=output_path,
+        checkpoint_path=checkpoint_path,
+        bpls_output=_bpls(),
+    )
+    assert assertions
+    assert all(item["passed"] is True for item in assertions)
+
+
+def test_missing_physical_timestep_fails_explicit_assertion() -> None:
+    """JARVIS metadata cannot hide an incomplete physical ADIOS2 dataset."""
+    output_path = Path("/mnt/common/probe/gray-scott.bp")
+    checkpoint_path = Path(f"{output_path}.checkpoint.bp")
+    bpls = _bpls()
+    bpls["output_steps"]["stdout"] = "step: 10\n"
+    assertions = evaluate_semantics(
+        record=_record(),
+        progress=_progress(),
+        artifacts=_artifacts(output_path, checkpoint_path),
+        output_path=output_path,
+        checkpoint_path=checkpoint_path,
+        bpls_output=bpls,
+    )
+    failures = {item["name"] for item in assertions if item["passed"] is False}
+    assert failures == {"bpls.output.step.20"}
+
+
+def test_missing_native_terminal_signal_fails_production_contract() -> None:
+    """Two writes alone cannot claim completed progress or a finalized dataset."""
+    output_path = Path("/mnt/common/probe/gray-scott.bp")
+    checkpoint_path = Path(f"{output_path}.checkpoint.bp")
+    progress = _progress()
+    package = progress["packages"][0]
+    package["event_count"] = 3
+    package["latest"]["state"] = "running"
+    package["latest"]["metadata"]["completion_signal"] = "compute_step_completed"
+    artifacts = _artifacts(output_path, checkpoint_path)
+    artifact = artifacts["artifacts"][0]
+    artifact["state"] = "incomplete"
+    artifact["metadata"].pop("completion_signal")
+
+    assertions = evaluate_semantics(
+        record=_record(),
+        progress=progress,
+        artifacts=artifacts,
+        output_path=output_path,
+        checkpoint_path=checkpoint_path,
+        bpls_output=_bpls(),
+    )
+    failures = {item["name"] for item in assertions if item["passed"] is False}
+    assert {
+        "progress.event_count",
+        "progress.latest.state",
+        "progress.completion_signal",
+        "artifacts.output.state",
+        "artifacts.output.metadata.completion_signal",
+    }.issubset(failures)
+
+
+def test_invalid_invocation_still_writes_failure_report(tmp_path: Path) -> None:
+    """A pre-install validation error still produces the report contract."""
+    root = tmp_path / "shared-root"
+    report = tmp_path / "reports" / "failure.json"
+    exit_code = PROBE.main(
+        [
+            "--wheel",
+            str(tmp_path / "missing.whl"),
+            "--root",
+            str(root),
+            "--report",
+            str(report),
+            "--partition",
+            "compute",
+        ]
+    )
+
+    document = json.loads(report.read_text(encoding="utf-8"))
+    assert exit_code == 1
+    assert document["schema_version"] == REPORT_SCHEMA
+    assert document["success"] is False
+    assert document["finished_at"] is not None
+    assert document["error"]["type"] == "ValueError"

--- a/test/unit/core/test_adios2_gray_scott_artifacts.py
+++ b/test/unit/core/test_adios2_gray_scott_artifacts.py
@@ -46,6 +46,7 @@ def test_adios2_gray_scott_exposes_output_and_checkpoint_lifecycles() -> None:
         "checkpoint at step 70 create file /scratch/run/ckpt.bp\n"
         "Rank 0 - ET 2345 - milliseconds\n"
     )
+    observations += adapter.finalize_artifacts()
 
     outputs = [item for item in observations if item.role is ArtifactRole.OUTPUT]
     checkpoints = [
@@ -117,9 +118,50 @@ def test_adios2_gray_scott_resolves_default_relative_checkpoint() -> None:
         "checkpoint at step 70 create file /work/pipeline/ckpt.bp\n"
         "Rank 0 - ET 2345 - milliseconds\n"
     )
+    observations += adapter.finalize_artifacts()
 
     checkpoint = next(
         item for item in observations if item.role is ArtifactRole.CHECKPOINT
     )
     assert checkpoint.location is not None
     assert checkpoint.location.value == "/work/pipeline/ckpt.bp"
+
+
+@pytest.mark.parametrize("include_terminal_line", [False, True])
+def test_adios2_gray_scott_nonzero_exit_marks_outputs_incomplete(
+    include_terminal_line: bool,
+) -> None:
+    """Process failure leaves both output and checkpoint terminally incomplete."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_gray_scott",
+            "engine": "bp5",
+            "out_file": "/scratch/run/gs.bp",
+            "checkpoint_output": "/scratch/run/ckpt.bp",
+        }
+    )
+    assert adapter is not None
+
+    output = (
+        "steps: 100\n"
+        "Simulation at step 50 writing output step 5\n"
+        "checkpoint at step 40 create file /scratch/run/ckpt.bp\n"
+    )
+    if include_terminal_line:
+        output += "Rank 0 - ET 2345 - milliseconds\n"
+    observations = adapter.observe_artifacts(output)
+    observations += adapter.finalize_artifacts_for_exit(7)
+
+    terminal = observations[-2:]
+    assert {item.role for item in terminal} == {
+        ArtifactRole.OUTPUT,
+        ArtifactRole.CHECKPOINT,
+    }
+    assert all(item.state is ArtifactState.INCOMPLETE for item in terminal)
+    assert all(item.metadata["return_code"] == 7 for item in terminal)
+    if include_terminal_line:
+        assert all(
+            item.metadata["application_completion_signal"]
+            == "writer_closed_and_timing_reported"
+            for item in terminal
+        )

--- a/test/unit/core/test_adios2_gray_scott_progress.py
+++ b/test/unit/core/test_adios2_gray_scott_progress.py
@@ -62,6 +62,7 @@ def test_adios2_gray_scott_tracks_restart_outputs_and_completion() -> None:
         "Rank 0 - ET 1234 - milliseconds\n"
         "Rank 1 - ET 1235 - milliseconds\n"
     )
+    observations += adapter.finalize_progress()
 
     assert [item.current for item in observations] == [40.0, 50.0, 60.0, 100.0]
     assert [item.total for item in observations] == [100.0] * 4
@@ -99,14 +100,59 @@ def test_adios2_gray_scott_factory_is_package_local() -> None:
     assert module.adapter_from_package({"pkg_type": "builtin.gray_scott"}) is None
 
 
+@pytest.mark.parametrize("include_terminal_line", [False, True])
+def test_adios2_gray_scott_nonzero_exit_is_terminal_failure(
+    include_terminal_line: bool,
+) -> None:
+    """Neither partial output nor timing text can conceal producer failure."""
+    module = _progress_module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_gray_scott",
+            "steps": 100,
+            "plotgap": 10,
+        }
+    )
+    assert adapter is not None
+
+    output = "steps: 100\nSimulation at step 50 writing output step 5\n"
+    if include_terminal_line:
+        output += "Rank 0 - ET 1234 - milliseconds\n"
+    observations = adapter.observe_progress(output)
+    observations += adapter.finalize_progress_for_exit(11)
+
+    assert all(item.state is not ProgressState.COMPLETED for item in observations)
+    assert observations[-1].state is ProgressState.FAILED
+    assert observations[-1].current == 50.0
+    assert observations[-1].metadata["return_code"] == 11
+    if include_terminal_line:
+        assert observations[-1].metadata["application_completion_signal"] == (
+            "writer_closed_and_timing_reported"
+        )
+
+
 class _CapturedExec:
     calls: list[tuple[str, Any]] = []
+    launch_exit_codes: dict[str, int] = {"localhost": 0}
+    wait_exit_codes: dict[str, int] = {"localhost": 0}
 
     def __init__(self, command: str, exec_info: Any) -> None:
         self.calls.append((command, exec_info))
+        self.exit_code = dict(self.launch_exit_codes)
+        self.wait_calls = 0
+        self.kill_calls = 0
 
     def run(self) -> "_CapturedExec":
         return self
+
+    def wait_all(self) -> dict[str, int]:
+        self.wait_calls += 1
+        self.exit_code.clear()
+        self.exit_code.update(self.wait_exit_codes)
+        return dict(self.exit_code)
+
+    def kill_all(self) -> None:
+        self.kill_calls += 1
 
 
 def test_adios2_gray_scott_runtime_streams_stdout_to_owned_provider(
@@ -124,8 +170,9 @@ def test_adios2_gray_scott_runtime_streams_stdout_to_owned_provider(
         "nprocs": 2,
         "ppn": 2,
         "run_async": False,
+        "executable": "/opt/coeus apps/adios2-gray-scott",
     }
-    package.settings_json_path = "/tmp/settings.json"
+    package.settings_json_path = "/tmp/settings files.json"
     package.pipeline = SimpleNamespace(get_hostfile=lambda: object())
     package.mod_env = {}
     package.runtime_line_callback = lambda: callback
@@ -135,5 +182,61 @@ def test_adios2_gray_scott_runtime_streams_stdout_to_owned_provider(
     package.start()
 
     assert len(_CapturedExec.calls) == 1
-    _, exec_info = _CapturedExec.calls[0]
+    command, exec_info = _CapturedExec.calls[0]
+    assert command == (
+        "'/opt/coeus apps/adios2-gray-scott' '/tmp/settings files.json' 0"
+    )
     assert exec_info.line_callback is callback
+
+
+def test_adios2_gray_scott_sync_start_propagates_nonzero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A synchronous Coeus producer cannot report a successful package start."""
+    module = _package_module()
+    package = object.__new__(module.Adios2GrayScott)
+    package.config = {
+        "engine": "bp5",
+        "nprocs": 2,
+        "ppn": 2,
+        "run_async": False,
+        "executable": "adios2-gray-scott",
+    }
+    package.settings_json_path = "/tmp/settings.json"
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: object())
+    package.mod_env = {}
+    package.runtime_line_callback = lambda: None
+    _CapturedExec.calls = []
+    monkeypatch.setattr(_CapturedExec, "launch_exit_codes", {"ares": 5})
+    monkeypatch.setattr(module, "Exec", _CapturedExec)
+
+    with pytest.raises(RuntimeError, match="ADIOS2 Gray-Scott.*ares=5"):
+        package.start()
+
+
+def test_adios2_gray_scott_async_stop_propagates_wait_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Waiting for an async producer raises after its checked nonzero exit."""
+    module = _package_module()
+    package = object.__new__(module.Adios2GrayScott)
+    package.config = {
+        "engine": "bp5",
+        "nprocs": 2,
+        "ppn": 2,
+        "run_async": True,
+        "executable": "adios2-gray-scott",
+    }
+    package.settings_json_path = "/tmp/settings.json"
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: object())
+    package.mod_env = {}
+    package.runtime_line_callback = lambda: None
+    _CapturedExec.calls = []
+    monkeypatch.setattr(_CapturedExec, "wait_exit_codes", {"ares": 6})
+    monkeypatch.setattr(module, "Exec", _CapturedExec)
+
+    package.start()
+    with pytest.raises(RuntimeError, match="async producer.*ares=6"):
+        package.stop()
+
+    assert package.process.wait_calls == 1

--- a/test/unit/core/test_artifact_spi.py
+++ b/test/unit/core/test_artifact_spi.py
@@ -222,6 +222,20 @@ def test_artifact_history_enforces_revisions_and_terminal_lifecycle() -> None:
                 replace(finalized, revision=4, sequence=4),
             ]
         )
+    with pytest.raises(ValueError, match="cannot transition"):
+        validate_artifact_history(
+            [
+                producing,
+                available,
+                finalized,
+                replace(
+                    finalized,
+                    state=ArtifactState.INCOMPLETE,
+                    revision=4,
+                    sequence=4,
+                ),
+            ]
+        )
     with pytest.raises(ValueError, match="contiguous"):
         validate_artifact_history([producing, replace(available, sequence=3)])
 
@@ -535,3 +549,200 @@ def test_package_runtime_callback_persists_artifact_provider_output(
     assert event.package_name == "site.application"
     assert event.package_id == "application-a"
     assert event.state is ArtifactState.FINALIZED
+
+
+def test_package_callback_passes_owned_process_exit_to_artifact_provider(
+    tmp_path: Path,
+) -> None:
+    """Exit-aware artifact providers can finalize only successful outputs."""
+
+    artifact_id = new_artifact_id()
+
+    class Provider:
+        def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+            del text
+            return [
+                ArtifactObservation(
+                    artifact_id=artifact_id,
+                    logical_name="result",
+                    kind="scientific_dataset",
+                    role=ArtifactRole.OUTPUT,
+                    structure=ArtifactStructure.COLLECTION,
+                    ownership=ArtifactOwnership.SHARED,
+                    state=ArtifactState.PRODUCING,
+                    location=ArtifactLocation.cluster_path("/scratch/result.bp"),
+                )
+            ]
+
+        def finalize_artifacts(self) -> list[ArtifactObservation]:
+            raise AssertionError("exit-aware provider used legacy finalization")
+
+        def finalize_artifacts_for_exit(
+            self, return_code: int
+        ) -> list[ArtifactObservation]:
+            return [
+                ArtifactObservation(
+                    artifact_id=artifact_id,
+                    logical_name="result",
+                    kind="scientific_dataset",
+                    role=ArtifactRole.OUTPUT,
+                    structure=ArtifactStructure.COLLECTION,
+                    ownership=ArtifactOwnership.SHARED,
+                    state=(
+                        ArtifactState.FINALIZED
+                        if return_code == 0
+                        else ArtifactState.PRODUCING
+                    ),
+                    location=ArtifactLocation.cluster_path("/scratch/result.bp"),
+                    metadata={"return_code": return_code},
+                )
+            ]
+
+        def reset_artifacts(self) -> None:
+            return None
+
+    path = (tmp_path / "exit-artifacts.jsonl").resolve()
+    package = object.__new__(Pkg)
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec-exit",
+        "JARVIS_PACKAGE_NAME": "site.application",
+        "JARVIS_PACKAGE_ID": "application-a",
+        "JARVIS_ARTIFACT_PATH": str(path),
+    }
+    package.get_artifact_provider = lambda: Provider()  # type: ignore[method-assign]
+
+    callback = package.runtime_line_callback()
+    assert callback is not None
+    callback("stdout", "wrote result.bp\n")
+    getattr(callback, "finalize_process")(0)
+
+    event = ArtifactStore(path).latest()
+    assert event is not None
+    assert event.state is ArtifactState.FINALIZED
+    assert event.metadata["return_code"] == 0
+    assert event.revision == 2
+
+
+def test_structured_finalized_artifacts_are_reconciled_after_nonzero_exit(
+    tmp_path: Path,
+) -> None:
+    """A failed process corrects finalized output without erasing its identity."""
+    path = (tmp_path / "reconciled-artifacts.jsonl").resolve()
+    stream = io.StringIO()
+    child_reporter = ArtifactReporter(
+        package_name="site.application",
+        package_id="container_app",
+        execution_id="exec_failed_container",
+        stream=stream,
+    )
+    finalized = child_reporter.emit(
+        logical_name="simulation-output",
+        kind="scientific_dataset",
+        role=ArtifactRole.OUTPUT,
+        structure=ArtifactStructure.COLLECTION,
+        ownership=ArtifactOwnership.SHARED,
+        state=ArtifactState.FINALIZED,
+        location=ArtifactLocation.cluster_path("/scratch/run/result.bp"),
+        format="adios2-bp5",
+        checksum="sha256:" + "a" * 64,
+        metadata={"application_signal": "writer_close"},
+    )
+    checkpoint = child_reporter.emit(
+        logical_name="restart-checkpoint",
+        kind="checkpoint",
+        role=ArtifactRole.CHECKPOINT,
+        structure=ArtifactStructure.FILE,
+        ownership=ArtifactOwnership.SHARED,
+        state=ArtifactState.FINALIZED,
+        location=ArtifactLocation.cluster_path("/scratch/run/restart.bp"),
+    )
+    available = child_reporter.emit(
+        logical_name="shared-input",
+        kind="input_dataset",
+        role=ArtifactRole.INTERMEDIATE,
+        structure=ArtifactStructure.FILE,
+        ownership=ArtifactOwnership.SHARED,
+        state=ArtifactState.AVAILABLE,
+        location=ArtifactLocation.cluster_path("/shared/input.bp"),
+    )
+
+    package = object.__new__(Pkg)
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec_failed_container",
+        "JARVIS_PACKAGE_ID": "container_app",
+        "JARVIS_PACKAGE_NAME": "site.application",
+        "JARVIS_ARTIFACT_PATH": str(path),
+        "JARVIS_ARTIFACT_TRANSPORT": "stdout",
+    }
+    package.get_progress_provider = lambda: None  # type: ignore[method-assign]
+    package.get_artifact_provider = lambda: None  # type: ignore[method-assign]
+
+    callback = package.runtime_line_callback()
+    assert callback is not None
+    for line in stream.getvalue().splitlines(keepends=True):
+        callback("stdout", line)
+    getattr(callback, "finalize_process")(19)
+    getattr(callback, "finalize_process")(19)
+
+    events = ArtifactStore(path).read_all()
+    assert events[:3] == [finalized, checkpoint, available]
+    assert len(events) == 5
+    corrected = events[3]
+    assert corrected.artifact_id == finalized.artifact_id
+    assert corrected.state is ArtifactState.INCOMPLETE
+    assert corrected.revision == finalized.revision + 1
+    assert corrected.sequence == available.sequence + 1
+    assert corrected.location == finalized.location
+    assert corrected.checksum == finalized.checksum
+    assert corrected.metadata["jarvis_process_exit"] == {
+        "reported_state": "finalized",
+        "return_code": 19,
+        "source": "jarvis_process_owner",
+    }
+    corrected_checkpoint = events[4]
+    assert corrected_checkpoint.artifact_id == checkpoint.artifact_id
+    assert corrected_checkpoint.state is ArtifactState.INCOMPLETE
+    assert corrected_checkpoint.revision == checkpoint.revision + 1
+    assert corrected_checkpoint.sequence == corrected.sequence + 1
+    assert ArtifactStore(path).latest(available.artifact_id) == available
+
+
+def test_structured_finalized_artifact_survives_zero_process_exit(
+    tmp_path: Path,
+) -> None:
+    """A zero JARVIS-owned return code leaves a finalized artifact intact."""
+    path = (tmp_path / "successful-artifacts.jsonl").resolve()
+    stream = io.StringIO()
+    child_reporter = ArtifactReporter(
+        package_name="site.application",
+        package_id="container_app",
+        execution_id="exec_successful_container",
+        stream=stream,
+    )
+    finalized = child_reporter.emit(
+        logical_name="simulation-output",
+        kind="scientific_dataset",
+        role=ArtifactRole.OUTPUT,
+        structure=ArtifactStructure.COLLECTION,
+        ownership=ArtifactOwnership.SHARED,
+        state=ArtifactState.FINALIZED,
+        location=ArtifactLocation.cluster_path("/scratch/run/result.bp"),
+    )
+
+    package = object.__new__(Pkg)
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec_successful_container",
+        "JARVIS_PACKAGE_ID": "container_app",
+        "JARVIS_PACKAGE_NAME": "site.application",
+        "JARVIS_ARTIFACT_PATH": str(path),
+        "JARVIS_ARTIFACT_TRANSPORT": "stdout",
+    }
+    package.get_progress_provider = lambda: None  # type: ignore[method-assign]
+    package.get_artifact_provider = lambda: None  # type: ignore[method-assign]
+
+    callback = package.runtime_line_callback()
+    assert callback is not None
+    callback("stdout", stream.getvalue())
+    getattr(callback, "finalize_process")(0)
+
+    assert ArtifactStore(path).read_all() == [finalized]

--- a/test/unit/core/test_execution.py
+++ b/test/unit/core/test_execution.py
@@ -1233,6 +1233,46 @@ def test_pipeline_stop_reuses_the_started_async_package_instance() -> None:
     pipeline._load_package_instance.assert_not_called()
 
 
+def test_pipeline_stop_attempts_every_package_before_reraising() -> None:
+    """One failed async wait cannot prevent cleanup of remaining packages."""
+    pipeline = Pipeline.__new__(Pipeline)
+    pipeline.name = "example"
+    pipeline.packages = [
+        {"pkg_id": package_id, "pkg_type": f"builtin.{package_id}", "config": {}}
+        for package_id in ("first", "failed", "last")
+    ]
+    pipeline.env = {}
+    pipeline._execution_root = None
+    pipeline._execution_id = None
+    pipeline.is_containerized = Mock(return_value=False)
+    attempts: list[str] = []
+
+    class StartedPackage:
+        def __init__(self, package_id: str, *, fail: bool = False) -> None:
+            self.pkg_id = package_id
+            self._fail = fail
+
+        def stop(self) -> None:
+            attempts.append(self.pkg_id)
+            if self._fail:
+                raise RuntimeError(f"{self.pkg_id} wait failed")
+
+    pipeline._started_instances = [
+        StartedPackage("first"),
+        StartedPackage("failed", fail=True),
+        StartedPackage("last"),
+    ]
+    pipeline._load_package_instance = Mock()
+
+    with pytest.raises(ExceptionGroup, match="pipeline package stop failed") as error:
+        pipeline.stop()
+
+    assert attempts == ["last", "failed", "first"]
+    assert len(error.value.exceptions) == 1
+    assert str(error.value.exceptions[0]) == "failed wait failed"
+    pipeline._load_package_instance.assert_not_called()
+
+
 def test_terminal_record_update_seals_and_finalizes_core_logs(tmp_path: Path) -> None:
     """Every terminal transition seals manifests while closing owned logs."""
     store = ExecutionStore(tmp_path / "executions", "example")
@@ -1348,9 +1388,7 @@ def test_package_alias_cannot_overwrite_core_artifact_index(tmp_path: Path) -> N
             logical_name=logical_name,
             kind="log" if logical_name == "stdout" else "result",
             role=(
-                ArtifactRole.LOG
-                if logical_name == "stdout"
-                else ArtifactRole.OUTPUT
+                ArtifactRole.LOG if logical_name == "stdout" else ArtifactRole.OUTPUT
             ),
             structure=ArtifactStructure.FILE,
             ownership=ArtifactOwnership.EXECUTION,

--- a/test/unit/core/test_gray_scott_artifacts.py
+++ b/test/unit/core/test_gray_scott_artifacts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import ModuleType
+from xml.etree import ElementTree
 
 import pytest
 
@@ -28,6 +29,45 @@ def _module() -> ModuleType:
     return load_artifacts_module(path)
 
 
+def test_gray_scott_adios_config_pins_output_and_checkpoint_to_bp5() -> None:
+    """Artifact format claims are enforced for both direct application writers."""
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "gray_scott"
+        / "config"
+        / "adios2.xml"
+    )
+    document = ElementTree.parse(path)
+    engines = {
+        io.attrib["name"]: engine.attrib.get("type")
+        for io in document.getroot().findall("io")
+        if (engine := io.find("engine")) is not None
+    }
+
+    assert engines["SimulationOutput"] == "BP5"
+    assert engines["SimulationCheckpoint"] == "BP5"
+
+
+def test_gray_scott_checkpoint_fingerprint_tracks_metadata_only(
+    tmp_path: Path,
+) -> None:
+    """Checkpoint detection notices BP metadata without reading data payloads."""
+    module = _module()
+    checkpoint = tmp_path / "restart.bp"
+    checkpoint.mkdir()
+    configured_path = module.PurePosixPath(checkpoint.as_posix())
+
+    before = module._path_fingerprint(configured_path)
+    (checkpoint / "md.idx").write_bytes(b"metadata")
+    after = module._path_fingerprint(configured_path)
+
+    assert before is not None
+    assert after is not None
+    assert after != before
+
+
 def test_gray_scott_exposes_one_evolving_hdf5_collection() -> None:
     """A timestep series is one artifact with producing and final revisions."""
     adapter = _module().adapter_from_package(
@@ -43,6 +83,7 @@ def test_gray_scott_exposes_one_evolving_hdf5_collection() -> None:
         "wrote /scratch/run/gray-scott/gs_000200.h5\n"
     )
     finalized = adapter.observe_artifacts("Done.\n")
+    finalized += adapter.finalize_artifacts()
 
     observations = producing + finalized
     assert len({item.artifact_id for item in observations}) == 1
@@ -98,7 +139,216 @@ def test_gray_scott_default_mode_exposes_adios_collection() -> None:
         "Simulation at step 10 writing output step 1\n"
         "Rank 0 - ET 123 - milliseconds\n"
     )
+    observations += adapter.finalize_artifacts()
 
     assert observations[-1].state is ArtifactState.FINALIZED
     assert observations[-1].format == "adios2-bp5"
     assert observations[-1].metadata["io_backend"] == "adios2"
+
+
+def test_gray_scott_direct_iowarp_artifact_finalizes_on_zero_exit() -> None:
+    """A successful writer process closes the directly produced BP5 dataset."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.gray_scott",
+            "effective_deploy_mode": "default",
+            "outdir": "/scratch/run/gray-scott.bp",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts(
+        "steps: 20\n"
+        "Simulation at step 10 writing output step 1\n"
+        "Simulation at step 20 writing output step 2\n"
+    )
+    observations += adapter.finalize_artifacts_for_exit(0)
+
+    assert observations[-1].state is ArtifactState.FINALIZED
+    assert observations[-1].metadata["members_observed"] == 2
+    assert observations[-1].metadata["latest_timestep"] == 20
+    assert observations[-1].metadata["completion_signal"] == (
+        "process_exit_zero_after_final_output"
+    )
+
+
+def test_gray_scott_failed_process_marks_artifact_incomplete() -> None:
+    """A nonzero process exit terminally marks the partial BP5 dataset."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.gray_scott",
+            "effective_deploy_mode": "default",
+            "outdir": "/scratch/run/gray-scott.bp",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts(
+        "steps: 20\nSimulation at step 10 writing output step 1\n"
+    )
+    observations += adapter.finalize_artifacts_for_exit(9)
+
+    assert observations[-1].state is ArtifactState.INCOMPLETE
+    assert observations[-1].metadata["return_code"] == 9
+    assert observations[-1].metadata["completion_signal"] == "process_exit_nonzero"
+
+
+def test_gray_scott_done_marker_cannot_finalize_after_failed_exit() -> None:
+    """A provisional native success marker cannot hide process failure."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.gray_scott",
+            "effective_deploy_mode": "default",
+            "outdir": "/scratch/run/gray-scott.bp",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts(
+        "steps: 20\n"
+        "Simulation at step 10 writing output step 1\n"
+        "Rank 0 - ET 123 - milliseconds\n"
+    )
+    observations += adapter.finalize_artifacts_for_exit(23)
+
+    assert all(item.state is not ArtifactState.FINALIZED for item in observations)
+    assert observations[-1].state is ArtifactState.INCOMPLETE
+    assert observations[-1].metadata["return_code"] == 23
+    assert observations[-1].metadata["application_completion_signal"] == (
+        "writer_closed_and_timing_reported"
+    )
+
+
+def test_gray_scott_reports_checkpoint_created_by_owned_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured checkpoint is reported only when its BP path changes."""
+    module = _module()
+    changed = (
+        (".", 16877, 1, 64, 2, 2),
+        (("md.idx", 33188, 2, 128, 2, 2),),
+    )
+    fingerprints = iter([None, changed])
+    monkeypatch.setattr(
+        module,
+        "_path_fingerprint",
+        lambda _path: next(fingerprints),
+    )
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.gray_scott",
+            "effective_deploy_mode": "default",
+            "outdir": "/scratch/run/gray-scott.bp",
+            "checkpoint": True,
+            "checkpoint_output": "/scratch/checkpoints/restart.bp",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts(
+        "steps: 20\nSimulation at step 20 writing output step 2\n"
+    )
+    observations += adapter.finalize_artifacts_for_exit(0)
+
+    checkpoint = next(
+        item for item in observations if item.role is ArtifactRole.CHECKPOINT
+    )
+    assert checkpoint.logical_name == "gray-scott-restart-checkpoint"
+    assert checkpoint.state is ArtifactState.FINALIZED
+    assert checkpoint.location is not None
+    assert checkpoint.location.value == "/scratch/checkpoints/restart.bp"
+    assert checkpoint.metadata["physical_path_observed"] is True
+    assert checkpoint.metadata["completion_signal"] == (
+        "process_exit_zero_after_final_output"
+    )
+
+
+def test_gray_scott_does_not_claim_unchanged_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A checkpoint left by an earlier run is not attributed to this run."""
+    module = _module()
+    unchanged = ((".", 16877, 1, 64, 2, 2), ())
+    monkeypatch.setattr(module, "_path_fingerprint", lambda _path: unchanged)
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.gray_scott",
+            "effective_deploy_mode": "default",
+            "outdir": "/scratch/run/gray-scott.bp",
+            "checkpoint": True,
+            "checkpoint_output": "/scratch/checkpoints/restart.bp",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts(
+        "steps: 20\nSimulation at step 20 writing output step 2\n"
+    )
+    observations += adapter.finalize_artifacts_for_exit(0)
+
+    assert all(item.role is not ArtifactRole.CHECKPOINT for item in observations)
+
+
+def test_gray_scott_failed_process_leaves_changed_checkpoint_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A physical checkpoint cannot be finalized after producer failure."""
+    module = _module()
+    changed = ((".", 16877, 1, 64, 2, 2), ())
+    fingerprints = iter([None, changed])
+    monkeypatch.setattr(
+        module,
+        "_path_fingerprint",
+        lambda _path: next(fingerprints),
+    )
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.gray_scott",
+            "effective_deploy_mode": "default",
+            "outdir": "/scratch/run/gray-scott.bp",
+            "checkpoint": True,
+            "checkpoint_output": "/scratch/checkpoints/restart.bp",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts(
+        "steps: 20\nSimulation at step 10 writing output step 1\n"
+    )
+    observations += adapter.finalize_artifacts_for_exit(12)
+
+    checkpoint = next(
+        item for item in observations if item.role is ArtifactRole.CHECKPOINT
+    )
+    assert checkpoint.state is ArtifactState.INCOMPLETE
+    assert checkpoint.metadata["return_code"] == 12
+    assert checkpoint.metadata["completion_signal"] == "process_exit_nonzero"
+
+
+def test_gray_scott_disabled_checkpoint_is_never_probed_or_claimed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured filename alone does not imply checkpoint production."""
+    module = _module()
+
+    def unexpected_probe(_path: object) -> object:
+        raise AssertionError("disabled checkpoints must not touch the filesystem")
+
+    monkeypatch.setattr(module, "_path_fingerprint", unexpected_probe)
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.gray_scott",
+            "effective_deploy_mode": "default",
+            "outdir": "/scratch/run/gray-scott.bp",
+            "checkpoint": False,
+            "checkpoint_output": "/scratch/checkpoints/restart.bp",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts(
+        "steps: 20\nSimulation at step 20 writing output step 2\n"
+    )
+    observations += adapter.finalize_artifacts_for_exit(0)
+
+    assert all(item.role is not ArtifactRole.CHECKPOINT for item in observations)

--- a/test/unit/core/test_gray_scott_progress.py
+++ b/test/unit/core/test_gray_scott_progress.py
@@ -59,8 +59,9 @@ def test_gray_scott_tracks_completed_outputs_and_terminal_state() -> None:
         "  wrote /scratch/run/gray-scott/gs_000500"
     )
     second = adapter.observe_progress(".h5\nDone.\n")
+    terminal = adapter.finalize_progress()
 
-    observations = first + second
+    observations = first + second + terminal
     assert [item.current for item in observations] == [0.0, 250.0, 500.0, 1000.0]
     assert [item.total for item in observations] == [1000.0] * 4
     assert observations[-1].state is ProgressState.COMPLETED
@@ -126,6 +127,7 @@ def test_gray_scott_default_adios_mode_uses_native_terminal_signal() -> None:
         "Simulation at step 50 writing output step 5\n"
         "Rank 0 - ET 900 - milliseconds\n"
     )
+    observations += adapter.finalize_progress()
 
     assert [item.current for item in observations] == [40.0, 50.0, 100.0]
     assert observations[-1].state is ProgressState.COMPLETED
@@ -134,22 +136,289 @@ def test_gray_scott_default_adios_mode_uses_native_terminal_signal() -> None:
     )
 
 
+def test_gray_scott_direct_iowarp_run_uses_successful_process_exit() -> None:
+    """The direct clio-core binary needs no fabricated terminal stdout line."""
+    module = _progress_module()
+    adapter = module.adapter_from_package(
+        {"pkg_type": "builtin.gray_scott", "steps": 20, "out_every": 10}
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_progress(
+        "steps: 20\n"
+        "Simulation at step 10 writing output step 1\n"
+        "Simulation at step 20 writing output step 2\n"
+    )
+    observations += adapter.finalize_progress_for_exit(0)
+
+    assert [item.current for item in observations] == [0.0, 10.0, 20.0, 20.0]
+    assert observations[-1].state is ProgressState.COMPLETED
+    assert observations[-1].metadata["completion_signal"] == (
+        "process_exit_zero_after_final_output"
+    )
+
+
+def test_gray_scott_failed_process_is_not_reported_completed() -> None:
+    """A nonzero direct process exit terminates the last truthful state."""
+    module = _progress_module()
+    adapter = module.adapter_from_package(
+        {"pkg_type": "builtin.gray_scott", "steps": 20, "out_every": 10}
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_progress(
+        "steps: 20\nSimulation at step 10 writing output step 1\n"
+    )
+    observations += adapter.finalize_progress_for_exit(3)
+
+    assert observations[-1].state is ProgressState.FAILED
+    assert observations[-1].current == 10.0
+    assert observations[-1].metadata["return_code"] == 3
+
+
+def test_gray_scott_done_marker_cannot_override_failed_process_exit() -> None:
+    """Application success text remains provisional until the process exits."""
+    module = _progress_module()
+    adapter = module.adapter_from_package(
+        {"pkg_type": "builtin.gray_scott", "steps": 20, "out_every": 10}
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_progress(
+        "steps: 20\nSimulation at step 10 writing output step 1\nDone.\n"
+    )
+    observations += adapter.finalize_progress_for_exit(9)
+
+    assert all(item.state is not ProgressState.COMPLETED for item in observations)
+    assert observations[-1].state is ProgressState.FAILED
+    assert observations[-1].metadata["completion_signal"] == "process_exit_nonzero"
+    assert observations[-1].metadata["application_completion_signal"] == (
+        "application_reported_done"
+    )
+
+
 class _CapturedExec:
     calls: list[tuple[str, Any]] = []
+    exit_codes: dict[str, int] = {"localhost": 0}
 
     def __init__(self, command: str, exec_info: Any) -> None:
         self.calls.append((command, exec_info))
+        self.exit_code = dict(self.exit_codes)
 
     def run(self) -> "_CapturedExec":
         return self
 
 
 class _CapturedMkdir:
-    def __init__(self, _path: object, *_args: object, **_kwargs: object) -> None:
-        pass
+    exit_codes: dict[str, int] = {"localhost": 0}
+
+    def __init__(self, path: object, *_args: object, **_kwargs: object) -> None:
+        self.path = path
+        self.exit_code = dict(self.exit_codes)
 
     def run(self) -> "_CapturedMkdir":
         return self
+
+
+class _CapturedJsonFile:
+    documents: list[dict[str, object]] = []
+
+    def __init__(self, _path: object) -> None:
+        pass
+
+    def save(self, document: dict[str, object]) -> None:
+        self.documents.append(document)
+
+
+def test_gray_scott_configuration_matches_direct_iowarp_settings_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JARVIS writes every field required by clio-core's Settings::from_json."""
+    module = _package_module()
+    package = object.__new__(module.GrayScott)
+    package.config = {"deploy_mode": "default"}
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: None)
+    package.env = {}
+    package.shared_dir = "/scratch/shared"
+    package.settings_json_path = "/scratch/shared/settings-files.json"
+    package.adios2_xml_path = "/scratch/shared/adios2.xml"
+    package.pkg_dir = "/packages/gray_scott"
+    package.copy_template_file = lambda *_args: None
+    _CapturedJsonFile.documents = []
+    monkeypatch.setattr(
+        module.Application,
+        "_configure",
+        lambda self, **kwargs: self.config.update(kwargs),
+    )
+    monkeypatch.setattr(module, "Mkdir", _CapturedMkdir)
+    monkeypatch.setattr(module, "JsonFile", _CapturedJsonFile)
+
+    package._configure(
+        outdir="/scratch/run/gray-scott.bp",
+        width=32,
+        height=32,
+        steps=20,
+        out_every=10,
+    )
+
+    assert len(_CapturedJsonFile.documents) == 1
+    settings = _CapturedJsonFile.documents[0]
+    assert set(settings) == {
+        "L",
+        "Du",
+        "Dv",
+        "F",
+        "k",
+        "dt",
+        "plotgap",
+        "steps",
+        "noise",
+        "output",
+        "checkpoint",
+        "checkpoint_freq",
+        "checkpoint_output",
+        "adios_config",
+        "adios_span",
+        "adios_memory_selection",
+        "mesh_type",
+    }
+    assert settings["output"] == "/scratch/run/gray-scott.bp"
+    assert settings["checkpoint"] is False
+    assert settings["checkpoint_output"] == ("/scratch/run/gray-scott.bp.checkpoint.bp")
+    assert settings["adios_span"] is False
+    assert settings["adios_memory_selection"] is False
+    assert settings["mesh_type"] == "image"
+
+
+def test_gray_scott_default_output_uses_package_shared_directory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An omitted output path resolves to durable package-shared storage."""
+    module = _package_module()
+    package = object.__new__(module.GrayScott)
+    package.config = {"deploy_mode": "default", "outdir": ""}
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: None)
+    package.env = {}
+    package.shared_dir = "/scratch/pipeline/gray-scott-step"
+    package.settings_json_path = "/scratch/pipeline/settings-files.json"
+    package.adios2_xml_path = "/scratch/pipeline/adios2.xml"
+    package.pkg_dir = "/packages/gray_scott"
+    package.copy_template_file = lambda *_args: None
+    _CapturedJsonFile.documents = []
+    monkeypatch.setattr(
+        module.Application,
+        "_configure",
+        lambda self, **kwargs: self.config.update(kwargs),
+    )
+    monkeypatch.setattr(module, "Mkdir", _CapturedMkdir)
+    monkeypatch.setattr(module, "JsonFile", _CapturedJsonFile)
+
+    package._configure(width=32, height=32, steps=20, out_every=10)
+
+    expected = "/scratch/pipeline/gray-scott-step/gray-scott-output"
+    assert package.config["outdir"] == expected
+    assert package.config["checkpoint_output"] == f"{expected}.checkpoint.bp"
+    assert _CapturedJsonFile.documents[0]["output"] == expected
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("outdir", "relative/output.bp"),
+        ("outdir", "/scratch/../escape.bp"),
+        ("checkpoint_output", "relative/restart.bp"),
+    ],
+)
+def test_gray_scott_rejects_ambiguous_dataset_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    field_name: str,
+    value: str,
+) -> None:
+    """Run and cleanup must share one absolute normalized path identity."""
+    module = _package_module()
+    package = object.__new__(module.GrayScott)
+    package.config = {"deploy_mode": "default"}
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: None)
+    package.env = {}
+    package.shared_dir = "/scratch/shared"
+    monkeypatch.setattr(
+        module.Application,
+        "_configure",
+        lambda self, **kwargs: self.config.update(kwargs),
+    )
+
+    with pytest.raises(ValueError, match=f"unsafe {field_name}"):
+        package._configure(
+            width=32,
+            height=32,
+            steps=20,
+            out_every=10,
+            **{field_name: value},
+        )
+
+
+def test_gray_scott_configuration_propagates_directory_setup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing durable output directory aborts configuration."""
+    module = _package_module()
+    package = object.__new__(module.GrayScott)
+    package.config = {"deploy_mode": "default"}
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: None)
+    package.env = {}
+    package.shared_dir = "/scratch/shared"
+    monkeypatch.setattr(
+        module.Application,
+        "_configure",
+        lambda self, **kwargs: self.config.update(kwargs),
+    )
+    monkeypatch.setattr(_CapturedMkdir, "exit_codes", {"localhost": 13})
+    monkeypatch.setattr(module, "Mkdir", _CapturedMkdir)
+
+    with pytest.raises(RuntimeError, match="output setup.*localhost=13"):
+        package._configure(
+            outdir="/scratch/run/gray-scott.bp",
+            width=32,
+            height=32,
+            steps=20,
+            out_every=10,
+        )
+
+
+@pytest.mark.parametrize(
+    ("settings", "message"),
+    [
+        ({"width": 32, "height": 64}, "width and height to match"),
+        ({"steps": 21, "out_every": 10}, "steps to be divisible"),
+        (
+            {"checkpoint": True, "checkpoint_freq": 0},
+            "checkpoint_freq must be a positive integer",
+        ),
+    ],
+)
+def test_gray_scott_rejects_unsupported_direct_grid_contracts(
+    monkeypatch: pytest.MonkeyPatch,
+    settings: dict[str, int],
+    message: str,
+) -> None:
+    """Invalid direct-app settings fail instead of being silently ignored."""
+    module = _package_module()
+    package = object.__new__(module.GrayScott)
+    package.config = {
+        "deploy_mode": "default",
+        "width": 32,
+        "height": 32,
+        "steps": 20,
+        "out_every": 10,
+    }
+    monkeypatch.setattr(
+        module.Application,
+        "_configure",
+        lambda self, **kwargs: self.config.update(kwargs),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        package._configure(**settings)
 
 
 def test_gray_scott_runtime_streams_stdout_to_owned_provider(
@@ -191,3 +460,149 @@ def test_gray_scott_runtime_streams_stdout_to_owned_provider(
     assert len(_CapturedExec.calls) == 1
     _, exec_info = _CapturedExec.calls[0]
     assert exec_info.line_callback is callback
+
+
+def test_gray_scott_default_runtime_uses_explicit_quoted_executable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bare-metal execution can target an exact installed IOWarp binary."""
+    module = _package_module()
+    package = object.__new__(module.GrayScott)
+    package.config = {
+        "deploy_mode": "default",
+        "nprocs": 1,
+        "ppn": 1,
+        "executable": "/opt/iowarp tools/gray-scott",
+    }
+    package.mod_env = {}
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: "/tmp/host file")
+    package.settings_json_path = "/tmp/settings files.json"
+    package.runtime_line_callback = lambda: None
+    package.log = lambda *_args, **_kwargs: None
+    _CapturedExec.calls = []
+    monkeypatch.setattr(module, "Exec", _CapturedExec)
+
+    package.start()
+
+    assert len(_CapturedExec.calls) == 1
+    command, _ = _CapturedExec.calls[0]
+    assert command == "'/opt/iowarp tools/gray-scott' '/tmp/settings files.json'"
+
+
+def test_gray_scott_default_runtime_rejects_empty_executable() -> None:
+    """Invalid executable settings fail before constructing an MPI process."""
+    module = _package_module()
+    package = object.__new__(module.GrayScott)
+    package.config = {
+        "deploy_mode": "default",
+        "nprocs": 1,
+        "ppn": 1,
+        "executable": "   ",
+    }
+    package.mod_env = {}
+    package.settings_json_path = "/tmp/settings.json"
+    package.runtime_line_callback = lambda: None
+
+    with pytest.raises(ValueError, match="executable must be a non-empty string"):
+        package.start()
+
+
+def test_gray_scott_runtime_propagates_nonzero_process_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed direct IOWarp producer fails package start synchronously."""
+    module = _package_module()
+    package = object.__new__(module.GrayScott)
+    package.config = {
+        "deploy_mode": "default",
+        "nprocs": 2,
+        "ppn": 2,
+        "executable": "gray-scott",
+    }
+    package.mod_env = {}
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: "/tmp/hostfile")
+    package.settings_json_path = "/tmp/settings.json"
+    package.runtime_line_callback = lambda: None
+    package.log = lambda *_args, **_kwargs: None
+    _CapturedExec.calls = []
+    monkeypatch.setattr(_CapturedExec, "exit_codes", {"ares": 17})
+    monkeypatch.setattr(module, "Exec", _CapturedExec)
+
+    with pytest.raises(RuntimeError, match="IOWarp Gray-Scott.*ares=17"):
+        package.start()
+
+
+def test_gray_scott_runtime_surfaces_callback_failure_diagnostic() -> None:
+    """A callback-triggered process termination retains its causal error."""
+    module = _package_module()
+    result = SimpleNamespace(
+        exit_code={"localhost": -15},
+        stderr={
+            "localhost": (
+                "Output line callback failed for stdout: "
+                "progress store is unavailable\n"
+            )
+        },
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        module.GrayScott._raise_for_exec_failure(
+            result,
+            operation="IOWarp Gray-Scott",
+        )
+
+    message = str(raised.value)
+    assert "localhost=-15" in message
+    assert "Output line callback failed for stdout" in message
+    assert "progress store is unavailable" in message
+
+
+def test_gray_scott_clean_removes_exact_output_and_checkpoint_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cleanup covers independent datasets without wildcard expansion."""
+    module = _package_module()
+    package = object.__new__(module.GrayScott)
+    package.config = {
+        "outdir": "/scratch/results/main output.bp",
+        "checkpoint_output": "/scratch/checkpoints/restart.bp",
+    }
+    package.env = {"ADIOS2_ENGINE": "BP5"}
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: None)
+    _CapturedExec.calls = []
+    monkeypatch.setattr(module, "Exec", _CapturedExec)
+
+    package.clean()
+
+    assert len(_CapturedExec.calls) == 1
+    command, exec_info = _CapturedExec.calls[0]
+    assert command == (
+        "rm -rf -- '/scratch/results/main output.bp' /scratch/checkpoints/restart.bp"
+    )
+    assert "*" not in command
+    assert exec_info.env == {"ADIOS2_ENGINE": "BP5"}
+
+
+def test_gray_scott_clean_deduplicates_paths_and_rejects_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cleanup never repeats a path or permits a filesystem-root target."""
+    module = _package_module()
+    package = object.__new__(module.GrayScott)
+    package.config = {
+        "outdir": "/scratch/results/gray-scott.bp",
+        "checkpoint_output": "/scratch/results/gray-scott.bp",
+    }
+    package.env = {}
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: None)
+    _CapturedExec.calls = []
+    monkeypatch.setattr(module, "Exec", _CapturedExec)
+
+    package.clean()
+
+    assert _CapturedExec.calls[0][0] == ("rm -rf -- /scratch/results/gray-scott.bp")
+
+    package.config["outdir"] = "/"
+    with pytest.raises(ValueError, match="unsafe outdir cleanup path"):
+        package.clean()
+    assert len(_CapturedExec.calls) == 1

--- a/test/unit/core/test_pipeline_coverage.py
+++ b/test/unit/core/test_pipeline_coverage.py
@@ -18,6 +18,7 @@ import sys
 import shutil
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 import yaml
 
@@ -210,6 +211,33 @@ class TestPipelineCoverage(unittest.TestCase):
         self.assertIsInstance(result, dict)
         self.assertGreater(len(result), 0)
 
+    def test_append_rejects_unknown_package_setting_atomically(self):
+        """Invalid package settings cannot leave a partially appended step."""
+        pipeline = self._make_pipeline("append_unknown")
+
+        with self.assertRaisesRegex(ValueError, "Unknown argument"):
+            pipeline.append(
+                "builtin.echo",
+                package_alias="echo",
+                config_args=["message=not-supported"],
+            )
+
+        self.assertEqual(pipeline.packages, [])
+        self.assertEqual(Pipeline("append_unknown").packages, [])
+
+    def test_append_persists_valid_package_setting(self):
+        """Package-owned settings are parsed and saved with an appended step."""
+        pipeline = self._make_pipeline("append_valid")
+
+        pipeline.append(
+            "builtin.echo",
+            package_alias="echo",
+            config_args=["retry_count=4"],
+        )
+
+        reloaded = Pipeline("append_valid")
+        self.assertEqual(reloaded.packages[0]["config"]["retry_count"], 4)
+
     # ------------------------------------------------------------------
     # configure_package()
     # ------------------------------------------------------------------
@@ -228,6 +256,140 @@ class TestPipelineCoverage(unittest.TestCase):
         # Reload pipeline and confirm nprocs was persisted
         pipeline2 = Pipeline("cfgpkg_test")
         self.assertEqual(pipeline2.packages[0]["config"].get("nprocs"), 8)
+
+    def test_configure_package_can_reset_a_value_to_its_default(self):
+        """Explicit default values replace an earlier non-default value."""
+        pipeline = self._make_pipeline("cfgpkg_reset_default")
+        pkg_def = self._make_ior_pkg_def("cfgpkg_reset_default")
+        pipeline.packages.append(pkg_def)
+        pipeline._propagate_deploy_mode()
+        pipeline.save()
+
+        pipeline.configure_package("ior", ["nprocs=8"])
+        pipeline.configure_package("ior", ["nprocs=1"])
+
+        reloaded = Pipeline("cfgpkg_reset_default")
+        self.assertEqual(reloaded.packages[0]["config"].get("nprocs"), 1)
+
+    def test_configure_package_accepts_spaced_boolean_values(self):
+        """Long boolean options retain the parser's documented value form."""
+        pipeline = self._make_pipeline("cfgpkg_spaced_bool")
+        pkg_def = self._make_ior_pkg_def("cfgpkg_spaced_bool")
+        pipeline.packages.append(pkg_def)
+        pipeline._propagate_deploy_mode()
+        pipeline.save()
+
+        pipeline.configure_package("ior", ["--container_cache", "false"])
+
+        reloaded = Pipeline("cfgpkg_spaced_bool")
+        self.assertIs(reloaded.packages[0]["config"].get("container_cache"), False)
+
+    def test_configure_package_rejects_unknown_key_without_persisting(self):
+        """Unknown key=value arguments fail closed and leave YAML unchanged."""
+        pipeline = self._make_pipeline("cfgpkg_unknown")
+        pkg_def = self._make_ior_pkg_def("cfgpkg_unknown")
+        pipeline.packages.append(pkg_def)
+        pipeline._propagate_deploy_mode()
+        pipeline.save()
+        pipeline_path = self.jarvis.get_pipeline_dir("cfgpkg_unknown") / "pipeline.yaml"
+        original = pipeline_path.read_bytes()
+
+        with self.assertRaisesRegex(ValueError, "Unknown argument"):
+            pipeline.configure_package("ior", ["message=not-supported"])
+
+        self.assertEqual(pipeline_path.read_bytes(), original)
+        self.assertNotIn("message", pipeline.packages[0]["config"])
+
+    def test_configure_package_failure_is_not_persisted(self):
+        """A package configuration failure cannot mutate durable pipeline state."""
+        from jarvis_cd.util import PkgArgParse
+
+        class FailingPackage:
+            def __init__(self, config):
+                self.config = config
+
+            @staticmethod
+            def configure_menu():
+                return [{"name": "count", "type": int, "default": 1}]
+
+            def get_argparse(self):
+                return PkgArgParse("failing", self.configure_menu())
+
+            def configure(self, **kwargs):
+                self.config["count"] = kwargs["count"]
+                self.config["leaked_default"] = True
+                raise RuntimeError(f"rejected count {kwargs['count']}")
+
+        pipeline = self._make_pipeline("cfgpkg_failure")
+        pipeline.packages.append(
+            {
+                "pkg_type": "builtin.test_pkg",
+                "pkg_id": "failing",
+                "pkg_name": "failing",
+                "global_id": "cfgpkg_failure.failing",
+                "config": {"count": 1},
+            }
+        )
+
+        with (
+            patch.object(
+                pipeline,
+                "_load_package_instance",
+                return_value=FailingPackage(pipeline.packages[0]["config"]),
+            ),
+            patch.object(pipeline, "save") as save,
+            self.assertRaisesRegex(ValueError, "rejected count 2"),
+        ):
+            pipeline.configure_package("failing", ["count=2"])
+
+        save.assert_not_called()
+        self.assertEqual(pipeline.packages[0]["config"], {"count": 1})
+
+    def test_configure_package_persists_package_derived_values(self):
+        """Successful package-owned configuration commits its derived settings."""
+        from jarvis_cd.util import PkgArgParse
+
+        class DerivedPackage:
+            def __init__(self):
+                self.config = {}
+
+            @staticmethod
+            def configure_menu():
+                return [{"name": "count", "type": int, "default": 1}]
+
+            def get_argparse(self):
+                return PkgArgParse("derived", self.configure_menu())
+
+            def configure(self, **kwargs):
+                self.config["count"] = kwargs["count"]
+                self.config["derived_path"] = f"/output/{kwargs['count']}"
+
+        pipeline = self._make_pipeline("cfgpkg_derived")
+        pipeline.packages.append(
+            {
+                "pkg_type": "builtin.test_pkg",
+                "pkg_id": "derived",
+                "pkg_name": "derived",
+                "global_id": "cfgpkg_derived.derived",
+                "config": {"count": 1},
+            }
+        )
+
+        with (
+            patch.object(
+                pipeline,
+                "_load_package_instance",
+                return_value=DerivedPackage(),
+            ),
+            patch.object(pipeline, "save") as save,
+        ):
+            pipeline.configure_package("derived", ["count=2"])
+
+        save.assert_called_once_with()
+        self.assertEqual(
+            pipeline.packages[0]["config"],
+            {"count": 2, "derived_path": "/output/2"},
+        )
 
     def test_configure_localhost_does_not_require_ssh(self):
         """Local IOR setup remains usable when localhost SSH is unavailable."""
@@ -305,6 +467,73 @@ class TestPipelineCoverage(unittest.TestCase):
 
         pipeline2 = Pipeline("di_test")
         self.assertEqual(pipeline2.container_image, "myimg:latest")
+
+    def test_container_stop_rejects_local_nonzero_exit(self):
+        """A local container teardown cannot report success after exit failure."""
+        pipeline = self._make_pipeline("container_stop_local_failure")
+        pipeline.container_engine = "docker"
+        pipeline.packages = []
+        pipeline.hostfile = Hostfile(hosts=["localhost"], find_ips=False)
+
+        result = SimpleNamespace(
+            exit_code={"localhost": 7},
+            stderr={"localhost": "compose teardown failed"},
+        )
+        with (
+            patch("jarvis_cd.shell.Exec") as executor,
+            self.assertRaises(ExceptionGroup) as raised,
+        ):
+            executor.return_value.run.return_value = result
+            pipeline._stop_containerized_pipeline()
+
+        self.assertIn("localhost=exit 7", str(raised.exception.exceptions[0]))
+        exec_info = executor.call_args.args[1]
+        self.assertEqual(exec_info.exec_type, ExecType.LOCAL)
+
+    def test_container_stop_rejects_one_remote_nonzero_exit(self):
+        """A PSSH teardown fails when any selected host returns nonzero."""
+        pipeline = self._make_pipeline("container_stop_remote_failure")
+        pipeline.container_engine = "podman"
+        pipeline.packages = []
+        pipeline.hostfile = Hostfile(
+            hosts=["node-a", "node-b"],
+            find_ips=False,
+        )
+
+        result = SimpleNamespace(
+            exit_code={"node-a": 0, "node-b": 9},
+            stderr={"node-a": "", "node-b": "podman unavailable"},
+        )
+        with (
+            patch("jarvis_cd.shell.Exec") as executor,
+            self.assertRaises(ExceptionGroup) as raised,
+        ):
+            executor.return_value.run.return_value = result
+            pipeline._stop_containerized_pipeline()
+
+        self.assertIn("node-b=exit 9", str(raised.exception.exceptions[0]))
+        exec_info = executor.call_args.args[1]
+        self.assertEqual(exec_info.exec_type, ExecType.PSSH)
+        self.assertEqual(exec_info.hostfile.hosts, ["node-a", "node-b"])
+
+    def test_container_force_kill_aggregates_executor_failure(self):
+        """Forced container cleanup exposes missing executor status."""
+        pipeline = self._make_pipeline("container_kill_failure")
+        pipeline.container_engine = "docker"
+        pipeline.packages = []
+        pipeline.hostfile = Hostfile(hosts=["localhost"], find_ips=False)
+
+        with (
+            patch("jarvis_cd.shell.Exec") as executor,
+            self.assertRaises(ExceptionGroup) as raised,
+        ):
+            executor.return_value.run.return_value = SimpleNamespace(
+                exit_code={},
+                stderr={},
+            )
+            pipeline._kill_containerized_pipeline()
+
+        self.assertIn("no per-host exit status", str(raised.exception.exceptions[0]))
 
     # ------------------------------------------------------------------
     # _generate_pipeline_container_yaml()

--- a/test/unit/core/test_progress_spi.py
+++ b/test/unit/core/test_progress_spi.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import io
 import os
+import subprocess
+import sys
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -12,6 +14,8 @@ from typing import Any, cast
 import pytest
 
 from jarvis_cd.core.pkg import Pkg
+from jarvis_cd.shell.core_exec import LocalExec
+from jarvis_cd.shell.exec_info import LocalExecInfo
 from jarvis_cd.progress import (
     PROGRESS_LINE_PREFIX,
     ProgressEvent,
@@ -314,6 +318,61 @@ def test_package_callback_persists_typed_final_observation(tmp_path: Path) -> No
     assert event.sequence == 1
 
 
+def test_package_callback_passes_owned_process_exit_to_provider(
+    tmp_path: Path,
+) -> None:
+    """The optional exit-aware SPI receives JARVIS's authoritative code."""
+
+    class Provider:
+        def observe_progress(self, text: str) -> list[ProgressObservation]:
+            del text
+            return [ProgressObservation(label="phase", current=1, total=1)]
+
+        def finalize_progress(self) -> list[ProgressObservation]:
+            raise AssertionError("exit-aware provider used legacy finalization")
+
+        def finalize_progress_for_exit(
+            self, return_code: int
+        ) -> list[ProgressObservation]:
+            return [
+                ProgressObservation(
+                    label="phase",
+                    state=(
+                        ProgressState.COMPLETED
+                        if return_code == 0
+                        else ProgressState.RUNNING
+                    ),
+                    current=1,
+                    total=1,
+                    metadata={"return_code": return_code},
+                )
+            ]
+
+        def reset_progress(self) -> None:
+            return None
+
+    path = (tmp_path / "exit-progress.jsonl").resolve()
+    package = object.__new__(Pkg)
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec_exit",
+        "JARVIS_PACKAGE_ID": "app_a",
+        "JARVIS_PACKAGE_NAME": "site.application",
+        "JARVIS_PROGRESS_PATH": str(path),
+    }
+    package.get_progress_provider = lambda: Provider()  # type: ignore[method-assign]
+
+    callback = package.progress_line_callback()
+    assert callback is not None
+    callback("stdout", "finished work\n")
+    getattr(callback, "finalize_process")(0)
+
+    event = ProgressStore(path).latest()
+    assert event is not None
+    assert event.state is ProgressState.COMPLETED
+    assert event.metadata["return_code"] == 0
+    assert event.sequence == 2
+
+
 def test_container_callback_persists_structured_stdout_without_provider(
     tmp_path: Path,
 ) -> None:
@@ -348,6 +407,240 @@ def test_container_callback_persists_structured_stdout_without_provider(
     assert event.execution_id == "exec_container"
     assert event.package_id == "container_app"
     assert event.current == 1
+
+
+def test_structured_completion_is_corrected_after_nonzero_process_exit(
+    tmp_path: Path,
+) -> None:
+    """JARVIS process ownership overrides a premature application success."""
+    path = (tmp_path / "reconciled-progress.jsonl").resolve()
+    stream = io.StringIO()
+    child_reporter = ProgressReporter(
+        package_name="site.application",
+        package_id="container_app",
+        execution_id="exec_failed_container",
+        stream=stream,
+    )
+    completed = child_reporter.emit(
+        label="frame",
+        state=ProgressState.COMPLETED,
+        current=2,
+        total=2,
+        unit="frame",
+        message="Application reported completion",
+        metadata={"application_signal": "last_frame"},
+    )
+
+    package = object.__new__(Pkg)
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec_failed_container",
+        "JARVIS_PACKAGE_ID": "container_app",
+        "JARVIS_PACKAGE_NAME": "site.application",
+        "JARVIS_PROGRESS_PATH": str(path),
+        "JARVIS_PROGRESS_TRANSPORT": "stdout",
+    }
+    package.get_progress_provider = lambda: None  # type: ignore[method-assign]
+
+    callback = package.progress_line_callback()
+    assert callback is not None
+    callback("stdout", stream.getvalue())
+    getattr(callback, "finalize_process")(23)
+    getattr(callback, "finalize_process")(23)
+
+    events = ProgressStore(path).read_all()
+    assert len(events) == 2
+    assert events[0] == completed
+    corrected = events[1]
+    assert corrected.state is ProgressState.FAILED
+    assert corrected.sequence == completed.sequence + 1
+    assert corrected.current == completed.current
+    assert corrected.total == completed.total
+    assert corrected.unit == completed.unit
+    assert corrected.metadata["jarvis_process_exit"] == {
+        "reported_state": "completed",
+        "return_code": 23,
+        "source": "jarvis_process_owner",
+    }
+
+
+def test_structured_completion_remains_terminal_after_zero_process_exit(
+    tmp_path: Path,
+) -> None:
+    """A zero JARVIS-owned return code leaves structured completion intact."""
+    path = (tmp_path / "successful-progress.jsonl").resolve()
+    stream = io.StringIO()
+    child_reporter = ProgressReporter(
+        package_name="site.application",
+        package_id="container_app",
+        execution_id="exec_successful_container",
+        stream=stream,
+    )
+    completed = child_reporter.emit(
+        label="frame",
+        state=ProgressState.COMPLETED,
+        current=2,
+        total=2,
+    )
+
+    package = object.__new__(Pkg)
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec_successful_container",
+        "JARVIS_PACKAGE_ID": "container_app",
+        "JARVIS_PACKAGE_NAME": "site.application",
+        "JARVIS_PROGRESS_PATH": str(path),
+        "JARVIS_PROGRESS_TRANSPORT": "stdout",
+    }
+    package.get_progress_provider = lambda: None  # type: ignore[method-assign]
+
+    callback = package.progress_line_callback()
+    assert callback is not None
+    callback("stdout", stream.getvalue())
+    getattr(callback, "finalize_process")(0)
+
+    assert ProgressStore(path).read_all() == [completed]
+
+
+def test_line_callback_failure_reconciles_structured_completion(
+    tmp_path: Path,
+) -> None:
+    """A stream failure cannot leave an earlier structured success terminal."""
+    progress_path = (tmp_path / "line-failure-progress.jsonl").resolve()
+    stream = io.StringIO()
+    child_reporter = ProgressReporter(
+        package_name="site.application",
+        package_id="container_app",
+        execution_id="exec_line_failure",
+        stream=stream,
+    )
+    child_reporter.emit(
+        label="frame",
+        state=ProgressState.COMPLETED,
+        current=2,
+        total=2,
+    )
+    structured_line = stream.getvalue().strip()
+
+    package = object.__new__(Pkg)
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec_line_failure",
+        "JARVIS_PACKAGE_ID": "container_app",
+        "JARVIS_PACKAGE_NAME": "site.application",
+        "JARVIS_PROGRESS_PATH": str(progress_path),
+        "JARVIS_PROGRESS_TRANSPORT": "stdout",
+    }
+    package.get_progress_provider = lambda: None  # type: ignore[method-assign]
+    package.get_artifact_provider = lambda: None  # type: ignore[method-assign]
+    runtime_callback = package.runtime_line_callback()
+    assert runtime_callback is not None
+
+    class FailAfterStructuredSuccess:
+        def __call__(self, stream_name: str, line: str) -> None:
+            runtime_callback(stream_name, line)
+            if line.strip() == "trigger-callback-failure":
+                raise RuntimeError("forced failure after structured success")
+
+        def finalize_process(self, return_code: int) -> None:
+            getattr(runtime_callback, "finalize_process")(return_code)
+
+    command = subprocess.list2cmdline(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import time; "
+                f"print({structured_line!r}, flush=True); "
+                "print('trigger-callback-failure', flush=True); "
+                "time.sleep(30)"
+            ),
+        ]
+    )
+    execution = LocalExec(
+        command,
+        LocalExecInfo(
+            hide_output=True,
+            line_callback=FailAfterStructuredSuccess(),
+        ),
+    )
+
+    assert execution.exit_code["localhost"] != 0
+    events = ProgressStore(progress_path).read_all()
+    assert [event.state for event in events] == [
+        ProgressState.COMPLETED,
+        ProgressState.FAILED,
+    ]
+    assert events[-1].metadata["jarvis_process_exit"]["return_code"] != 0
+
+
+def test_later_artifact_finalizer_failure_reconciles_progress_success(
+    tmp_path: Path,
+) -> None:
+    """A later semantic failure corrects progress finalized earlier in the batch."""
+
+    class CompletedProgressProvider:
+        def observe_progress(self, text: str) -> list[ProgressObservation]:
+            del text
+            return []
+
+        def finalize_progress(self) -> list[ProgressObservation]:
+            return [
+                ProgressObservation(
+                    label="phase",
+                    state=ProgressState.COMPLETED,
+                    current=1,
+                    total=1,
+                )
+            ]
+
+        def reset_progress(self) -> None:
+            return None
+
+    class FailingArtifactProvider:
+        def observe_artifacts(self, text: str) -> list[Any]:
+            del text
+            return []
+
+        def finalize_artifacts(self) -> list[Any]:
+            raise RuntimeError("artifact finalizer failed after progress")
+
+        def reset_artifacts(self) -> None:
+            return None
+
+    progress_path = (tmp_path / "ordered-progress.jsonl").resolve()
+    artifact_path = (tmp_path / "ordered-artifacts.jsonl").resolve()
+    package = object.__new__(Pkg)
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec_ordered_failure",
+        "JARVIS_PACKAGE_ID": "application_a",
+        "JARVIS_PACKAGE_NAME": "site.application",
+        "JARVIS_PROGRESS_PATH": str(progress_path),
+        "JARVIS_ARTIFACT_PATH": str(artifact_path),
+    }
+    package.get_progress_provider = (  # type: ignore[method-assign]
+        lambda: CompletedProgressProvider()
+    )
+    package.get_artifact_provider = (  # type: ignore[method-assign]
+        lambda: FailingArtifactProvider()
+    )
+    runtime_callback = package.runtime_line_callback()
+    assert runtime_callback is not None
+
+    execution = LocalExec(
+        subprocess.list2cmdline([sys.executable, "-c", "pass"]),
+        LocalExecInfo(hide_output=True, line_callback=runtime_callback),
+    )
+
+    assert execution.exit_code["localhost"] == 1
+    assert "artifact finalizer failed" in execution.stderr["localhost"]
+    events = ProgressStore(progress_path).read_all()
+    assert [event.state for event in events] == [
+        ProgressState.COMPLETED,
+        ProgressState.FAILED,
+    ]
+    assert events[-1].metadata["jarvis_process_exit"] == {
+        "reported_state": "completed",
+        "return_code": 1,
+        "source": "jarvis_process_owner",
+    }
 
 
 def test_filesystem_repository_discovers_sibling_progress_module(

--- a/test/unit/core/test_scheduler_submission.py
+++ b/test/unit/core/test_scheduler_submission.py
@@ -266,10 +266,17 @@ def _run_execution_scheduler_script(
         elif initial_state != "submitting":
             raise ValueError(f"unsupported test execution state: {initial_state}")
     execution_root = store.executions_dir / execution_id
+    runtime_dir = execution_root / "runtime"
+    runtime_dir.mkdir()
+    (runtime_dir / "pipeline.yaml").write_text(
+        "name: example\npkgs: []\ninterceptors: []\n",
+        encoding="utf-8",
+    )
+    (runtime_dir / "environment.yaml").write_text("{}\n", encoding="utf-8")
     scheduler = SlurmScheduler(
         {"name": "slurm"},
         execution_root,
-        pipeline_snapshot_dir=execution_root / "runtime",
+        pipeline_snapshot_dir=runtime_dir,
     )
 
     executable_dir = tmp_path / "bin"

--- a/test/unit/core/test_scheduler_submission.py
+++ b/test/unit/core/test_scheduler_submission.py
@@ -4,6 +4,7 @@ import multiprocessing
 import os
 import shlex
 import subprocess
+import sys
 from copy import deepcopy
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -48,6 +49,7 @@ def _real_pipeline(tmp_path: Path) -> Pipeline:
         get_pipeline_private_dir=lambda name: tmp_path / "private" / name,
         get_builtin_repo_path=lambda: repository_root / "builtin",
         set_current_pipeline=lambda _name: None,
+        jarvis_root=tmp_path / "jarvis-root",
     )
     with patch("jarvis_cd.core.pipeline.Jarvis.get_instance", return_value=jarvis):
         pipeline = Pipeline()
@@ -106,6 +108,49 @@ def test_slurm_submission_uses_and_parses_parsable_identity(tmp_path: Path) -> N
         "scheduler_cluster": "ares",
         "identity_source": "scheduler_submit_api",
     }
+
+
+def test_jarvis_root_environment_selects_scheduler_configuration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A scheduled CLI process can retain the submitting JARVIS root."""
+    selected_root = tmp_path / "selected-root"
+    monkeypatch.setenv("JARVIS_ROOT", str(selected_root))
+    Jarvis._instance = None
+    try:
+        assert Jarvis.get_instance().jarvis_root == selected_root
+    finally:
+        Jarvis._instance = None
+
+
+def test_jarvis_root_environment_normalizes_relative_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A scheduler inherits one absolute root independent of its working directory."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("JARVIS_ROOT", "relative-root")
+    Jarvis._instance = None
+    try:
+        assert (
+            Jarvis.get_instance().jarvis_root == (tmp_path / "relative-root").resolve()
+        )
+    finally:
+        Jarvis._instance = None
+
+
+def test_jarvis_root_environment_rejects_control_characters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The scheduler configuration root cannot inject structured values."""
+    monkeypatch.setenv("JARVIS_ROOT", "/safe/path\nattacker")
+    Jarvis._instance = None
+    try:
+        with pytest.raises(ValueError, match="printable path"):
+            Jarvis.get_instance()
+    finally:
+        Jarvis._instance = None
 
 
 @pytest.mark.parametrize(
@@ -312,6 +357,51 @@ def test_slurm_runtime_identity_closes_submitter_crash_window(
     assert record.state == "completed"
     assert record.scheduler_native_id == "41"
     assert record.cluster == "ares"
+
+
+def test_runtime_cluster_backfills_submission_projection(tmp_path: Path) -> None:
+    """A cluster known only inside the allocation remains queryable afterward."""
+    pipeline = _real_pipeline(tmp_path)
+    store = pipeline._execution_store()
+    execution_id = "runtime-cluster"
+    store.create(execution_id, mode="scheduler", scheduler_provider="slurm")
+    store.update(execution_id, state="submitting", terminal=False)
+    store.activate_scheduler(
+        execution_id,
+        provider="slurm",
+        native_id="42",
+        cluster="linux",
+    )
+    execution_root = store.executions_dir / execution_id
+    pipeline.last_submission = {
+        "schema_version": "jarvis.scheduler.submission.v1",
+        "execution_id": execution_id,
+        "provider": "slurm",
+        "script_path": str(execution_root / "submit.slurm"),
+        "scheduler_job_id": "42",
+        "scheduler_cluster": None,
+        "identity_source": "scheduler_submit_api",
+        "state": "completed",
+        "submitted": True,
+        "wait": True,
+        "terminal": True,
+        "scheduler_stderr": None,
+        "submission_returncode": 0,
+        "terminal_returncode": 0,
+    }
+
+    pipeline._update_execution_marker(execution_root)
+
+    record = store.get(execution_id)
+    submission = record.metadata["submission"]
+    assert record.cluster == "linux"
+    assert submission["scheduler_cluster"] == "linux"
+    assert submission["cluster_identity_source"] == "scheduler_runtime_environment"
+    assert pipeline.last_submission["scheduler_cluster"] == "linux"
+    assert (
+        pipeline.last_submission["cluster_identity_source"]
+        == "scheduler_runtime_environment"
+    )
 
 
 def test_generated_script_can_activate_and_complete_after_manual_submission(
@@ -743,6 +833,12 @@ def test_scheduler_submission_uses_isolated_pipeline_environment_and_paths(
     )
     script_text = script_a.read_text(encoding="utf-8")
     assert "JARVIS_PIPELINE_SNAPSHOT_DIR" in script_text
+    assert f"JARVIS_ROOT={shlex.quote(str(pipeline.jarvis.jarvis_root))}" in script_text
+    assert (
+        f"{shlex.quote(sys.executable)} -m jarvis_cd.core.cli ppl run yaml"
+        in script_text
+    )
+    assert " jarvis ppl run" not in script_text
     assert str(runtime_a) in script_text
     assert "jarvis cd example" not in script_text
     assert len(str(submission_a["pipeline_snapshot_sha256"])) == 64

--- a/test/unit/shell/test_local_exec.py
+++ b/test/unit/shell/test_local_exec.py
@@ -108,6 +108,34 @@ class TestLocalExec(unittest.TestCase):
         self.assertEqual(callback.lines, [("stdout", "tail")])
         self.assertEqual(callback.finalized, 1)
 
+    def test_stateful_callback_receives_owned_process_return_code(self):
+        """Exit-aware callbacks receive the real code after output drains."""
+
+        class Callback:
+            def __init__(self):
+                self.return_codes = []
+
+            def __call__(self, stream, line):
+                del stream, line
+
+            def finalize_process(self, return_code):
+                self.return_codes.append(return_code)
+
+        success = Callback()
+        failed = Callback()
+        LocalExec(
+            self.python_command("pass"),
+            LocalExecInfo(hide_output=True, line_callback=success),
+        )
+        execution = LocalExec(
+            self.python_command("raise SystemExit(7)"),
+            LocalExecInfo(hide_output=True, line_callback=failed),
+        )
+
+        self.assertEqual(success.return_codes, [0])
+        self.assertEqual(failed.return_codes, [7])
+        self.assertEqual(execution.exit_code["localhost"], 7)
+
     def test_line_callback_finalization_failure_is_reported(self):
         """A final provider flush failure makes an otherwise clean process fail."""
 
@@ -130,6 +158,33 @@ class TestLocalExec(unittest.TestCase):
         self.assertIn(
             "cannot flush final progress fragment", local_exec.stderr["localhost"]
         )
+
+    def test_finalizer_failure_reconciles_with_effective_return_code(self):
+        """A failed finalizer receives the effective failure in a correction pass."""
+
+        class Callback:
+            def __init__(self):
+                self.reconciled = []
+
+            def __call__(self, stream, line):
+                del stream, line
+
+            def finalize_process(self, return_code):
+                self.reported_return_code = return_code
+                raise RuntimeError("terminal metadata write failed")
+
+            def reconcile_process_exit(self, return_code):
+                self.reconciled.append(return_code)
+
+        callback = Callback()
+        local_exec = LocalExec(
+            self.python_command("pass"),
+            LocalExecInfo(hide_output=True, line_callback=callback),
+        )
+
+        self.assertEqual(callback.reported_return_code, 0)
+        self.assertEqual(callback.reconciled, [1])
+        self.assertEqual(local_exec.exit_code["localhost"], 1)
 
     def test_single_env_variable(self):
         """Test execution with a single environment variable"""

--- a/test/unit/shell/test_mpi_exec.py
+++ b/test/unit/shell/test_mpi_exec.py
@@ -1,11 +1,12 @@
 import unittest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 import sys
 import os
 
 # Add the project root to the path so we can import jarvis_cd
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
+from jarvis_cd.shell.core_exec import MpiVersion
 from jarvis_cd.shell.exec_factory import Exec as MpiExec
 from jarvis_cd.shell.mpi_exec import OpenMpiExec, MpichExec, CrayMpichExec, IntelMpiExec
 from jarvis_cd.shell.exec_info import MpiExecInfo, ExecType
@@ -13,10 +14,9 @@ from jarvis_cd.util.hostfile import Hostfile
 
 
 class TestMpiExec(unittest.TestCase):
-
     def setUp(self):
         """Set up test fixtures"""
-        self.hostfile = Hostfile(hosts=['localhost'], find_ips=False)
+        self.hostfile = Hostfile(hosts=["localhost"], find_ips=False)
 
     def test_single_command_format(self):
         """Test MPI execution with a single command string"""
@@ -24,198 +24,207 @@ class TestMpiExec(unittest.TestCase):
             nprocs=4,
             ppn=2,
             hostfile=self.hostfile,
-            env={'TEST_VAR': 'test_value'},
-            dry_run=True
+            env={"TEST_VAR": "test_value"},
+            dry_run=True,
         )
 
         mpi_exec = OpenMpiExec('echo "hello world"', exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Verify basic command structure
-        self.assertIn('mpiexec', cmd)
+        self.assertIn("mpiexec", cmd)
         self.assertIn('echo "hello world"', cmd)
+
+    @patch("jarvis_cd.shell.core_exec.LocalExec")
+    def test_mpi_detection_does_not_consume_application_callback(self, mock_local_exec):
+        """The internal version probe cannot own application stream state."""
+        callback = Mock()
+        probe = Mock()
+        probe.exit_code = {"localhost": 0}
+        probe.stdout = {"localhost": "Open MPI 5.0.5\n"}
+        probe.stderr = {"localhost": ""}
+        probe.processes = {}
+        probe.output_threads = {}
+        mock_local_exec.return_value = probe
+        exec_info = MpiExecInfo(
+            nprocs=1,
+            hostfile=self.hostfile,
+            line_callback=callback,
+        )
+
+        detected = MpiVersion(exec_info)
+
+        introspect_info = mock_local_exec.call_args.args[1]
+        self.assertIsNone(introspect_info.line_callback)
+        self.assertIs(exec_info.line_callback, callback)
+        self.assertEqual(detected.version, ExecType.OPENMPI)
 
     def test_multi_command_format(self):
         """Test MPI execution with multiple commands"""
-        exec_info = MpiExecInfo(
-            nprocs=10,
-            hostfile=self.hostfile,
-            dry_run=True
-        )
+        exec_info = MpiExecInfo(nprocs=10, hostfile=self.hostfile, dry_run=True)
 
         cmd_list = [
-            {'cmd': 'gdbserver :1234 ./myapp', 'nprocs': 1},
-            {'cmd': './myapp', 'nprocs': None}  # Should get remaining 9 procs
+            {"cmd": "gdbserver :1234 ./myapp", "nprocs": 1},
+            {"cmd": "./myapp", "nprocs": None},  # Should get remaining 9 procs
         ]
 
         mpi_exec = OpenMpiExec(cmd_list, exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Verify multi-command structure
-        self.assertIn('mpiexec', cmd)
-        self.assertIn('gdbserver', cmd)
-        self.assertIn('./myapp', cmd)
+        self.assertIn("mpiexec", cmd)
+        self.assertIn("gdbserver", cmd)
+        self.assertIn("./myapp", cmd)
 
     def test_multi_command_with_zero_nprocs(self):
         """Test that commands with 0 nprocs are skipped"""
-        exec_info = MpiExecInfo(
-            nprocs=4,
-            hostfile=self.hostfile,
-            dry_run=True
-        )
+        exec_info = MpiExecInfo(nprocs=4, hostfile=self.hostfile, dry_run=True)
 
         cmd_list = [
-            {'cmd': 'gdbserver :1234 ./myapp', 'nprocs': 0},  # Should be skipped
-            {'cmd': './myapp', 'nprocs': None}  # Should get all 4 procs
+            {"cmd": "gdbserver :1234 ./myapp", "nprocs": 0},  # Should be skipped
+            {"cmd": "./myapp", "nprocs": None},  # Should get all 4 procs
         ]
 
         mpi_exec = OpenMpiExec(cmd_list, exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Verify gdbserver command is not included
-        self.assertNotIn('gdbserver', cmd)
-        self.assertIn('./myapp', cmd)
+        self.assertNotIn("gdbserver", cmd)
+        self.assertIn("./myapp", cmd)
 
     def test_environment_variables(self):
         """Test that environment variables are properly forwarded"""
         exec_info = MpiExecInfo(
             nprocs=2,
             hostfile=self.hostfile,
-            env={'MY_VAR': 'my_value', 'ANOTHER_VAR': 'another_value'},
-            dry_run=True
+            env={"MY_VAR": "my_value", "ANOTHER_VAR": "another_value"},
+            dry_run=True,
         )
 
-        mpi_exec = OpenMpiExec('./myapp', exec_info)
+        mpi_exec = OpenMpiExec("./myapp", exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Verify environment variables are in the command
         # The exact format depends on MPI implementation
         self.assertTrue(
-            'MY_VAR' in cmd or 'ANOTHER_VAR' in cmd,
-            "Environment variables should be included in MPI command"
+            "MY_VAR" in cmd or "ANOTHER_VAR" in cmd,
+            "Environment variables should be included in MPI command",
         )
 
     def test_single_env_variable(self):
         """Test MPI execution with a single environment variable"""
-        test_binary = os.path.join(os.path.dirname(__file__), 'test_env_checker')
+        test_binary = os.path.join(os.path.dirname(__file__), "test_env_checker")
         exec_info = MpiExecInfo(
             nprocs=1,
             hostfile=self.hostfile,
-            env={'TEST_VAR': 'test_value'},
-            dry_run=True
+            env={"TEST_VAR": "test_value"},
+            dry_run=True,
         )
 
         if os.path.exists(test_binary):
-            mpi_exec = OpenMpiExec(f'{test_binary} TEST_VAR', exec_info)
+            mpi_exec = OpenMpiExec(f"{test_binary} TEST_VAR", exec_info)
             cmd = mpi_exec.get_cmd()
 
-            self.assertIn('TEST_VAR', cmd)
-            self.assertIn('test_value', cmd)
+            self.assertIn("TEST_VAR", cmd)
+            self.assertIn("test_value", cmd)
 
     def test_multiple_env_variables(self):
         """Test MPI execution with multiple environment variables"""
-        test_binary = os.path.join(os.path.dirname(__file__), 'test_env_checker')
+        test_binary = os.path.join(os.path.dirname(__file__), "test_env_checker")
         exec_info = MpiExecInfo(
             nprocs=1,
             hostfile=self.hostfile,
-            env={
-                'VAR1': 'value1',
-                'VAR2': 'value2',
-                'VAR3': 'value3'
-            },
-            dry_run=True
+            env={"VAR1": "value1", "VAR2": "value2", "VAR3": "value3"},
+            dry_run=True,
         )
 
         if os.path.exists(test_binary):
-            mpi_exec = OpenMpiExec(f'{test_binary} VAR1 VAR2 VAR3', exec_info)
+            mpi_exec = OpenMpiExec(f"{test_binary} VAR1 VAR2 VAR3", exec_info)
             cmd = mpi_exec.get_cmd()
 
-            self.assertIn('VAR1', cmd)
-            self.assertIn('value1', cmd)
-            self.assertIn('VAR2', cmd)
-            self.assertIn('value2', cmd)
-            self.assertIn('VAR3', cmd)
-            self.assertIn('value3', cmd)
+            self.assertIn("VAR1", cmd)
+            self.assertIn("value1", cmd)
+            self.assertIn("VAR2", cmd)
+            self.assertIn("value2", cmd)
+            self.assertIn("VAR3", cmd)
+            self.assertIn("value3", cmd)
 
     def test_env_with_special_characters(self):
         """Test environment variables with special characters"""
         exec_info = MpiExecInfo(
             nprocs=1,
             hostfile=self.hostfile,
-            env={'SPECIAL_VAR': 'value with "quotes" and spaces'},
-            dry_run=True
+            env={"SPECIAL_VAR": 'value with "quotes" and spaces'},
+            dry_run=True,
         )
 
-        mpi_exec = OpenMpiExec('echo $SPECIAL_VAR', exec_info)
+        mpi_exec = OpenMpiExec("echo $SPECIAL_VAR", exec_info)
         cmd = mpi_exec.get_cmd()
 
-        self.assertIn('SPECIAL_VAR', cmd)
+        self.assertIn("SPECIAL_VAR", cmd)
 
     def test_numeric_env_values(self):
         """Test environment variables with numeric values"""
         exec_info = MpiExecInfo(
             nprocs=1,
             hostfile=self.hostfile,
-            env={
-                'INT_VAR': 42,
-                'FLOAT_VAR': 3.14
-            },
-            dry_run=True
+            env={"INT_VAR": 42, "FLOAT_VAR": 3.14},
+            dry_run=True,
         )
 
-        mpi_exec = OpenMpiExec('echo test', exec_info)
+        mpi_exec = OpenMpiExec("echo test", exec_info)
         cmd = mpi_exec.get_cmd()
 
-        self.assertIn('INT_VAR', cmd)
-        self.assertIn('42', cmd)
-        self.assertIn('FLOAT_VAR', cmd)
-        self.assertIn('3.14', cmd)
+        self.assertIn("INT_VAR", cmd)
+        self.assertIn("42", cmd)
+        self.assertIn("FLOAT_VAR", cmd)
+        self.assertIn("3.14", cmd)
 
     def test_basic_env_without_ld_preload(self):
         """Test that basic_env removes LD_PRELOAD"""
         exec_info = MpiExecInfo(
             nprocs=1,
             hostfile=self.hostfile,
-            env={'LD_PRELOAD': '/lib/test.so', 'OTHER_VAR': 'value'},
-            dry_run=True
+            env={"LD_PRELOAD": "/lib/test.so", "OTHER_VAR": "value"},
+            dry_run=True,
         )
 
         # basic_env should not have LD_PRELOAD
-        self.assertNotIn('LD_PRELOAD', exec_info.basic_env)
-        self.assertIn('OTHER_VAR', exec_info.basic_env)
+        self.assertNotIn("LD_PRELOAD", exec_info.basic_env)
+        self.assertIn("OTHER_VAR", exec_info.basic_env)
 
     def test_multi_command_env_per_command(self):
         """Test environment variables in multi-command MPI execution"""
         exec_info = MpiExecInfo(
             nprocs=4,
             hostfile=self.hostfile,
-            env={'GLOBAL_VAR': 'global_value'},
-            dry_run=True
+            env={"GLOBAL_VAR": "global_value"},
+            dry_run=True,
         )
 
         cmd_list = [
-            {'cmd': 'echo cmd1', 'nprocs': 2},
-            {'cmd': 'echo cmd2', 'nprocs': 2}
+            {"cmd": "echo cmd1", "nprocs": 2},
+            {"cmd": "echo cmd2", "nprocs": 2},
         ]
 
         mpi_exec = OpenMpiExec(cmd_list, exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Environment should be included for both commands
-        self.assertIn('GLOBAL_VAR', cmd)
+        self.assertIn("GLOBAL_VAR", cmd)
 
     def test_disable_preload_in_multi_command(self):
         """Test that disable_preload removes LD_PRELOAD for specific commands"""
         exec_info = MpiExecInfo(
             nprocs=4,
             hostfile=self.hostfile,
-            env={'LD_PRELOAD': '/lib/test.so', 'OTHER_VAR': 'value'},
-            dry_run=True
+            env={"LD_PRELOAD": "/lib/test.so", "OTHER_VAR": "value"},
+            dry_run=True,
         )
 
         cmd_list = [
-            {'cmd': 'echo cmd1', 'nprocs': 2, 'disable_preload': True},
-            {'cmd': 'echo cmd2', 'nprocs': 2, 'disable_preload': False}
+            {"cmd": "echo cmd1", "nprocs": 2, "disable_preload": True},
+            {"cmd": "echo cmd2", "nprocs": 2, "disable_preload": False},
         ]
 
         mpi_exec = OpenMpiExec(cmd_list, exec_info)
@@ -226,72 +235,53 @@ class TestMpiExec(unittest.TestCase):
 
     def test_ppn_option(self):
         """Test processes per node option"""
-        exec_info = MpiExecInfo(
-            nprocs=8,
-            ppn=4,
-            hostfile=self.hostfile,
-            dry_run=True
-        )
+        exec_info = MpiExecInfo(nprocs=8, ppn=4, hostfile=self.hostfile, dry_run=True)
 
-        mpi_exec = OpenMpiExec('./myapp', exec_info)
+        mpi_exec = OpenMpiExec("./myapp", exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Verify ppn option is included (format varies by MPI)
         self.assertTrue(
-            'ppn' in cmd or 'npernode' in cmd,
-            "PPN option should be in MPI command"
+            "ppn" in cmd or "npernode" in cmd, "PPN option should be in MPI command"
         )
 
     def test_hostfile_option(self):
         """Test hostfile option with multiple hosts"""
-        multi_host = Hostfile(hosts=['host1', 'host2', 'host3'], find_ips=False)
-        exec_info = MpiExecInfo(
-            nprocs=6,
-            hostfile=multi_host,
-            dry_run=True
-        )
+        multi_host = Hostfile(hosts=["host1", "host2", "host3"], find_ips=False)
+        exec_info = MpiExecInfo(nprocs=6, hostfile=multi_host, dry_run=True)
 
-        mpi_exec = OpenMpiExec('./myapp', exec_info)
+        mpi_exec = OpenMpiExec("./myapp", exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Verify hostfile or host option is included
         self.assertTrue(
-            'host' in cmd.lower(),
-            "Hostfile option should be in MPI command"
+            "host" in cmd.lower(), "Hostfile option should be in MPI command"
         )
 
     def test_remainder_calculation(self):
         """Test that remainder nprocs are calculated correctly"""
-        exec_info = MpiExecInfo(
-            nprocs=10,
-            hostfile=self.hostfile,
-            dry_run=True
-        )
+        exec_info = MpiExecInfo(nprocs=10, hostfile=self.hostfile, dry_run=True)
 
         cmd_list = [
-            {'cmd': 'cmd1', 'nprocs': 2},
-            {'cmd': 'cmd2', 'nprocs': 3},
-            {'cmd': 'cmd3', 'nprocs': None}  # Should get 10 - 2 - 3 = 5
+            {"cmd": "cmd1", "nprocs": 2},
+            {"cmd": "cmd2", "nprocs": 3},
+            {"cmd": "cmd3", "nprocs": None},  # Should get 10 - 2 - 3 = 5
         ]
 
         mpi_exec = OpenMpiExec(cmd_list, exec_info)
 
         # Access internal cmd_list to verify calculation
         processed_list = mpi_exec.cmd_list
-        self.assertEqual(processed_list[2]['nprocs'], 5)
+        self.assertEqual(processed_list[2]["nprocs"], 5)
 
     def test_nprocs_overflow(self):
         """Test error when total nprocs exceeds available"""
-        exec_info = MpiExecInfo(
-            nprocs=5,
-            hostfile=self.hostfile,
-            dry_run=True
-        )
+        exec_info = MpiExecInfo(nprocs=5, hostfile=self.hostfile, dry_run=True)
 
         cmd_list = [
-            {'cmd': 'cmd1', 'nprocs': 3},
-            {'cmd': 'cmd2', 'nprocs': 3},  # Total = 6, exceeds 5
-            {'cmd': 'cmd3', 'nprocs': None}
+            {"cmd": "cmd1", "nprocs": 3},
+            {"cmd": "cmd2", "nprocs": 3},  # Total = 6, exceeds 5
+            {"cmd": "cmd3", "nprocs": None},
         ]
 
         with self.assertRaises(ValueError):
@@ -299,159 +289,129 @@ class TestMpiExec(unittest.TestCase):
 
 
 class TestOpenMpiExec(unittest.TestCase):
-
     def setUp(self):
         """Set up test fixtures"""
-        self.hostfile = Hostfile(hosts=['localhost'], find_ips=False)
+        self.hostfile = Hostfile(hosts=["localhost"], find_ips=False)
 
     def test_openmpi_specific_flags(self):
         """Test OpenMPI-specific flags"""
-        exec_info = MpiExecInfo(
-            nprocs=2,
-            hostfile=self.hostfile
-        )
+        exec_info = MpiExecInfo(nprocs=2, hostfile=self.hostfile)
 
-        mpi_exec = OpenMpiExec('./myapp', exec_info)
+        mpi_exec = OpenMpiExec("./myapp", exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Verify OpenMPI-specific flags
-        self.assertIn('--oversubscribe', cmd)
-        self.assertIn('--allow-run-as-root', cmd)
+        self.assertIn("--oversubscribe", cmd)
+        self.assertIn("--allow-run-as-root", cmd)
 
     def test_openmpi_env_format(self):
         """Test OpenMPI environment variable format"""
         exec_info = MpiExecInfo(
-            nprocs=2,
-            hostfile=self.hostfile,
-            env={'TEST_VAR': 'value'}
+            nprocs=2, hostfile=self.hostfile, env={"TEST_VAR": "value"}
         )
 
-        mpi_exec = OpenMpiExec('./myapp', exec_info)
+        mpi_exec = OpenMpiExec("./myapp", exec_info)
         cmd = mpi_exec.get_cmd()
 
         # OpenMPI uses -x for environment variables
-        self.assertIn('-x', cmd)
+        self.assertIn("-x", cmd)
 
 
 class TestMpichExec(unittest.TestCase):
-
     def setUp(self):
         """Set up test fixtures"""
-        self.hostfile = Hostfile(hosts=['localhost'], find_ips=False)
+        self.hostfile = Hostfile(hosts=["localhost"], find_ips=False)
 
     def test_mpich_env_format(self):
         """Test MPICH environment variable format"""
         exec_info = MpiExecInfo(
-            nprocs=2,
-            hostfile=self.hostfile,
-            env={'TEST_VAR': 'value'}
+            nprocs=2, hostfile=self.hostfile, env={"TEST_VAR": "value"}
         )
 
-        mpi_exec = MpichExec('./myapp', exec_info)
+        mpi_exec = MpichExec("./myapp", exec_info)
         cmd = mpi_exec.get_cmd()
 
         # MPICH uses -genv for environment variables
-        self.assertIn('-genv', cmd)
+        self.assertIn("-genv", cmd)
 
 
 class TestCrayMpichExec(unittest.TestCase):
-
     def setUp(self):
         """Set up test fixtures"""
-        self.hostfile = Hostfile(hosts=['localhost'], find_ips=False)
+        self.hostfile = Hostfile(hosts=["localhost"], find_ips=False)
 
     def test_cray_env_format(self):
         """Test Cray MPICH environment variable format"""
         exec_info = MpiExecInfo(
-            nprocs=2,
-            hostfile=self.hostfile,
-            env={'TEST_VAR': 'value'}
+            nprocs=2, hostfile=self.hostfile, env={"TEST_VAR": "value"}
         )
 
-        mpi_exec = CrayMpichExec('./myapp', exec_info)
+        mpi_exec = CrayMpichExec("./myapp", exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Cray MPICH uses --env for environment variables
-        self.assertIn('--env', cmd)
+        self.assertIn("--env", cmd)
 
     def test_cray_localhost_only_no_hostfile(self):
         """Test that Cray skips hostfile for localhost-only"""
-        localhost_only = Hostfile(hosts=['localhost'], find_ips=False)
-        exec_info = MpiExecInfo(
-            nprocs=2,
-            hostfile=localhost_only,
-            env={}
-        )
+        localhost_only = Hostfile(hosts=["localhost"], find_ips=False)
+        exec_info = MpiExecInfo(nprocs=2, hostfile=localhost_only, env={})
 
-        mpi_exec = CrayMpichExec('./myapp', exec_info)
+        mpi_exec = CrayMpichExec("./myapp", exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Should not include hostfile option for localhost-only
-        self.assertNotIn('--hostfile', cmd)
-        self.assertNotIn('--hosts', cmd)
+        self.assertNotIn("--hostfile", cmd)
+        self.assertNotIn("--hosts", cmd)
 
     def test_cray_multi_host(self):
         """Test Cray with multiple hosts"""
-        multi_host = Hostfile(hosts=['host1', 'host2'], find_ips=False)
-        exec_info = MpiExecInfo(
-            nprocs=4,
-            hostfile=multi_host,
-            env={}
-        )
+        multi_host = Hostfile(hosts=["host1", "host2"], find_ips=False)
+        exec_info = MpiExecInfo(nprocs=4, hostfile=multi_host, env={})
 
-        mpi_exec = CrayMpichExec('./myapp', exec_info)
+        mpi_exec = CrayMpichExec("./myapp", exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Should include hosts option
-        self.assertTrue('--hosts' in cmd or '--hostfile' in cmd)
+        self.assertTrue("--hosts" in cmd or "--hostfile" in cmd)
 
     def test_cray_ppn_option(self):
         """Test Cray MPICH ppn option"""
-        exec_info = MpiExecInfo(
-            nprocs=8,
-            ppn=4,
-            hostfile=self.hostfile,
-            env={}
-        )
+        exec_info = MpiExecInfo(nprocs=8, ppn=4, hostfile=self.hostfile, env={})
 
-        mpi_exec = CrayMpichExec('./myapp', exec_info)
+        mpi_exec = CrayMpichExec("./myapp", exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Cray uses --ppn
-        self.assertIn('--ppn', cmd)
+        self.assertIn("--ppn", cmd)
 
     def test_cray_multi_command(self):
         """Test Cray MPICH multi-command format"""
         exec_info = MpiExecInfo(
-            nprocs=4,
-            hostfile=self.hostfile,
-            env={'MY_VAR': 'value'}
+            nprocs=4, hostfile=self.hostfile, env={"MY_VAR": "value"}
         )
 
-        cmd_list = [
-            {'cmd': 'cmd1', 'nprocs': 2},
-            {'cmd': 'cmd2', 'nprocs': 2}
-        ]
+        cmd_list = [{"cmd": "cmd1", "nprocs": 2}, {"cmd": "cmd2", "nprocs": 2}]
 
         mpi_exec = CrayMpichExec(cmd_list, exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Verify multi-command structure with ' : ' separator
-        self.assertIn(':', cmd)
-        self.assertIn('cmd1', cmd)
-        self.assertIn('cmd2', cmd)
+        self.assertIn(":", cmd)
+        self.assertIn("cmd1", cmd)
+        self.assertIn("cmd2", cmd)
 
     def test_cray_multi_command_with_disable_preload(self):
         """Test Cray multi-command with disable_preload"""
         exec_info = MpiExecInfo(
             nprocs=4,
             hostfile=self.hostfile,
-            env={'LD_PRELOAD': '/lib/test.so', 'OTHER_VAR': 'value'}
+            env={"LD_PRELOAD": "/lib/test.so", "OTHER_VAR": "value"},
         )
 
         cmd_list = [
-            {'cmd': 'cmd1', 'nprocs': 2, 'disable_preload': True},
-            {'cmd': 'cmd2', 'nprocs': 2, 'disable_preload': False}
+            {"cmd": "cmd1", "nprocs": 2, "disable_preload": True},
+            {"cmd": "cmd2", "nprocs": 2, "disable_preload": False},
         ]
 
         mpi_exec = CrayMpichExec(cmd_list, exec_info)
@@ -462,101 +422,85 @@ class TestCrayMpichExec(unittest.TestCase):
     def test_cray_hostfile_path(self):
         """Test Cray MPICH with hostfile path"""
         import tempfile
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.hosts') as f:
-            f.write('host1\nhost2\n')
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".hosts") as f:
+            f.write("host1\nhost2\n")
             hostfile_path = f.name
 
         try:
             hostfile = Hostfile(path=hostfile_path)
-            exec_info = MpiExecInfo(
-                nprocs=4,
-                hostfile=hostfile,
-                env={}
-            )
+            exec_info = MpiExecInfo(nprocs=4, hostfile=hostfile, env={})
 
-            mpi_exec = CrayMpichExec('./myapp', exec_info)
+            mpi_exec = CrayMpichExec("./myapp", exec_info)
             cmd = mpi_exec.get_cmd()
 
             # Should include hostfile path
-            self.assertIn('--hostfile', cmd)
+            self.assertIn("--hostfile", cmd)
             self.assertIn(hostfile_path, cmd)
         finally:
             os.unlink(hostfile_path)
 
 
 class TestIntelMpiExec(unittest.TestCase):
-
     def setUp(self):
         """Set up test fixtures"""
-        self.hostfile = Hostfile(hosts=['localhost'], find_ips=False)
+        self.hostfile = Hostfile(hosts=["localhost"], find_ips=False)
 
     def test_intel_mpi_inherits_mpich(self):
         """Test that Intel MPI uses MPICH-style commands"""
         exec_info = MpiExecInfo(
-            nprocs=2,
-            hostfile=self.hostfile,
-            env={'TEST_VAR': 'value'}
+            nprocs=2, hostfile=self.hostfile, env={"TEST_VAR": "value"}
         )
 
-        mpi_exec = IntelMpiExec('./myapp', exec_info)
+        mpi_exec = IntelMpiExec("./myapp", exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Intel MPI inherits from MPICH, so uses -genv
-        self.assertIn('-genv', cmd)
+        self.assertIn("-genv", cmd)
 
 
 class TestOpenMpiMultiCommand(unittest.TestCase):
-
     def setUp(self):
         """Set up test fixtures"""
-        self.hostfile = Hostfile(hosts=['localhost'], find_ips=False)
+        self.hostfile = Hostfile(hosts=["localhost"], find_ips=False)
 
     def test_openmpi_multi_command(self):
         """Test OpenMPI multi-command format"""
         exec_info = MpiExecInfo(
-            nprocs=6,
-            hostfile=self.hostfile,
-            env={'MY_VAR': 'value'}
+            nprocs=6, hostfile=self.hostfile, env={"MY_VAR": "value"}
         )
 
-        cmd_list = [
-            {'cmd': 'cmd1', 'nprocs': 2},
-            {'cmd': 'cmd2', 'nprocs': 4}
-        ]
+        cmd_list = [{"cmd": "cmd1", "nprocs": 2}, {"cmd": "cmd2", "nprocs": 4}]
 
         mpi_exec = OpenMpiExec(cmd_list, exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Verify multi-command structure with ' : ' separator
-        self.assertIn(':', cmd)
-        self.assertIn('cmd1', cmd)
-        self.assertIn('cmd2', cmd)
-        self.assertIn('-x', cmd)  # OpenMPI env format
+        self.assertIn(":", cmd)
+        self.assertIn("cmd1", cmd)
+        self.assertIn("cmd2", cmd)
+        self.assertIn("-x", cmd)  # OpenMPI env format
 
     def test_openmpi_ppn_with_hostfile_path(self):
         """Test OpenMPI with ppn and hostfile path"""
         # Create a temporary hostfile path
         import tempfile
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.hosts') as f:
-            f.write('host1\nhost2\n')
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".hosts") as f:
+            f.write("host1\nhost2\n")
             hostfile_path = f.name
 
         try:
             hostfile = Hostfile(path=hostfile_path)
-            exec_info = MpiExecInfo(
-                nprocs=4,
-                ppn=2,
-                hostfile=hostfile,
-                env={}
-            )
+            exec_info = MpiExecInfo(nprocs=4, ppn=2, hostfile=hostfile, env={})
 
-            mpi_exec = OpenMpiExec('./myapp', exec_info)
+            mpi_exec = OpenMpiExec("./myapp", exec_info)
             cmd = mpi_exec.get_cmd()
 
             # Should include hostfile path
-            self.assertIn('--hostfile', cmd)
+            self.assertIn("--hostfile", cmd)
             self.assertIn(hostfile_path, cmd)
-            self.assertIn('-npernode', cmd)
+            self.assertIn("-npernode", cmd)
         finally:
             os.unlink(hostfile_path)
 
@@ -565,12 +509,12 @@ class TestOpenMpiMultiCommand(unittest.TestCase):
         exec_info = MpiExecInfo(
             nprocs=4,
             hostfile=self.hostfile,
-            env={'LD_PRELOAD': '/lib/test.so', 'OTHER_VAR': 'value'}
+            env={"LD_PRELOAD": "/lib/test.so", "OTHER_VAR": "value"},
         )
 
         cmd_list = [
-            {'cmd': 'cmd1', 'nprocs': 2, 'disable_preload': True},
-            {'cmd': 'cmd2', 'nprocs': 2, 'disable_preload': False}
+            {"cmd": "cmd1", "nprocs": 2, "disable_preload": True},
+            {"cmd": "cmd2", "nprocs": 2, "disable_preload": False},
         ]
 
         mpi_exec = OpenMpiExec(cmd_list, exec_info)
@@ -579,85 +523,70 @@ class TestOpenMpiMultiCommand(unittest.TestCase):
         # First command should not have LD_PRELOAD, second should have it
         # This tests the LD_PRELOAD deletion logic
         self.assertIsNotNone(cmd)
-        self.assertIn('cmd1', cmd)
-        self.assertIn('cmd2', cmd)
+        self.assertIn("cmd1", cmd)
+        self.assertIn("cmd2", cmd)
 
 
 class TestMpichMultiCommand(unittest.TestCase):
-
     def setUp(self):
         """Set up test fixtures"""
-        self.hostfile = Hostfile(hosts=['localhost'], find_ips=False)
+        self.hostfile = Hostfile(hosts=["localhost"], find_ips=False)
 
     def test_mpich_multi_command(self):
         """Test MPICH multi-command format"""
         exec_info = MpiExecInfo(
-            nprocs=6,
-            hostfile=self.hostfile,
-            env={'MY_VAR': 'value'}
+            nprocs=6, hostfile=self.hostfile, env={"MY_VAR": "value"}
         )
 
-        cmd_list = [
-            {'cmd': 'cmd1', 'nprocs': 2},
-            {'cmd': 'cmd2', 'nprocs': 4}
-        ]
+        cmd_list = [{"cmd": "cmd1", "nprocs": 2}, {"cmd": "cmd2", "nprocs": 4}]
 
         mpi_exec = MpichExec(cmd_list, exec_info)
         cmd = mpi_exec.get_cmd()
 
         # Verify multi-command structure with ' : ' separator
-        self.assertIn(':', cmd)
-        self.assertIn('cmd1', cmd)
-        self.assertIn('cmd2', cmd)
-        self.assertIn('-env', cmd)  # MPICH env format for multi-command
+        self.assertIn(":", cmd)
+        self.assertIn("cmd1", cmd)
+        self.assertIn("cmd2", cmd)
+        self.assertIn("-env", cmd)  # MPICH env format for multi-command
 
     def test_mpich_ppn_option(self):
         """Test MPICH ppn option"""
-        exec_info = MpiExecInfo(
-            nprocs=8,
-            ppn=4,
-            hostfile=self.hostfile,
-            env={}
-        )
+        exec_info = MpiExecInfo(nprocs=8, ppn=4, hostfile=self.hostfile, env={})
 
-        mpi_exec = MpichExec('./myapp', exec_info)
+        mpi_exec = MpichExec("./myapp", exec_info)
         cmd = mpi_exec.get_cmd()
 
         # MPICH uses -ppn
-        self.assertIn('-ppn', cmd)
+        self.assertIn("-ppn", cmd)
 
     def test_mpich_hostfile_path(self):
         """Test MPICH with hostfile path"""
         import tempfile
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.hosts') as f:
-            f.write('host1\nhost2\n')
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".hosts") as f:
+            f.write("host1\nhost2\n")
             hostfile_path = f.name
 
         try:
             hostfile = Hostfile(path=hostfile_path)
-            exec_info = MpiExecInfo(
-                nprocs=4,
-                hostfile=hostfile,
-                env={}
-            )
+            exec_info = MpiExecInfo(nprocs=4, hostfile=hostfile, env={})
 
-            mpi_exec = MpichExec('./myapp', exec_info)
+            mpi_exec = MpichExec("./myapp", exec_info)
             cmd = mpi_exec.get_cmd()
 
             # Should include hostfile path
-            self.assertIn('--hostfile', cmd)
+            self.assertIn("--hostfile", cmd)
             self.assertIn(hostfile_path, cmd)
         finally:
             os.unlink(hostfile_path)
 
 
 class TestMpiExecFactory(unittest.TestCase):
-
     def setUp(self):
         """Set up test fixtures"""
-        self.hostfile = Hostfile(hosts=['localhost'], find_ips=False)
+        self.hostfile = Hostfile(hosts=["localhost"], find_ips=False)
 
-    @patch('jarvis_cd.shell.exec_factory.MpiVersion')
+    @patch("jarvis_cd.shell.exec_factory.MpiVersion")
     def test_factory_openmpi_detection(self, mock_mpi_version):
         """Test factory creates OpenMpiExec when OpenMPI is detected"""
         # Mock MPI version detection to return OpenMPI
@@ -665,20 +594,15 @@ class TestMpiExecFactory(unittest.TestCase):
         mock_version.version = ExecType.OPENMPI
         mock_mpi_version.return_value = mock_version
 
-        exec_info = MpiExecInfo(
-            nprocs=2,
-            hostfile=self.hostfile,
-            env={},
-            dry_run=True
-        )
+        exec_info = MpiExecInfo(nprocs=2, hostfile=self.hostfile, env={}, dry_run=True)
 
-        mpi_exec = MpiExec('./myapp', exec_info)
+        mpi_exec = MpiExec("./myapp", exec_info)
         mpi_exec.run()
 
         # Should be an instance of OpenMpiExec
         self.assertIsInstance(mpi_exec._delegate, OpenMpiExec)
 
-    @patch('jarvis_cd.shell.exec_factory.MpiVersion')
+    @patch("jarvis_cd.shell.exec_factory.MpiVersion")
     def test_factory_mpich_detection(self, mock_mpi_version):
         """Test factory creates MpichExec when MPICH is detected"""
         # Mock MPI version detection to return MPICH
@@ -686,20 +610,15 @@ class TestMpiExecFactory(unittest.TestCase):
         mock_version.version = ExecType.MPICH
         mock_mpi_version.return_value = mock_version
 
-        exec_info = MpiExecInfo(
-            nprocs=2,
-            hostfile=self.hostfile,
-            env={},
-            dry_run=True
-        )
+        exec_info = MpiExecInfo(nprocs=2, hostfile=self.hostfile, env={}, dry_run=True)
 
-        mpi_exec = MpiExec('./myapp', exec_info)
+        mpi_exec = MpiExec("./myapp", exec_info)
         mpi_exec.run()
 
         # Should be an instance of MpichExec
         self.assertIsInstance(mpi_exec._delegate, MpichExec)
 
-    @patch('jarvis_cd.shell.exec_factory.MpiVersion')
+    @patch("jarvis_cd.shell.exec_factory.MpiVersion")
     def test_factory_intel_mpi_detection(self, mock_mpi_version):
         """Test factory creates IntelMpiExec when Intel MPI is detected"""
         # Mock MPI version detection to return Intel MPI
@@ -707,20 +626,15 @@ class TestMpiExecFactory(unittest.TestCase):
         mock_version.version = ExecType.INTEL_MPI
         mock_mpi_version.return_value = mock_version
 
-        exec_info = MpiExecInfo(
-            nprocs=2,
-            hostfile=self.hostfile,
-            env={},
-            dry_run=True
-        )
+        exec_info = MpiExecInfo(nprocs=2, hostfile=self.hostfile, env={}, dry_run=True)
 
-        mpi_exec = MpiExec('./myapp', exec_info)
+        mpi_exec = MpiExec("./myapp", exec_info)
         mpi_exec.run()
 
         # Should be an instance of IntelMpiExec
         self.assertIsInstance(mpi_exec._delegate, IntelMpiExec)
 
-    @patch('jarvis_cd.shell.exec_factory.MpiVersion')
+    @patch("jarvis_cd.shell.exec_factory.MpiVersion")
     def test_factory_cray_mpich_detection(self, mock_mpi_version):
         """Test factory creates CrayMpichExec when Cray MPICH is detected"""
         # Mock MPI version detection to return Cray MPICH
@@ -728,20 +642,15 @@ class TestMpiExecFactory(unittest.TestCase):
         mock_version.version = ExecType.CRAY_MPICH
         mock_mpi_version.return_value = mock_version
 
-        exec_info = MpiExecInfo(
-            nprocs=2,
-            hostfile=self.hostfile,
-            env={},
-            dry_run=True
-        )
+        exec_info = MpiExecInfo(nprocs=2, hostfile=self.hostfile, env={}, dry_run=True)
 
-        mpi_exec = MpiExec('./myapp', exec_info)
+        mpi_exec = MpiExec("./myapp", exec_info)
         mpi_exec.run()
 
         # Should be an instance of CrayMpichExec
         self.assertIsInstance(mpi_exec._delegate, CrayMpichExec)
 
-    @patch('jarvis_cd.shell.exec_factory.MpiVersion')
+    @patch("jarvis_cd.shell.exec_factory.MpiVersion")
     def test_factory_unknown_mpi_defaults_to_mpich(self, mock_mpi_version):
         """Test factory defaults to MPICH for unknown MPI type"""
         # Mock MPI version detection to return unknown type
@@ -749,20 +658,16 @@ class TestMpiExecFactory(unittest.TestCase):
         mock_version.version = ExecType.LOCAL  # Unknown MPI type
         mock_mpi_version.return_value = mock_version
 
-        exec_info = MpiExecInfo(
-            nprocs=2,
-            hostfile=self.hostfile,
-            env={},
-            dry_run=True
-        )
+        exec_info = MpiExecInfo(nprocs=2, hostfile=self.hostfile, env={}, dry_run=True)
 
         # Capture print output
         import io
         import sys
+
         captured_output = io.StringIO()
         sys.stdout = captured_output
 
-        mpi_exec = MpiExec('./myapp', exec_info)
+        mpi_exec = MpiExec("./myapp", exec_info)
         mpi_exec.run()
 
         sys.stdout = sys.__stdout__
@@ -770,29 +675,24 @@ class TestMpiExecFactory(unittest.TestCase):
         # Should default to MpichExec
         self.assertIsInstance(mpi_exec._delegate, MpichExec)
         # Should print warning
-        self.assertIn('Unknown MPI type', captured_output.getvalue())
+        self.assertIn("Unknown MPI type", captured_output.getvalue())
 
 
 class TestEmptyCmdList(unittest.TestCase):
-
     def setUp(self):
         """Set up test fixtures"""
-        self.hostfile = Hostfile(hosts=['localhost'], find_ips=False)
+        self.hostfile = Hostfile(hosts=["localhost"], find_ips=False)
 
     def test_empty_cmd_list_error(self):
         """Test that empty command list raises ValueError"""
-        exec_info = MpiExecInfo(
-            nprocs=4,
-            hostfile=self.hostfile,
-            env={}
-        )
+        exec_info = MpiExecInfo(nprocs=4, hostfile=self.hostfile, env={})
 
         cmd_list = []
 
         with self.assertRaises(ValueError) as ctx:
             OpenMpiExec(cmd_list, exec_info)
-        self.assertIn('empty', str(ctx.exception).lower())
+        self.assertIn("empty", str(ctx.exception).lower())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/unit/test_release_workflow.py
+++ b/test/unit/test_release_workflow.py
@@ -318,6 +318,12 @@ def test_exact_release_request_gates_artifact_build() -> None:
     assert "collaborators/$release_admin/permission" in WORKFLOW
     assert '.permission == "admin" and .role_name == "admin"' in WORKFLOW
     assert "test/unit/core/test_artifact_spi.py" in WORKFLOW
+    assert "test/unit/core/test_progress_spi.py" in WORKFLOW
+    assert "test/unit/core/test_pipeline_coverage.py" in WORKFLOW
+    assert "test/unit/ci/test_live_ares_gray_scott_probe.py" in WORKFLOW
+    assert "test/unit/shell/test_local_exec.py" in WORKFLOW
+    assert "test/unit/shell/test_mpi_exec.py" in WORKFLOW
+    assert "test/unit/util/test_pkg_argparse.py" in WORKFLOW
     assert "'schema_version': 'jarvis.artifact.v1'" in WORKFLOW
     assert "jarvis execution artifacts" in WORKFLOW
     build_block = WORKFLOW[build_index : WORKFLOW.index("  release:")]

--- a/test/unit/util/test_pkg_argparse.py
+++ b/test/unit/util/test_pkg_argparse.py
@@ -1,12 +1,13 @@
 """
 Tests for pkg_argparse.py - Package-specific argument parser
 """
+
 import unittest
 import sys
 import os
 from io import StringIO
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
 from jarvis_cd.util.pkg_argparse import PkgArgParse
 
@@ -17,37 +18,91 @@ class TestPkgArgParse(unittest.TestCase):
     def setUp(self):
         """Set up test parser with sample configure menu"""
         self.configure_menu = [
-            {'name': 'install_dir', 'msg': 'Installation directory', 'type': str, 'default': '/usr/local'},
-            {'name': 'num_threads', 'msg': 'Number of threads', 'type': int, 'default': 4},
-            {'name': 'enable_debug', 'msg': 'Enable debug mode', 'type': bool, 'default': False},
+            {
+                "name": "install_dir",
+                "msg": "Installation directory",
+                "type": str,
+                "default": "/usr/local",
+            },
+            {
+                "name": "num_threads",
+                "msg": "Number of threads",
+                "type": int,
+                "default": 4,
+            },
+            {
+                "name": "enable_debug",
+                "msg": "Enable debug mode",
+                "type": bool,
+                "default": False,
+            },
         ]
-        self.parser = PkgArgParse('test_package', self.configure_menu)
+        self.parser = PkgArgParse("test_package", self.configure_menu)
 
     def test_initialization(self):
         """Test PkgArgParse initialization"""
-        self.assertEqual(self.parser.pkg_name, 'test_package')
+        self.assertEqual(self.parser.pkg_name, "test_package")
         self.assertIsNotNone(self.parser.commands)
 
     def test_configure_command_exists(self):
         """Test that configure command is automatically added"""
-        self.assertIn('configure', self.parser.commands)
+        self.assertIn("configure", self.parser.commands)
 
     def test_parse_configure_with_args(self):
         """Test parsing configure command with arguments"""
-        args = ['configure', '--install_dir=/opt', '--num_threads=8']
+        args = ["configure", "--install_dir=/opt", "--num_threads=8"]
         self.parser.parse(args)
 
-        self.assertEqual(self.parser.kwargs['install_dir'], '/opt')
-        self.assertEqual(self.parser.kwargs['num_threads'], 8)
+        self.assertEqual(self.parser.kwargs["install_dir"], "/opt")
+        self.assertEqual(self.parser.kwargs["num_threads"], 8)
 
     def test_parse_configure_with_defaults(self):
         """Test that default values are used"""
-        args = ['configure']
+        args = ["configure"]
         self.parser.parse(args)
 
         # Should have defaults
-        self.assertIn('install_dir', self.parser.kwargs)
-        self.assertIn('num_threads', self.parser.kwargs)
+        self.assertIn("install_dir", self.parser.kwargs)
+        self.assertIn("num_threads", self.parser.kwargs)
+
+    def test_explicit_default_is_recorded_as_provided(self):
+        """Explicit values remain distinguishable when equal to defaults."""
+        self.parser.parse(["configure", "num_threads=4"])
+
+        self.assertEqual(self.parser.provided_args, {"num_threads"})
+
+    def test_unknown_key_value_fails_closed(self):
+        """Unknown structured arguments cannot be silently ignored."""
+        with self.assertRaises(SystemExit):
+            self.parser.parse(["configure", "message=unsupported"])
+
+    def test_positional_arguments_follow_parser_order_and_are_recorded(self):
+        """Positionals retain class/rank ordering and explicit-name tracking."""
+        parser = PkgArgParse(
+            "positional_package",
+            [
+                {
+                    "name": "later",
+                    "type": str,
+                    "pos": True,
+                    "class": "b",
+                    "rank": 0,
+                },
+                {
+                    "name": "first",
+                    "type": str,
+                    "pos": True,
+                    "class": "a",
+                    "rank": 0,
+                },
+            ],
+        )
+
+        parser.parse(["configure", "value=with-equals", "-5"])
+
+        self.assertEqual(parser.kwargs["first"], "value=with-equals")
+        self.assertEqual(parser.kwargs["later"], "-5")
+        self.assertEqual(parser.provided_args, {"first", "later"})
 
     def test_print_help(self):
         """Test print_help for package"""
@@ -59,9 +114,9 @@ class TestPkgArgParse(unittest.TestCase):
             output = sys.stdout.getvalue()
 
             # Should contain package name and parameters
-            self.assertIn('test_package', output)
-            self.assertIn('install_dir', output.lower())
-            self.assertIn('num_threads', output.lower())
+            self.assertIn("test_package", output)
+            self.assertIn("install_dir", output.lower())
+            self.assertIn("num_threads", output.lower())
 
         finally:
             sys.stdout = old_stdout
@@ -72,11 +127,11 @@ class TestPkgArgParse(unittest.TestCase):
         sys.stdout = StringIO()
 
         try:
-            self.parser.print_help('unknown_cmd')
+            self.parser.print_help("unknown_cmd")
             output = sys.stdout.getvalue()
 
             # Should indicate unknown command
-            self.assertIn('unknown', output.lower())
+            self.assertIn("unknown", output.lower())
 
         finally:
             sys.stdout = old_stdout
@@ -87,24 +142,24 @@ class TestPkgArgParse(unittest.TestCase):
         sys.stdout = StringIO()
 
         try:
-            self.parser.print_help('configure')
+            self.parser.print_help("configure")
             output = sys.stdout.getvalue()
 
             # Should show configure help
-            self.assertIn('test_package', output)
+            self.assertIn("test_package", output)
 
         finally:
             sys.stdout = old_stdout
 
     def test_empty_configure_menu(self):
         """Test PkgArgParse with empty configure menu"""
-        parser = PkgArgParse('empty_package', [])
-        args = ['configure']
+        parser = PkgArgParse("empty_package", [])
+        args = ["configure"]
         parser.parse(args)
 
         # Should not crash
         self.assertIsNotNone(parser.kwargs)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Make every pipeline run return a durable execution handle with explicit scheduler identity, queryable lifecycle state, package progress, and generated artifacts.
- Fail closed across parsing, package configuration, process callbacks, progress, and artifact finalization so durable state cannot report success after execution failure.
- Add production Gray-Scott and ADIOS2 Gray-Scott progress/artifact providers, including explicit BP5 output and restart-checkpoint contracts, exact-path cleanup, and safe defaults.
- Enforce the v1.2.1 release boundary with scoped type/lint checks, immutable release-contract tests, and an exact-wheel Ares acceptance probe.

## Validation
- Full local suite: `1179 passed, 3 subtests passed`.
- Immutable release-contract suite: `369 passed`.
- Pyright: `0 errors, 0 warnings`; scoped Ruff check/format, `uv lock --check`, workflow parsing, and `git diff --check` pass.
- Fresh wheel SHA-256: `f5f855218fe487b08be14b02349b93dff2e45032984a0e224a90da50800eb557`.
- Ares report: `/mnt/common/jcernudagarcia/.local/share/live-validation/jarvis-gray-direct/pre-20260713T012058Z-r9/report.json`.
- Ares: 67/67 assertions passed for execution `jarvis_e384e94c21de42529d50318ec93ef5e0`, Slurm job `21873`; progress completed 20/20 and both the timestep collection and restart checkpoint were finalized and physically inspected with `bpls`.