### PR TITLE
fix: resolve Slurm execution log artifact paths

### DIFF
--- a/ci/live_ares_gray_scott_probe.py
+++ b/ci/live_ares_gray_scott_probe.py
@@ -479,6 +479,8 @@ def _new_report(args: argparse.Namespace) -> dict[str, Any]:
             "artifact_state": "finalized",
             "artifact_format": "adios2-bp5",
             "artifact_completion_signal": "process_exit_zero_after_final_output",
+            "scheduler_log_pattern": "%j",
+            "scheduler_log_validation": ("resolved-path-exists-and-contains-native-id"),
         },
         "execution": {},
         "queries": {},
@@ -984,6 +986,8 @@ def _configured_pipeline(
     )
     pipeline = Pipeline()
     pipeline.create(run_id)
+    scheduler_log_root = output_path.parent / "scheduler-logs"
+    scheduler_log_root.mkdir(parents=False, exist_ok=False)
     scheduler: dict[str, Any] = {
         "name": "slurm",
         "job_name": run_id,
@@ -992,6 +996,8 @@ def _configured_pipeline(
         "ntasks_per_node": 1,
         "time": "00:10:00",
         "partition": args.partition,
+        "output": str((scheduler_log_root / "stdout-%j.log").resolve()),
+        "error": str((scheduler_log_root / "stderr-%j.log").resolve()),
     }
     if args.account is not None:
         scheduler["account"] = args.account
@@ -1152,15 +1158,60 @@ def _run_bpls(
     return results
 
 
-def _execution_log_evidence(submission: Mapping[str, Any]) -> dict[str, Any]:
-    """Return bounded scheduler stdout/stderr evidence and full-file digests."""
+def _execution_log_evidence(
+    submission: Mapping[str, Any],
+    artifacts: Mapping[str, Any],
+    scheduler_native_id: str,
+) -> dict[str, Any]:
+    """Validate referenced core logs and return bounded physical evidence."""
+    if not scheduler_native_id:
+        raise RuntimeError("execution record has no scheduler-native identity")
     root_value = submission.get("execution_root_path")
     if not isinstance(root_value, str) or not root_value:
         raise RuntimeError("scheduler submission did not retain its execution root")
     execution_root = Path(root_value)
     evidence: dict[str, Any] = {}
-    for name in ("stdout.log", "stderr.log"):
-        path = execution_root / name
+    current_artifacts = artifacts.get("artifacts")
+    for logical_name in ("stdout", "stderr"):
+        artifact = _single_by_key(
+            current_artifacts,
+            "logical_name",
+            logical_name,
+        )
+        if artifact is None or artifact.get("package_id") != "jarvis-core":
+            raise RuntimeError(
+                f"scheduler {logical_name} artifact reference is missing or duplicated"
+            )
+        if artifact.get("state") != "finalized":
+            raise RuntimeError(
+                f"scheduler {logical_name} artifact reference is not finalized"
+            )
+        location = artifact.get("location")
+        if not isinstance(location, Mapping):
+            raise RuntimeError(
+                f"scheduler {logical_name} artifact has no resolved location"
+            )
+        location_kind = location.get("kind")
+        location_value = location.get("value")
+        if not isinstance(location_value, str) or not location_value:
+            raise RuntimeError(f"scheduler {logical_name} artifact location is invalid")
+        if "%" in location_value:
+            raise RuntimeError(
+                f"scheduler {logical_name} artifact location retains a Slurm token"
+            )
+        if scheduler_native_id not in location_value:
+            raise RuntimeError(
+                f"scheduler {logical_name} artifact location does not contain "
+                "the execution scheduler-native ID"
+            )
+        if location_kind == "execution_path":
+            path = execution_root / location_value
+        elif location_kind == "cluster_path":
+            path = Path(location_value)
+        else:
+            raise RuntimeError(
+                f"scheduler {logical_name} artifact location kind is unsupported"
+            )
         status = path.stat(follow_symlinks=False)
         if not stat.S_ISREG(status.st_mode):
             raise RuntimeError(f"scheduler log is not a regular file: {path}")
@@ -1168,7 +1219,10 @@ def _execution_log_evidence(submission: Mapping[str, Any]) -> dict[str, Any]:
             if status.st_size > 65_536:
                 stream.seek(status.st_size - 65_536)
             tail = stream.read().decode("utf-8", errors="replace")
-        evidence[name] = {
+        evidence[logical_name] = {
+            "artifact_id": artifact.get("artifact_id"),
+            "artifact_state": artifact.get("state"),
+            "location": dict(location),
             "path": str(path),
             "size_bytes": status.st_size,
             "sha256": sha256_file(path),
@@ -1268,7 +1322,9 @@ def _run_installed_probe(args: argparse.Namespace, report: dict[str, Any]) -> No
         {"record": record, "progress": progress, "artifacts": artifacts}
     )
     report["execution"]["logs"] = _execution_log_evidence(
-        report["execution"]["submission"]
+        report["execution"]["submission"],
+        artifacts,
+        str(record.get("scheduler_native_id") or ""),
     )
     report["phase"] = "physical_validation"
     bpls_output = _run_bpls(

--- a/jarvis_cd/artifacts/store.py
+++ b/jarvis_cd/artifacts/store.py
@@ -166,12 +166,16 @@ class ArtifactStore:
     def finalize_open(
         self,
         state_for_open: ArtifactState = ArtifactState.INCOMPLETE,
+        *,
+        state_without_location: ArtifactState | None = None,
     ) -> list[ArtifactEvent]:
         """Seal every still-producing artifact during execution terminalization.
 
         ``AVAILABLE`` artifacts remain available. The execution layer seals
         application output as ``INCOMPLETE``/``FAILED`` unless its authoritative
         producer explicitly owns completion, such as JARVIS core log streams.
+        A caller that normally finalizes owned output may select a fail-closed
+        terminal state for a producing artifact whose location is still unset.
         """
         if state_for_open not in {
             ArtifactState.FINALIZED,
@@ -179,6 +183,13 @@ class ArtifactStore:
             ArtifactState.FAILED,
         }:
             raise ValueError("open artifacts require a terminal sealing state")
+        if state_without_location is not None and state_without_location not in {
+            ArtifactState.INCOMPLETE,
+            ArtifactState.FAILED,
+        }:
+            raise ValueError(
+                "location-less artifacts require an incomplete or failed state"
+            )
         self._prepare_parent()
         with _exclusive_store_lock(self.path):
             if _store_is_sealed(self.path):
@@ -197,10 +208,15 @@ class ArtifactStore:
                     if event.state is not ArtifactState.PRODUCING:
                         continue
                     sequence += 1
+                    terminal_state = (
+                        state_without_location
+                        if event.location is None and state_without_location is not None
+                        else state_for_open
+                    )
                     sealed.append(
                         replace(
                             event,
-                            state=state_for_open,
+                            state=terminal_state,
                             revision=event.revision + 1,
                             sequence=sequence,
                             observed_at_epoch=observed_at,

--- a/jarvis_cd/core/execution.py
+++ b/jarvis_cd/core/execution.py
@@ -13,10 +13,16 @@ from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from time import monotonic, sleep
-from typing import Any, Iterator, Literal, Mapping, Optional, cast
+from typing import Any, Iterator, List, Literal, Mapping, Optional, cast
 from uuid import uuid4
 
-from jarvis_cd.artifacts import ArtifactEvent, ArtifactState, ArtifactStore
+from jarvis_cd.artifacts import (
+    ArtifactEvent,
+    ArtifactLocation,
+    ArtifactReporter,
+    ArtifactState,
+    ArtifactStore,
+)
 from jarvis_cd.progress import ProgressEvent, ProgressStore
 from jarvis_cd.util.private_path import (
     ensure_private_descriptor,
@@ -34,6 +40,13 @@ PROGRESS_SNAPSHOT_SCHEMA = "jarvis.execution.progress.v1"
 ARTIFACT_SNAPSHOT_SCHEMA = "jarvis.execution.artifacts.v1"
 DIRECT_LAUNCH_SCHEMA = "jarvis.direct-launch.v1"
 DIRECT_LEASE_NAME = ".jarvis-direct-execution.lease"
+SCHEDULER_ARTIFACT_PATH_SCHEMA = "jarvis.scheduler.artifact-path.v1"
+SCHEDULER_ARTIFACT_PATH_METADATA_KEY = "jarvis_scheduler_path"
+SCHEDULER_ARTIFACT_PATH_UNRESOLVED_CODE = "scheduler_artifact_path_unresolved"
+SCHEDULER_ARTIFACT_PATH_TERMINAL_DIAGNOSTIC = (
+    "JARVIS reached execution terminalization before the scheduler artifact "
+    "path was resolved"
+)
 
 ExecutionMode = Literal["direct", "scheduler"]
 
@@ -1270,7 +1283,9 @@ class ExecutionStore:
                         f"artifact identity mismatch for package {package_id!r}"
                     )
                 if event.artifact_id in seen_ids:
-                    raise RuntimeError("artifact ID is duplicated across package manifests")
+                    raise RuntimeError(
+                        "artifact ID is duplicated across package manifests"
+                    )
                 seen_ids.add(event.artifact_id)
                 latest.append(event)
         return ExecutionArtifactSnapshot(
@@ -1295,7 +1310,7 @@ class ExecutionStore:
         execution_id: str,
         *,
         failed: bool = False,
-    ) -> list[ArtifactEvent]:
+    ) -> List[ArtifactEvent]:
         """Seal every producing artifact before execution terminalization."""
         validated_id = validate_execution_id(execution_id)
         record = read_execution_record(
@@ -1306,7 +1321,7 @@ class ExecutionStore:
         if not isinstance(artifact_files, dict):
             raise RuntimeError("execution artifact index is invalid")
         artifact_root = self.executions_dir / record.execution_id / "artifacts"
-        sealed: list[ArtifactEvent] = []
+        sealed: List[ArtifactEvent] = []
         for artifact_key, entry in artifact_files.items():
             if (
                 not isinstance(artifact_key, str)
@@ -1324,22 +1339,291 @@ class ExecutionStore:
             relative = Path(filename)
             if relative.name != filename or relative.suffix != ".jsonl":
                 raise RuntimeError("execution artifact index contains an invalid path")
+            artifact_path = artifact_root / filename
+            core_artifacts = (
+                artifact_key == "jarvis-core"
+                and entry["package_id"] == "jarvis-core"
+                and entry["package_name"] == "jarvis.core"
+            )
+            if core_artifacts:
+                sealed.extend(
+                    self._terminalize_pending_scheduler_artifact_paths(
+                        artifact_path,
+                        execution_id=validated_id,
+                    )
+                )
             sealed.extend(
-                ArtifactStore(artifact_root / filename).finalize_open(
+                ArtifactStore(artifact_path).finalize_open(
                     ArtifactState.FINALIZED
-                    if (
-                        artifact_key == "jarvis-core"
-                        and entry["package_id"] == "jarvis-core"
-                        and entry["package_name"] == "jarvis.core"
-                    )
-                    else (
-                        ArtifactState.FAILED
-                        if failed
-                        else ArtifactState.INCOMPLETE
-                    )
+                    if core_artifacts
+                    else (ArtifactState.FAILED if failed else ArtifactState.INCOMPLETE),
+                    state_without_location=(
+                        ArtifactState.INCOMPLETE if core_artifacts else None
+                    ),
                 )
             )
         return sealed
+
+    def _terminalize_pending_scheduler_artifact_paths(
+        self,
+        artifact_path: Path,
+        *,
+        execution_id: str,
+    ) -> List[ArtifactEvent]:
+        """Give unresolved scheduler logs coherent fail-closed terminal metadata."""
+        current = ArtifactStore(artifact_path).current()
+        reporter = ArtifactReporter(
+            package_name="jarvis.core",
+            package_id="jarvis-core",
+            execution_id=execution_id,
+            path=artifact_path,
+        )
+        revised: List[ArtifactEvent] = []
+        for event in current.values():
+            details_value = event.metadata.get(SCHEDULER_ARTIFACT_PATH_METADATA_KEY)
+            if details_value is None:
+                continue
+            if not isinstance(details_value, dict):
+                raise RuntimeError("scheduler artifact path metadata is invalid")
+            if details_value.get("status") != "pending":
+                continue
+            if (
+                set(details_value)
+                != {
+                    "schema_version",
+                    "provider",
+                    "path_pattern",
+                    "scope",
+                    "array_requested",
+                    "status",
+                }
+                or details_value.get("schema_version") != SCHEDULER_ARTIFACT_PATH_SCHEMA
+                or not isinstance(details_value.get("provider"), str)
+                or not isinstance(details_value.get("path_pattern"), str)
+                or details_value.get("scope") not in {"execution", "cluster"}
+                or not isinstance(details_value.get("array_requested"), bool)
+                or event.location is not None
+                or event.state is not ArtifactState.PRODUCING
+            ):
+                raise RuntimeError("pending scheduler artifact path is invalid")
+            details = dict(details_value)
+            details.update(
+                {
+                    "status": "incomplete",
+                    "diagnostic_code": SCHEDULER_ARTIFACT_PATH_UNRESOLVED_CODE,
+                    "diagnostic": SCHEDULER_ARTIFACT_PATH_TERMINAL_DIAGNOSTIC,
+                }
+            )
+            metadata = dict(event.metadata)
+            metadata[SCHEDULER_ARTIFACT_PATH_METADATA_KEY] = details
+            revised.append(
+                reporter.emit(
+                    artifact_id=event.artifact_id,
+                    logical_name=event.logical_name,
+                    kind=event.kind,
+                    role=event.role,
+                    structure=event.structure,
+                    ownership=event.ownership,
+                    state=ArtifactState.INCOMPLETE,
+                    location=None,
+                    media_type=event.media_type,
+                    format=event.format,
+                    size_bytes=event.size_bytes,
+                    checksum=event.checksum,
+                    message=SCHEDULER_ARTIFACT_PATH_TERMINAL_DIAGNOSTIC,
+                    metadata=metadata,
+                )
+            )
+        return revised
+
+    def resolve_scheduler_artifact_paths(
+        self,
+        execution_id: str,
+        *,
+        provider: str,
+        native_id: str,
+    ) -> List[ArtifactEvent]:
+        """Resolve pending core log paths through trusted scheduler identity.
+
+        Resolution is serialized with execution terminalization. A provider
+        that cannot prove one concrete path produces a terminal, location-less
+        ``INCOMPLETE`` revision instead of an invented filesystem reference.
+        Repeated submitter/runtime calls are idempotent.
+        """
+        from jarvis_cd.core.scheduler import resolve_scheduler_artifact_path
+
+        validated_id = validate_execution_id(execution_id)
+        validated_provider = _validated_text(
+            provider,
+            field_name="scheduler_provider",
+            maximum=64,
+        )
+        validated_native_id = _validated_text(
+            native_id,
+            field_name="scheduler_native_id",
+            maximum=256,
+        )
+        assert validated_provider is not None and validated_native_id is not None
+        if validated_provider == "slurm" and (
+            _SLURM_NATIVE_ID_PATTERN.fullmatch(validated_native_id) is None
+        ):
+            raise ValueError("SLURM native execution identity must be numeric")
+        execution_root = self.executions_dir / validated_id
+        with execution_transaction_lock(self.executions_dir, validated_id):
+            record = read_execution_record(
+                execution_root,
+                expected_execution_id=validated_id,
+            )
+            if record.pipeline_id != self.pipeline_id or record.mode != "scheduler":
+                raise RuntimeError(
+                    "scheduler artifact resolution identity did not match"
+                )
+            if record.scheduler_provider not in {None, validated_provider}:
+                raise RuntimeError("scheduler artifact provider identity did not match")
+            if record.scheduler_native_id != validated_native_id:
+                raise RuntimeError("scheduler artifact native identity did not match")
+            artifact_files = record.metadata.get("artifact_files", {})
+            if not isinstance(artifact_files, dict):
+                raise RuntimeError("execution artifact index is invalid")
+            entry = artifact_files.get("jarvis-core")
+            if entry is None:
+                return []
+            if (
+                not isinstance(entry, dict)
+                or set(entry) != {"filename", "package_id", "package_name"}
+                or entry.get("package_id") != "jarvis-core"
+                or entry.get("package_name") != "jarvis.core"
+                or not isinstance(entry.get("filename"), str)
+            ):
+                raise RuntimeError("JARVIS core artifact index is invalid")
+            filename = entry["filename"]
+            relative = Path(filename)
+            if relative.name != filename or relative.suffix != ".jsonl":
+                raise RuntimeError("JARVIS core artifact path is invalid")
+            artifact_path = execution_root / "artifacts" / filename
+            current = ArtifactStore(artifact_path).current()
+            pending: List[ArtifactEvent] = []
+            for event in current.values():
+                details_value = event.metadata.get(SCHEDULER_ARTIFACT_PATH_METADATA_KEY)
+                if details_value is None:
+                    continue
+                if not isinstance(details_value, dict):
+                    raise RuntimeError("scheduler artifact path metadata is invalid")
+                if details_value.get("provider") != validated_provider:
+                    raise RuntimeError("scheduler artifact path provider did not match")
+                status = details_value.get("status")
+                if status in {"resolved", "incomplete"}:
+                    continue
+                if (
+                    status == "pending"
+                    and event.state is ArtifactState.INCOMPLETE
+                    and record.terminal
+                    and event.location is None
+                ):
+                    continue
+                if (
+                    status != "pending"
+                    or set(details_value)
+                    != {
+                        "schema_version",
+                        "provider",
+                        "path_pattern",
+                        "scope",
+                        "array_requested",
+                        "status",
+                    }
+                    or details_value.get("schema_version")
+                    != SCHEDULER_ARTIFACT_PATH_SCHEMA
+                    or details_value.get("scope") not in {"execution", "cluster"}
+                    or not isinstance(details_value.get("path_pattern"), str)
+                    or not isinstance(details_value.get("array_requested"), bool)
+                    or event.location is not None
+                    or event.state is not ArtifactState.PRODUCING
+                ):
+                    raise RuntimeError("pending scheduler artifact path is invalid")
+                pending.append(event)
+            if not pending:
+                return []
+
+            reporter = ArtifactReporter(
+                package_name="jarvis.core",
+                package_id="jarvis-core",
+                execution_id=validated_id,
+                path=artifact_path,
+            )
+            revised: List[ArtifactEvent] = []
+            for event in pending:
+                details_value = event.metadata[SCHEDULER_ARTIFACT_PATH_METADATA_KEY]
+                assert isinstance(details_value, dict)
+                details = dict(details_value)
+                resolution = resolve_scheduler_artifact_path(
+                    validated_provider,
+                    str(details["path_pattern"]),
+                    native_id=validated_native_id,
+                    array_requested=bool(details["array_requested"]),
+                )
+                location = None
+                state = ArtifactState.INCOMPLETE
+                diagnostic_code = resolution.diagnostic_code
+                diagnostic = resolution.diagnostic
+                if resolution.path is not None:
+                    try:
+                        location = (
+                            ArtifactLocation.execution_relative(resolution.path)
+                            if details["scope"] == "execution"
+                            else ArtifactLocation.cluster_path(resolution.path)
+                        )
+                    except ValueError:
+                        diagnostic_code = "scheduler_artifact_path_invalid"
+                        diagnostic = (
+                            "JARVIS could not validate the resolved scheduler "
+                            "artifact path"
+                        )
+                    else:
+                        state = ArtifactState.PRODUCING
+                metadata = dict(event.metadata)
+                if location is None:
+                    diagnostic_code = (
+                        diagnostic_code or "scheduler_artifact_path_unresolved"
+                    )
+                    diagnostic = diagnostic or (
+                        "JARVIS could not resolve the scheduler artifact path"
+                    )
+                    details.update(
+                        {
+                            "status": "incomplete",
+                            "diagnostic_code": diagnostic_code,
+                            "diagnostic": diagnostic,
+                        }
+                    )
+                else:
+                    details.update(
+                        {
+                            "status": "resolved",
+                            "native_id": validated_native_id,
+                            "resolved_path": resolution.path,
+                        }
+                    )
+                metadata[SCHEDULER_ARTIFACT_PATH_METADATA_KEY] = details
+                revised.append(
+                    reporter.emit(
+                        artifact_id=event.artifact_id,
+                        logical_name=event.logical_name,
+                        kind=event.kind,
+                        role=event.role,
+                        structure=event.structure,
+                        ownership=event.ownership,
+                        state=state,
+                        location=location,
+                        media_type=event.media_type,
+                        format=event.format,
+                        size_bytes=event.size_bytes,
+                        checksum=event.checksum,
+                        message=(event.message if location is not None else diagnostic),
+                        metadata=metadata,
+                    )
+                )
+            return revised
 
     def update(
         self,
@@ -1606,12 +1890,19 @@ def activate_scheduler_execution(
     current = read_execution_record(root, expected_execution_id=validated_id)
     if current.mode != "scheduler":
         raise RuntimeError("scheduler activation cannot update a direct execution")
-    return ExecutionStore(root.parent, current.pipeline_id).activate_scheduler(
+    store = ExecutionStore(root.parent, current.pipeline_id)
+    store.activate_scheduler(
         validated_id,
         provider=provider,
         native_id=native_id,
         cluster=cluster,
     )
+    store.resolve_scheduler_artifact_paths(
+        validated_id,
+        provider=provider,
+        native_id=native_id,
+    )
+    return store.get(validated_id)
 
 
 def _main(argv: Optional[list[str]] = None) -> int:

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -6,6 +6,7 @@ Provides the consolidated Pipeline class that combines pipeline creation, loadin
 import os
 import hashlib
 import json
+import posixpath
 import re
 import shlex
 import shutil
@@ -33,6 +34,8 @@ from jarvis_cd.core.execution import (
     LEGACY_RECORD_SCHEMA,
     RECORD_NAME,
     RECORD_SCHEMA,
+    SCHEDULER_ARTIFACT_PATH_METADATA_KEY,
+    SCHEDULER_ARTIFACT_PATH_SCHEMA,
     ExecutionHandle,
     ExecutionArtifactSnapshot,
     ExecutionProgressSnapshot,
@@ -53,6 +56,15 @@ _EXECUTION_MARKER = RECORD_NAME
 _EXECUTION_MARKER_SCHEMA = LEGACY_RECORD_SCHEMA
 _EXECUTION_CLEANUP_SCHEMA = "jarvis.execution-cleanup.v1"
 _MAX_EXPLICIT_EXECUTION_CLEANUP = 1024
+
+
+def _absolute_scheduler_log_path(value: object) -> str:
+    """Return one lexical absolute path without expanding or resolving links."""
+    if not isinstance(value, str) or not value:
+        raise ValueError("scheduler output and error paths must be non-empty strings")
+    if os.name == "nt" and value.startswith("/"):
+        return posixpath.normpath(value)
+    return os.path.normpath(os.path.abspath(value))
 
 
 def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> Dict[str, Any]:
@@ -1261,6 +1273,10 @@ class Pipeline:
             scheduler_spec["hostfile"] = str(execution_root / "hostfile.txt")
             scheduler_spec.setdefault("output", str(execution_root / "stdout.log"))
             scheduler_spec.setdefault("error", str(execution_root / "stderr.log"))
+            for scheduler_key in ("output", "error"):
+                scheduler_spec[scheduler_key] = _absolute_scheduler_log_path(
+                    scheduler_spec[scheduler_key]
+                )
             snapshot_dir, input_dir, snapshot_sha256 = self._write_execution_snapshot(
                 execution_root,
                 scheduler_spec,
@@ -1294,58 +1310,6 @@ class Pipeline:
                     media_type="text/x-shellscript",
                     format_name="slurm-shell",
                 )
-            if submit:
-                for logical_name, scheduler_key in (
-                    ("stdout", "output"),
-                    ("stderr", "error"),
-                ):
-                    configured_path = Path(str(scheduler_spec[scheduler_key]))
-                    try:
-                        relative_path = configured_path.relative_to(
-                            execution_root
-                        ).as_posix()
-                    except ValueError:
-                        if not configured_path.is_absolute():
-                            configured_path = (Path.cwd() / configured_path).resolve()
-                        if os.name == "nt":
-                            continue
-                        self._core_artifact_reporter(
-                            store,
-                            resolved_execution_id,
-                        ).emit(
-                            logical_name=logical_name,
-                            kind="log",
-                            role=ArtifactRole.LOG,
-                            structure=ArtifactStructure.STREAM,
-                            ownership=ArtifactOwnership.SHARED,
-                            state=ArtifactState.PRODUCING,
-                            location=ArtifactLocation.cluster_path(
-                                configured_path.as_posix()
-                            ),
-                            media_type="text/plain",
-                            format="log",
-                            message=(
-                                "Scheduler output stream; content may grow until "
-                                "execution ends"
-                            ),
-                        )
-                        continue
-                    self._register_execution_file(
-                        store,
-                        resolved_execution_id,
-                        logical_name=logical_name,
-                        relative_path=relative_path,
-                        kind="log",
-                        role=ArtifactRole.LOG,
-                        structure=ArtifactStructure.STREAM,
-                        state=ArtifactState.PRODUCING,
-                        media_type="text/plain",
-                        format_name="log",
-                        message=(
-                            "Scheduler output stream; content may grow until "
-                            "execution ends"
-                        ),
-                    )
         except BaseException as exc:
             try:
                 store.update(
@@ -1416,6 +1380,30 @@ class Pipeline:
         if not submit:
             return store.get(resolved_execution_id).handle
 
+        try:
+            for logical_name, scheduler_key in (
+                ("stdout", "output"),
+                ("stderr", "error"),
+            ):
+                self._register_scheduler_log_artifact(
+                    store,
+                    resolved_execution_id,
+                    execution_root=execution_root,
+                    provider=sched.NAME,
+                    array_requested=sched.array_requested,
+                    logical_name=logical_name,
+                    configured_path=str(scheduler_spec[scheduler_key]),
+                )
+        except BaseException as exc:
+            self.last_submission["state"] = "pre_submit_failed"
+            self.last_submission["terminal"] = True
+            persist_stage_exception(
+                exc,
+                "scheduler_artifact_registration",
+                ambiguous=False,
+            )
+            raise
+
         from jarvis_cd.shell import Exec, LocalExecInfo
 
         argv = sched.submit_command(wait=wait)
@@ -1482,9 +1470,18 @@ class Pipeline:
             }
         )
         try:
+            provider_value = provider_metadata.get("provider")
+            native_id_value = provider_metadata.get("scheduler_job_id")
+            if not isinstance(provider_value, str) or not isinstance(
+                native_id_value, str
+            ):
+                raise RuntimeError(
+                    "scheduler provider returned incomplete artifact identity"
+                )
             self._update_execution_marker(execution_root)
             # Persist the provider-owned identity immediately after parsing;
-            # later logging or state decoration must not reopen the orphan gap.
+            # artifact resolution, logging, and state decoration must not
+            # reopen the orphan gap for an accepted scheduler job.
             self.save()
         except BaseException as exc:
             self.last_submission["state"] = "identity_persistence_failed"
@@ -1499,6 +1496,26 @@ class Pipeline:
                 "Scheduler accepted job "
                 f"{self.last_submission['scheduler_job_id']}, but JARVIS could not "
                 "persist its complete submission identity"
+            ) from exc
+        try:
+            store.resolve_scheduler_artifact_paths(
+                resolved_execution_id,
+                provider=provider_value,
+                native_id=native_id_value,
+            )
+        except BaseException as exc:
+            self.last_submission["state"] = "artifact_resolution_failed"
+            self.last_submission["terminal"] = False
+            persist_stage_exception(
+                exc,
+                "scheduler_artifact_resolution",
+                ambiguous=True,
+                accepted=True,
+            )
+            raise RuntimeError(
+                "Scheduler accepted job "
+                f"{self.last_submission['scheduler_job_id']} and JARVIS persisted "
+                "its identity, but scheduler artifact path resolution failed"
             ) from exc
         logger.pipeline(
             f"Scheduler job identity: {self.last_submission['scheduler_job_id']}"
@@ -2651,6 +2668,55 @@ class Pipeline:
             media_type=media_type,
             format=format_name,
             message=message,
+        )
+
+    def _register_scheduler_log_artifact(
+        self,
+        store: ExecutionStore,
+        execution_id: str,
+        *,
+        execution_root: Path,
+        provider: str,
+        array_requested: bool,
+        logical_name: str,
+        configured_path: str,
+    ) -> None:
+        """Register a location-less log pending provider-owned path resolution."""
+        path = Path(configured_path)
+        try:
+            path_pattern = path.relative_to(execution_root).as_posix()
+        except ValueError:
+            scope = "cluster"
+            path_pattern = (
+                posixpath.normpath(configured_path)
+                if os.name == "nt" and configured_path.startswith("/")
+                else path.as_posix()
+            )
+            ownership = ArtifactOwnership.SHARED
+        else:
+            scope = "execution"
+            ownership = ArtifactOwnership.EXECUTION
+        self._core_artifact_reporter(store, execution_id).emit(
+            logical_name=logical_name,
+            kind="log",
+            role=ArtifactRole.LOG,
+            structure=ArtifactStructure.STREAM,
+            ownership=ownership,
+            state=ArtifactState.PRODUCING,
+            location=None,
+            media_type="text/plain",
+            format="log",
+            message=("Scheduler output stream; content may grow until execution ends"),
+            metadata={
+                SCHEDULER_ARTIFACT_PATH_METADATA_KEY: {
+                    "schema_version": SCHEDULER_ARTIFACT_PATH_SCHEMA,
+                    "provider": provider,
+                    "path_pattern": path_pattern,
+                    "scope": scope,
+                    "array_requested": array_requested,
+                    "status": "pending",
+                }
+            },
         )
 
     def _register_execution_snapshot_artifacts(

--- a/jarvis_cd/core/scheduler.py
+++ b/jarvis_cd/core/scheduler.py
@@ -23,12 +23,26 @@ import re
 import shlex
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
 _DIRECTIVE_KEY = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
 _HOST_SUFFIX = re.compile(r"^[A-Za-z0-9_.:-]{1,64}$")
+_SLURM_NATIVE_ID = re.compile(r"^[0-9]{1,64}$")
+_UNRESOLVED_SLURM_ARTIFACT_PATH = (
+    "JARVIS could not prove one concrete path for this SLURM filename pattern"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulerArtifactPathResolution:
+    """One provider-owned attempt to resolve a scheduler filename pattern."""
+
+    path: Optional[str]
+    diagnostic_code: Optional[str] = None
+    diagnostic: Optional[str] = None
 
 
 def _validated_single_line(value: Any, *, field: str, limit: int = 4096) -> str:
@@ -191,6 +205,25 @@ class Scheduler:
         """
         raise NotImplementedError
 
+    @property
+    def array_requested(self) -> bool:
+        """Return whether this submission can create an array of jobs."""
+        return False
+
+    @classmethod
+    def resolve_artifact_path(
+        cls,
+        path_pattern: str,
+        *,
+        native_id: str,
+        array_requested: bool = False,
+    ) -> SchedulerArtifactPathResolution:
+        """Resolve one provider filename pattern from trusted submission identity."""
+        del native_id, array_requested
+        return SchedulerArtifactPathResolution(
+            path=_validated_single_line(path_pattern, field="artifact_path")
+        )
+
     def _pipeline_invocation(self) -> str:
         """Shell snippet that runs the pipeline once the hostfile is in
         place. Always points jarvis at the persisted YAML when one was
@@ -334,6 +367,13 @@ class SlurmScheduler(Scheduler):
                     ):
                         raise ValueError(
                             "scheduler.sbatch_args entries must be single --flag tokens"
+                        )
+                    if key == "sbatch_args" and rendered.split("=", 1)[0] in {
+                        "--error",
+                        "--output",
+                    }:
+                        raise ValueError(
+                            "scheduler.sbatch_args cannot override output or error"
                         )
                 continue
             if value is None or isinstance(value, bool):
@@ -491,9 +531,17 @@ class SlurmScheduler(Scheduler):
     def submit_command(self, wait: bool = False) -> List[str]:
         # ``--parsable`` is the provider boundary: stdout is a stable
         # ``job_id[;cluster]`` record rather than human-oriented text.
-        cmd = ["sbatch", "--parsable"]
+        # Command-line output/error options override both inherited SBATCH_*
+        # variables and script directives. Removing SBATCH_ARRAY_INX prevents
+        # an ambient shell variable from silently turning a scalar submission
+        # into an array whose log paths require task identity.
+        cmd = ["env", "-u", "SBATCH_ARRAY_INX", "sbatch", "--parsable"]
         if wait:
             cmd.append("--wait")
+        for key in ("output", "error"):
+            value = self.spec.get(key)
+            if value is not None:
+                cmd.append(f"--{key}={value}")
         cmd.append(str(self.script_path))
         return cmd
 
@@ -513,7 +561,99 @@ class SlurmScheduler(Scheduler):
             "identity_source": "scheduler_submit_api",
         }
 
+    @property
+    def array_requested(self) -> bool:
+        """Return whether spec or raw arguments request a SLURM job array."""
+        configured = self.spec.get("array")
+        if configured is not None and configured is not False and configured != "":
+            return True
+        return any(
+            str(argument).split("=", 1)[0] == "--array"
+            for argument in self.spec.get("sbatch_args", []) or []
+        )
 
-_SCHEDULERS: Dict[str, type] = {
+    @classmethod
+    def resolve_artifact_path(
+        cls,
+        path_pattern: str,
+        *,
+        native_id: str,
+        array_requested: bool = False,
+    ) -> SchedulerArtifactPathResolution:
+        """Resolve only SLURM path tokens proven by scalar submission output.
+
+        ``%j`` and width-qualified forms are bound to the parsed native job ID.
+        ``%%`` is a literal percent and is never reinterpreted. Other percent
+        replacement symbols depend on allocation or task state, so JARVIS
+        leaves their artifact location unset rather than guessing.
+        """
+        pattern = _validated_single_line(path_pattern, field="artifact_path")
+        if _SLURM_NATIVE_ID.fullmatch(native_id) is None:
+            raise ValueError("SLURM artifact resolution requires a numeric job ID")
+        if "\\" in pattern:
+            return SchedulerArtifactPathResolution(
+                path=None,
+                diagnostic_code="slurm_artifact_path_unresolved",
+                diagnostic=_UNRESOLVED_SLURM_ARTIFACT_PATH,
+            )
+        rendered: list[str] = []
+        index = 0
+        while index < len(pattern):
+            if pattern[index] != "%":
+                rendered.append(pattern[index])
+                index += 1
+                continue
+            if index + 1 < len(pattern) and pattern[index + 1] == "%":
+                rendered.append("%")
+                index += 2
+                continue
+            token_end = index + 1
+            while token_end < len(pattern) and "0" <= pattern[token_end] <= "9":
+                token_end += 1
+            if token_end >= len(pattern) or not pattern[token_end].isalpha():
+                return SchedulerArtifactPathResolution(
+                    path=None,
+                    diagnostic_code="slurm_artifact_path_unresolved",
+                    diagnostic=_UNRESOLVED_SLURM_ARTIFACT_PATH,
+                )
+            token = pattern[token_end]
+            if token != "j" or array_requested:
+                return SchedulerArtifactPathResolution(
+                    path=None,
+                    diagnostic_code="slurm_artifact_path_unresolved",
+                    diagnostic=_UNRESOLVED_SLURM_ARTIFACT_PATH,
+                )
+            width_text = pattern[index + 1 : token_end]
+            width = 0
+            if width_text:
+                width = min(int(width_text), 10)
+            rendered.append(native_id.zfill(width))
+            index = token_end + 1
+        return SchedulerArtifactPathResolution(path="".join(rendered))
+
+
+_SCHEDULERS: Dict[str, type[Scheduler]] = {
     SlurmScheduler.NAME: SlurmScheduler,
 }
+
+
+def resolve_scheduler_artifact_path(
+    provider: str,
+    path_pattern: str,
+    *,
+    native_id: str,
+    array_requested: bool = False,
+) -> SchedulerArtifactPathResolution:
+    """Resolve a filename pattern through its explicit scheduler provider."""
+    scheduler_type = _SCHEDULERS.get(provider.strip().lower())
+    if scheduler_type is None:
+        return SchedulerArtifactPathResolution(
+            path=None,
+            diagnostic_code="scheduler_artifact_provider_unsupported",
+            diagnostic="JARVIS has no artifact path resolver for this scheduler",
+        )
+    return scheduler_type.resolve_artifact_path(
+        path_pattern,
+        native_id=native_id,
+        array_requested=array_requested,
+    )

--- a/test/unit/ci/test_live_ares_gray_scott_probe.py
+++ b/test/unit/ci/test_live_ares_gray_scott_probe.py
@@ -36,6 +36,7 @@ assert_installed_package_source = PROBE._assert_installed_package_source
 assert_fresh_install_root = PROBE._assert_fresh_install_root
 configured_pipeline = PROBE._configured_pipeline
 assert_expected_release_artifact = PROBE._assert_expected_release_artifact
+execution_log_evidence = PROBE._execution_log_evidence
 
 
 def _record() -> dict[str, Any]:
@@ -163,6 +164,138 @@ def test_digest_and_atomic_report_are_deterministic(tmp_path: Path) -> None:
         "schema_version": REPORT_SCHEMA,
         "success": True,
     }
+
+
+def test_execution_log_evidence_reads_the_artifact_references(tmp_path: Path) -> None:
+    """The live gate proves the physical files named by JARVIS core artifacts."""
+    execution_root = tmp_path / "execution"
+    execution_root.mkdir()
+    stdout = execution_root / "stdout-41.log"
+    stderr = tmp_path / "cluster-stderr-41.log"
+    stdout.write_text("standard output\n", encoding="utf-8")
+    stderr.write_text("standard error\n", encoding="utf-8")
+    artifacts = {
+        "artifacts": [
+            {
+                "artifact_id": "art_0123456789abcdef0123456789abcdef",
+                "package_id": "jarvis-core",
+                "logical_name": "stdout",
+                "state": "finalized",
+                "location": {
+                    "kind": "execution_path",
+                    "value": stdout.relative_to(execution_root).as_posix(),
+                },
+            },
+            {
+                "artifact_id": "art_fedcba9876543210fedcba9876543210",
+                "package_id": "jarvis-core",
+                "logical_name": "stderr",
+                "state": "finalized",
+                "location": {
+                    "kind": "cluster_path",
+                    "value": stderr.as_posix(),
+                },
+            },
+        ]
+    }
+
+    evidence = execution_log_evidence(
+        {"execution_root_path": str(execution_root)},
+        artifacts,
+        "41",
+    )
+
+    assert evidence["stdout"]["path"] == str(stdout)
+    assert evidence["stdout"]["location"]["kind"] == "execution_path"
+    assert evidence["stderr"]["path"] == str(stderr)
+    assert evidence["stderr"]["artifact_state"] == "finalized"
+
+
+def test_execution_log_evidence_rejects_a_missing_referenced_file(
+    tmp_path: Path,
+) -> None:
+    """A plausible log name cannot pass unless its referenced file exists."""
+    execution_root = tmp_path / "execution"
+    execution_root.mkdir()
+    artifacts = {
+        "artifacts": [
+            {
+                "artifact_id": "art_0123456789abcdef0123456789abcdef",
+                "package_id": "jarvis-core",
+                "logical_name": "stdout",
+                "state": "finalized",
+                "location": {
+                    "kind": "execution_path",
+                    "value": "missing-41.log",
+                },
+            },
+            {
+                "artifact_id": "art_fedcba9876543210fedcba9876543210",
+                "package_id": "jarvis-core",
+                "logical_name": "stderr",
+                "state": "finalized",
+                "location": {
+                    "kind": "execution_path",
+                    "value": "also-missing-41.log",
+                },
+            },
+        ]
+    }
+
+    with pytest.raises(FileNotFoundError):
+        execution_log_evidence(
+            {"execution_root_path": str(execution_root)},
+            artifacts,
+            "41",
+        )
+
+
+@pytest.mark.parametrize(
+    ("location_value", "message"),
+    [
+        ("stdout-%j.log", "retains a Slurm token"),
+        ("stdout.log", "does not contain the execution scheduler-native ID"),
+    ],
+)
+def test_execution_log_evidence_rejects_unbound_log_locations(
+    tmp_path: Path,
+    location_value: str,
+    message: str,
+) -> None:
+    """The live gate binds every resolved log reference to its native job ID."""
+    execution_root = tmp_path / "execution"
+    execution_root.mkdir()
+    artifacts = {
+        "artifacts": [
+            {
+                "artifact_id": "art_0123456789abcdef0123456789abcdef",
+                "package_id": "jarvis-core",
+                "logical_name": "stdout",
+                "state": "finalized",
+                "location": {
+                    "kind": "execution_path",
+                    "value": location_value,
+                },
+            },
+            {
+                "artifact_id": "art_fedcba9876543210fedcba9876543210",
+                "package_id": "jarvis-core",
+                "logical_name": "stderr",
+                "state": "finalized",
+                "location": {
+                    "kind": "execution_path",
+                    "value": "stderr-41.log",
+                },
+            },
+        ]
+    }
+
+    with pytest.raises(RuntimeError, match=message):
+        execution_log_evidence(
+            {"execution_root_path": str(execution_root)},
+            artifacts,
+            "41",
+        )
 
 
 def test_release_artifact_assertions_bind_digest_and_version(tmp_path: Path) -> None:
@@ -340,6 +473,13 @@ def test_live_pipeline_uses_base_default_instead_of_private_package_argument(
     assert report["pipeline"]["package"]["effective_deploy_mode"] == "default"
     assert report["pipeline"]["package"]["config"]["checkpoint"] is True
     assert report["pipeline"]["package"]["config"]["checkpoint_freq"] == 1
+    scheduler = report["pipeline"]["scheduler"]
+    for key in ("output", "error"):
+        pattern = Path(scheduler[key])
+        assert pattern.is_absolute()
+        assert "%j" in pattern.name
+        assert pattern.parent == tmp_path / "scheduler-logs"
+        assert pattern.parent.is_dir()
     source_path = Path(report["pipeline"]["package"]["source_path"])
     assert source_path.parts[-4:] == ("builtin", "builtin", "gray_scott", "pkg.py")
 

--- a/test/unit/core/test_artifact_spi.py
+++ b/test/unit/core/test_artifact_spi.py
@@ -287,6 +287,31 @@ def test_store_is_durable_and_terminalization_seals_only_producing(
         assert path.stat().st_mode & 0o077 == 0
 
 
+def test_store_fail_closes_locationless_core_output_during_finalization(
+    tmp_path: Path,
+) -> None:
+    """A core producer cannot become finalized before its path is resolved."""
+    path = tmp_path / "locationless.jsonl"
+    store = ArtifactStore(path)
+    pending = replace(
+        _event(state=ArtifactState.PRODUCING),
+        location=None,
+    )
+    store.append(pending)
+
+    sealed = store.finalize_open(
+        ArtifactState.FINALIZED,
+        state_without_location=ArtifactState.INCOMPLETE,
+    )
+
+    assert len(sealed) == 1
+    assert sealed[0].artifact_id == pending.artifact_id
+    assert sealed[0].revision == 2
+    assert sealed[0].state is ArtifactState.INCOMPLETE
+    assert sealed[0].location is None
+    assert store.is_sealed() is True
+
+
 def test_store_rejects_identity_replay_torn_records_and_redirects(
     tmp_path: Path,
 ) -> None:

--- a/test/unit/core/test_scheduler_submission.py
+++ b/test/unit/core/test_scheduler_submission.py
@@ -15,10 +15,18 @@ from unittest.mock import Mock, patch
 import pytest
 import yaml
 
+from jarvis_cd.artifacts import ArtifactLocationKind, ArtifactState, ArtifactStore
 from jarvis_cd.core.config import Jarvis
-from jarvis_cd.core.execution import ExecutionStore
+from jarvis_cd.core.execution import (
+    SCHEDULER_ARTIFACT_PATH_TERMINAL_DIAGNOSTIC,
+    SCHEDULER_ARTIFACT_PATH_UNRESOLVED_CODE,
+    ExecutionStore,
+    activate_scheduler_execution,
+    finalize_execution,
+)
 from jarvis_cd.core.pipeline import (
     Pipeline,
+    _absolute_scheduler_log_path,
     _atomic_yaml_dump,
     _remove_execution_tree,
     _unlock_execution_input_for_cleanup,
@@ -70,6 +78,27 @@ def _real_pipeline(tmp_path: Path) -> Pipeline:
     return pipeline
 
 
+def _core_artifact_history(
+    pipeline: Pipeline,
+    execution_id: str,
+) -> list[Any]:
+    """Return the append-only JARVIS core artifact history for one execution."""
+    record = pipeline.get_execution(execution_id)
+    artifact_files = record.metadata["artifact_files"]
+    filename = artifact_files["jarvis-core"]["filename"]
+    execution_root = Path(record.metadata["submission"]["execution_root_path"])
+    return ArtifactStore(execution_root / "artifacts" / filename).read_all()
+
+
+def _current_artifacts_by_name(
+    pipeline: Pipeline,
+    execution_id: str,
+) -> dict[str, Any]:
+    """Index the current execution artifact snapshot by logical name."""
+    snapshot = pipeline.get_execution_artifacts(execution_id)
+    return {artifact.logical_name: artifact for artifact in snapshot.artifacts}
+
+
 def _load_real_scheduler_snapshot(
     jarvis_root: str,
     runtime_dir: str,
@@ -92,11 +121,17 @@ def test_slurm_submission_uses_and_parses_parsable_identity(tmp_path: Path) -> N
     )
 
     assert scheduler.submit_command() == [
+        "env",
+        "-u",
+        "SBATCH_ARRAY_INX",
         "sbatch",
         "--parsable",
         str(tmp_path / "submit.slurm"),
     ]
     assert scheduler.submit_command(wait=True) == [
+        "env",
+        "-u",
+        "SBATCH_ARRAY_INX",
         "sbatch",
         "--parsable",
         "--wait",
@@ -108,6 +143,138 @@ def test_slurm_submission_uses_and_parses_parsable_identity(tmp_path: Path) -> N
         "scheduler_cluster": "ares",
         "identity_source": "scheduler_submit_api",
     }
+
+
+@pytest.mark.parametrize(
+    ("pattern", "expected"),
+    [
+        ("/logs/job-%j.out", "/logs/job-7.out"),
+        ("/logs/job-%4j.out", "/logs/job-0007.out"),
+        ("/logs/job-%05j.out", "/logs/job-00007.out"),
+        ("/logs/job-%11j.out", "/logs/job-0000000007.out"),
+        ("/logs/job-%0001j.out", "/logs/job-7.out"),
+        ("/logs/rate-100%%-%%j.out", "/logs/rate-100%-%j.out"),
+        ("/logs/static.out", "/logs/static.out"),
+    ],
+)
+def test_slurm_resolves_only_proven_scalar_artifact_paths(
+    pattern: str,
+    expected: str,
+) -> None:
+    resolution = SlurmScheduler.resolve_artifact_path(pattern, native_id="7")
+
+    assert resolution.path == expected
+    assert resolution.diagnostic_code is None
+    assert resolution.diagnostic is None
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "/logs/job-%.out",
+        "/logs/job-%42",
+        "/logs/job-%4.out",
+        "/logs/job-%N.out",
+        "/logs/job-%²j.out",
+        "/logs/job-%４j.out",
+        r"/logs/job-\%j.out",
+    ],
+)
+def test_slurm_leaves_unprovable_artifact_paths_unresolved(pattern: str) -> None:
+    resolution = SlurmScheduler.resolve_artifact_path(pattern, native_id="7")
+
+    assert resolution.path is None
+    assert resolution.diagnostic_code == "slurm_artifact_path_unresolved"
+    assert isinstance(resolution.diagnostic, str) and resolution.diagnostic
+
+
+def test_slurm_array_identity_does_not_claim_one_percent_j_path() -> None:
+    resolution = SlurmScheduler.resolve_artifact_path(
+        "/logs/job-%j.out",
+        native_id="7",
+        array_requested=True,
+    )
+
+    assert resolution.path is None
+    assert resolution.diagnostic_code == "slurm_artifact_path_unresolved"
+
+
+@pytest.mark.parametrize(
+    "argument",
+    [
+        "--output",
+        "--output=/tmp/other.out",
+        "--error",
+        "--error=/tmp/other.err",
+    ],
+)
+def test_slurm_rejects_raw_log_directive_overrides(
+    tmp_path: Path,
+    argument: str,
+) -> None:
+    with pytest.raises(ValueError, match="cannot override output or error"):
+        SlurmScheduler(
+            {"name": "slurm", "sbatch_args": [argument]},
+            tmp_path,
+        )
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {"name": "slurm", "array": "1-2"},
+        {"name": "slurm", "array": 0},
+        {"name": "slurm", "sbatch_args": ["--array=1-2"]},
+    ],
+)
+def test_slurm_detects_spec_and_raw_array_requests(
+    tmp_path: Path,
+    spec: dict[str, Any],
+) -> None:
+    assert SlurmScheduler(spec, tmp_path).array_requested is True
+
+
+def test_scheduler_log_path_normalization_does_not_resolve_symlinks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Relative scheduler paths become lexical absolutes without filesystem IO."""
+    monkeypatch.chdir(tmp_path)
+    configured = os.path.join("linked-logs", "stdout-%j.log")
+    expected = os.path.normpath(os.path.abspath(configured))
+
+    with patch(
+        "jarvis_cd.core.pipeline.Path.resolve",
+        side_effect=AssertionError("scheduler paths must not dereference symlinks"),
+    ):
+        resolved = _absolute_scheduler_log_path(configured)
+
+    assert resolved == expected
+
+
+def test_slurm_submission_cli_overrides_inherited_log_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "logs" / "stdout-%j.log"
+    error = tmp_path / "logs" / "stderr-%j.log"
+    monkeypatch.setenv("SBATCH_OUTPUT", "/forged/stdout.log")
+    monkeypatch.setenv("SBATCH_ERROR", "/forged/stderr.log")
+    scheduler = SlurmScheduler(
+        {"name": "slurm", "output": str(output), "error": str(error)},
+        tmp_path,
+    )
+
+    assert scheduler.submit_command() == [
+        "env",
+        "-u",
+        "SBATCH_ARRAY_INX",
+        "sbatch",
+        "--parsable",
+        f"--output={output}",
+        f"--error={error}",
+        str(tmp_path / "submit.slurm"),
+    ]
 
 
 def test_jarvis_root_environment_selects_scheduler_configuration(
@@ -545,6 +712,7 @@ def test_pipeline_persists_provider_owned_submission_identity(tmp_path: Path) ->
     script_path.write_text("#!/bin/bash\n", encoding="utf-8")
     scheduler = SimpleNamespace(
         NAME="slurm",
+        array_requested=False,
         hostfile=str(tmp_path / "hostfile.txt"),
         write_script=Mock(return_value=script_path),
         submit_command=Mock(return_value=["sbatch", "--parsable", str(script_path)]),
@@ -610,6 +778,377 @@ def test_pipeline_persists_provider_owned_submission_identity(tmp_path: Path) ->
     assert saved_submissions[2]["scheduler_job_id"] == "24680"
     assert saved_submissions[2]["submitted"] is True
     assert saved_submissions[3]["state"] == "submitted"
+
+
+def test_scheduler_log_artifacts_resolve_same_ids_and_finalize(
+    tmp_path: Path,
+) -> None:
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.scheduler.update(
+        {
+            "output": "/cluster/logs/stdout-%j.log",
+            "error": "/cluster/logs/stderr-100%%.log",
+        }
+    )
+    pipeline.save()
+    execution = SimpleNamespace(
+        exit_code={"localhost": 0},
+        stdout={"localhost": "24680;ares\n"},
+        stderr={"localhost": ""},
+    )
+    executor = Mock()
+    executor.run.return_value = execution
+
+    with patch("jarvis_cd.shell.Exec", return_value=executor) as execute:
+        handle = pipeline.submit(
+            submit=True,
+            wait=False,
+            execution_id="resolved-logs",
+        )
+
+    command = execute.call_args.args[0]
+    assert "--output=/cluster/logs/stdout-%j.log" in command
+    assert "--error=/cluster/logs/stderr-100%%.log" in command
+    current = _current_artifacts_by_name(pipeline, handle.execution_id)
+    stdout = current["stdout"]
+    stderr = current["stderr"]
+    assert stdout.state is ArtifactState.PRODUCING
+    assert stdout.revision == 2
+    assert stdout.location is not None
+    assert stdout.location.kind is ArtifactLocationKind.CLUSTER_PATH
+    assert stdout.location.value == "/cluster/logs/stdout-24680.log"
+    assert stderr.state is ArtifactState.PRODUCING
+    assert stderr.revision == 2
+    assert stderr.location is not None
+    assert stderr.location.value == "/cluster/logs/stderr-100%.log"
+    for artifact in (stdout, stderr):
+        path_metadata = artifact.metadata["jarvis_scheduler_path"]
+        assert path_metadata["status"] == "resolved"
+        assert path_metadata["native_id"] == "24680"
+
+    history = _core_artifact_history(pipeline, handle.execution_id)
+    for logical_name in ("stdout", "stderr"):
+        revisions = [event for event in history if event.logical_name == logical_name]
+        assert [event.revision for event in revisions] == [1, 2]
+        assert revisions[0].artifact_id == revisions[1].artifact_id
+        assert revisions[0].location is None
+
+    pipeline._execution_store().update(
+        handle.execution_id,
+        state="completed",
+        terminal=True,
+        return_code=0,
+    )
+    finalized = _current_artifacts_by_name(pipeline, handle.execution_id)
+    assert finalized["stdout"].state is ArtifactState.FINALIZED
+    assert finalized["stdout"].revision == 3
+    assert finalized["stderr"].state is ArtifactState.FINALIZED
+    assert finalized["stderr"].revision == 3
+
+
+@pytest.mark.parametrize(
+    "scheduler_update",
+    [
+        {"output": "/cluster/logs/stdout-%N.log"},
+        {"output": "/cluster/logs/stdout-%j.log", "array": "1-2"},
+    ],
+)
+def test_unprovable_scheduler_log_path_is_incomplete_without_failing_workload(
+    tmp_path: Path,
+    scheduler_update: dict[str, str],
+) -> None:
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.scheduler.update(scheduler_update)
+    pipeline.scheduler["error"] = "/cluster/logs/stderr-%j.log"
+    pipeline.save()
+    executor = Mock()
+    executor.run.return_value = SimpleNamespace(
+        exit_code={"localhost": 0},
+        stdout={"localhost": "31415;ares\n"},
+        stderr={"localhost": ""},
+    )
+
+    with patch("jarvis_cd.shell.Exec", return_value=executor):
+        handle = pipeline.submit(
+            submit=True,
+            wait=False,
+            execution_id=f"unresolved-{len(scheduler_update)}",
+        )
+
+    assert handle.refresh().state == "submitted"
+    current = _current_artifacts_by_name(pipeline, handle.execution_id)
+    stdout = current["stdout"]
+    assert stdout.state is ArtifactState.INCOMPLETE
+    assert stdout.location is None
+    assert stdout.revision == 2
+    metadata = stdout.metadata["jarvis_scheduler_path"]
+    assert metadata["status"] == "incomplete"
+    assert metadata["diagnostic_code"] == "slurm_artifact_path_unresolved"
+    assert isinstance(metadata["diagnostic"], str) and metadata["diagnostic"]
+
+    pipeline._execution_store().update(
+        handle.execution_id,
+        state="completed",
+        terminal=True,
+        return_code=0,
+    )
+    terminal = _current_artifacts_by_name(pipeline, handle.execution_id)
+    assert terminal["stdout"].state is ArtifactState.INCOMPLETE
+    assert terminal["stdout"].revision == 2
+    assert terminal["stderr"].state is (
+        ArtifactState.INCOMPLETE
+        if "array" in scheduler_update
+        else ArtifactState.FINALIZED
+    )
+
+
+def test_fast_wait_runtime_resolution_is_idempotent_for_submitter(
+    tmp_path: Path,
+) -> None:
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.scheduler.update(
+        {
+            "output": "/cluster/logs/stdout-%j.log",
+            "error": "/cluster/logs/stderr-%j.log",
+        }
+    )
+    pipeline.save()
+    executor = Mock()
+
+    def finish_before_sbatch_returns() -> SimpleNamespace:
+        submission = pipeline.last_submission
+        execution_root = Path(submission["execution_root_path"])
+        execution_id = str(submission["execution_id"])
+        activate_scheduler_execution(
+            execution_root,
+            execution_id,
+            "slurm",
+            "41",
+            "ares",
+        )
+        finalize_execution(execution_root, execution_id, 0)
+        return SimpleNamespace(
+            exit_code={"localhost": 0},
+            stdout={"localhost": "41;ares\n"},
+            stderr={"localhost": ""},
+        )
+
+    executor.run.side_effect = finish_before_sbatch_returns
+    with patch("jarvis_cd.shell.Exec", return_value=executor):
+        handle = pipeline.submit(
+            submit=True,
+            wait=True,
+            execution_id="fast-wait",
+        )
+
+    assert handle.refresh().state == "completed"
+    history = _core_artifact_history(pipeline, handle.execution_id)
+    for logical_name in ("stdout", "stderr"):
+        revisions = [event for event in history if event.logical_name == logical_name]
+        assert [event.revision for event in revisions] == [1, 2, 3]
+        assert len({event.artifact_id for event in revisions}) == 1
+        assert revisions[-1].state is ArtifactState.FINALIZED
+        assert revisions[-1].location is not None
+        assert revisions[-1].location.value.endswith(f"-{41}.log")
+
+
+def test_runtime_unresolved_log_does_not_fail_fast_wait_workload(
+    tmp_path: Path,
+) -> None:
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.scheduler.update(
+        {
+            "output": "/cluster/logs/stdout-%N.log",
+            "error": "/cluster/logs/stderr-%j.log",
+        }
+    )
+    pipeline.save()
+    executor = Mock()
+
+    def finish_before_sbatch_returns() -> SimpleNamespace:
+        submission = pipeline.last_submission
+        execution_root = Path(submission["execution_root_path"])
+        execution_id = str(submission["execution_id"])
+        activate_scheduler_execution(
+            execution_root,
+            execution_id,
+            "slurm",
+            "52",
+            "ares",
+        )
+        completed = finalize_execution(execution_root, execution_id, 0)
+        assert completed.state == "completed"
+        return SimpleNamespace(
+            exit_code={"localhost": 0},
+            stdout={"localhost": "52;ares\n"},
+            stderr={"localhost": ""},
+        )
+
+    executor.run.side_effect = finish_before_sbatch_returns
+    with patch("jarvis_cd.shell.Exec", return_value=executor):
+        handle = pipeline.submit(
+            submit=True,
+            wait=True,
+            execution_id="runtime-unresolved",
+        )
+
+    assert handle.refresh().state == "completed"
+    current = _current_artifacts_by_name(pipeline, handle.execution_id)
+    stdout = current["stdout"]
+    stderr = current["stderr"]
+    assert stdout.state is ArtifactState.INCOMPLETE
+    assert stdout.location is None
+    assert stdout.revision == 2
+    assert stdout.metadata["jarvis_scheduler_path"]["diagnostic_code"] == (
+        "slurm_artifact_path_unresolved"
+    )
+    assert stderr.state is ArtifactState.FINALIZED
+    assert stderr.location is not None
+    assert stderr.location.value == "/cluster/logs/stderr-52.log"
+    assert stderr.revision == 3
+
+
+def test_scheduler_artifact_resolution_rejects_mismatched_bound_identity(
+    tmp_path: Path,
+) -> None:
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.scheduler["output"] = "/cluster/logs/stdout-%j.log"
+    pipeline.save()
+    executor = Mock()
+    executor.run.side_effect = RuntimeError("submit transport disappeared")
+    with patch("jarvis_cd.shell.Exec", return_value=executor):
+        with pytest.raises(RuntimeError, match="submit transport disappeared"):
+            pipeline.submit(
+                submit=True,
+                execution_id="identity-mismatch",
+            )
+
+    store = pipeline._execution_store()
+    with pytest.raises(RuntimeError, match="native identity did not match"):
+        store.resolve_scheduler_artifact_paths(
+            "identity-mismatch",
+            provider="slurm",
+            native_id="41",
+        )
+    store.activate_scheduler(
+        "identity-mismatch",
+        provider="slurm",
+        native_id="41",
+        cluster="ares",
+    )
+    with pytest.raises(RuntimeError, match="native identity did not match"):
+        store.resolve_scheduler_artifact_paths(
+            "identity-mismatch",
+            provider="slurm",
+            native_id="42",
+        )
+
+    stdout = _current_artifacts_by_name(pipeline, "identity-mismatch")["stdout"]
+    assert stdout.state is ArtifactState.PRODUCING
+    assert stdout.location is None
+    assert stdout.revision == 1
+
+
+def test_artifact_resolution_failure_preserves_durable_submission_identity(
+    tmp_path: Path,
+) -> None:
+    """An artifact-store failure cannot reopen the accepted-job orphan gap."""
+    pipeline = _real_pipeline(tmp_path)
+    pipeline.scheduler["output"] = "/cluster/logs/stdout-%j.log"
+    pipeline.save()
+    executor = Mock()
+    executor.run.return_value = SimpleNamespace(
+        exit_code={"localhost": 0},
+        stdout={"localhost": "41;ares\n"},
+        stderr={"localhost": ""},
+    )
+    observed_identity: dict[str, str | None] = {}
+
+    def fail_after_identity(
+        store: ExecutionStore,
+        execution_id: str,
+        *,
+        provider: str,
+        native_id: str,
+    ) -> list[Any]:
+        record = store.get(execution_id)
+        observed_identity.update(
+            {
+                "provider": record.scheduler_provider,
+                "native_id": record.scheduler_native_id,
+                "cluster": record.cluster,
+            }
+        )
+        raise RuntimeError("artifact store failed")
+
+    with patch("jarvis_cd.shell.Exec", return_value=executor):
+        with patch.object(
+            ExecutionStore,
+            "resolve_scheduler_artifact_paths",
+            new=fail_after_identity,
+        ):
+            with pytest.raises(RuntimeError, match="persisted its identity"):
+                pipeline.submit(
+                    submit=True,
+                    execution_id="artifact-resolution-failure",
+                )
+
+    assert observed_identity == {
+        "provider": "slurm",
+        "native_id": "41",
+        "cluster": "ares",
+    }
+    record = pipeline.get_execution("artifact-resolution-failure")
+    assert record.state == "unknown"
+    assert record.submitted is True
+    assert record.terminal is False
+    assert record.scheduler_provider == "slurm"
+    assert record.scheduler_native_id == "41"
+    assert record.cluster == "ares"
+    assert record.metadata["failure_stage"] == "scheduler_artifact_resolution"
+    stdout = _current_artifacts_by_name(
+        pipeline,
+        "artifact-resolution-failure",
+    )["stdout"]
+    assert stdout.revision == 1
+    assert stdout.state is ArtifactState.PRODUCING
+    assert stdout.location is None
+    assert stdout.metadata["jarvis_scheduler_path"]["status"] == "pending"
+
+
+def test_rejected_submission_terminalizes_pending_logs_with_diagnostic(
+    tmp_path: Path,
+) -> None:
+    """Terminal sealing replaces pending scheduler-log claims with diagnostics."""
+    pipeline = _real_pipeline(tmp_path)
+    executor = Mock()
+    executor.run.return_value = SimpleNamespace(
+        exit_code={"localhost": 1},
+        stdout={"localhost": ""},
+        stderr={"localhost": "sbatch: submission rejected"},
+    )
+
+    with patch("jarvis_cd.shell.Exec", return_value=executor):
+        with pytest.raises(RuntimeError, match="Scheduler submission failed"):
+            pipeline.submit(
+                submit=True,
+                execution_id="rejected-submission",
+            )
+
+    record = pipeline.get_execution("rejected-submission")
+    assert record.state == "failed"
+    assert record.terminal is True
+    current = _current_artifacts_by_name(pipeline, "rejected-submission")
+    for logical_name in ("stdout", "stderr"):
+        event = current[logical_name]
+        assert event.revision == 2
+        assert event.state is ArtifactState.INCOMPLETE
+        assert event.location is None
+        assert event.message == SCHEDULER_ARTIFACT_PATH_TERMINAL_DIAGNOSTIC
+        metadata = event.metadata["jarvis_scheduler_path"]
+        assert metadata["status"] == "incomplete"
+        assert metadata["diagnostic_code"] == (SCHEDULER_ARTIFACT_PATH_UNRESOLVED_CODE)
+        assert metadata["diagnostic"] == (SCHEDULER_ARTIFACT_PATH_TERMINAL_DIAGNOSTIC)
 
 
 def test_pre_submit_persistence_failure_is_terminal_without_scheduler_effect(
@@ -681,6 +1220,7 @@ def test_pipeline_never_accepts_unstructured_submission_stdout(tmp_path: Path) -
     script_path = tmp_path / "submit.slurm"
     scheduler = SimpleNamespace(
         NAME="slurm",
+        array_requested=False,
         hostfile=str(tmp_path / "hostfile.txt"),
         write_script=Mock(return_value=script_path),
         submit_command=Mock(return_value=["sbatch", "--parsable", str(script_path)]),
@@ -716,6 +1256,7 @@ def test_pipeline_preserves_waited_job_identity_when_workload_fails(
     script_path = tmp_path / "submit.slurm"
     scheduler = SimpleNamespace(
         NAME="slurm",
+        array_requested=False,
         hostfile=str(tmp_path / "hostfile.txt"),
         write_script=Mock(return_value=script_path),
         submit_command=Mock(
@@ -767,6 +1308,7 @@ def test_pipeline_records_true_submission_failure_without_job_identity(
     script_path = tmp_path / "submit.slurm"
     scheduler = SimpleNamespace(
         NAME="slurm",
+        array_requested=False,
         hostfile=str(tmp_path / "hostfile.txt"),
         write_script=Mock(return_value=script_path),
         submit_command=Mock(return_value=["sbatch", "--parsable", str(script_path)]),


### PR DESCRIPTION
## Summary

- make JARVIS own the effective absolute Slurm stdout/stderr options and prevent ambient scheduler variables from changing scalar log semantics
- register scheduler logs without guessed locations, then resolve them only after the exact scheduler-native identity is durably bound
- preserve the same artifact IDs through pending, resolved, and finalized revisions; mark array-dependent or unsupported patterns incomplete with stable diagnostics without failing the workload
- strengthen the Gray-Scott Ares gate so it submits `%j` paths and physically verifies the finalized artifact references

## Validation

- `uv run --frozen pytest -q test/unit/ -ra`: 1,216 passed plus 3 subtests, zero skips/failures
- focused scheduler/artifact/probe tests: 114 passed
- exact workflow Pyright: 0 errors; Ruff check/format, lock check, and `git diff --check`: clean
- exact-version candidate wheel SHA-256: `7a90a533324572dbcc291572f7cb26267070b5023ec354648b599b792a2b7836`
- Ares Gray-Scott acceptance: Slurm job `21876`, 67/67 assertions, finalized concrete `stdout-21876.log` and `stderr-21876.log` artifact references verified on disk
- machine report SHA-256: `29ea8fd9daa6b6ebc03df2e789449679d0f5ea6a38cdbdbbee1694b86118db8d`