### PR TITLE
feat: add durable service runtimes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,6 @@ include builtin/builtin/gray_scott/artifacts.py
 include builtin/builtin/gray_scott/progress.py
 include builtin/builtin/lammps/artifacts.py
 include builtin/builtin/paraview/artifacts.py
+include builtin/builtin/paraview/service.py
+include builtin/builtin/paraview/service_http.py
+include builtin/builtin/paraview/service_supervisor.py

--- a/builtin/builtin/paraview/README.md
+++ b/builtin/builtin/paraview/README.md
@@ -1,5 +1,40 @@
-# paraview 
-ParaView is an open-source data analysis and visualization application designed to handle large-scale scientific datasets. It supports interactive and batch processing for visualizing complex simulations and performing quantitative analysis.
+# ParaView
 
+`builtin.paraview` supports three explicit modes:
 
+- `server` launches `pvserver` for a native ParaView client;
+- `batch` launches a user/site-owned `pvbatch` script and records structured
+  progress and generated artifacts;
+- `service` launches the generic JARVIS HTTP/SSE runtime for relay and agentic
+  clients.
 
+Service mode requires a `jarvis.dataset-descriptor.v1` JSON document. The
+descriptor contains intrinsic identity, bounded source members, optional time
+and array facts, and a SHA-256 fingerprint. It cannot contain a camera,
+threshold, filter, colormap, or scene recipe. Those are explicit versioned
+commands sent to the running service.
+
+`inspect_selection` supports either an explicit point/cell index or a
+normalized human viewport drag box. Viewport selection is resolved by
+ParaView's real visible-cell picker and returns bounded IDs, an explicit empty
+result, or an explicit unsupported result; it never guesses a world-space
+location from browser coordinates.
+
+```bash
+jarvis ppl append paraview \
+  mode=service \
+  dataset_descriptor=/site/descriptors/asteroid-subset.json \
+  pvpython_bin=/opt/ParaView/bin/pvpython \
+  service_bind_host=127.0.0.1 \
+  service_advertise_host=127.0.0.1 \
+  nprocs=1
+jarvis ppl submit +no_wait +json
+jarvis execution service-runtimes <execution-id> +json
+```
+
+JARVIS reports the actual service host/port and lifecycle through the durable
+execution handle. A relay owns authenticated desktop routing; direct SSH
+tunnel instructions are intentionally not part of the package contract.
+
+See [`docs/service-runtimes.md`](../../../docs/service-runtimes.md) for the
+exact report, state, command, SSE, and artifact schemas.

--- a/builtin/builtin/paraview/USE.MD
+++ b/builtin/builtin/paraview/USE.MD
@@ -1,33 +1,16 @@
-## how to use it with Jarvis in cluster
+# Using `builtin.paraview`
 
-### set the environment
-load paraview and openmpi
-```
-module load paraview
-spack load openmpi
+Use `server` mode for a native ParaView client, `batch` for a site-owned
+`pvbatch` script, and `service` for an execution-owned agent/relay runtime.
 
-```
-### create jarvis pipeline
-```
-jarvis ppl create paraview
-jarvis ppl env build
-jarvis ppl append paraview port_id=11111
-```
-Note: If the connect has issues, try change the port_id first, for example change the port_id to 11112. 
-### run the application
-```
-jarvis ppl run
+The service itself publishes cluster endpoints only. Obtain desktop-local URLs
+through the configured relay/gateway instead of creating an undocumented SSH
+tunnel. Query the durable JARVIS handle to discover readiness:
+
+```bash
+jarvis execution service-runtimes <execution-id> \
+  --pipeline-id <pipeline> +json
 ```
 
-## How to use it in local computer 
-###
-Run this command in local terminal:
-```
-ssh -N -L 11111:localhost:11111 your_id@ares.cs.iit.edu
-```
-In local paraview, following these instructions:
-File -> connect </br>
-![Simulation Diagram](server_setup.png)
-
-Once coonect the server, The remote paraview are good to go.
-
+See [the service-runtime reference](../../../docs/service-runtimes.md) for
+configuration and command examples.

--- a/builtin/builtin/paraview/pkg.py
+++ b/builtin/builtin/paraview/pkg.py
@@ -1,7 +1,8 @@
-"""Launch generic ParaView servers or user-supplied pvbatch scripts."""
+"""Launch generic ParaView servers, services, or user-supplied batch scripts."""
 
 import os
 import shlex
+import sys
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
@@ -33,7 +34,7 @@ class Paraview(Application):
         return [
             {
                 "name": "mode",
-                "msg": "ParaView mode: server or batch",
+                "msg": "ParaView mode: server, service, or batch",
                 "type": str,
                 "default": "server",
             },
@@ -97,6 +98,48 @@ class Paraview(Application):
                 "type": str,
                 "default": "",
             },
+            {
+                "name": "dataset_descriptor",
+                "msg": "Service-mode dataset descriptor JSON or JSON file path",
+                "type": str,
+                "default": "",
+            },
+            {
+                "name": "pvpython_bin",
+                "msg": "Path or command used to launch the ParaView service",
+                "type": str,
+                "default": "pvpython",
+            },
+            {
+                "name": "pvpython_options",
+                "msg": "Options passed to pvpython in service mode",
+                "type": str,
+                "default": "",
+            },
+            {
+                "name": "service_bind_host",
+                "msg": "Loopback interface on which the private service listens",
+                "type": str,
+                "default": "127.0.0.1",
+            },
+            {
+                "name": "service_advertise_host",
+                "msg": "Loopback host recorded for the colocated relay connector",
+                "type": str,
+                "default": "127.0.0.1",
+            },
+            {
+                "name": "service_port",
+                "msg": "HTTP service port (zero selects an ephemeral port)",
+                "type": int,
+                "default": 0,
+            },
+            {
+                "name": "service_startup_timeout",
+                "msg": "Seconds allowed for the real HTTP health probe",
+                "type": int,
+                "default": 120,
+            },
         ]
 
     def _configure(self, **kwargs):
@@ -121,6 +164,9 @@ class Paraview(Application):
         environment = dict(self.mod_env)
         environment.setdefault("JARVIS_PACKAGE_NAME", "builtin.paraview")
         environment.setdefault("JARVIS_PACKAGE_ID", str(self.pkg_id or "paraview"))
+        if mode == "service":
+            self._start_service(environment)
+            return
         reporter_path = self._stage_progress_reporter()
         reporter_dir = str(reporter_path.parent)
         current_pythonpath = environment.get("PYTHONPATH", "")
@@ -176,6 +222,140 @@ class Paraview(Application):
         ).run()
         self._raise_for_exec_failure(result, operation="ParaView server")
 
+    def _start_service(self, environment: dict[str, str]) -> None:
+        """Launch a durable HTTP/SSE service through the JARVIS supervisor."""
+        from jarvis_cd.service_runtime import (
+            DatasetDescriptor,
+            ServiceRuntimeReporter,
+        )
+
+        if self._configured_int("nprocs", 1) != 1:
+            raise ValueError("ParaView service mode currently requires nprocs=1")
+        advertise_host = cast(
+            str,
+            self.config.get("service_advertise_host") or "127.0.0.1",
+        )
+        bind_host = cast(
+            str,
+            self.config.get("service_bind_host") or "127.0.0.1",
+        )
+        if bind_host != "127.0.0.1" or advertise_host != "127.0.0.1":
+            raise ValueError(
+                "ParaView service mode is loopback-only; the relay connector "
+                "must run inside the owned execution allocation"
+            )
+        execution_id = environment.get("JARVIS_EXECUTION_ID")
+        runtime_path = environment.get("JARVIS_SERVICE_RUNTIME_PATH")
+        artifact_path = environment.get("JARVIS_ARTIFACT_PATH")
+        if not execution_id or not runtime_path or not artifact_path:
+            raise RuntimeError(
+                "ParaView service mode requires a durable JARVIS execution binding"
+            )
+        descriptor_value = cast(
+            str,
+            self.config.get("dataset_descriptor") or "",
+        )
+        descriptor = self._load_dataset_descriptor(
+            descriptor_value,
+            DatasetDescriptor,
+        )
+        if not self.shared_dir:
+            raise RuntimeError("ParaView package has no shared directory")
+        service_instance_id = ServiceRuntimeReporter.new_service_instance_id()
+        service_root = (
+            Path(self.shared_dir)
+            / ".jarvis-service"
+            / execution_id
+            / service_instance_id
+        )
+        service_root.mkdir(parents=True, exist_ok=False, mode=0o700)
+        if os.name != "nt":
+            service_root.chmod(0o700)
+        package_root = Path(__file__).resolve().parent
+        service_script = self._stage_payload(
+            package_root / "service.py",
+            service_root / "service.py",
+        )
+        self._stage_payload(
+            package_root / "service_http.py",
+            service_root / "service_http.py",
+        )
+        supervisor = self._stage_payload(
+            package_root / "service_supervisor.py",
+            service_root / "service_supervisor.py",
+        )
+        descriptor_path = service_root / "dataset-descriptor.json"
+        self._write_private_payload(
+            descriptor_path,
+            (descriptor.to_json() + "\n").encode("utf-8"),
+        )
+        output_dir = service_root / "output"
+        output_dir.mkdir(mode=0o700)
+        service_port = self._configured_int("service_port", 0)
+        if not 0 <= service_port <= 65535:
+            raise ValueError("service_port must be between 0 and 65535")
+        startup_timeout = self._configured_int("service_startup_timeout", 120)
+        pvpython_bin = os.path.expandvars(
+            cast(str, self.config.get("pvpython_bin") or "pvpython")
+        )
+        pvpython_options = cast(str, self.config.get("pvpython_options") or "")
+        command = [
+            sys.executable,
+            str(supervisor),
+            "--service-script",
+            str(service_script),
+            "--descriptor",
+            str(descriptor_path),
+            "--output-dir",
+            str(output_dir),
+            "--pvpython-bin",
+            pvpython_bin,
+            "--pvpython-options",
+            pvpython_options,
+            "--bind-host",
+            bind_host,
+            "--advertise-host",
+            advertise_host,
+            "--port",
+            str(service_port),
+            "--startup-timeout",
+            str(startup_timeout),
+            "--service-instance-id",
+            service_instance_id,
+        ]
+        environment.update(
+            {
+                "JARVIS_ARTIFACT_TRANSPORT": "sidecar",
+                "JARVIS_PROGRESS_TRANSPORT": "sidecar",
+                "JARVIS_SERVICE_INSTANCE_ID": service_instance_id,
+            }
+        )
+        self.mod_env.update(environment)
+        line_callback = self.runtime_line_callback()
+        result = Exec(
+            " ".join(shlex.quote(item) for item in command),
+            self._execution_info(environment, line_callback),
+        ).run()
+        self._raise_for_exec_failure(result, operation="ParaView service")
+
+    @staticmethod
+    def _load_dataset_descriptor(
+        configured: str,
+        descriptor_type: type[Any],
+    ) -> Any:
+        """Load one strict intrinsic descriptor from JSON or a JSON file."""
+        rendered = os.path.expandvars(configured).strip()
+        if not rendered:
+            raise ValueError("ParaView service mode requires dataset_descriptor")
+        if rendered.startswith("{"):
+            payload = rendered
+        else:
+            path = Path(rendered).expanduser()
+            if not path.is_file() or path.stat().st_size > 256 * 1024:
+                raise ValueError("dataset_descriptor file is missing or too large")
+            payload = path.read_text(encoding="utf-8")
+        return descriptor_type.from_json(payload)
+
     def _stage_progress_reporter(self) -> Path:
         """Copy the standalone reporter into the package's mounted shared path."""
         if not self.shared_dir:
@@ -214,13 +394,50 @@ class Paraview(Application):
             temporary.unlink(missing_ok=True)
         return target
 
+    @classmethod
+    def _stage_payload(cls, source: Path, target: Path) -> Path:
+        """Atomically stage one package-owned runtime module."""
+        cls._write_private_payload(target, source.read_bytes())
+        return target
+
+    @staticmethod
+    def _write_private_payload(target: Path, payload: bytes) -> None:
+        """Durably replace a private package-owned service file."""
+        descriptor, temporary_name = tempfile.mkstemp(
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+        )
+        temporary = Path(temporary_name)
+        descriptor_open = True
+        try:
+            try:
+                stream = os.fdopen(descriptor, "wb")
+            except BaseException:
+                os.close(descriptor)
+                descriptor_open = False
+                raise
+            descriptor_open = False
+            with stream:
+                stream.write(payload)
+                stream.flush()
+                os.fsync(stream.fileno())
+            temporary.chmod(0o600)
+            os.replace(temporary, target)
+            if os.name != "nt":
+                target.chmod(0o600)
+        finally:
+            if descriptor_open:
+                os.close(descriptor)
+            temporary.unlink(missing_ok=True)
+
     def _execution_info(
         self,
         environment: dict[str, str],
         line_callback: Callable[[str, str], None] | None,
     ) -> ExecInfo:
         """Select direct execution for one rank and MPI for multiple ranks."""
-        nprocs = int(self.config["nprocs"])
+        nprocs = self._configured_int("nprocs", 1)
         common: dict[str, Any] = {
             "env": environment,
             "cwd": os.path.expandvars(cast(str, self.config.get("cwd") or "")) or None,
@@ -247,6 +464,16 @@ class Paraview(Application):
             ),
             **common,
         )
+
+    def _configured_int(self, name: str, default: int) -> int:
+        """Return one package integer without accepting booleans or objects."""
+        value = self.config.get(name, default)
+        if isinstance(value, bool) or not isinstance(value, (int, str)):
+            raise ValueError(f"ParaView {name} must be an integer")
+        try:
+            return int(value)
+        except ValueError as exc:
+            raise ValueError(f"ParaView {name} must be an integer") from exc
 
     @staticmethod
     def _raise_for_exec_failure(result: Any, *, operation: str) -> None:

--- a/builtin/builtin/paraview/service.py
+++ b/builtin/builtin/paraview/service.py
@@ -1,0 +1,1341 @@
+"""Real ParaView backend for the generic JARVIS HTTP/SSE service."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib
+import json
+import math
+import os
+import secrets
+import signal
+import stat
+import tempfile
+import threading
+import time
+from contextlib import contextmanager
+from http import HTTPStatus
+from pathlib import Path, PurePosixPath
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Sequence, Tuple, cast
+
+try:
+    from .service_http import CommandError, ServiceStateController, create_server
+except ImportError:  # Staged pvpython scripts are executed outside a package.
+    from service_http import CommandError, ServiceStateController, create_server
+
+MAX_FILTERS = 16
+MAX_ARTIFACTS = 128
+MAX_SELECTION_ELEMENTS = 100_000_000_000
+MAX_SELECTION_RESULTS = 256
+MAX_EXPORTED_ARTIFACT_BYTES = 128 * 1024 * 1024
+LIVE_VIEW_SIZE = (960, 540)
+ARTIFACT_PREFIX = "JARVIS_ARTIFACT "
+
+
+class ParaViewBackend:
+    """Drive a real ``paraview.simple`` pipeline from semantic commands."""
+
+    def __init__(
+        self,
+        *,
+        descriptor: Mapping[str, Any],
+        output_dir: Path,
+        service_instance_id: str,
+    ) -> None:
+        """Open the descriptor members and initialize an automatic view."""
+        try:
+            servermanager = importlib.import_module("paraview.servermanager")
+            simple = importlib.import_module("paraview.simple")
+            vtk = importlib.import_module("paraview.vtk")
+        except ImportError as exc:
+            raise RuntimeError(
+                "ParaView service mode requires pvpython with paraview.simple"
+            ) from exc
+        self.simple = simple
+        self.servermanager = servermanager
+        self.vtk = vtk
+        self.descriptor = _validate_descriptor(descriptor)
+        self.output_dir = output_dir.resolve()
+        self.output_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if os.name != "nt":
+            self.output_dir.chmod(0o700)
+        self.service_instance_id = service_instance_id
+        locations = [member["location"] for member in self.descriptor["members"]]
+        missing = [location for location in locations if not Path(location).exists()]
+        if missing:
+            raise FileNotFoundError(
+                "dataset descriptor member does not exist: " + missing[0]
+            )
+        source_input: object = locations[0] if len(locations) == 1 else locations
+        self.reader = simple.OpenDataFile(source_input)
+        if self.reader is None:
+            raise RuntimeError("ParaView could not open the dataset descriptor members")
+        self.reader.UpdatePipeline()
+        self.active_source = self.reader
+        self.view = simple.GetActiveViewOrCreate("RenderView")
+        self.view.ViewSize = list(LIVE_VIEW_SIZE)
+        self.display = simple.Show(self.active_source, self.view)
+        simple.ResetCamera(self.view)
+        simple.Render(self.view)
+        self._filters: List[Dict[str, Any]] = []
+        self._active_field: Optional[Dict[str, Any]] = None
+        self._colormap: Optional[Dict[str, Any]] = None
+        self._selection: Optional[Dict[str, Any]] = None
+        self._artifacts: List[Dict[str, Any]] = []
+        self._arrays = self._discover_arrays()
+        self._bounds = self._discover_bounds()
+        self._timesteps = self._discover_timesteps()
+        self._timestep_index = 0
+
+    def dataset_state(self) -> Dict[str, Any]:
+        """Return immutable identity plus facts discovered from ParaView."""
+        return {
+            "descriptor": _json_copy(self.descriptor),
+            "discovery": {
+                "arrays": _json_copy_list(self._arrays),
+                "bounds": list(self._bounds) if self._bounds is not None else None,
+                "timestep_values": list(self._timesteps),
+            },
+        }
+
+    def pipeline_state(self) -> Dict[str, Any]:
+        """Return the exact state currently applied to the ParaView pipeline."""
+        current_value = (
+            self._timesteps[self._timestep_index] if self._timesteps else None
+        )
+        return {
+            "timestep": {
+                "index": self._timestep_index,
+                "value": current_value,
+                "count": len(self._timesteps),
+            },
+            "active_field": _json_copy_optional(self._active_field),
+            "filters": _json_copy_list(self._filters),
+            "colormap": _json_copy_optional(self._colormap),
+            "camera": self._camera_state(),
+            "selection": _json_copy_optional(self._selection),
+            "artifacts": _json_copy_list(self._artifacts),
+        }
+
+    def execute(
+        self,
+        operation: str,
+        arguments: Mapping[str, Any],
+        command_id: str,
+    ) -> Dict[str, Any]:
+        """Apply one allowlisted operation to real ParaView state."""
+        handlers = {
+            "set_timestep": self._set_timestep,
+            "set_active_field": self._set_active_field,
+            "set_camera": self._set_camera,
+            "apply_filter": self._apply_filter,
+            "set_colormap": self._set_colormap,
+            "inspect_selection": self._inspect_selection,
+            "export_artifact": self._export_artifact,
+        }
+        handler = handlers.get(operation)
+        if handler is None:
+            raise CommandError("unsupported_operation", "operation is not supported")
+        return handler(arguments, command_id)
+
+    def render_png(self) -> bytes:
+        """Render current state to a bounded temporary PNG."""
+        descriptor, temporary_name = tempfile.mkstemp(
+            dir=self.output_dir,
+            prefix=".live-frame.",
+            suffix=".png",
+        )
+        os.close(descriptor)
+        path = Path(temporary_name)
+        try:
+            self.simple.SaveScreenshot(
+                str(path),
+                self.view,
+                ImageResolution=list(LIVE_VIEW_SIZE),
+            )
+            payload = path.read_bytes()
+            if len(payload) > 32 * 1024 * 1024:
+                raise RuntimeError("rendered live frame exceeds 32 MiB")
+            return payload
+        finally:
+            path.unlink(missing_ok=True)
+
+    def _set_timestep(
+        self,
+        arguments: Mapping[str, Any],
+        _command_id: str,
+    ) -> Dict[str, Any]:
+        _require_fields(arguments, {"index"}, "set_timestep")
+        index = _bounded_int(arguments.get("index"), "index", minimum=0)
+        if not self._timesteps:
+            if index != 0:
+                raise CommandError(
+                    "timestep_out_of_range",
+                    "static datasets only expose timestep index 0",
+                )
+            value = None
+        else:
+            if index >= len(self._timesteps):
+                raise CommandError(
+                    "timestep_out_of_range",
+                    "timestep index exceeds the discovered series",
+                )
+            value = self._timesteps[index]
+            self.view.ViewTime = value
+            self.reader.UpdatePipeline(value)
+            self.active_source.UpdatePipeline(value)
+        self._timestep_index = index
+        self.simple.Render(self.view)
+        return {"timestep": {"index": index, "value": value}}
+
+    def _set_active_field(
+        self,
+        arguments: Mapping[str, Any],
+        _command_id: str,
+    ) -> Dict[str, Any]:
+        _require_fields(arguments, {"name", "association"}, "set_active_field")
+        name = _bounded_text(arguments.get("name"), "name", maximum=512)
+        association = _association(arguments.get("association"))
+        match = next(
+            (
+                array
+                for array in self._arrays
+                if array["name"] == name and array["association"] == association
+            ),
+            None,
+        )
+        if match is None:
+            raise CommandError(
+                "field_not_found",
+                "active field is not present in discovered ParaView arrays",
+            )
+        paraview_association = "POINTS" if association == "point" else "CELLS"
+        self.simple.ColorBy(self.display, (paraview_association, name))
+        self.display.RescaleTransferFunctionToDataRange(True, False)
+        active_field = {
+            "name": name,
+            "association": association,
+            "components": match["components"],
+        }
+        self.simple.Render(self.view)
+        self._active_field = active_field
+        # A transfer-function preset is bound to the previously active array.
+        # Changing arrays must not claim that preset is still applied.
+        self._colormap = None
+        return {"active_field": dict(self._active_field)}
+
+    def _set_camera(
+        self,
+        arguments: Mapping[str, Any],
+        _command_id: str,
+    ) -> Dict[str, Any]:
+        allowed = {"position", "focal_point", "view_up", "parallel_scale"}
+        if not arguments or set(arguments) - allowed:
+            raise CommandError(
+                "invalid_arguments",
+                "set_camera accepts position, focal_point, view_up, and parallel_scale",
+            )
+        previous = self._camera_state()
+        candidate = _json_copy(previous)
+        if "position" in arguments:
+            candidate["position"] = _vector3(arguments["position"], "position")
+        if "focal_point" in arguments:
+            candidate["focal_point"] = _vector3(arguments["focal_point"], "focal_point")
+        if "view_up" in arguments:
+            candidate["view_up"] = _vector3(arguments["view_up"], "view_up")
+        if "parallel_scale" in arguments:
+            scale = _finite_number(arguments["parallel_scale"], "parallel_scale")
+            if scale <= 0:
+                raise CommandError(
+                    "invalid_arguments",
+                    "parallel_scale must be positive",
+                )
+            candidate["parallel_scale"] = scale
+        _validate_camera_geometry(candidate)
+        try:
+            _apply_camera_state(self.view, candidate)
+            self.simple.Render(self.view)
+        except Exception as exc:
+            try:
+                _apply_camera_state(self.view, previous)
+                self.simple.Render(self.view)
+            except Exception as rollback_error:
+                raise RuntimeError(
+                    "set_camera failed and the previous camera could not be restored: "
+                    + str(rollback_error)
+                ) from exc
+            raise
+        return {"camera": self._camera_state()}
+
+    def _apply_filter(
+        self,
+        arguments: Mapping[str, Any],
+        command_id: str,
+    ) -> Dict[str, Any]:
+        _require_fields(arguments, {"type", "parameters"}, "apply_filter")
+        if len(self._filters) >= MAX_FILTERS:
+            raise CommandError("filter_limit", "the service filter limit was reached")
+        filter_type = _bounded_text(arguments.get("type"), "type", maximum=64)
+        parameters = arguments.get("parameters")
+        if not isinstance(parameters, dict):
+            raise CommandError(
+                "invalid_arguments", "filter parameters must be an object"
+            )
+        origin: Optional[List[float]] = None
+        normal: Optional[List[float]] = None
+        threshold_name: Optional[str] = None
+        threshold_association: Optional[str] = None
+        threshold_lower: Optional[float] = None
+        threshold_upper: Optional[float] = None
+        if filter_type == "slice":
+            _require_fields(parameters, {"origin", "normal"}, "slice")
+            origin = _vector3(parameters["origin"], "origin")
+            normal = _nonzero_vector3(parameters["normal"], "normal")
+            recorded_parameters = {
+                "origin": list(origin),
+                "normal": list(normal),
+            }
+        elif filter_type == "clip":
+            _require_fields(parameters, {"origin", "normal"}, "clip")
+            origin = _vector3(parameters["origin"], "origin")
+            normal = _nonzero_vector3(parameters["normal"], "normal")
+            recorded_parameters = {
+                "origin": list(origin),
+                "normal": list(normal),
+            }
+        elif filter_type == "threshold":
+            _require_fields(
+                parameters,
+                {"name", "association", "lower", "upper"},
+                "threshold",
+            )
+            threshold_name = _bounded_text(parameters.get("name"), "name", maximum=512)
+            threshold_association = _association(parameters.get("association"))
+            threshold_lower = _finite_number(parameters.get("lower"), "lower")
+            threshold_upper = _finite_number(parameters.get("upper"), "upper")
+            if threshold_lower > threshold_upper:
+                raise CommandError(
+                    "invalid_arguments", "threshold lower cannot exceed upper"
+                )
+            if not any(
+                array["name"] == threshold_name
+                and array["association"] == threshold_association
+                for array in self._arrays
+            ):
+                raise CommandError(
+                    "field_not_found", "threshold field was not discovered"
+                )
+            recorded_parameters = {
+                "name": threshold_name,
+                "association": threshold_association,
+                "lower": threshold_lower,
+                "upper": threshold_upper,
+            }
+        else:
+            raise CommandError(
+                "unsupported_filter",
+                "filter type must be slice, clip, or threshold",
+            )
+        filter_id = "flt_" + hashlib.sha256(command_id.encode("utf-8")).hexdigest()[:24]
+        record = {
+            "filter_id": filter_id,
+            "type": filter_type,
+            "parameters": recorded_parameters,
+        }
+        previous_source = self.active_source
+        previous_camera = self._camera_state()
+        proxy: Any = None
+        new_display: Any = None
+        try:
+            if filter_type == "slice":
+                assert origin is not None and normal is not None
+                proxy = self.simple.Slice(Input=previous_source)
+                proxy.SliceType.Origin = origin
+                proxy.SliceType.Normal = normal
+            elif filter_type == "clip":
+                assert origin is not None and normal is not None
+                proxy = self.simple.Clip(Input=previous_source)
+                proxy.ClipType.Origin = origin
+                proxy.ClipType.Normal = normal
+            else:
+                assert (
+                    threshold_name is not None
+                    and threshold_association is not None
+                    and threshold_lower is not None
+                    and threshold_upper is not None
+                )
+                proxy = self.simple.Threshold(Input=previous_source)
+                proxy.Scalars = [
+                    "POINTS" if threshold_association == "point" else "CELLS",
+                    threshold_name,
+                ]
+                proxy.LowerThreshold = threshold_lower
+                proxy.UpperThreshold = threshold_upper
+            proxy.UpdatePipeline()
+            new_arrays = self._discover_arrays(proxy)
+            new_bounds = self._discover_bounds(proxy)
+            new_display = self.simple.Show(proxy, self.view)
+            self.simple.Hide(previous_source, self.view)
+            _apply_camera_state(self.view, previous_camera)
+            self.simple.Render(self.view)
+        except Exception as exc:
+            try:
+                if proxy is not None and new_display is not None:
+                    self.simple.Hide(proxy, self.view)
+                self.simple.Show(previous_source, self.view)
+                if proxy is not None:
+                    self.simple.Delete(proxy)
+                _apply_camera_state(self.view, previous_camera)
+                self.simple.Render(self.view)
+            except Exception as rollback_error:
+                raise RuntimeError(
+                    "apply_filter failed and the previous pipeline could not be restored: "
+                    + str(rollback_error)
+                ) from exc
+            raise
+        self.active_source = proxy
+        self.display = new_display
+        self._filters.append(record)
+        self._arrays = new_arrays
+        self._bounds = new_bounds
+        self._active_field = None
+        self._colormap = None
+        self._selection = None
+        return {"filter": _json_copy(record)}
+
+    def _set_colormap(
+        self,
+        arguments: Mapping[str, Any],
+        _command_id: str,
+    ) -> Dict[str, Any]:
+        _require_fields(arguments, {"preset", "invert"}, "set_colormap")
+        if self._active_field is None:
+            raise CommandError(
+                "active_field_required",
+                "set_colormap requires an active scalar field",
+            )
+        preset = _bounded_text(arguments.get("preset"), "preset", maximum=256)
+        invert = arguments.get("invert")
+        if not isinstance(invert, bool):
+            raise CommandError("invalid_arguments", "invert must be boolean")
+        lookup = self.simple.GetColorTransferFunction(self._active_field["name"])
+        if not lookup.ApplyPreset(preset, True):
+            raise CommandError(
+                "preset_not_found", "ParaView colormap preset was not found"
+            )
+        if invert:
+            lookup.InvertTransferFunction()
+        self.display.RescaleTransferFunctionToDataRange(True, False)
+        self._colormap = {"preset": preset, "invert": invert}
+        self.simple.Render(self.view)
+        return {"colormap": dict(self._colormap)}
+
+    def _inspect_selection(
+        self,
+        arguments: Mapping[str, Any],
+        _command_id: str,
+    ) -> Dict[str, Any]:
+        if set(arguments) == {"association", "index"}:
+            return self._inspect_element_selection(arguments)
+        if set(arguments) == {"viewport"}:
+            return self._inspect_viewport_selection(arguments.get("viewport"))
+        raise CommandError(
+            "invalid_arguments",
+            "inspect_selection requires either association/index or viewport",
+        )
+
+    def _inspect_element_selection(
+        self,
+        arguments: Mapping[str, Any],
+    ) -> Dict[str, Any]:
+        """Select one real point or cell by its ParaView element index."""
+        association = _association(arguments.get("association"))
+        index = _bounded_int(
+            arguments.get("index"),
+            "index",
+            minimum=0,
+            maximum=MAX_SELECTION_ELEMENTS,
+        )
+        information = self.active_source.GetDataInformation()
+        count = (
+            information.GetNumberOfPoints()
+            if association == "point"
+            else information.GetNumberOfCells()
+        )
+        if index >= count:
+            raise CommandError(
+                "selection_out_of_range",
+                "selection index exceeds the real ParaView element count",
+            )
+        field_type = "POINT" if association == "point" else "CELL"
+        self.simple.SelectIDs(
+            IDs=[0, index],
+            FieldType=field_type,
+            Source=self.active_source,
+        )
+        self._selection = {
+            "selector": "element",
+            "status": "selected",
+            "association": association,
+            "index": index,
+            "element_count": count,
+            "selected_count": 1,
+            "returned_count": 1,
+            "truncated": False,
+            "ids": [{"process_id": 0, "element_id": index}],
+            "reason": None,
+        }
+        self.simple.Render(self.view)
+        return {"selection": dict(self._selection)}
+
+    def _inspect_viewport_selection(self, value: object) -> Dict[str, Any]:
+        """Select visible cells through ParaView's real render-view picker."""
+        viewport = _viewport(value)
+        pixel_rectangle = _viewport_pixel_rectangle(viewport, LIVE_VIEW_SIZE)
+        selected_representations = self.vtk.vtkCollection()
+        selection_sources = self.vtk.vtkCollection()
+        try:
+            self.simple.Render(self.view)
+            self.view.SelectSurfaceCells(
+                pixel_rectangle,
+                selected_representations,
+                selection_sources,
+                0,
+            )
+            ids, selected_count, unsupported_reason = _surface_selection_ids(
+                selected_representations=selected_representations,
+                selection_sources=selection_sources,
+                active_source=self.active_source,
+                servermanager=self.servermanager,
+                limit=MAX_SELECTION_RESULTS,
+            )
+            self.simple.SelectSurfaceCells(
+                Rectangle=pixel_rectangle,
+                View=self.view,
+            )
+            self.simple.Render(self.view)
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            ids = []
+            selected_count = None
+            unsupported_reason = "paraview_surface_selection_unavailable"
+
+        if unsupported_reason is not None:
+            status = "unsupported"
+        elif selected_count == 0:
+            status = "empty"
+        else:
+            status = "selected"
+        self._selection = {
+            "selector": "viewport",
+            "status": status,
+            "association": "cell",
+            "viewport": viewport,
+            "pixel_rectangle": pixel_rectangle,
+            "selected_count": selected_count,
+            "returned_count": len(ids),
+            "truncated": (selected_count is not None and selected_count > len(ids)),
+            "ids": ids,
+            "reason": unsupported_reason,
+        }
+        return {"selection": _json_copy(self._selection)}
+
+    def _export_artifact(
+        self,
+        arguments: Mapping[str, Any],
+        command_id: str,
+    ) -> Dict[str, Any]:
+        _require_fields(
+            arguments,
+            {"filename", "width", "height"},
+            "export_artifact",
+        )
+        filename = _safe_relative_png(arguments.get("filename"))
+        width = _bounded_int(arguments.get("width"), "width", minimum=64, maximum=4096)
+        height = _bounded_int(
+            arguments.get("height"), "height", minimum=64, maximum=4096
+        )
+        if len(self._artifacts) >= MAX_ARTIFACTS:
+            raise CommandError(
+                "artifact_limit", "the service artifact limit was reached"
+            )
+        candidate_path = self.output_dir / filename
+        output_parent = candidate_path.parent.resolve()
+        if (
+            output_parent != self.output_dir
+            and self.output_dir not in output_parent.parents
+        ):
+            raise CommandError("invalid_arguments", "artifact path escapes output root")
+        # Resolve parent directories, but preserve the leaf itself so a caller
+        # cannot smuggle a symlink target through Path.resolve().
+        output_path = output_parent / candidate_path.name
+        payload = _write_unique_png(
+            simple=self.simple,
+            view=self.view,
+            output_path=output_path,
+            width=width,
+            height=height,
+        )
+        digest = hashlib.sha256(payload).hexdigest()
+        artifact_id = "art_" + secrets.token_urlsafe(18)
+        try:
+            artifact = _append_artifact(
+                artifact_id=artifact_id,
+                logical_name=filename.as_posix(),
+                path=output_path,
+                size_bytes=len(payload),
+                sha256=digest,
+                service_instance_id=self.service_instance_id,
+                command_id=command_id,
+            )
+        except Exception as exc:
+            try:
+                output_path.unlink()
+                _fsync_directory(output_path.parent)
+            except OSError as cleanup_error:
+                raise RuntimeError(
+                    "artifact publication failed and the exported PNG could not be removed: "
+                    + str(cleanup_error)
+                ) from exc
+            raise
+        self._artifacts.append(artifact)
+        return {"artifact": _json_copy(artifact)}
+
+    def _discover_arrays(self, source: Any = None) -> List[Dict[str, Any]]:
+        selected_source = self.active_source if source is None else source
+        information = selected_source.GetDataInformation()
+        arrays: List[Dict[str, Any]] = []
+        for association, attribute_information in (
+            ("point", information.GetPointDataInformation()),
+            ("cell", information.GetCellDataInformation()),
+        ):
+            for index in range(min(attribute_information.GetNumberOfArrays(), 256)):
+                array = attribute_information.GetArrayInformation(index)
+                if array is None or not array.GetName():
+                    continue
+                arrays.append(
+                    {
+                        "name": str(array.GetName()),
+                        "association": association,
+                        "components": int(array.GetNumberOfComponents()),
+                        "units": None,
+                    }
+                )
+        return arrays
+
+    def _discover_bounds(
+        self,
+        source: Any = None,
+    ) -> Optional[Tuple[float, float, float, float, float, float]]:
+        selected_source = self.active_source if source is None else source
+        values = selected_source.GetDataInformation().GetBounds()
+        if values is None or len(values) != 6:
+            return None
+        bounds = tuple(float(value) for value in values)
+        if not all(math.isfinite(value) for value in bounds):
+            return None
+        return cast(Tuple[float, float, float, float, float, float], bounds)
+
+    def _discover_timesteps(self) -> List[float]:
+        values = getattr(self.reader, "TimestepValues", None)
+        if values:
+            return [float(value) for value in values]
+        descriptor_values = [
+            member.get("timestep")
+            for member in self.descriptor["members"]
+            if member.get("timestep") is not None
+        ]
+        return [float(value) for value in descriptor_values]
+
+    def _camera_state(self) -> Dict[str, Any]:
+        return {
+            "position": [float(value) for value in self.view.CameraPosition],
+            "focal_point": [float(value) for value in self.view.CameraFocalPoint],
+            "view_up": [float(value) for value in self.view.CameraViewUp],
+            "parallel_scale": float(self.view.CameraParallelScale),
+        }
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Run the real ParaView service until a scheduler or operator stops it."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--descriptor", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--bind-host", required=True)
+    parser.add_argument("--port", required=True, type=int)
+    parser.add_argument("--execution-id", required=True)
+    parser.add_argument("--service-instance-id", required=True)
+    args = parser.parse_args(argv)
+    descriptor_path = Path(args.descriptor)
+    descriptor = _load_json_file(descriptor_path)
+    backend = ParaViewBackend(
+        descriptor=descriptor,
+        output_dir=Path(args.output_dir),
+        service_instance_id=args.service_instance_id,
+    )
+    controller = ServiceStateController(
+        backend=backend,
+        execution_id=args.execution_id,
+        service_instance_id=args.service_instance_id,
+    )
+    server = create_server(args.bind_host, args.port, controller)
+
+    def stop(_signum: int, _frame: object) -> None:
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    try:
+        server.serve_forever(poll_interval=0.25)
+    finally:
+        server.server_close()
+    return 0
+
+
+def _validate_descriptor(value: Mapping[str, Any]) -> Dict[str, Any]:
+    expected = {
+        "schema_version",
+        "dataset_id",
+        "kind",
+        "format",
+        "members",
+        "arrays",
+        "bounds",
+        "fingerprint",
+        "source_artifact",
+    }
+    if set(value) != expected or value.get("schema_version") != (
+        "jarvis.dataset-descriptor.v1"
+    ):
+        raise ValueError("dataset descriptor does not match the JARVIS schema")
+    forbidden = {
+        "camera",
+        "threshold",
+        "filter",
+        "filters",
+        "colormap",
+        "scene",
+        "recipe",
+        "active_field",
+    }
+    if set(value) & forbidden:
+        raise ValueError("dataset descriptor cannot contain visualization choices")
+    members = value.get("members")
+    if not isinstance(members, list) or not 1 <= len(members) <= 512:
+        raise ValueError("dataset descriptor requires 1-512 members")
+    for expected_index, member in enumerate(members):
+        if not isinstance(member, dict) or set(member) - {
+            "index",
+            "location",
+            "timestep",
+        }:
+            raise ValueError("dataset member schema is invalid")
+        if member.get("index") != expected_index:
+            raise ValueError("dataset member indexes must be contiguous")
+        _normalized_absolute_path(member.get("location"))
+    fingerprint = value.get("fingerprint")
+    if (
+        not isinstance(fingerprint, dict)
+        or set(fingerprint) != {"algorithm", "digest"}
+        or fingerprint.get("algorithm") != "sha256"
+        or not isinstance(fingerprint.get("digest"), str)
+    ):
+        raise ValueError("dataset descriptor fingerprint is invalid")
+    intrinsic = {key: item for key, item in value.items() if key != "fingerprint"}
+    calculated = hashlib.sha256(
+        json.dumps(
+            intrinsic,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    if fingerprint["digest"] != calculated:
+        raise ValueError(
+            "dataset fingerprint does not match the canonical intrinsic descriptor"
+        )
+    return _json_copy(value)
+
+
+def _load_json_file(path: Path) -> Dict[str, Any]:
+    if not path.is_file() or path.stat().st_size > 256 * 1024:
+        raise ValueError("dataset descriptor file is missing or too large")
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise ValueError("dataset descriptor file is not valid JSON") from exc
+    if not isinstance(value, dict):
+        raise ValueError("dataset descriptor file must contain an object")
+    return cast(Dict[str, Any], value)
+
+
+def _append_artifact(
+    *,
+    artifact_id: str,
+    logical_name: str,
+    path: Path,
+    size_bytes: int,
+    sha256: str,
+    service_instance_id: str,
+    command_id: str,
+    cluster_location: Optional[str] = None,
+) -> Dict[str, Any]:
+    artifact_path_value = os.environ.get("JARVIS_ARTIFACT_PATH")
+    execution_id = os.environ.get("JARVIS_EXECUTION_ID")
+    package_name = os.environ.get("JARVIS_PACKAGE_NAME")
+    package_id = os.environ.get("JARVIS_PACKAGE_ID")
+    if not all((artifact_path_value, execution_id, package_name, package_id)):
+        raise RuntimeError("JARVIS artifact bindings are missing")
+    artifact_path = Path(cast(str, artifact_path_value))
+    if not artifact_path.is_absolute():
+        raise RuntimeError("JARVIS artifact sidecar path must be absolute")
+    artifact_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if os.name != "nt":
+        artifact_path.parent.chmod(0o700)
+    with _artifact_lock(artifact_path):
+        existing = _read_artifact_lines(artifact_path)
+        sequence = 1
+        if existing:
+            sequence_value = existing[-1].get("sequence")
+            if isinstance(sequence_value, bool) or not isinstance(sequence_value, int):
+                raise RuntimeError("JARVIS artifact sidecar has an invalid sequence")
+            sequence = sequence_value + 1
+        location = cluster_location or path.as_posix()
+        _normalized_absolute_path(location)
+        event = {
+            "schema_version": "jarvis.artifact.v1",
+            "package_name": package_name,
+            "package_id": package_id,
+            "execution_id": execution_id,
+            "artifact_id": artifact_id,
+            "logical_name": logical_name,
+            "kind": "image",
+            "role": "output",
+            "structure": "file",
+            "ownership": "shared",
+            "state": "finalized",
+            "location": {"kind": "cluster_path", "value": location},
+            "media_type": "image/png",
+            "format": "png",
+            "size_bytes": size_bytes,
+            "checksum": "sha256:" + sha256,
+            "message": "ParaView service exported an image",
+            "revision": 1,
+            "sequence": sequence,
+            "observed_at_epoch": time.time(),
+            "metadata": {
+                "application": "paraview",
+                "service_instance_id": service_instance_id,
+                "command_id": command_id,
+                "generation_stage": "final",
+            },
+        }
+        payload = (
+            json.dumps(
+                event,
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+            + b"\n"
+        )
+        if len(payload) > 64 * 1024:
+            raise RuntimeError("ParaView artifact event exceeds the JARVIS limit")
+        descriptor = _open_private_append(artifact_path)
+        try:
+            offset = 0
+            while offset < len(payload):
+                written = os.write(descriptor, payload[offset:])
+                if written <= 0:
+                    raise OSError("short write while appending ParaView artifact")
+                offset += written
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+    return event
+
+
+@contextmanager
+def _artifact_lock(path: Path) -> Iterator[None]:
+    lock_path = path.with_name(path.name + ".lock")
+    if lock_path.is_symlink():
+        raise RuntimeError("JARVIS artifact lock cannot be a symlink")
+    descriptor = os.open(
+        lock_path,
+        os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+    )
+    try:
+        if os.name != "nt":
+            os.fchmod(descriptor, 0o600)
+        if os.fstat(descriptor).st_size == 0:
+            os.write(descriptor, b"0")
+            os.fsync(descriptor)
+        if os.name == "nt":
+            import msvcrt
+
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if os.name == "nt":
+                import msvcrt
+
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
+
+
+def _read_artifact_lines(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    if path.is_symlink() or not stat.S_ISREG(path.stat().st_mode):
+        raise RuntimeError("JARVIS artifact sidecar must be a regular file")
+    if path.stat().st_size > 128 * 1024 * 1024:
+        raise RuntimeError("JARVIS artifact sidecar exceeds the size limit")
+    payload = path.read_bytes()
+    if payload and not payload.endswith(b"\n"):
+        raise RuntimeError("JARVIS artifact sidecar has incomplete framing")
+    values: List[Dict[str, Any]] = []
+    for line in payload.splitlines():
+        value = json.loads(
+            line.decode("utf-8"), object_pairs_hook=_reject_duplicate_keys
+        )
+        if not isinstance(value, dict):
+            raise RuntimeError("JARVIS artifact sidecar line must be an object")
+        values.append(cast(Dict[str, Any], value))
+    return values
+
+
+def _open_private_append(path: Path) -> int:
+    flags = os.O_APPEND | os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags, 0o600)
+    if os.name != "nt":
+        os.fchmod(descriptor, 0o600)
+    information = os.fstat(descriptor)
+    if not stat.S_ISREG(information.st_mode):
+        os.close(descriptor)
+        raise RuntimeError("JARVIS artifact sidecar must be a regular file")
+    return descriptor
+
+
+def _require_fields(
+    value: Mapping[str, Any],
+    expected: set[str],
+    operation: str,
+) -> None:
+    if set(value) != expected:
+        raise CommandError(
+            "invalid_arguments",
+            f"{operation} arguments do not match the command contract",
+        )
+
+
+def _bounded_text(value: object, name: str, *, maximum: int) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(value.encode("utf-8")) > maximum
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise CommandError("invalid_arguments", f"{name} must be bounded text")
+    return value
+
+
+def _bounded_int(
+    value: object,
+    name: str,
+    *,
+    minimum: int,
+    maximum: int = 2_147_483_647,
+) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not minimum <= value <= maximum
+    ):
+        raise CommandError(
+            "invalid_arguments",
+            f"{name} must be an integer between {minimum} and {maximum}",
+        )
+    return value
+
+
+def _finite_number(value: object, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise CommandError("invalid_arguments", f"{name} must be numeric")
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise CommandError("invalid_arguments", f"{name} must be finite")
+    return parsed
+
+
+def _vector3(value: object, name: str) -> List[float]:
+    if not isinstance(value, list) or len(value) != 3:
+        raise CommandError("invalid_arguments", f"{name} must contain three values")
+    return [_finite_number(item, name) for item in value]
+
+
+def _nonzero_vector3(value: object, name: str) -> List[float]:
+    parsed = _vector3(value, name)
+    if math.sqrt(sum(component * component for component in parsed)) <= 1e-12:
+        raise CommandError("invalid_arguments", f"{name} cannot be a zero vector")
+    return parsed
+
+
+def _validate_camera_geometry(value: Mapping[str, Any]) -> None:
+    """Reject camera vectors that ParaView cannot orient deterministically."""
+    position = _vector3(value.get("position"), "position")
+    focal_point = _vector3(value.get("focal_point"), "focal_point")
+    view_up = _nonzero_vector3(value.get("view_up"), "view_up")
+    direction = [focal_point[index] - position[index] for index in range(3)]
+    direction_length = math.sqrt(sum(component * component for component in direction))
+    if direction_length <= 1e-12:
+        raise CommandError(
+            "invalid_arguments",
+            "camera position and focal_point must be distinct",
+        )
+    cross = [
+        direction[1] * view_up[2] - direction[2] * view_up[1],
+        direction[2] * view_up[0] - direction[0] * view_up[2],
+        direction[0] * view_up[1] - direction[1] * view_up[0],
+    ]
+    cross_length = math.sqrt(sum(component * component for component in cross))
+    if cross_length <= 1e-12 * direction_length:
+        raise CommandError(
+            "invalid_arguments",
+            "camera view_up cannot be parallel to the viewing direction",
+        )
+    scale = _finite_number(value.get("parallel_scale"), "parallel_scale")
+    if scale <= 0:
+        raise CommandError("invalid_arguments", "parallel_scale must be positive")
+
+
+def _apply_camera_state(view: Any, value: Mapping[str, Any]) -> None:
+    """Apply one already validated complete camera state."""
+    view.CameraPosition = list(value["position"])
+    view.CameraFocalPoint = list(value["focal_point"])
+    view.CameraViewUp = list(value["view_up"])
+    view.CameraParallelScale = value["parallel_scale"]
+
+
+def _write_unique_png(
+    *,
+    simple: Any,
+    view: Any,
+    output_path: Path,
+    width: int,
+    height: int,
+) -> bytes:
+    """Render, validate, durably publish, and never overwrite one PNG."""
+    output_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if os.name != "nt":
+        output_path.parent.chmod(0o700)
+    if output_path.exists() or output_path.is_symlink():
+        raise CommandError(
+            "artifact_exists",
+            "export filename already exists for this service instance",
+            status=HTTPStatus.CONFLICT,
+        )
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=output_path.parent,
+        prefix=f".{output_path.name}.",
+        suffix=".tmp.png",
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    published = False
+    succeeded = False
+    try:
+        simple.SaveScreenshot(
+            str(temporary),
+            view,
+            ImageResolution=[width, height],
+        )
+        size = temporary.stat().st_size
+        if not 8 <= size <= MAX_EXPORTED_ARTIFACT_BYTES:
+            raise RuntimeError(
+                "ParaView export must be a non-empty bounded PNG artifact"
+            )
+        with temporary.open("rb") as stream:
+            signature = stream.read(8)
+            if signature != b"\x89PNG\r\n\x1a\n":
+                raise RuntimeError("ParaView export did not produce a PNG artifact")
+            stream.seek(0)
+            payload = stream.read(MAX_EXPORTED_ARTIFACT_BYTES + 1)
+        if len(payload) != size:
+            raise RuntimeError("ParaView export changed while it was being validated")
+        # Windows rejects fsync on a descriptor opened read-only. A read/write
+        # descriptor is portable and does not change the validated payload.
+        read_descriptor = os.open(temporary, os.O_RDWR)
+        try:
+            os.fsync(read_descriptor)
+        finally:
+            os.close(read_descriptor)
+        if os.name != "nt":
+            temporary.chmod(0o600)
+        try:
+            os.link(temporary, output_path)
+        except FileExistsError as exc:
+            raise CommandError(
+                "artifact_exists",
+                "export filename already exists for this service instance",
+                status=HTTPStatus.CONFLICT,
+            ) from exc
+        published = True
+        if os.name != "nt":
+            output_path.chmod(0o600)
+        _fsync_directory(output_path.parent)
+        succeeded = True
+        return payload
+    finally:
+        temporary.unlink(missing_ok=True)
+        if published and not succeeded:
+            output_path.unlink(missing_ok=True)
+            _fsync_directory(output_path.parent)
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist one directory update where descriptor fsync is supported."""
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _viewport(value: object) -> Dict[str, float]:
+    if not isinstance(value, dict) or set(value) != {"x0", "y0", "x1", "y1"}:
+        raise CommandError(
+            "invalid_arguments",
+            "viewport must contain exactly x0, y0, x1, and y1",
+        )
+    parsed = {
+        name: _finite_number(value.get(name), name) for name in ("x0", "y0", "x1", "y1")
+    }
+    if any(number < 0 or number > 1 for number in parsed.values()):
+        raise CommandError(
+            "invalid_arguments",
+            "viewport coordinates must be normalized between zero and one",
+        )
+    if parsed["x0"] >= parsed["x1"] or parsed["y0"] >= parsed["y1"]:
+        raise CommandError(
+            "invalid_arguments",
+            "viewport must have positive width and height",
+        )
+    return parsed
+
+
+def _viewport_pixel_rectangle(
+    viewport: Mapping[str, float],
+    view_size: Tuple[int, int],
+) -> List[int]:
+    """Map a normalized top-left browser rectangle to ParaView bottom-left pixels."""
+    width, height = view_size
+    if width < 2 or height < 2:
+        raise ValueError("ParaView view size must be at least two pixels per axis")
+    x_max = width - 1
+    y_max = height - 1
+    return [
+        max(0, min(x_max, math.floor(viewport["x0"] * x_max))),
+        max(0, min(y_max, math.floor((1.0 - viewport["y1"]) * y_max))),
+        max(0, min(x_max, math.ceil(viewport["x1"] * x_max))),
+        max(0, min(y_max, math.ceil((1.0 - viewport["y0"]) * y_max))),
+    ]
+
+
+def _surface_selection_ids(
+    *,
+    selected_representations: Any,
+    selection_sources: Any,
+    active_source: Any,
+    servermanager: Any,
+    limit: int,
+) -> Tuple[List[Dict[str, int]], Optional[int], Optional[str]]:
+    """Read real IDs returned by ParaView's render-view surface selection."""
+    representation_count = _collection_size(selected_representations)
+    selection_count = _collection_size(selection_sources)
+    if representation_count != selection_count:
+        return [], None, "paraview_selection_collection_mismatch"
+    if selection_count == 0:
+        return [], 0, None
+    active_sm_proxy = getattr(active_source, "SMProxy", active_source)
+    returned: List[Dict[str, int]] = []
+    total = 0
+    matched_active_source = False
+    for index in range(selection_count):
+        representation = selected_representations.GetItemAsObject(index)
+        if not _representation_uses_source(representation, active_sm_proxy):
+            continue
+        matched_active_source = True
+        raw_source = selection_sources.GetItemAsObject(index)
+        xml_name = _proxy_xml_name(raw_source)
+        try:
+            selection_proxy = servermanager._getPyProxy(raw_source)
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            return [], None, "paraview_selection_proxy_unavailable"
+        values = _integer_property_values(getattr(selection_proxy, "IDs", None))
+        if values is None:
+            return [], None, "paraview_selection_ids_unavailable"
+        if xml_name == "IDSelectionSource":
+            width = 2
+        elif xml_name == "CompositeDataIDSelectionSource":
+            width = 3
+        elif xml_name == "HierarchicalDataIDSelectionSource":
+            width = 3
+        else:
+            return [], None, "paraview_selection_source_unsupported"
+        if len(values) % width:
+            return [], None, "paraview_selection_ids_invalid"
+        total += len(values) // width
+        for offset in range(0, len(values), width):
+            if len(returned) >= limit:
+                continue
+            group = values[offset : offset + width]
+            if xml_name == "IDSelectionSource":
+                returned.append({"process_id": group[0], "element_id": group[1]})
+            elif xml_name == "CompositeDataIDSelectionSource":
+                returned.append(
+                    {
+                        "block_index": group[0],
+                        "process_id": group[1],
+                        "element_id": group[2],
+                    }
+                )
+            else:
+                returned.append(
+                    {
+                        "level": group[0],
+                        "hierarchy_index": group[1],
+                        "element_id": group[2],
+                    }
+                )
+    if not matched_active_source:
+        return [], 0, None
+    return returned, total, None
+
+
+def _collection_size(value: object) -> int:
+    getter = getattr(value, "GetNumberOfItems", None)
+    if not callable(getter):
+        raise RuntimeError("ParaView selection collection is unavailable")
+    result = getter()
+    if isinstance(result, bool) or not isinstance(result, int) or result < 0:
+        raise RuntimeError("ParaView selection collection size is invalid")
+    return result
+
+
+def _representation_uses_source(
+    representation: Any,
+    active_sm_proxy: Any,
+) -> bool:
+    try:
+        input_property = representation.GetProperty("Input")
+        selected_source = input_property.GetProxy(0)
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return False
+    if selected_source is active_sm_proxy:
+        return True
+    try:
+        return selected_source.GetGlobalID() == active_sm_proxy.GetGlobalID()
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return False
+
+
+def _proxy_xml_name(value: Any) -> str:
+    try:
+        name = value.GetXMLName()
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return ""
+    return name if isinstance(name, str) else ""
+
+
+def _integer_property_values(value: object) -> Optional[List[int]]:
+    if value is None:
+        return None
+    getter = getattr(value, "GetData", None)
+    if callable(getter):
+        try:
+            value = getter()
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            return None
+    try:
+        values = list(value)  # type: ignore[arg-type]
+    except TypeError:
+        return None
+    if any(isinstance(item, bool) or not isinstance(item, int) for item in values):
+        return None
+    return cast(List[int], values)
+
+
+def _association(value: object) -> str:
+    if value not in {"point", "cell"}:
+        raise CommandError("invalid_arguments", "association must be point or cell")
+    return cast(str, value)
+
+
+def _safe_relative_png(value: object) -> PurePosixPath:
+    rendered = _bounded_text(value, "filename", maximum=1024)
+    if "\\" in rendered:
+        raise CommandError("invalid_arguments", "filename must use POSIX separators")
+    path = PurePosixPath(rendered)
+    if path.is_absolute() or path.as_posix() != rendered or ".." in path.parts:
+        raise CommandError(
+            "invalid_arguments", "filename must be normalized and relative"
+        )
+    if path.suffix.casefold() != ".png":
+        raise CommandError("invalid_arguments", "export_artifact supports PNG output")
+    return path
+
+
+def _normalized_absolute_path(value: object) -> PurePosixPath:
+    if not isinstance(value, str) or "\\" in value:
+        raise ValueError("dataset member location must use POSIX separators")
+    path = PurePosixPath(value)
+    if not path.is_absolute() or path.as_posix() != value or ".." in path.parts:
+        raise ValueError("dataset member location must be normalized and absolute")
+    return path
+
+
+def _json_copy(value: Mapping[str, Any]) -> Dict[str, Any]:
+    return cast(Dict[str, Any], json.loads(json.dumps(value, allow_nan=False)))
+
+
+def _json_copy_list(value: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return cast(List[Dict[str, Any]], json.loads(json.dumps(value, allow_nan=False)))
+
+
+def _json_copy_optional(
+    value: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    return None if value is None else _json_copy(value)
+
+
+def _reject_duplicate_keys(pairs: List[Tuple[str, Any]]) -> Dict[str, Any]:
+    value: Dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError("duplicate JSON key: %s" % key)
+        value[key] = item
+    return value
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builtin/builtin/paraview/service_http.py
+++ b/builtin/builtin/paraview/service_http.py
@@ -1,0 +1,503 @@
+"""Bounded HTTP/SSE control plane for an authoritative ParaView backend.
+
+This module intentionally uses only the Python standard library so it can run
+inside the Python bundled with ParaView. Dataset-specific rendering choices do
+not belong here; every visualization mutation arrives as a versioned command.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import threading
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, Mapping, Optional, Protocol, Tuple, cast
+
+STATE_SCHEMA = "jarvis.paraview.service-state.v1"
+COMMAND_SCHEMA = "jarvis.paraview.command.v1"
+COMMAND_RESULT_SCHEMA = "jarvis.paraview.command-result.v1"
+COMMAND_ERROR_SCHEMA = "jarvis.paraview.command-error.v1"
+FRAME_SCHEMA = "jarvis.paraview.frame.v1"
+MAX_COMMAND_BYTES = 64 * 1024
+MAX_FRAME_BYTES = 32 * 1024 * 1024
+MAX_COMMANDS_PER_SERVICE = 4096
+_COMMAND_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
+_OPERATIONS = frozenset(
+    {
+        "set_timestep",
+        "set_active_field",
+        "set_camera",
+        "apply_filter",
+        "set_colormap",
+        "inspect_selection",
+        "export_artifact",
+    }
+)
+
+
+class VisualizationBackend(Protocol):
+    """Real renderer contract consumed by the transport layer."""
+
+    def dataset_state(self) -> Dict[str, Any]:
+        """Return descriptor plus real bounded discovery facts."""
+        ...
+
+    def pipeline_state(self) -> Dict[str, Any]:
+        """Return the complete authoritative visualization state."""
+        ...
+
+    def execute(
+        self,
+        operation: str,
+        arguments: Mapping[str, Any],
+        command_id: str,
+    ) -> Dict[str, Any]:
+        """Apply one semantic operation and return its real result."""
+        ...
+
+    def render_png(self) -> bytes:
+        """Render the current view and return a PNG frame."""
+        ...
+
+
+class CommandError(ValueError):
+    """A bounded client command failed validation or execution."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        status: HTTPStatus = HTTPStatus.BAD_REQUEST,
+        details: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status = status
+        self.details = details or {}
+
+
+class ServiceStateController:
+    """Serialize commands, revisions, state, frames, and idempotent results."""
+
+    def __init__(
+        self,
+        *,
+        backend: VisualizationBackend,
+        execution_id: str,
+        service_instance_id: str,
+        max_commands: int = MAX_COMMANDS_PER_SERVICE,
+    ) -> None:
+        """Initialize from one real backend and produce the first frame."""
+        if (
+            isinstance(max_commands, bool)
+            or not isinstance(max_commands, int)
+            or max_commands < 1
+        ):
+            raise ValueError("max_commands must be a positive integer")
+        self.backend = backend
+        self.execution_id = execution_id
+        self.service_instance_id = service_instance_id
+        self.max_commands = max_commands
+        self._lock = threading.RLock()
+        self._changed = threading.Condition(self._lock)
+        self._revision = 1
+        self._results: Dict[str, Tuple[str, Dict[str, Any]]] = {}
+        self._frame = self._bounded_frame(backend.render_png())
+        self._state = self._capture_state()
+
+    def state(self) -> Dict[str, Any]:
+        """Return a JSON-safe copy of current authoritative state."""
+        with self._lock:
+            return _json_copy(self._state)
+
+    def frame(self) -> Tuple[int, bytes]:
+        """Return current state revision and immutable PNG bytes."""
+        with self._lock:
+            return self._revision, self._frame
+
+    def wait_for_change(
+        self,
+        revision: int,
+        *,
+        timeout: float,
+    ) -> Tuple[int, Dict[str, Any], bytes]:
+        """Wait for a newer state or a heartbeat timeout."""
+        with self._changed:
+            if self._revision <= revision:
+                self._changed.wait(timeout=timeout)
+            return self._revision, _json_copy(self._state), self._frame
+
+    def command(self, payload: Mapping[str, Any]) -> Dict[str, Any]:
+        """Validate, de-duplicate, apply, and version one command."""
+        canonical, command_id, operation, expected, arguments = _validate_command(
+            payload
+        )
+        with self._changed:
+            previous = self._results.get(command_id)
+            if previous is not None:
+                previous_request, previous_response = previous
+                if previous_request != canonical:
+                    raise CommandError(
+                        "idempotency_conflict",
+                        "command_id was already used for a different command",
+                        status=HTTPStatus.CONFLICT,
+                    )
+                return _json_copy(previous_response)
+            if len(self._results) >= self.max_commands:
+                raise CommandError(
+                    "command_limit",
+                    "the service lifetime command limit was reached",
+                    status=HTTPStatus.TOO_MANY_REQUESTS,
+                    details={"max_commands": self.max_commands},
+                )
+            if expected is not None and expected != self._revision:
+                raise CommandError(
+                    "revision_conflict",
+                    "expected_revision does not match authoritative state",
+                    status=HTTPStatus.CONFLICT,
+                    details={
+                        "expected_revision": expected,
+                        "actual_revision": self._revision,
+                    },
+                )
+            try:
+                result = self.backend.execute(operation, arguments, command_id)
+            except CommandError:
+                raise
+            except Exception as exc:
+                raise CommandError(
+                    "operation_failed",
+                    f"ParaView operation failed: {exc}",
+                    status=HTTPStatus.UNPROCESSABLE_ENTITY,
+                ) from exc
+            if not isinstance(result, dict):
+                raise RuntimeError("ParaView backend returned a non-object result")
+            # Exporting a screenshot does not change the visible view. Reusing the
+            # already validated frame avoids introducing a failure after the
+            # durable artifact has been published.
+            if operation != "export_artifact":
+                self._frame = self._bounded_frame(self.backend.render_png())
+            self._revision += 1
+            self._state = self._capture_state()
+            response = {
+                "schema_version": COMMAND_RESULT_SCHEMA,
+                "command_id": command_id,
+                "operation": operation,
+                "applied": True,
+                "state": self._state,
+                "result": result,
+            }
+            _canonical_json(response)
+            self._results[command_id] = (canonical, _json_copy(response))
+            self._changed.notify_all()
+            return _json_copy(response)
+
+    def _capture_state(self) -> Dict[str, Any]:
+        state = {
+            "schema_version": STATE_SCHEMA,
+            "service_instance_id": self.service_instance_id,
+            "revision": self._revision,
+            "execution_id": self.execution_id,
+            "dataset": self.backend.dataset_state(),
+            "pipeline": self.backend.pipeline_state(),
+        }
+        _validate_state_shape(state)
+        _canonical_json(state)
+        return state
+
+    @staticmethod
+    def _bounded_frame(value: bytes) -> bytes:
+        if not isinstance(value, bytes) or not value:
+            raise RuntimeError("ParaView backend returned an empty non-byte frame")
+        if len(value) > MAX_FRAME_BYTES:
+            raise RuntimeError("ParaView frame exceeds the service size limit")
+        if not value.startswith(b"\x89PNG\r\n\x1a\n"):
+            raise RuntimeError("ParaView backend did not return a PNG frame")
+        return value
+
+
+class _Server(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = False
+
+    def __init__(
+        self,
+        address: Tuple[str, int],
+        controller: ServiceStateController,
+    ) -> None:
+        self.controller = controller
+        super().__init__(address, _Handler)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "JarvisParaView/1"
+
+    @property
+    def controller(self) -> ServiceStateController:
+        return cast(_Server, self.server).controller
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+        """Serve bounded health, state, frame, and event streams."""
+        path = self.path.split("?", 1)[0]
+        if path == "/healthz":
+            self._json(
+                HTTPStatus.OK,
+                {
+                    "schema_version": "jarvis.paraview.health.v1",
+                    "status": "ready",
+                    "service_instance_id": self.controller.service_instance_id,
+                    "revision": self.controller.state()["revision"],
+                },
+            )
+            return
+        if path == "/state":
+            self._json(HTTPStatus.OK, self.controller.state())
+            return
+        if path == "/live-data":
+            self._serve_sse(frames=True)
+            return
+        if path == "/events":
+            self._serve_sse(frames=False)
+            return
+        self._error(HTTPStatus.NOT_FOUND, "not_found", "endpoint does not exist")
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
+        """Apply one authoritative semantic command."""
+        if self.path.split("?", 1)[0] != "/commands":
+            self._error(HTTPStatus.NOT_FOUND, "not_found", "endpoint does not exist")
+            return
+        try:
+            payload = self._read_json()
+            response = self.controller.command(payload)
+        except CommandError as exc:
+            self._error(exc.status, exc.code, str(exc), details=exc.details)
+            return
+        self._json(HTTPStatus.OK, response)
+
+    def _read_json(self) -> Dict[str, Any]:
+        content_type = self.headers.get("Content-Type", "").split(";", 1)[0]
+        if content_type != "application/json":
+            raise CommandError(
+                "unsupported_media_type",
+                "commands require Content-Type application/json",
+                status=HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
+            )
+        rendered_length = self.headers.get("Content-Length")
+        try:
+            length = int(rendered_length or "")
+        except ValueError as exc:
+            raise CommandError("invalid_length", "Content-Length is required") from exc
+        if not 1 <= length <= MAX_COMMAND_BYTES:
+            raise CommandError(
+                "invalid_length",
+                f"command body must be 1-{MAX_COMMAND_BYTES} bytes",
+                status=HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+            )
+        payload = self.rfile.read(length)
+        if len(payload) != length:
+            raise CommandError("incomplete_body", "command body was incomplete")
+        try:
+            value = json.loads(
+                payload.decode("utf-8"),
+                object_pairs_hook=_reject_duplicate_keys,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            raise CommandError(
+                "invalid_json", "command body is not valid JSON"
+            ) from exc
+        if not isinstance(value, dict):
+            raise CommandError("invalid_command", "command body must be an object")
+        return cast(Dict[str, Any], value)
+
+    def _serve_sse(self, *, frames: bool) -> None:
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache, no-transform")
+        self.send_header("Connection", "keep-alive")
+        self.send_header("X-Accel-Buffering", "no")
+        self.end_headers()
+        revision = 0
+        try:
+            while True:
+                current, state, frame = self.controller.wait_for_change(
+                    revision,
+                    timeout=15.0,
+                )
+                if current == revision:
+                    self.wfile.write(b": heartbeat\n\n")
+                    self.wfile.flush()
+                    continue
+                if frames:
+                    value: Dict[str, Any] = {
+                        "schema_version": FRAME_SCHEMA,
+                        "service_instance_id": self.controller.service_instance_id,
+                        "revision": current,
+                        "media_type": "image/png",
+                        "encoding": "base64",
+                        "data": base64.b64encode(frame).decode("ascii"),
+                    }
+                    event_name = "frame"
+                else:
+                    value = state
+                    event_name = "state"
+                payload = _canonical_json(value).encode("utf-8")
+                self.wfile.write(b"event: " + event_name.encode("ascii") + b"\n")
+                self.wfile.write(b"id: " + str(current).encode("ascii") + b"\n")
+                self.wfile.write(b"data: " + payload + b"\n\n")
+                self.wfile.flush()
+                revision = current
+        except (BrokenPipeError, ConnectionResetError, TimeoutError):
+            return
+
+    def _json(self, status: HTTPStatus, value: Mapping[str, Any]) -> None:
+        payload = _canonical_json(value).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _error(
+        self,
+        status: HTTPStatus,
+        code: str,
+        message: str,
+        *,
+        details: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self._json(
+            status,
+            {
+                "schema_version": COMMAND_ERROR_SCHEMA,
+                "error": {
+                    "code": code,
+                    "message": message,
+                    "details": details or {},
+                },
+            },
+        )
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Emit bounded request logs without command payloads."""
+        print(
+            "%s - - [%s] %s"
+            % (self.address_string(), self.log_date_time_string(), format % args),
+            flush=True,
+        )
+
+
+def create_server(
+    host: str,
+    port: int,
+    controller: ServiceStateController,
+) -> ThreadingHTTPServer:
+    """Create a bound service; callers control lifecycle and signal handling."""
+    return _Server((host, port), controller)
+
+
+def _validate_command(
+    value: Mapping[str, Any],
+) -> Tuple[str, str, str, Optional[int], Mapping[str, Any]]:
+    expected_fields = {
+        "schema_version",
+        "command_id",
+        "operation",
+        "expected_revision",
+        "arguments",
+    }
+    if set(value) != expected_fields:
+        raise CommandError(
+            "invalid_command",
+            "command fields do not match jarvis.paraview.command.v1",
+        )
+    if value.get("schema_version") != COMMAND_SCHEMA:
+        raise CommandError("invalid_schema", "unsupported command schema_version")
+    command_id = value.get("command_id")
+    if not isinstance(command_id, str) or _COMMAND_ID.fullmatch(command_id) is None:
+        raise CommandError("invalid_command_id", "command_id is invalid")
+    operation = value.get("operation")
+    if not isinstance(operation, str) or operation not in _OPERATIONS:
+        raise CommandError("unsupported_operation", "operation is not supported")
+    expected = value.get("expected_revision")
+    if expected is not None and (
+        isinstance(expected, bool) or not isinstance(expected, int) or expected < 1
+    ):
+        raise CommandError(
+            "invalid_revision",
+            "expected_revision must be a positive integer or null",
+        )
+    arguments = value.get("arguments")
+    if not isinstance(arguments, dict):
+        raise CommandError("invalid_arguments", "arguments must be an object")
+    canonical = _canonical_json(value)
+    return canonical, command_id, operation, expected, arguments
+
+
+def _validate_state_shape(value: Mapping[str, Any]) -> None:
+    if set(value) != {
+        "schema_version",
+        "service_instance_id",
+        "revision",
+        "execution_id",
+        "dataset",
+        "pipeline",
+    }:
+        raise RuntimeError("ParaView state fields do not match the stable schema")
+    dataset = value.get("dataset")
+    pipeline = value.get("pipeline")
+    if not isinstance(dataset, dict) or set(dataset) != {"descriptor", "discovery"}:
+        raise RuntimeError("ParaView dataset state is incomplete")
+    if not isinstance(pipeline, dict) or set(pipeline) != {
+        "timestep",
+        "active_field",
+        "filters",
+        "colormap",
+        "camera",
+        "selection",
+        "artifacts",
+    }:
+        raise RuntimeError("ParaView pipeline state is incomplete")
+
+
+def _canonical_json(value: object) -> str:
+    try:
+        return json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("service payload must contain finite JSON values") from exc
+
+
+def _json_copy(value: Mapping[str, Any]) -> Dict[str, Any]:
+    return cast(Dict[str, Any], json.loads(_canonical_json(value)))
+
+
+def _reject_duplicate_keys(pairs: list[Tuple[str, Any]]) -> Dict[str, Any]:
+    value: Dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError("duplicate JSON key: %s" % key)
+        value[key] = item
+    return value
+
+
+__all__ = [
+    "COMMAND_ERROR_SCHEMA",
+    "COMMAND_RESULT_SCHEMA",
+    "COMMAND_SCHEMA",
+    "FRAME_SCHEMA",
+    "STATE_SCHEMA",
+    "CommandError",
+    "ServiceStateController",
+    "VisualizationBackend",
+    "create_server",
+]

--- a/builtin/builtin/paraview/service_supervisor.py
+++ b/builtin/builtin/paraview/service_supervisor.py
@@ -1,0 +1,364 @@
+"""Supervise a pvpython service and report real lifecycle to JARVIS."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import IO, Optional, Sequence
+
+from jarvis_cd.service_runtime import (
+    DatasetDescriptor,
+    ServiceLifecycle,
+    ServiceRuntimeReporter,
+)
+
+HEALTH_PROBE_INTERVAL_SECONDS = 2.0
+HEALTH_FAILURE_THRESHOLD = 3
+TERMINATION_GRACE_SECONDS = 10.0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Launch pvpython, health-probe it, and persist lifecycle revisions."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--service-script", required=True)
+    parser.add_argument("--descriptor", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--pvpython-bin", required=True)
+    parser.add_argument("--pvpython-options", default="")
+    parser.add_argument("--bind-host", required=True)
+    parser.add_argument("--advertise-host", required=True)
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--startup-timeout", type=float, required=True)
+    parser.add_argument("--service-instance-id", required=True)
+    args = parser.parse_args(argv)
+
+    if not 1 <= args.startup_timeout <= 600:
+        raise ValueError("startup timeout must be between 1 and 600 seconds")
+    if args.bind_host != "127.0.0.1" or args.advertise_host != "127.0.0.1":
+        raise ValueError(
+            "ParaView service supervisor requires loopback bind and advertisement"
+        )
+    descriptor = DatasetDescriptor.from_json(
+        Path(args.descriptor).read_text(encoding="utf-8")
+    )
+    port = args.port or _available_port(args.bind_host)
+    if not 1 <= port <= 65535:
+        raise ValueError("service port must be zero or between 1 and 65535")
+    reporter = ServiceRuntimeReporter.from_environment(
+        service_instance_id=args.service_instance_id,
+        host=args.advertise_host,
+        port=port,
+        dataset_descriptor=descriptor,
+    )
+    command = [
+        args.pvpython_bin,
+        *shlex.split(args.pvpython_options),
+        args.service_script,
+        "--descriptor",
+        args.descriptor,
+        "--output-dir",
+        args.output_dir,
+        "--bind-host",
+        args.bind_host,
+        "--port",
+        str(port),
+        "--execution-id",
+        reporter.execution_id,
+        "--service-instance-id",
+        args.service_instance_id,
+    ]
+    stopping = threading.Event()
+    lifecycle: Optional[ServiceLifecycle] = None
+    process: Optional[subprocess.Popen[str]] = None
+    forwarders: list[threading.Thread] = []
+
+    def request_stop(_signum: int, _frame: object) -> None:
+        # Signal handlers only communicate intent. Metadata I/O and process
+        # termination happen in the supervised control loop, where failures
+        # cannot prevent cleanup.
+        stopping.set()
+
+    previous_sigterm = signal.getsignal(signal.SIGTERM)
+    previous_sigint = signal.getsignal(signal.SIGINT)
+    signal.signal(signal.SIGTERM, request_stop)
+    signal.signal(signal.SIGINT, request_stop)
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+        )
+        assert process.stdout is not None and process.stderr is not None
+        forwarders = [
+            threading.Thread(
+                target=_forward,
+                args=(process.stdout, sys.stdout),
+                daemon=True,
+            ),
+            threading.Thread(
+                target=_forward,
+                args=(process.stderr, sys.stderr),
+                daemon=True,
+            ),
+        ]
+        for forwarder in forwarders:
+            forwarder.start()
+        reporter.report(
+            ServiceLifecycle.STARTING,
+            message="ParaView service process started; waiting for health readiness",
+        )
+        lifecycle = ServiceLifecycle.STARTING
+
+        deadline = time.monotonic() + args.startup_timeout
+        probe_host = _probe_host(args.bind_host)
+        ready = False
+        while time.monotonic() < deadline and process.poll() is None:
+            if stopping.is_set():
+                return _stop_after_request(process, reporter, lifecycle)
+            if _health_ready(
+                probe_host,
+                port,
+                service_instance_id=args.service_instance_id,
+            ):
+                reporter.report(
+                    ServiceLifecycle.READY,
+                    message="ParaView HTTP service passed its health probe",
+                )
+                lifecycle = ServiceLifecycle.READY
+                ready = True
+                break
+            stopping.wait(0.1)
+        if not ready:
+            return_code = process.poll()
+            if return_code is None:
+                _terminate_process(process)
+                diagnostic = "ParaView HTTP service did not become ready before timeout"
+            else:
+                diagnostic = (
+                    "ParaView service process exited before readiness with code "
+                    f"{return_code}"
+                )
+            reporter.report(ServiceLifecycle.FAILED, message=diagnostic)
+            lifecycle = ServiceLifecycle.FAILED
+            print(diagnostic, file=sys.stderr, flush=True)
+            return 1
+
+        health_failures = 0
+        while process.poll() is None:
+            if stopping.is_set():
+                return _stop_after_request(process, reporter, lifecycle)
+            healthy = _health_ready(
+                probe_host,
+                port,
+                service_instance_id=args.service_instance_id,
+            )
+            if healthy:
+                health_failures = 0
+                if lifecycle is ServiceLifecycle.DEGRADED:
+                    reporter.report(
+                        ServiceLifecycle.READY,
+                        message="ParaView HTTP service health recovered",
+                    )
+                    lifecycle = ServiceLifecycle.READY
+            else:
+                health_failures += 1
+                if (
+                    health_failures >= HEALTH_FAILURE_THRESHOLD
+                    and lifecycle is ServiceLifecycle.READY
+                ):
+                    reporter.report(
+                        ServiceLifecycle.DEGRADED,
+                        message=(
+                            "ParaView HTTP service failed consecutive health probes"
+                        ),
+                    )
+                    lifecycle = ServiceLifecycle.DEGRADED
+            stopping.wait(HEALTH_PROBE_INTERVAL_SECONDS)
+
+        return_code = process.wait()
+        if return_code == 0:
+            reporter.report(
+                ServiceLifecycle.STOPPED,
+                message="ParaView service exited cleanly",
+            )
+            lifecycle = ServiceLifecycle.STOPPED
+            return 0
+        reporter.report(
+            ServiceLifecycle.FAILED,
+            message=f"ParaView service process exited with code {return_code}",
+        )
+        lifecycle = ServiceLifecycle.FAILED
+        return return_code if 0 < return_code <= 255 else 1
+    except Exception as exc:
+        diagnostic = f"ParaView service supervisor failed: {exc}"
+        if process is not None and process.poll() is None:
+            try:
+                _terminate_process(process)
+            except Exception as cleanup_error:
+                diagnostic += f"; child cleanup failed: {cleanup_error}"
+        if lifecycle not in {ServiceLifecycle.STOPPED, ServiceLifecycle.FAILED}:
+            try:
+                reporter.report(ServiceLifecycle.FAILED, message=diagnostic)
+            except Exception as report_error:
+                diagnostic += f"; failure reporting failed: {report_error}"
+        print(diagnostic, file=sys.stderr, flush=True)
+        return 1
+    finally:
+        try:
+            if process is not None and process.poll() is None:
+                _terminate_process(process)
+        finally:
+            for forwarder in forwarders:
+                forwarder.join(timeout=2)
+            signal.signal(signal.SIGTERM, previous_sigterm)
+            signal.signal(signal.SIGINT, previous_sigint)
+
+
+def _stop_after_request(
+    process: subprocess.Popen[str],
+    reporter: ServiceRuntimeReporter,
+    lifecycle: ServiceLifecycle,
+) -> int:
+    """Stop the child even when lifecycle persistence fails."""
+    report_errors: list[str] = []
+    if lifecycle not in {ServiceLifecycle.STOPPED, ServiceLifecycle.FAILED}:
+        try:
+            reporter.report(
+                ServiceLifecycle.STOPPING,
+                message="ParaView service received an owned termination request",
+            )
+        except Exception as exc:
+            report_errors.append(f"stopping report failed: {exc}")
+    try:
+        _, forced = _terminate_process(process)
+    except Exception as exc:
+        report_errors.append(f"child cleanup failed: {exc}")
+        try:
+            reporter.report(
+                ServiceLifecycle.FAILED,
+                message="ParaView service could not be stopped after an owned request",
+            )
+        except Exception as report_error:
+            report_errors.append(f"cleanup failure report failed: {report_error}")
+        print("; ".join(report_errors), file=sys.stderr, flush=True)
+        return 1
+    try:
+        reporter.report(
+            ServiceLifecycle.STOPPED,
+            message=(
+                "ParaView service was forcibly stopped after an owned termination request"
+                if forced
+                else "ParaView service stopped after an owned termination request"
+            ),
+        )
+    except Exception as exc:
+        report_errors.append(f"stopped report failed: {exc}")
+    if report_errors:
+        print("; ".join(report_errors), file=sys.stderr, flush=True)
+        return 1
+    return 0
+
+
+def _terminate_process(
+    process: subprocess.Popen[str],
+    *,
+    grace_seconds: float = TERMINATION_GRACE_SECONDS,
+) -> tuple[int, bool]:
+    """Terminate one owned child with a bounded kill escalation."""
+    if grace_seconds <= 0:
+        raise ValueError("termination grace_seconds must be positive")
+    current = process.poll()
+    if current is not None:
+        return current, False
+    process.terminate()
+    try:
+        return process.wait(timeout=grace_seconds), False
+    except subprocess.TimeoutExpired:
+        process.kill()
+        return process.wait(timeout=grace_seconds), True
+
+
+def _available_port(bind_host: str) -> int:
+    """Reserve and release an ephemeral port immediately before child launch."""
+    family = socket.AF_INET6 if ":" in bind_host else socket.AF_INET
+    with socket.socket(family, socket.SOCK_STREAM) as candidate:
+        candidate.bind((bind_host, 0))
+        return int(candidate.getsockname()[1])
+
+
+def _probe_host(bind_host: str) -> str:
+    if bind_host == "0.0.0.0":
+        return "127.0.0.1"
+    if bind_host == "::":
+        return "::1"
+    return bind_host
+
+
+def _health_ready(
+    host: str,
+    port: int,
+    *,
+    service_instance_id: str,
+) -> bool:
+    """Accept readiness only from the versioned service health response."""
+    rendered_host = f"[{host}]" if ":" in host else host
+    request = urllib.request.Request(
+        f"http://{rendered_host}:{port}/healthz",
+        headers={"Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=0.5) as response:
+            if response.status != 200:
+                return False
+            payload = response.read(16 * 1024 + 1)
+    except (OSError, urllib.error.URLError, TimeoutError):
+        return False
+    if len(payload) > 16 * 1024:
+        return False
+    try:
+        value = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    revision = value.get("revision") if isinstance(value, dict) else None
+    return (
+        isinstance(value, dict)
+        and value
+        == {
+            "schema_version": "jarvis.paraview.health.v1",
+            "status": "ready",
+            "service_instance_id": service_instance_id,
+            "revision": revision,
+        }
+        and not isinstance(revision, bool)
+        and isinstance(revision, int)
+        and revision >= 1
+    )
+
+
+def _forward(source: IO[str], destination: IO[str]) -> None:
+    """Forward child diagnostics without treating them as metadata."""
+    try:
+        for line in source:
+            destination.write(line)
+            destination.flush()
+    finally:
+        source.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Jarvis-CD is a unified platform for deploying scientific applications, storage s
 - [Pipeline Tests](pipeline_tests.md) — Automated testing with grid search and parameter sweeps
 - [Execution Handles](executions.md) — Durable direct and scheduler run identities, status records, and JSON queries
 - [Generated Artifacts](artifacts.md) — Durable output manifests, package providers, lifecycle, and location semantics
+- [Service Runtimes](service-runtimes.md) — Durable network-service lifecycle, intrinsic dataset descriptors, and ParaView HTTP/SSE commands
 - [Hostfile Configuration](hostfile.md) — Multi-node setup, pattern expansion, IP resolution
 - [Scheduler Integration](scheduler.md) — Submit pipelines as SLURM jobs, automatic hostfile from `$SLURM_JOB_NODELIST`
 - [Resource Graph](resource_graph.md) — Storage and network topology discovery

--- a/docs/executions.md
+++ b/docs/executions.md
@@ -17,6 +17,7 @@ live = pipeline.run(wait=False)
 while not live.refresh().terminal:
     print(live.progress().to_dict())
     print(live.artifacts().to_dict())
+    print(live.service_runtimes().to_dict())
 
 scheduled = pipeline.submit(wait=False)
 print(scheduled.scheduler_provider)   # "slurm"
@@ -45,6 +46,7 @@ record = pipeline.get_execution(handle.execution_id)
 records = pipeline.list_executions()
 progress = handle.progress()
 artifacts = handle.artifacts()
+services = handle.service_runtimes()
 ```
 
 CLI queries accept `--pipeline-id`, so a handle remains queryable after the
@@ -58,6 +60,7 @@ jarvis execution get render-2018-asteroid --pipeline-id visualization +json
 jarvis execution list --pipeline-id visualization +json
 jarvis execution progress render-2018-asteroid --pipeline-id visualization +json
 jarvis execution artifacts render-2018-asteroid --pipeline-id visualization +json
+jarvis execution service-runtimes render-2018-asteroid --pipeline-id visualization +json
 ```
 
 `execution get +json` and `execution list +json` emit clean machine-readable
@@ -67,11 +70,17 @@ current identity-checked artifact manifest. Neither query exposes its internal
 sidecar paths. `ppl run +json` and `ppl submit +json` emit the handle JSON as
 their final line because package and scheduler logs remain visible before it.
 
+`execution service-runtimes +json` returns the latest identity-checked service
+revision for every package-owned instance. See [Execution-owned service
+runtimes](service-runtimes.md) for the package SPI and generic ParaView
+HTTP/SSE command contract.
+
 During a run, JARVIS binds package shared/private paths to the owned execution
 root. It also exports authoritative `JARVIS_EXECUTION_ID`, `JARVIS_PACKAGE_ID`,
 `JARVIS_PACKAGE_NAME`, `JARVIS_PROGRESS_PATH`, and
 `JARVIS_PROGRESS_TRANSPORT`, `JARVIS_ARTIFACT_PATH`, and
-`JARVIS_ARTIFACT_TRANSPORT` values before each package starts. Application
+`JARVIS_ARTIFACT_TRANSPORT`, and `JARVIS_SERVICE_RUNTIME_PATH` values before
+each package starts. Application
 packages may report through the selected sidecar/stdout transports, but cannot
 choose the authoritative execution or sidecar identity. See
 [Generated artifacts](artifacts.md) for the package contract.

--- a/docs/service-runtimes.md
+++ b/docs/service-runtimes.md
@@ -1,0 +1,208 @@
+# Execution-owned service runtimes
+
+JARVIS applications may expose a long-lived network service as part of a
+durable pipeline execution. JARVIS owns the execution and package identity,
+persists lifecycle observations without scraping stdout, and returns the
+current service records from the same `ExecutionHandle` used for status,
+progress, and artifacts.
+
+```python
+handle = pipeline.submit(wait=False)
+services = handle.service_runtimes()
+for runtime in services.service_runtimes:
+    print(runtime.service_instance_id, runtime.lifecycle, runtime.base_url)
+```
+
+The machine-readable CLI form is:
+
+```bash
+jarvis execution service-runtimes <execution-id> \
+  --pipeline-id <pipeline> +json
+```
+
+The result is an exact `jarvis.execution.service-runtimes.v1` document with
+`schema_version`, `execution_id`, `pipeline_id`, `execution_state`, `terminal`,
+and `service_runtimes`. The array contains the latest
+`jarvis.service-runtime.v1` revision for every concrete service instance.
+
+## Package reporting contract
+
+Before package startup, execution core exports:
+
+- `JARVIS_EXECUTION_ID`;
+- `JARVIS_PACKAGE_NAME`;
+- `JARVIS_PACKAGE_ID`;
+- `JARVIS_SERVICE_RUNTIME_PATH`, an exact owner-private JSONL sidecar inside
+  the execution root.
+
+Packages use `ServiceRuntimeReporter.from_environment(...)`. They choose the
+service instance, actual advertised host and bound port, protocol, and
+intrinsic dataset descriptor; they cannot choose another execution/package
+identity or storage path. Every revision is appended under an inter-process
+lock and fsynced. Revisions increase by one per `service_instance_id` and the
+validated lifecycle is:
+
+```text
+starting -> ready <-> degraded -> stopping -> stopped
+     |          |          |          |
+     +----------+----------+----------+-> failed
+```
+
+`stopped` and `failed` cannot reopen. Host, port, protocol, endpoint paths,
+delivery mode, and dataset descriptor cannot change within one service
+instance.
+
+Each report explicitly contains `/healthz`, `/live-data`, `/events`, `/state`,
+and `/commands` paths. `delivery_mode` is `push`. These cluster endpoints are
+not desktop URLs: relay owns authenticated routing, tunnels/connectors, and
+local URL publication.
+
+## Dataset descriptor
+
+`jarvis.dataset-descriptor.v1` contains only intrinsic data facts:
+
+- a stable `dataset_id`, `kind`, and format;
+- a bounded ordered list of normalized absolute cluster members and optional
+  timestep values;
+- optional discovered arrays, associations, component counts, units, and
+  bounds;
+- a required SHA-256 fingerprint and optional source JARVIS artifact identity.
+
+The fingerprint is the lowercase SHA-256 of canonical JSON for the complete
+descriptor with the `fingerprint` field omitted. Member ordering, arrays,
+bounds, and optional source artifact therefore participate in identity. Both
+JARVIS and the staged pvpython service recompute it. The service also verifies
+that every selected member exists before readiness. This avoids reading huge
+site datasets merely to identify a bounded catalog selection; when content
+integrity is known, `source_artifact.sha256` carries that separate fact.
+
+It deliberately cannot contain a camera, active field, colormap, filter,
+threshold, scene, or recipe. Selecting data does not silently select a view.
+The generic ParaView service accepts visualization choices only as explicit
+versioned commands.
+
+## ParaView service state and commands
+
+`builtin.paraview mode=service` launches a real `pvpython` service under a
+JARVIS Python supervisor. The supervisor reports `starting` only after process
+creation and reports `ready` only after the versioned HTTP health response
+passes. It continues probing for the service lifetime: three consecutive
+failures report `degraded`, a later successful probe reports recovery to
+`ready`, and process exit reports `stopped` or `failed`. Owned termination is
+bounded; a child that ignores terminate is killed after the grace period, and
+metadata-reporting failure never bypasses child cleanup. Missing ParaView
+imports, a failed startup probe, or a nonzero process exit fail explicitly.
+
+`GET /state` returns exactly:
+
+```json
+{
+  "schema_version": "jarvis.paraview.service-state.v1",
+  "service_instance_id": "srv_...",
+  "revision": 1,
+  "execution_id": "jarvis_...",
+  "dataset": {
+    "descriptor": {},
+    "discovery": {
+      "arrays": [],
+      "bounds": null,
+      "timestep_values": []
+    }
+  },
+  "pipeline": {
+    "timestep": {},
+    "active_field": null,
+    "filters": [],
+    "colormap": null,
+    "camera": {},
+    "selection": null,
+    "artifacts": []
+  }
+}
+```
+
+`POST /commands` accepts an exact `jarvis.paraview.command.v1` object:
+
+```json
+{
+  "schema_version": "jarvis.paraview.command.v1",
+  "command_id": "agent-command-42",
+  "operation": "set_timestep",
+  "expected_revision": 1,
+  "arguments": {"index": 3}
+}
+```
+
+Supported operations are `set_timestep`, `set_active_field`, `set_camera`,
+`apply_filter`, `set_colormap`, `inspect_selection`, and `export_artifact`.
+Commands are serialized against authoritative state. A stale
+`expected_revision` returns HTTP 409 with `revision_conflict`. Repeating the
+same `command_id` and exact payload returns the original result without
+applying it again; reusing an ID for different content returns
+`idempotency_conflict`. Results remain replayable for the complete service
+lifetime. A service accepts at most 4096 distinct commands; after that, a new
+ID returns HTTP 429 with `command_limit`, while every previously accepted ID
+remains replayable. Restarting the service creates a new service instance and
+a new command-ID lifetime.
+
+`inspect_selection` accepts exactly one of two selector forms. A known element
+uses `{"association":"point|cell","index":N}`. A human drag box uses
+`{"viewport":{"x0":0.1,"y0":0.2,"x1":0.9,"y1":0.8}}`, with finite
+normalized coordinates, positive area, and a top-left origin matching the live
+PNG. The service converts that rectangle to the fixed render-view pixels and
+calls ParaView's real visible-cell surface selector. It returns a `selection`
+object with `selector`, `status`, `association`, `selected_count`,
+`returned_count`, `truncated`, `ids`, and nullable `reason`; viewport results
+also include the normalized `viewport` and exact `pixel_rectangle`. At most 256
+real IDs are returned while `selected_count` preserves the full count. A
+backend that cannot expose real selection IDs returns `status=unsupported`; an
+area with no visible cells returns `status=empty`. JARVIS never approximates a
+screen selection as world coordinates.
+
+The `jarvis.paraview.command-result.v1` response contains the resulting full
+authoritative state and the real operation result. `/events` pushes those state
+revisions as SSE. `/live-data` pushes bounded base64 PNG frames as
+`jarvis.paraview.frame.v1` SSE events; a browser never invents state locally.
+
+Camera and filter commands validate their complete semantic input before
+mutation. A failed camera render restores the previous camera, filter failures
+remove any partial proxy and restore the previous source and camera, and a
+successful filter never performs a hidden camera reset. Changing the active
+field clears any colormap preset that belonged to the prior field.
+
+`export_artifact` writes only under the package-owned service output root. A
+filename is create-once for that service instance: an existing file or symlink
+returns HTTP 409 with `artifact_exists` and is never overwritten. The service
+renders to a private temporary file, bounds and validates the PNG, fsyncs it,
+publishes it atomically, and fsyncs the directory. It then fsyncs a real
+`jarvis.artifact.v1` record before returning the artifact result, so
+`ExecutionHandle.artifacts()` is the authoritative manifest. If manifest
+publication fails, the newly published PNG is removed before the command
+fails.
+
+## ParaView package configuration
+
+Service mode requires `nprocs=1` and a durable `ppl run` or `ppl submit`
+execution. A minimal package configuration is:
+
+```yaml
+pkg_type: builtin.paraview
+pkg_name: viewer
+mode: service
+dataset_descriptor: /site/descriptors/asteroid-subset.json
+pvpython_bin: /opt/ParaView/bin/pvpython
+pvpython_options: --mesa
+service_bind_host: 127.0.0.1
+service_advertise_host: 127.0.0.1
+service_port: 0
+service_startup_timeout: 120
+nprocs: 1
+```
+
+The ParaView backend is deliberately loopback-only. The relay connector must
+run inside the execution's owned allocation and dial `127.0.0.1`; JARVIS
+rejects non-loopback bind or advertised hosts so unauthenticated service
+commands are never exposed to the shared cluster network. A zero
+port selects an ephemeral port and the actual bound port is persisted in the
+runtime report. Dataset member count is deliberately bounded; an interactive
+subset does not require loading every member of a large temporal collection.

--- a/jarvis_cd/core/cli.py
+++ b/jarvis_cd/core/cli.py
@@ -411,6 +411,37 @@ class JarvisCLI(ArgParse):
             ]
         )
 
+        self.add_cmd(
+            "execution service-runtimes",
+            msg="List current network services for one execution",
+            aliases=["execution services"],
+        )
+        self.add_args(
+            [
+                {
+                    "name": "execution_id",
+                    "msg": "JARVIS execution identity",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                },
+                {
+                    "name": "pipeline_id",
+                    "aliases": ["pipeline-id"],
+                    "msg": "Pipeline identity (defaults to current pipeline)",
+                    "type": str,
+                    "required": False,
+                },
+                {
+                    "name": "json",
+                    "msg": "Print the complete service-runtime snapshot as JSON",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
+                },
+            ]
+        )
+
         self.add_cmd("ppl update", msg="Update current pipeline")
         self.add_args(
             [
@@ -1553,6 +1584,27 @@ class JarvisCLI(ArgParse):
             print(
                 f"  {artifact.package_id}/{artifact.logical_name}: "
                 f"{artifact.state.value} {artifact.kind} ({artifact.artifact_id})"
+            )
+
+    def execution_service_runtimes(self) -> None:
+        """Print current services for a named or current pipeline execution."""
+        self._ensure_initialized()
+        pipeline_id = self.kwargs.get("pipeline_id")
+        pipeline = (
+            Pipeline(pipeline_id) if pipeline_id else self._require_current_pipeline()
+        )
+        snapshot = pipeline.get_execution_service_runtimes(self.kwargs["execution_id"])
+        if self.kwargs.get("json", False):
+            print(json.dumps(snapshot.to_dict(), separators=(",", ":"), sort_keys=True))
+            return
+        print(
+            f"{snapshot.execution_id}: {snapshot.execution_state} "
+            f"({len(snapshot.service_runtimes)} services)"
+        )
+        for runtime in snapshot.service_runtimes:
+            print(
+                f"  {runtime.package_id}/{runtime.service_instance_id}: "
+                f"{runtime.lifecycle.value} {runtime.base_url}"
             )
 
     def ppl_start(self):

--- a/jarvis_cd/core/execution.py
+++ b/jarvis_cd/core/execution.py
@@ -24,6 +24,11 @@ from jarvis_cd.artifacts import (
     ArtifactStore,
 )
 from jarvis_cd.progress import ProgressEvent, ProgressStore
+from jarvis_cd.service_runtime import (
+    SERVICE_RUNTIME_SNAPSHOT_SCHEMA_VERSION,
+    ServiceRuntimeReport,
+    ServiceRuntimeStore,
+)
 from jarvis_cd.util.private_path import (
     ensure_private_descriptor,
     ensure_private_path,
@@ -38,6 +43,7 @@ RECORD_NAME = ".jarvis-execution.json"
 MAX_RECORD_BYTES = 65_536
 PROGRESS_SNAPSHOT_SCHEMA = "jarvis.execution.progress.v1"
 ARTIFACT_SNAPSHOT_SCHEMA = "jarvis.execution.artifacts.v1"
+SERVICE_RUNTIME_SNAPSHOT_SCHEMA = SERVICE_RUNTIME_SNAPSHOT_SCHEMA_VERSION
 DIRECT_LAUNCH_SCHEMA = "jarvis.direct-launch.v1"
 DIRECT_LEASE_NAME = ".jarvis-direct-execution.lease"
 SCHEDULER_ARTIFACT_PATH_SCHEMA = "jarvis.scheduler.artifact-path.v1"
@@ -150,6 +156,30 @@ class ExecutionArtifactSnapshot:
             "execution_state": self.execution_state,
             "terminal": self.terminal,
             "artifacts": [artifact.as_dict() for artifact in self.artifacts],
+        }
+
+
+@dataclass(frozen=True)
+class ExecutionServiceRuntimeSnapshot:
+    """Queryable current service runtimes for one durable execution."""
+
+    execution_id: str
+    pipeline_id: str
+    execution_state: str
+    terminal: bool
+    service_runtimes: tuple[ServiceRuntimeReport, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the stable agent-facing service-runtime snapshot."""
+        return {
+            "schema_version": SERVICE_RUNTIME_SNAPSHOT_SCHEMA,
+            "execution_id": self.execution_id,
+            "pipeline_id": self.pipeline_id,
+            "execution_state": self.execution_state,
+            "terminal": self.terminal,
+            "service_runtimes": [
+                runtime.to_dict() for runtime in self.service_runtimes
+            ],
         }
 
 
@@ -358,6 +388,13 @@ class ExecutionHandle:
         assert record._record_path is not None
         store = ExecutionStore(record._record_path.parent.parent, self.pipeline_id)
         return store.artifacts(self.execution_id)
+
+    def service_runtimes(self) -> ExecutionServiceRuntimeSnapshot:
+        """Return current services owned by this exact execution."""
+        record = self.refresh()
+        assert record._record_path is not None
+        store = ExecutionStore(record._record_path.parent.parent, self.pipeline_id)
+        return store.service_runtimes(self.execution_id)
 
 
 @dataclass(frozen=True)
@@ -1305,6 +1342,89 @@ class ExecutionStore:
             ),
         )
 
+    def service_runtimes(
+        self,
+        execution_id: str,
+    ) -> ExecutionServiceRuntimeSnapshot:
+        """Return the current identity-checked service runtime set."""
+        record = self.get(execution_id)
+        runtime_files = record.metadata.get("service_runtime_files", {})
+        if not isinstance(runtime_files, dict):
+            raise RuntimeError("execution service runtime index is invalid")
+        execution_root = self.executions_dir / record.execution_id
+        runtime_root = execution_root / "service-runtimes"
+        if runtime_root.exists() or runtime_root.is_symlink():
+            status = runtime_root.lstat()
+            if not stat.S_ISDIR(status.st_mode) or stat.S_ISLNK(status.st_mode):
+                raise RuntimeError(
+                    "execution service runtime path is not a real directory"
+                )
+        current: list[ServiceRuntimeReport] = []
+        seen_instances: set[str] = set()
+        for runtime_key, entry in sorted(runtime_files.items()):
+            if (
+                not isinstance(runtime_key, str)
+                or not runtime_key
+                or not isinstance(entry, dict)
+                or set(entry) != {"filename", "package_id", "package_name"}
+                or not isinstance(entry.get("filename"), str)
+                or not entry["filename"]
+                or not isinstance(entry.get("package_id"), str)
+                or not entry["package_id"]
+                or not isinstance(entry.get("package_name"), str)
+                or not entry["package_name"]
+            ):
+                raise RuntimeError("execution service runtime index is invalid")
+            filename = entry["filename"]
+            package_id = entry["package_id"]
+            package_name = entry["package_name"]
+            relative = Path(filename)
+            if (
+                relative.name != filename
+                or relative.is_absolute()
+                or relative.suffix != ".jsonl"
+            ):
+                raise RuntimeError(
+                    "execution service runtime index contains an invalid path"
+                )
+            sidecar = runtime_root / filename
+            try:
+                reports = ServiceRuntimeStore(sidecar).current().values()
+            except (OSError, PermissionError, ValueError) as exc:
+                raise RuntimeError(
+                    f"invalid service runtime sidecar for package {package_id!r}"
+                ) from exc
+            for report in reports:
+                if (
+                    report.execution_id != record.execution_id
+                    or report.package_id != package_id
+                    or report.package_name != package_name
+                ):
+                    raise RuntimeError(
+                        f"service runtime identity mismatch for package {package_id!r}"
+                    )
+                if report.service_instance_id in seen_instances:
+                    raise RuntimeError(
+                        "service instance ID is duplicated across package runtimes"
+                    )
+                seen_instances.add(report.service_instance_id)
+                current.append(report)
+        return ExecutionServiceRuntimeSnapshot(
+            execution_id=record.execution_id,
+            pipeline_id=record.pipeline_id,
+            execution_state=record.state,
+            terminal=record.terminal,
+            service_runtimes=tuple(
+                sorted(
+                    current,
+                    key=lambda report: (
+                        report.package_id,
+                        report.service_instance_id,
+                    ),
+                )
+            ),
+        )
+
     def finalize_artifacts(
         self,
         execution_id: str,
@@ -1363,6 +1483,49 @@ class ExecutionStore:
                 )
             )
         return sealed
+
+    def finalize_service_runtimes(
+        self,
+        execution_id: str,
+        *,
+        failed: bool = False,
+    ) -> list[ServiceRuntimeReport]:
+        """Close every active service before execution terminalization."""
+        validated_id = validate_execution_id(execution_id)
+        record = read_execution_record(
+            self.executions_dir / validated_id,
+            expected_execution_id=validated_id,
+        )
+        runtime_files = record.metadata.get("service_runtime_files", {})
+        if not isinstance(runtime_files, dict):
+            raise RuntimeError("execution service runtime index is invalid")
+        runtime_root = self.executions_dir / validated_id / "service-runtimes"
+        finalized: list[ServiceRuntimeReport] = []
+        for runtime_key, entry in runtime_files.items():
+            if (
+                not isinstance(runtime_key, str)
+                or not runtime_key
+                or not isinstance(entry, dict)
+                or set(entry) != {"filename", "package_id", "package_name"}
+                or not isinstance(entry.get("filename"), str)
+                or not isinstance(entry.get("package_id"), str)
+                or not entry["package_id"]
+                or not isinstance(entry.get("package_name"), str)
+                or not entry["package_name"]
+            ):
+                raise RuntimeError("execution service runtime index is invalid")
+            filename = entry["filename"]
+            relative = Path(filename)
+            if relative.name != filename or relative.suffix != ".jsonl":
+                raise RuntimeError(
+                    "execution service runtime index contains an invalid path"
+                )
+            finalized.extend(
+                ServiceRuntimeStore(runtime_root / filename).finalize_active(
+                    failed=failed
+                )
+            )
+        return finalized
 
     def _terminalize_pending_scheduler_artifact_paths(
         self,
@@ -1724,6 +1887,10 @@ class ExecutionStore:
                 and updated.terminal
                 and updated.state != "scripted"
             ):
+                self.finalize_service_runtimes(
+                    validated_id,
+                    failed=updated.state == "failed",
+                )
                 self.finalize_artifacts(
                     validated_id,
                     failed=updated.state == "failed",

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -39,6 +39,7 @@ from jarvis_cd.core.execution import (
     ExecutionHandle,
     ExecutionArtifactSnapshot,
     ExecutionProgressSnapshot,
+    ExecutionServiceRuntimeSnapshot,
     ExecutionRecord,
     ExecutionStore,
     is_execution_transaction_lock,
@@ -1607,6 +1608,13 @@ class Pipeline:
         """Return generated artifacts for one exact execution."""
         return self._execution_store().artifacts(execution_id)
 
+    def get_execution_service_runtimes(
+        self,
+        execution_id: str,
+    ) -> ExecutionServiceRuntimeSnapshot:
+        """Return current service runtimes for one exact execution."""
+        return self._execution_store().service_runtimes(execution_id)
+
     def _pipeline_storage_dir(self) -> Path:
         """Return the directory this Pipeline instance is allowed to mutate."""
         return self.get_pipeline_config_dir()
@@ -2576,6 +2584,11 @@ class Pipeline:
         if os.name != "nt":
             artifact_dir.chmod(0o700)
         artifact_path = artifact_dir / f"{prefix}-{digest}.jsonl"
+        runtime_dir = Path(execution_root) / "service-runtimes"
+        runtime_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if os.name != "nt":
+            runtime_dir.chmod(0o700)
+        runtime_path = runtime_dir / f"{prefix}-{digest}.jsonl"
         package_config = pkg_def.get("config", {})
         package_containerized = isinstance(package_config, dict) and (
             package_config.get("deploy_mode") == "container"
@@ -2592,6 +2605,7 @@ class Pipeline:
                 "JARVIS_PROGRESS_TRANSPORT": progress_transport,
                 "JARVIS_ARTIFACT_PATH": str(artifact_path),
                 "JARVIS_ARTIFACT_TRANSPORT": progress_transport,
+                "JARVIS_SERVICE_RUNTIME_PATH": str(runtime_path),
             }
         )
         record = self._execution_store().get(execution_id)
@@ -2606,11 +2620,18 @@ class Pipeline:
             "package_id": package_id,
             "package_name": package_name,
         }
+        runtime_files = dict(record.metadata.get("service_runtime_files", {}))
+        runtime_files[f"package-{prefix}-{digest}"] = {
+            "filename": runtime_path.name,
+            "package_id": package_id,
+            "package_name": package_name,
+        }
         self._execution_store().update(
             execution_id,
             metadata={
                 "progress_files": progress_files,
                 "artifact_files": artifact_files,
+                "service_runtime_files": runtime_files,
             },
         )
 
@@ -2896,6 +2917,7 @@ class Pipeline:
                 "JARVIS_PROGRESS_TRANSPORT",
                 "JARVIS_ARTIFACT_PATH",
                 "JARVIS_ARTIFACT_TRANSPORT",
+                "JARVIS_SERVICE_RUNTIME_PATH",
             )
         }
         snapshot_execution_id = getattr(self, "_execution_id", None)

--- a/jarvis_cd/core/pkg.py
+++ b/jarvis_cd/core/pkg.py
@@ -534,6 +534,32 @@ class Pkg:
         self.env.update(values)
         self.mod_env.update(values)
 
+    def bind_execution_service_runtime(
+        self,
+        execution_id: str,
+        path: str | os.PathLike[str],
+    ) -> None:
+        """Bind service reporting to a JARVIS-owned runtime sidecar.
+
+        :param execution_id: Stable JARVIS execution identifier.
+        :param path: Absolute JSONL path inside the owned execution root.
+        """
+        if not isinstance(execution_id, str) or not execution_id.strip():
+            raise ValueError(
+                "execution service runtime requires a non-empty execution ID"
+            )
+        runtime_path = Path(path)
+        if not runtime_path.is_absolute():
+            raise ValueError("execution service runtime path must be absolute")
+        values = {
+            "JARVIS_EXECUTION_ID": execution_id,
+            "JARVIS_SERVICE_RUNTIME_PATH": str(runtime_path),
+            "JARVIS_PACKAGE_NAME": str(self.pkg_type),
+            "JARVIS_PACKAGE_ID": str(self.pkg_id),
+        }
+        self.env.update(values)
+        self.mod_env.update(values)
+
     def _progress_line_callback(self) -> Optional[Callable[[str, str], None]]:
         """Build the progress half of the package runtime callback.
 

--- a/jarvis_cd/service_runtime/__init__.py
+++ b/jarvis_cd/service_runtime/__init__.py
@@ -1,0 +1,33 @@
+"""Durable service-runtime semantics for JARVIS executions."""
+
+from .reporter import ServiceRuntimeReporter
+from .schema import (
+    DATASET_DESCRIPTOR_SCHEMA_VERSION,
+    SERVICE_RUNTIME_SCHEMA_VERSION,
+    SERVICE_RUNTIME_SNAPSHOT_SCHEMA_VERSION,
+    DatasetArray,
+    DatasetDescriptor,
+    DatasetMember,
+    ServiceLifecycle,
+    ServiceProtocol,
+    ServiceRuntimeReport,
+    calculate_dataset_fingerprint,
+    validate_service_runtime_history,
+)
+from .store import ServiceRuntimeStore
+
+__all__ = [
+    "DATASET_DESCRIPTOR_SCHEMA_VERSION",
+    "SERVICE_RUNTIME_SCHEMA_VERSION",
+    "SERVICE_RUNTIME_SNAPSHOT_SCHEMA_VERSION",
+    "DatasetArray",
+    "DatasetDescriptor",
+    "DatasetMember",
+    "ServiceLifecycle",
+    "ServiceProtocol",
+    "ServiceRuntimeReport",
+    "ServiceRuntimeReporter",
+    "ServiceRuntimeStore",
+    "calculate_dataset_fingerprint",
+    "validate_service_runtime_history",
+]

--- a/jarvis_cd/service_runtime/reporter.py
+++ b/jarvis_cd/service_runtime/reporter.py
@@ -1,0 +1,163 @@
+"""Package-facing reporter for JARVIS-owned service-runtime metadata."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Mapping
+from uuid import uuid4
+
+from .schema import (
+    DatasetDescriptor,
+    ServiceLifecycle,
+    ServiceProtocol,
+    ServiceRuntimeReport,
+)
+from .store import ServiceRuntimeStore
+
+
+class ServiceRuntimeReporter:
+    """Persist service lifecycle without parsing application stdout."""
+
+    def __init__(
+        self,
+        *,
+        execution_id: str,
+        package_name: str,
+        package_id: str,
+        path: str | os.PathLike[str],
+        service_instance_id: str,
+        host: str,
+        port: int,
+        protocol: ServiceProtocol = ServiceProtocol.HTTP,
+        health_path: str = "/healthz",
+        live_data_path: str = "/live-data",
+        events_path: str = "/events",
+        state_path: str = "/state",
+        command_path: str = "/commands",
+        dataset_descriptor: DatasetDescriptor,
+    ) -> None:
+        """Bind immutable service identity to an owned sidecar."""
+        self.execution_id = execution_id
+        self.package_name = package_name
+        self.package_id = package_id
+        self.path = Path(path)
+        self.service_instance_id = service_instance_id
+        self.host = host
+        self.port = port
+        self.protocol = protocol
+        self.health_path = health_path
+        self.live_data_path = live_data_path
+        self.events_path = events_path
+        self.state_path = state_path
+        self.command_path = command_path
+        self.dataset_descriptor = dataset_descriptor
+        if not self.path.is_absolute():
+            raise ValueError("service runtime sidecar path must be absolute")
+        # Validate all immutable values before the first storage mutation.
+        self._build_report(1, ServiceLifecycle.STARTING, None, time.time())
+
+    @classmethod
+    def from_environment(
+        cls,
+        *,
+        service_instance_id: str,
+        host: str,
+        port: int,
+        dataset_descriptor: DatasetDescriptor,
+        protocol: ServiceProtocol = ServiceProtocol.HTTP,
+        environ: Mapping[str, str] | None = None,
+    ) -> "ServiceRuntimeReporter":
+        """Construct a reporter from authoritative JARVIS package bindings."""
+        values = os.environ if environ is None else environ
+        required = {
+            name: values.get(name)
+            for name in (
+                "JARVIS_EXECUTION_ID",
+                "JARVIS_PACKAGE_NAME",
+                "JARVIS_PACKAGE_ID",
+                "JARVIS_SERVICE_RUNTIME_PATH",
+            )
+        }
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            raise ValueError(
+                "missing JARVIS service runtime bindings: " + ", ".join(missing)
+            )
+        return cls(
+            execution_id=required["JARVIS_EXECUTION_ID"] or "",
+            package_name=required["JARVIS_PACKAGE_NAME"] or "",
+            package_id=required["JARVIS_PACKAGE_ID"] or "",
+            path=required["JARVIS_SERVICE_RUNTIME_PATH"] or "",
+            service_instance_id=service_instance_id,
+            host=host,
+            port=port,
+            protocol=protocol,
+            dataset_descriptor=dataset_descriptor,
+        )
+
+    @staticmethod
+    def new_service_instance_id() -> str:
+        """Return a portable opaque identity for one concrete service process."""
+        return f"srv_{uuid4().hex}"
+
+    def report(
+        self,
+        lifecycle: ServiceLifecycle,
+        *,
+        message: str | None = None,
+    ) -> ServiceRuntimeReport:
+        """Append the next revision for this exact service instance."""
+        observed_at = time.time()
+
+        def build(
+            history: tuple[ServiceRuntimeReport, ...],
+        ) -> ServiceRuntimeReport:
+            previous = next(
+                (
+                    report
+                    for report in reversed(history)
+                    if report.service_instance_id == self.service_instance_id
+                ),
+                None,
+            )
+            revision = previous.revision + 1 if previous is not None else 1
+            return self._build_report(
+                revision,
+                lifecycle,
+                message,
+                observed_at,
+            )
+
+        return ServiceRuntimeStore(self.path).append_next(build)
+
+    def _build_report(
+        self,
+        revision: int,
+        lifecycle: ServiceLifecycle,
+        message: str | None,
+        observed_at: float,
+    ) -> ServiceRuntimeReport:
+        return ServiceRuntimeReport(
+            execution_id=self.execution_id,
+            package_name=self.package_name,
+            package_id=self.package_id,
+            service_instance_id=self.service_instance_id,
+            revision=revision,
+            lifecycle=lifecycle,
+            host=self.host,
+            port=self.port,
+            protocol=self.protocol,
+            health_path=self.health_path,
+            live_data_path=self.live_data_path,
+            events_path=self.events_path,
+            state_path=self.state_path,
+            command_path=self.command_path,
+            dataset_descriptor=self.dataset_descriptor,
+            message=message,
+            observed_at_epoch=observed_at,
+        )
+
+
+__all__ = ["ServiceRuntimeReporter"]

--- a/jarvis_cd/service_runtime/schema.py
+++ b/jarvis_cd/service_runtime/schema.py
@@ -1,0 +1,850 @@
+"""Typed service-runtime records owned by durable JARVIS executions."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import math
+import re
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import PurePosixPath
+from typing import Any, Final, Mapping, cast
+
+SERVICE_RUNTIME_SCHEMA_VERSION: Final = "jarvis.service-runtime.v1"
+DATASET_DESCRIPTOR_SCHEMA_VERSION: Final = "jarvis.dataset-descriptor.v1"
+SERVICE_RUNTIME_SNAPSHOT_SCHEMA_VERSION: Final = "jarvis.execution.service-runtimes.v1"
+MAX_SERVICE_RUNTIME_BYTES: Final = 256 * 1024
+MAX_DATASET_MEMBERS: Final = 512
+MAX_DATASET_ARRAYS: Final = 256
+MAX_TEXT_BYTES: Final = 4096
+_IDENTITY_PATTERN: Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
+_ARTIFACT_ID_PATTERN: Final = re.compile(r"^art_[A-Za-z0-9_-]{22,86}$")
+_SHA256_PATTERN: Final = re.compile(r"^[0-9a-f]{64}$")
+_REPORT_FIELDS: Final = frozenset(
+    {
+        "schema_version",
+        "execution_id",
+        "package_name",
+        "package_id",
+        "service_instance_id",
+        "revision",
+        "lifecycle",
+        "host",
+        "port",
+        "protocol",
+        "health_path",
+        "live_data_path",
+        "events_path",
+        "state_path",
+        "command_path",
+        "delivery_mode",
+        "dataset_descriptor",
+        "message",
+        "observed_at_epoch",
+    }
+)
+_DESCRIPTOR_FIELDS: Final = frozenset(
+    {
+        "schema_version",
+        "dataset_id",
+        "kind",
+        "format",
+        "members",
+        "arrays",
+        "bounds",
+        "fingerprint",
+        "source_artifact",
+    }
+)
+_MEMBER_FIELDS: Final = frozenset({"index", "location", "timestep"})
+_ARRAY_FIELDS: Final = frozenset({"name", "association", "components", "units"})
+_FINGERPRINT_FIELDS: Final = frozenset({"algorithm", "digest"})
+_SOURCE_ARTIFACT_FIELDS: Final = frozenset({"artifact_id", "sha256"})
+
+
+class ServiceLifecycle(StrEnum):
+    """Lifecycle states reported by an owned network service."""
+
+    STARTING = "starting"
+    READY = "ready"
+    DEGRADED = "degraded"
+    STOPPING = "stopping"
+    STOPPED = "stopped"
+    FAILED = "failed"
+
+
+class ServiceProtocol(StrEnum):
+    """Application protocols supported by the runtime contract."""
+
+    HTTP = "http"
+    HTTPS = "https"
+
+
+@dataclass(frozen=True, slots=True)
+class DatasetMember:
+    """One ordered, cluster-local source member in a bounded dataset view."""
+
+    index: int
+    location: str
+    timestep: float | None = None
+
+    def __post_init__(self) -> None:
+        """Validate ordering identity and a normalized absolute location."""
+        if isinstance(self.index, bool) or not isinstance(self.index, int):
+            raise ValueError("dataset member index must be an integer")
+        if self.index < 0:
+            raise ValueError("dataset member index cannot be negative")
+        _validate_cluster_path(self.location)
+        if self.timestep is not None:
+            _validate_finite(self.timestep, "dataset member timestep")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this member using the descriptor schema."""
+        value: dict[str, Any] = {
+            "index": self.index,
+            "location": self.location,
+        }
+        if self.timestep is not None:
+            value["timestep"] = self.timestep
+        return value
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "DatasetMember":
+        """Parse one member without accepting silent schema extensions."""
+        _reject_unknown(value, _MEMBER_FIELDS, "dataset member")
+        index = value.get("index")
+        location = value.get("location")
+        timestep = value.get("timestep")
+        if isinstance(index, bool) or not isinstance(index, int):
+            raise ValueError("dataset member index must be an integer")
+        if not isinstance(location, str):
+            raise ValueError("dataset member location must be a string")
+        if timestep is not None and (
+            isinstance(timestep, bool) or not isinstance(timestep, (int, float))
+        ):
+            raise ValueError("dataset member timestep must be numeric")
+        return cls(
+            index=index,
+            location=location,
+            timestep=float(timestep) if timestep is not None else None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DatasetArray:
+    """One discovered data-array fact, never a visualization selection."""
+
+    name: str
+    association: str
+    components: int
+    units: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate bounded intrinsic array metadata."""
+        _validate_text(self.name, "dataset array name", maximum=512)
+        if self.association not in {"point", "cell", "field"}:
+            raise ValueError("dataset array association must be point, cell, or field")
+        if (
+            isinstance(self.components, bool)
+            or not isinstance(self.components, int)
+            or not 1 <= self.components <= 64
+        ):
+            raise ValueError("dataset array components must be between 1 and 64")
+        if self.units is not None:
+            _validate_text(self.units, "dataset array units", maximum=256)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize one intrinsic array description."""
+        value: dict[str, Any] = {
+            "name": self.name,
+            "association": self.association,
+            "components": self.components,
+        }
+        if self.units is not None:
+            value["units"] = self.units
+        return value
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "DatasetArray":
+        """Parse one array description."""
+        _reject_unknown(value, _ARRAY_FIELDS, "dataset array")
+        name = value.get("name")
+        association = value.get("association")
+        components = value.get("components")
+        units = value.get("units")
+        if not isinstance(name, str) or not isinstance(association, str):
+            raise ValueError("dataset array name and association must be strings")
+        if isinstance(components, bool) or not isinstance(components, int):
+            raise ValueError("dataset array components must be an integer")
+        if units is not None and not isinstance(units, str):
+            raise ValueError("dataset array units must be a string")
+        return cls(name, association, components, units)
+
+
+@dataclass(frozen=True, slots=True)
+class DatasetDescriptor:
+    """Intrinsic dataset identity and bounded discovery facts.
+
+    The descriptor deliberately has no camera, colormap, threshold, filter, or
+    scene-recipe fields. Those are runtime commands, not dataset identity.
+    """
+
+    dataset_id: str
+    kind: str
+    format: str
+    members: tuple[DatasetMember, ...]
+    fingerprint: str
+    arrays: tuple[DatasetArray, ...] = ()
+    bounds: tuple[float, float, float, float, float, float] | None = None
+    source_artifact_id: str | None = None
+    source_artifact_sha256: str | None = None
+    schema_version: str = DATASET_DESCRIPTOR_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        """Reject ambiguous identity and visualization-specific metadata."""
+        if self.schema_version != DATASET_DESCRIPTOR_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported dataset descriptor schema: {self.schema_version!r}"
+            )
+        _validate_identity(self.dataset_id, "dataset_id")
+        _validate_text(self.kind, "dataset kind", maximum=256)
+        _validate_text(self.format, "dataset format", maximum=256)
+        if not self.members or len(self.members) > MAX_DATASET_MEMBERS:
+            raise ValueError(
+                f"dataset descriptor requires 1-{MAX_DATASET_MEMBERS} members"
+            )
+        if tuple(member.index for member in self.members) != tuple(
+            range(len(self.members))
+        ):
+            raise ValueError("dataset members must have contiguous ordered indexes")
+        locations = [member.location for member in self.members]
+        if len(locations) != len(set(locations)):
+            raise ValueError("dataset member locations must be unique")
+        if len(self.arrays) > MAX_DATASET_ARRAYS:
+            raise ValueError("dataset descriptor has too many arrays")
+        array_keys = [(array.association, array.name) for array in self.arrays]
+        if len(array_keys) != len(set(array_keys)):
+            raise ValueError("dataset array identities must be unique")
+        if self.bounds is not None:
+            if len(self.bounds) != 6:
+                raise ValueError("dataset bounds must contain six values")
+            for value in self.bounds:
+                _validate_finite(value, "dataset bound")
+            for lower, upper in zip(self.bounds[::2], self.bounds[1::2]):
+                if lower > upper:
+                    raise ValueError("dataset bound lower values cannot exceed upper")
+        _validate_sha256(self.fingerprint, "dataset fingerprint")
+        if (self.source_artifact_id is None) is not (
+            self.source_artifact_sha256 is None
+        ):
+            raise ValueError(
+                "dataset source artifact requires both artifact_id and sha256"
+            )
+        if self.source_artifact_id is not None:
+            if _ARTIFACT_ID_PATTERN.fullmatch(self.source_artifact_id) is None:
+                raise ValueError("dataset source artifact_id is invalid")
+            assert self.source_artifact_sha256 is not None
+            _validate_sha256(
+                self.source_artifact_sha256,
+                "dataset source artifact sha256",
+            )
+        calculated = calculate_dataset_fingerprint(
+            dataset_id=self.dataset_id,
+            kind=self.kind,
+            format=self.format,
+            members=self.members,
+            arrays=self.arrays,
+            bounds=self.bounds,
+            source_artifact_id=self.source_artifact_id,
+            source_artifact_sha256=self.source_artifact_sha256,
+        )
+        if self.fingerprint != calculated:
+            raise ValueError(
+                "dataset fingerprint does not match the canonical intrinsic descriptor"
+            )
+        self.to_json()
+
+    @property
+    def canonical_digest(self) -> str:
+        """Return the SHA-256 digest of this exact descriptor document."""
+        return hashlib.sha256(self.to_json().encode("utf-8")).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the stable descriptor schema."""
+        value: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "dataset_id": self.dataset_id,
+            "kind": self.kind,
+            "format": self.format,
+            "members": [member.to_dict() for member in self.members],
+            "arrays": [array.to_dict() for array in self.arrays],
+            "bounds": list(self.bounds) if self.bounds is not None else None,
+            "fingerprint": {
+                "algorithm": "sha256",
+                "digest": self.fingerprint,
+            },
+            "source_artifact": None,
+        }
+        if self.source_artifact_id is not None:
+            value["source_artifact"] = {
+                "artifact_id": self.source_artifact_id,
+                "sha256": self.source_artifact_sha256,
+            }
+        return value
+
+    def to_json(self) -> str:
+        """Serialize one canonical descriptor document."""
+        return _canonical_json(self.to_dict(), "dataset descriptor")
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "DatasetDescriptor":
+        """Parse and strictly validate a descriptor mapping."""
+        _reject_unknown(value, _DESCRIPTOR_FIELDS, "dataset descriptor")
+        schema_version = _required_str(value, "schema_version", "dataset descriptor")
+        dataset_id = _required_str(value, "dataset_id", "dataset descriptor")
+        kind = _required_str(value, "kind", "dataset descriptor")
+        format_name = _required_str(value, "format", "dataset descriptor")
+        members_value = value.get("members")
+        arrays_value = value.get("arrays", [])
+        bounds_value = value.get("bounds")
+        fingerprint_value = value.get("fingerprint")
+        source_value = value.get("source_artifact")
+        if not isinstance(members_value, list):
+            raise ValueError("dataset descriptor members must be a list")
+        if not isinstance(arrays_value, list):
+            raise ValueError("dataset descriptor arrays must be a list")
+        if not isinstance(fingerprint_value, dict):
+            raise ValueError("dataset descriptor fingerprint must be an object")
+        _reject_unknown(
+            fingerprint_value,
+            _FINGERPRINT_FIELDS,
+            "dataset fingerprint",
+        )
+        if fingerprint_value.get("algorithm") != "sha256":
+            raise ValueError("dataset fingerprint algorithm must be sha256")
+        fingerprint = fingerprint_value.get("digest")
+        if not isinstance(fingerprint, str):
+            raise ValueError("dataset fingerprint digest must be a string")
+        members = tuple(
+            DatasetMember.from_dict(_required_mapping(item, "dataset member"))
+            for item in members_value
+        )
+        arrays = tuple(
+            DatasetArray.from_dict(_required_mapping(item, "dataset array"))
+            for item in arrays_value
+        )
+        bounds: tuple[float, float, float, float, float, float] | None = None
+        if bounds_value is not None:
+            if not isinstance(bounds_value, list) or len(bounds_value) != 6:
+                raise ValueError("dataset descriptor bounds must be six values or null")
+            parsed_bounds: list[float] = []
+            for item in bounds_value:
+                if isinstance(item, bool) or not isinstance(item, (int, float)):
+                    raise ValueError("dataset descriptor bounds must be numeric")
+                parsed_bounds.append(float(item))
+            bounds = cast(
+                tuple[float, float, float, float, float, float],
+                tuple(parsed_bounds),
+            )
+        source_artifact_id: str | None = None
+        source_artifact_sha256: str | None = None
+        if source_value is not None:
+            source = _required_mapping(source_value, "dataset source artifact")
+            _reject_unknown(
+                source,
+                _SOURCE_ARTIFACT_FIELDS,
+                "dataset source artifact",
+            )
+            source_artifact_id = _required_str(
+                source,
+                "artifact_id",
+                "dataset source artifact",
+            )
+            source_artifact_sha256 = _required_str(
+                source,
+                "sha256",
+                "dataset source artifact",
+            )
+        return cls(
+            schema_version=schema_version,
+            dataset_id=dataset_id,
+            kind=kind,
+            format=format_name,
+            members=members,
+            arrays=arrays,
+            bounds=bounds,
+            fingerprint=fingerprint,
+            source_artifact_id=source_artifact_id,
+            source_artifact_sha256=source_artifact_sha256,
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> "DatasetDescriptor":
+        """Parse a duplicate-key-safe JSON descriptor."""
+        value = _load_json(payload, "dataset descriptor")
+        return cls.from_dict(value)
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceRuntimeReport:
+    """One durable observation of an execution-owned network service."""
+
+    execution_id: str
+    package_name: str
+    package_id: str
+    service_instance_id: str
+    revision: int
+    lifecycle: ServiceLifecycle
+    host: str
+    port: int
+    protocol: ServiceProtocol
+    health_path: str
+    live_data_path: str
+    events_path: str
+    state_path: str
+    command_path: str
+    dataset_descriptor: DatasetDescriptor
+    message: str | None = None
+    observed_at_epoch: float = field(default_factory=time.time)
+    delivery_mode: str = "push"
+    schema_version: str = SERVICE_RUNTIME_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        """Validate a complete, agent-queryable service observation."""
+        if self.schema_version != SERVICE_RUNTIME_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported service runtime schema: {self.schema_version!r}"
+            )
+        for field_name, value in (
+            ("execution_id", self.execution_id),
+            ("package_name", self.package_name),
+            ("package_id", self.package_id),
+            ("service_instance_id", self.service_instance_id),
+        ):
+            _validate_identity(value, field_name)
+        if (
+            isinstance(self.revision, bool)
+            or not isinstance(self.revision, int)
+            or self.revision < 1
+        ):
+            raise ValueError("service runtime revision must be a positive integer")
+        if not isinstance(self.lifecycle, ServiceLifecycle):
+            raise ValueError("service runtime lifecycle must be a ServiceLifecycle")
+        _validate_host(self.host)
+        if (
+            isinstance(self.port, bool)
+            or not isinstance(self.port, int)
+            or not 1 <= self.port <= 65535
+        ):
+            raise ValueError("service runtime port must be between 1 and 65535")
+        if not isinstance(self.protocol, ServiceProtocol):
+            raise ValueError("service runtime protocol must be a ServiceProtocol")
+        paths = (
+            self.health_path,
+            self.live_data_path,
+            self.events_path,
+            self.state_path,
+            self.command_path,
+        )
+        for path in paths:
+            _validate_http_path(path)
+        if len(set(paths)) != len(paths):
+            raise ValueError("service runtime endpoint paths must be distinct")
+        if self.delivery_mode != "push":
+            raise ValueError("service runtime delivery_mode must be push")
+        if self.message is not None:
+            _validate_text(self.message, "service runtime message")
+        _validate_finite(self.observed_at_epoch, "service runtime observed_at_epoch")
+        if self.observed_at_epoch < 0:
+            raise ValueError("service runtime observed_at_epoch cannot be negative")
+        self.to_json()
+
+    @property
+    def base_url(self) -> str:
+        """Return the service origin without granting desktop routing authority."""
+        host = f"[{self.host}]" if ":" in self.host else self.host
+        return f"{self.protocol.value}://{host}:{self.port}"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the stable service-runtime schema."""
+        return {
+            "schema_version": self.schema_version,
+            "execution_id": self.execution_id,
+            "package_name": self.package_name,
+            "package_id": self.package_id,
+            "service_instance_id": self.service_instance_id,
+            "revision": self.revision,
+            "lifecycle": self.lifecycle.value,
+            "host": self.host,
+            "port": self.port,
+            "protocol": self.protocol.value,
+            "health_path": self.health_path,
+            "live_data_path": self.live_data_path,
+            "events_path": self.events_path,
+            "state_path": self.state_path,
+            "command_path": self.command_path,
+            "delivery_mode": self.delivery_mode,
+            "dataset_descriptor": self.dataset_descriptor.to_dict(),
+            "message": self.message,
+            "observed_at_epoch": self.observed_at_epoch,
+        }
+
+    def to_json(self) -> str:
+        """Serialize a bounded canonical JSONL payload."""
+        payload = _canonical_json(self.to_dict(), "service runtime report")
+        if len(payload.encode("utf-8")) > MAX_SERVICE_RUNTIME_BYTES:
+            raise ValueError("service runtime report exceeds maximum encoded size")
+        return payload
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "ServiceRuntimeReport":
+        """Parse a report and reject unversioned extensions."""
+        _reject_unknown(value, _REPORT_FIELDS, "service runtime report")
+        descriptor_value = _required_mapping(
+            value.get("dataset_descriptor"),
+            "service runtime dataset_descriptor",
+        )
+        revision = value.get("revision")
+        port = value.get("port")
+        observed = value.get("observed_at_epoch")
+        if isinstance(revision, bool) or not isinstance(revision, int):
+            raise ValueError("service runtime revision must be an integer")
+        if isinstance(port, bool) or not isinstance(port, int):
+            raise ValueError("service runtime port must be an integer")
+        if isinstance(observed, bool) or not isinstance(observed, (int, float)):
+            raise ValueError("service runtime observed_at_epoch must be numeric")
+        message = value.get("message")
+        if message is not None and not isinstance(message, str):
+            raise ValueError("service runtime message must be a string or null")
+        try:
+            lifecycle = ServiceLifecycle(
+                _required_str(value, "lifecycle", "service runtime")
+            )
+            protocol = ServiceProtocol(
+                _required_str(value, "protocol", "service runtime")
+            )
+        except ValueError as exc:
+            raise ValueError("invalid service runtime lifecycle or protocol") from exc
+        return cls(
+            schema_version=_required_str(
+                value,
+                "schema_version",
+                "service runtime",
+            ),
+            execution_id=_required_str(value, "execution_id", "service runtime"),
+            package_name=_required_str(value, "package_name", "service runtime"),
+            package_id=_required_str(value, "package_id", "service runtime"),
+            service_instance_id=_required_str(
+                value,
+                "service_instance_id",
+                "service runtime",
+            ),
+            revision=revision,
+            lifecycle=lifecycle,
+            host=_required_str(value, "host", "service runtime"),
+            port=port,
+            protocol=protocol,
+            health_path=_required_str(value, "health_path", "service runtime"),
+            live_data_path=_required_str(
+                value,
+                "live_data_path",
+                "service runtime",
+            ),
+            events_path=_required_str(value, "events_path", "service runtime"),
+            state_path=_required_str(value, "state_path", "service runtime"),
+            command_path=_required_str(value, "command_path", "service runtime"),
+            delivery_mode=_required_str(
+                value,
+                "delivery_mode",
+                "service runtime",
+            ),
+            dataset_descriptor=DatasetDescriptor.from_dict(descriptor_value),
+            message=message,
+            observed_at_epoch=float(observed),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> "ServiceRuntimeReport":
+        """Parse one bounded, duplicate-key-safe report."""
+        if len(payload.encode("utf-8")) > MAX_SERVICE_RUNTIME_BYTES:
+            raise ValueError("service runtime report exceeds maximum encoded size")
+        return cls.from_dict(_load_json(payload, "service runtime report"))
+
+
+def validate_service_runtime_history(reports: list[ServiceRuntimeReport]) -> None:
+    """Validate immutable identities, revisions, and lifecycle transitions."""
+    latest: dict[str, ServiceRuntimeReport] = {}
+    transitions = {
+        ServiceLifecycle.STARTING: {
+            ServiceLifecycle.STARTING,
+            ServiceLifecycle.READY,
+            ServiceLifecycle.DEGRADED,
+            ServiceLifecycle.STOPPING,
+            ServiceLifecycle.STOPPED,
+            ServiceLifecycle.FAILED,
+        },
+        ServiceLifecycle.READY: {
+            ServiceLifecycle.READY,
+            ServiceLifecycle.DEGRADED,
+            ServiceLifecycle.STOPPING,
+            ServiceLifecycle.STOPPED,
+            ServiceLifecycle.FAILED,
+        },
+        ServiceLifecycle.DEGRADED: {
+            ServiceLifecycle.READY,
+            ServiceLifecycle.DEGRADED,
+            ServiceLifecycle.STOPPING,
+            ServiceLifecycle.STOPPED,
+            ServiceLifecycle.FAILED,
+        },
+        ServiceLifecycle.STOPPING: {
+            ServiceLifecycle.STOPPING,
+            ServiceLifecycle.STOPPED,
+            ServiceLifecycle.FAILED,
+        },
+        ServiceLifecycle.STOPPED: set(),
+        ServiceLifecycle.FAILED: set(),
+    }
+    stream_identity: tuple[str, str, str] | None = None
+    for report in reports:
+        identity = (
+            report.execution_id,
+            report.package_name,
+            report.package_id,
+        )
+        if stream_identity is None:
+            stream_identity = identity
+        elif identity != stream_identity:
+            raise ValueError("service runtime package identity changed within a store")
+        previous = latest.get(report.service_instance_id)
+        if previous is None:
+            if report.revision != 1:
+                raise ValueError("first service runtime revision must be 1")
+            if report.lifecycle not in {
+                ServiceLifecycle.STARTING,
+                ServiceLifecycle.READY,
+                ServiceLifecycle.FAILED,
+            }:
+                raise ValueError("first service runtime lifecycle is invalid")
+        else:
+            if report.revision != previous.revision + 1:
+                raise ValueError("service runtime revisions must increase by one")
+            if report.lifecycle not in transitions[previous.lifecycle]:
+                raise ValueError(
+                    "invalid service runtime lifecycle transition: "
+                    f"{previous.lifecycle.value} -> {report.lifecycle.value}"
+                )
+            immutable = (
+                "execution_id",
+                "package_name",
+                "package_id",
+                "service_instance_id",
+                "host",
+                "port",
+                "protocol",
+                "health_path",
+                "live_data_path",
+                "events_path",
+                "state_path",
+                "command_path",
+                "delivery_mode",
+                "dataset_descriptor",
+            )
+            for name in immutable:
+                if getattr(report, name) != getattr(previous, name):
+                    raise ValueError(f"service runtime {name} cannot change")
+            if report.observed_at_epoch < previous.observed_at_epoch:
+                raise ValueError("service runtime timestamps cannot move backward")
+        latest[report.service_instance_id] = report
+
+
+def calculate_dataset_fingerprint(
+    *,
+    dataset_id: str,
+    kind: str,
+    format: str,
+    members: tuple[DatasetMember, ...],
+    arrays: tuple[DatasetArray, ...] = (),
+    bounds: tuple[float, float, float, float, float, float] | None = None,
+    source_artifact_id: str | None = None,
+    source_artifact_sha256: str | None = None,
+) -> str:
+    """Hash canonical intrinsic descriptor content, excluding the digest itself.
+
+    This fingerprint authenticates the ordered catalog description without
+    reading potentially multi-terabyte member contents. When content identity
+    is known, ``source_artifact_sha256`` carries that separate integrity fact.
+    """
+    source_artifact: dict[str, str] | None = None
+    if source_artifact_id is not None or source_artifact_sha256 is not None:
+        if source_artifact_id is None or source_artifact_sha256 is None:
+            raise ValueError(
+                "dataset source artifact requires both artifact_id and sha256"
+            )
+        source_artifact = {
+            "artifact_id": source_artifact_id,
+            "sha256": source_artifact_sha256,
+        }
+    document = {
+        "schema_version": DATASET_DESCRIPTOR_SCHEMA_VERSION,
+        "dataset_id": dataset_id,
+        "kind": kind,
+        "format": format,
+        "members": [member.to_dict() for member in members],
+        "arrays": [array.to_dict() for array in arrays],
+        "bounds": list(bounds) if bounds is not None else None,
+        "source_artifact": source_artifact,
+    }
+    return hashlib.sha256(
+        _canonical_json(document, "dataset fingerprint input").encode("utf-8")
+    ).hexdigest()
+
+
+def _validate_identity(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or _IDENTITY_PATTERN.fullmatch(value) is None:
+        raise ValueError(f"service runtime {field_name} is invalid")
+
+
+def _validate_text(
+    value: str, field_name: str, *, maximum: int = MAX_TEXT_BYTES
+) -> None:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(value.encode("utf-8")) > maximum
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise ValueError(f"{field_name} must be bounded printable text")
+
+
+def _validate_cluster_path(value: str) -> None:
+    _validate_text(value, "dataset member location")
+    if "\\" in value:
+        raise ValueError("dataset member locations must use POSIX separators")
+    path = PurePosixPath(value)
+    if not path.is_absolute() or path.as_posix() != value or ".." in path.parts:
+        raise ValueError("dataset member locations must be normalized absolute paths")
+
+
+def _validate_sha256(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or _SHA256_PATTERN.fullmatch(value) is None:
+        raise ValueError(f"{field_name} must be a lowercase SHA-256 digest")
+
+
+def _validate_finite(value: float, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field_name} must be numeric")
+    if not math.isfinite(value):
+        raise ValueError(f"{field_name} must be finite")
+
+
+def _validate_host(value: str) -> None:
+    _validate_text(value, "service runtime host", maximum=255)
+    if value in {"0.0.0.0", "::", "*", "localhost"}:
+        raise ValueError("service runtime host must be an advertised reachable host")
+    try:
+        ipaddress.ip_address(value)
+        return
+    except ValueError:
+        pass
+    labels = value.rstrip(".").split(".")
+    if any(
+        not label
+        or len(label) > 63
+        or re.fullmatch(r"[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?", label) is None
+        for label in labels
+    ):
+        raise ValueError("service runtime host must be a DNS name or IP address")
+
+
+def _validate_http_path(value: str) -> None:
+    if (
+        not isinstance(value, str)
+        or not value.startswith("/")
+        or value.startswith("//")
+        or len(value.encode("ascii", errors="ignore")) != len(value)
+        or len(value) > 256
+        or any(character in value for character in "?#\\")
+        or any(ord(character) < 33 or ord(character) == 127 for character in value)
+    ):
+        raise ValueError(
+            "service runtime endpoint paths must be bounded absolute paths"
+        )
+    if PurePosixPath(value).as_posix() != value or ".." in PurePosixPath(value).parts:
+        raise ValueError("service runtime endpoint paths must be normalized")
+
+
+def _canonical_json(value: object, label: str) -> str:
+    try:
+        return json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{label} must contain finite JSON values") from exc
+
+
+def _load_json(payload: str, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(payload, object_pairs_hook=_reject_duplicate_keys)
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise ValueError(f"{label} is not valid JSON") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return cast(dict[str, Any], value)
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON key: {key}")
+        value[key] = item
+    return value
+
+
+def _reject_unknown(
+    value: Mapping[str, Any],
+    expected: frozenset[str],
+    label: str,
+) -> None:
+    unknown = set(value) - expected
+    if unknown:
+        raise ValueError(f"unknown {label} fields: {sorted(unknown)}")
+
+
+def _required_mapping(value: object, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return cast(dict[str, Any], value)
+
+
+def _required_str(value: Mapping[str, Any], key: str, label: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str):
+        raise ValueError(f"{label} {key} must be a string")
+    return item
+
+
+__all__ = [
+    "DATASET_DESCRIPTOR_SCHEMA_VERSION",
+    "MAX_DATASET_ARRAYS",
+    "MAX_DATASET_MEMBERS",
+    "MAX_SERVICE_RUNTIME_BYTES",
+    "SERVICE_RUNTIME_SCHEMA_VERSION",
+    "SERVICE_RUNTIME_SNAPSHOT_SCHEMA_VERSION",
+    "DatasetArray",
+    "DatasetDescriptor",
+    "DatasetMember",
+    "ServiceLifecycle",
+    "ServiceProtocol",
+    "ServiceRuntimeReport",
+    "calculate_dataset_fingerprint",
+    "validate_service_runtime_history",
+]

--- a/jarvis_cd/service_runtime/store.py
+++ b/jarvis_cd/service_runtime/store.py
@@ -1,0 +1,340 @@
+"""Durable append-only storage for execution-owned service runtimes."""
+
+from __future__ import annotations
+
+import os
+import stat
+import time
+from contextlib import contextmanager
+from dataclasses import replace
+from pathlib import Path
+from typing import Callable, Final, Iterator
+
+from jarvis_cd.util.private_path import (
+    ensure_private_descriptor,
+    ensure_private_path,
+    reject_private_path_redirection,
+)
+
+from .schema import (
+    MAX_SERVICE_RUNTIME_BYTES,
+    ServiceLifecycle,
+    ServiceRuntimeReport,
+    validate_service_runtime_history,
+)
+
+MAX_SERVICE_RUNTIME_STORE_BYTES: Final = 64 * 1024 * 1024
+
+
+class ServiceRuntimeStore:
+    """Append and query a bounded, owner-private JSONL runtime store."""
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        """Bind the store to an exact JARVIS-owned sidecar path."""
+        self.path = Path(path)
+
+    def append(self, report: ServiceRuntimeReport) -> None:
+        """Append one validated report under an inter-process lock."""
+        self._prepare_parent()
+        with _exclusive_store_lock(self.path):
+            descriptor = _open_store(self.path, write=True)
+            try:
+                information = _validate_descriptor(self.path, descriptor)
+                existing = _read_reports(descriptor, information.st_size)
+                _commit_reports(descriptor, information.st_size, existing, [report])
+            finally:
+                os.close(descriptor)
+
+    def append_next(
+        self,
+        builder: Callable[
+            [tuple[ServiceRuntimeReport, ...]],
+            ServiceRuntimeReport,
+        ],
+    ) -> ServiceRuntimeReport:
+        """Build and append a monotonic report from locked current history."""
+        self._prepare_parent()
+        with _exclusive_store_lock(self.path):
+            descriptor = _open_store(self.path, write=True)
+            try:
+                information = _validate_descriptor(self.path, descriptor)
+                existing = _read_reports(descriptor, information.st_size)
+                report = builder(tuple(existing))
+                if not isinstance(report, ServiceRuntimeReport):
+                    raise TypeError("service runtime builder returned an invalid value")
+                _commit_reports(descriptor, information.st_size, existing, [report])
+                return report
+            finally:
+                os.close(descriptor)
+
+    def read_all(self) -> list[ServiceRuntimeReport]:
+        """Read every complete report and validate the whole history."""
+        _reject_symlink_tree(self.path)
+        if not self.path.exists():
+            return []
+        _reject_symlink_tree(self.path.parent)
+        with _exclusive_store_lock(self.path):
+            descriptor = _open_store(self.path, write=False)
+            try:
+                information = _validate_descriptor(self.path, descriptor)
+                return _read_reports(descriptor, information.st_size)
+            finally:
+                os.close(descriptor)
+
+    def current(self) -> dict[str, ServiceRuntimeReport]:
+        """Return the latest report for every service instance."""
+        current: dict[str, ServiceRuntimeReport] = {}
+        for report in self.read_all():
+            current[report.service_instance_id] = report
+        return current
+
+    def latest(
+        self, service_instance_id: str | None = None
+    ) -> ServiceRuntimeReport | None:
+        """Return the last report globally or for one exact instance."""
+        reports = self.read_all()
+        if service_instance_id is None:
+            return reports[-1] if reports else None
+        return next(
+            (
+                report
+                for report in reversed(reports)
+                if report.service_instance_id == service_instance_id
+            ),
+            None,
+        )
+
+    def finalize_active(self, *, failed: bool) -> list[ServiceRuntimeReport]:
+        """Close nonterminal services when their owning execution terminates."""
+        _reject_symlink_tree(self.path)
+        if not self.path.exists():
+            return []
+        self._prepare_parent()
+        with _exclusive_store_lock(self.path):
+            descriptor = _open_store(self.path, write=True)
+            try:
+                information = _validate_descriptor(self.path, descriptor)
+                existing = _read_reports(descriptor, information.st_size)
+                current: dict[str, ServiceRuntimeReport] = {}
+                for report in existing:
+                    current[report.service_instance_id] = report
+                observed_at = time.time()
+                additions: list[ServiceRuntimeReport] = []
+                for report in current.values():
+                    if report.lifecycle in {
+                        ServiceLifecycle.STOPPED,
+                        ServiceLifecycle.FAILED,
+                    }:
+                        continue
+                    additions.append(
+                        replace(
+                            report,
+                            revision=report.revision + 1,
+                            lifecycle=(
+                                ServiceLifecycle.FAILED
+                                if failed
+                                else ServiceLifecycle.STOPPED
+                            ),
+                            message=(
+                                "JARVIS reconciled the service after its owning "
+                                + ("execution failed" if failed else "execution ended")
+                            ),
+                            observed_at_epoch=max(
+                                observed_at,
+                                report.observed_at_epoch,
+                            ),
+                        )
+                    )
+                if additions:
+                    _commit_reports(
+                        descriptor,
+                        information.st_size,
+                        existing,
+                        additions,
+                    )
+                return additions
+            finally:
+                os.close(descriptor)
+
+    def _prepare_parent(self) -> None:
+        """Create and protect the parent without following redirections."""
+        _reject_symlink_tree(self.path.parent)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_private_path(self.path.parent, directory=True)
+        _reject_symlink_tree(self.path.parent)
+
+
+def _commit_reports(
+    descriptor: int,
+    original_size: int,
+    existing: list[ServiceRuntimeReport],
+    additions: list[ServiceRuntimeReport],
+) -> None:
+    """Validate and durably append a batch, rolling back partial writes."""
+    combined = [*existing, *additions]
+    validate_service_runtime_history(combined)
+    payload = b"".join(
+        (report.to_json() + "\n").encode("utf-8") for report in additions
+    )
+    if original_size + len(payload) > MAX_SERVICE_RUNTIME_STORE_BYTES:
+        raise ValueError("service runtime store would exceed maximum size")
+    os.lseek(descriptor, 0, os.SEEK_END)
+    try:
+        offset = 0
+        while offset < len(payload):
+            written = os.write(descriptor, payload[offset:])
+            if written <= 0:
+                raise OSError("short write while appending service runtime report")
+            offset += written
+        os.fsync(descriptor)
+    except BaseException:
+        os.ftruncate(descriptor, original_size)
+        os.fsync(descriptor)
+        raise
+
+
+def _read_reports(descriptor: int, size: int) -> list[ServiceRuntimeReport]:
+    """Read one locked descriptor without closing the caller's handle."""
+    if size > MAX_SERVICE_RUNTIME_STORE_BYTES:
+        raise ValueError("service runtime store exceeds maximum size")
+    if size:
+        os.lseek(descriptor, size - 1, os.SEEK_SET)
+        if os.read(descriptor, 1) != b"\n":
+            raise ValueError("service runtime store has an incomplete JSONL record")
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    reports: list[ServiceRuntimeReport] = []
+    with os.fdopen(os.dup(descriptor), "r", encoding="utf-8", newline="") as stream:
+        for line_number, line in enumerate(stream, start=1):
+            if len(line.encode("utf-8")) > MAX_SERVICE_RUNTIME_BYTES + 1:
+                raise ValueError(
+                    f"service runtime line {line_number} exceeds maximum size"
+                )
+            payload = line.rstrip("\r\n")
+            if not payload:
+                raise ValueError(f"service runtime line {line_number} cannot be empty")
+            reports.append(ServiceRuntimeReport.from_json(payload))
+    validate_service_runtime_history(reports)
+    return reports
+
+
+def _reject_symlink(path: Path, *, label: str) -> None:
+    try:
+        information = path.lstat()
+    except FileNotFoundError:
+        return
+    attributes = getattr(information, "st_file_attributes", 0)
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    if stat.S_ISLNK(information.st_mode) or attributes & reparse_flag:
+        raise ValueError(f"{label} cannot be a symlink or reparse point: {path}")
+
+
+def _reject_symlink_tree(path: Path) -> None:
+    try:
+        reject_private_path_redirection(path)
+    except RuntimeError as exc:
+        raise ValueError(
+            "service runtime path cannot be redirected by a symlink or reparse "
+            f"point: {path}"
+        ) from exc
+
+
+def _open_store(path: Path, *, write: bool) -> int:
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if write:
+        try:
+            descriptor = os.open(
+                path,
+                os.O_APPEND | os.O_CREAT | os.O_EXCL | os.O_RDWR | nofollow,
+                0o600,
+            )
+        except FileExistsError:
+            descriptor = os.open(path, os.O_APPEND | os.O_RDWR | nofollow)
+        else:
+            if os.name != "nt":
+                os.fchmod(descriptor, 0o600)  # type: ignore[attr-defined]
+    else:
+        descriptor = os.open(path, os.O_RDONLY | nofollow)
+    try:
+        ensure_private_descriptor(path, descriptor, directory=False)
+    except BaseException:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
+def _validate_descriptor(path: Path, descriptor: int) -> os.stat_result:
+    information = os.fstat(descriptor)
+    if not stat.S_ISREG(information.st_mode):
+        raise ValueError(f"service runtime store must be a regular file: {path}")
+    path_information = path.lstat()
+    if stat.S_ISLNK(path_information.st_mode) or (
+        path_information.st_dev,
+        path_information.st_ino,
+    ) != (information.st_dev, information.st_ino):
+        raise ValueError(f"service runtime store changed during secure open: {path}")
+    if os.name != "nt":
+        getuid = getattr(os, "getuid", None)
+        if getuid is not None and information.st_uid != getuid():
+            raise PermissionError(
+                f"service runtime store is not owned by current user: {path}"
+            )
+        if stat.S_IMODE(information.st_mode) & 0o077:
+            raise PermissionError(
+                f"service runtime store permissions are not private: {path}"
+            )
+    return information
+
+
+@contextmanager
+def _exclusive_store_lock(path: Path) -> Iterator[None]:
+    lock_path = path.with_name(path.name + ".lock")
+    _reject_symlink(lock_path, label="service runtime lock")
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(
+            lock_path,
+            os.O_CREAT | os.O_EXCL | os.O_RDWR | nofollow,
+            0o600,
+        )
+    except FileExistsError:
+        descriptor = os.open(lock_path, os.O_RDWR | nofollow)
+    try:
+        ensure_private_descriptor(lock_path, descriptor, directory=False)
+        _validate_descriptor(lock_path, descriptor)
+        if os.fstat(descriptor).st_size == 0:
+            os.write(descriptor, b"0")
+            os.fsync(descriptor)
+        _lock_descriptor(descriptor)
+        try:
+            yield
+        finally:
+            _unlock_descriptor(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _lock_descriptor(descriptor: int) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
+        return
+    import fcntl
+
+    fcntl.flock(descriptor, fcntl.LOCK_EX)
+
+
+def _unlock_descriptor(descriptor: int) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+        return
+    import fcntl
+
+    fcntl.flock(descriptor, fcntl.LOCK_UN)
+
+
+__all__ = ["MAX_SERVICE_RUNTIME_STORE_BYTES", "ServiceRuntimeStore"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ requires = [
 ]
 
 [tool.setuptools]
-packages = ["jarvis_cd", "jarvis_cd.artifacts", "jarvis_cd.core", "jarvis_cd.progress", "jarvis_cd.shell", "jarvis_cd.util", "builtin", "builtin.builtin"]
+packages = ["jarvis_cd", "jarvis_cd.artifacts", "jarvis_cd.core", "jarvis_cd.progress", "jarvis_cd.service_runtime", "jarvis_cd.shell", "jarvis_cd.util", "builtin", "builtin.builtin"]
 include-package-data = true
 
 [tool.setuptools.package-data]

--- a/test/unit/core/test_execution.py
+++ b/test/unit/core/test_execution.py
@@ -617,6 +617,9 @@ def test_direct_run_returns_handle_and_restores_named_context(tmp_path: Path) ->
     def inspect_running_record() -> None:
         observed["root"] = pipeline._execution_root
         observed["record"] = pipeline.get_execution("direct-run")
+        pipeline.env["JARVIS_SERVICE_RUNTIME_PATH"] = str(
+            tmp_path / "execution" / "service-runtimes" / "viewer.jsonl"
+        )
 
     pipeline.start.side_effect = inspect_running_record
 

--- a/test/unit/core/test_execution_cli.py
+++ b/test/unit/core/test_execution_cli.py
@@ -116,6 +116,33 @@ def test_execution_artifacts_json_can_query_noncurrent_pipeline(
     constructor.assert_called_once_with("example")
 
 
+def test_execution_service_runtimes_json_can_query_noncurrent_pipeline(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Agents can discover owned services after the current pipeline changes."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    record = store.create("run-1", mode="direct")
+    snapshot = store.service_runtimes("run-1")
+    pipeline = SimpleNamespace(
+        get_execution_service_runtimes=Mock(return_value=snapshot),
+    )
+    cli = JarvisCLI()
+    cli.kwargs = {
+        "execution_id": record.execution_id,
+        "pipeline_id": "example",
+        "json": True,
+    }
+    cli._ensure_initialized = Mock()
+
+    with patch("jarvis_cd.core.cli.Pipeline", return_value=pipeline) as constructor:
+        cli.execution_service_runtimes()
+
+    assert json.loads(capsys.readouterr().out) == snapshot.to_dict()
+    pipeline.get_execution_service_runtimes.assert_called_once_with("run-1")
+    constructor.assert_called_once_with("example")
+
+
 def test_json_handle_is_emitted_as_one_final_line(capsys) -> None:
     """Run and submit handlers share the exact handle serialization."""
     handle = ExecutionHandle(
@@ -154,6 +181,10 @@ def test_submit_parser_accepts_execution_id_spellings(option: str) -> None:
         (["execution", "list"], "execution_list"),
         (["execution", "progress", "run-1"], "execution_progress"),
         (["execution", "artifacts", "run-1"], "execution_artifacts"),
+        (
+            ["execution", "service-runtimes", "run-1"],
+            "execution_service_runtimes",
+        ),
     ],
 )
 @pytest.mark.parametrize("option", ["--pipeline-id", "--pipeline_id"])

--- a/test/unit/core/test_paraview_service.py
+++ b/test/unit/core/test_paraview_service.py
@@ -1,0 +1,1162 @@
+"""Generic ParaView HTTP/SSE service and artifact-boundary tests."""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import threading
+import urllib.error
+import urllib.request
+from http import HTTPStatus
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Mapping, cast
+
+import pytest
+
+from builtin.builtin.paraview import service as service_module
+from builtin.builtin.paraview import pkg as package_module
+from builtin.builtin.paraview import service_supervisor as supervisor_module
+from builtin.builtin.paraview.service_http import (
+    COMMAND_RESULT_SCHEMA,
+    COMMAND_SCHEMA,
+    FRAME_SCHEMA,
+    STATE_SCHEMA,
+    CommandError,
+    ServiceStateController,
+    create_server,
+)
+from jarvis_cd.artifacts import ArtifactStore
+from jarvis_cd.service_runtime import (
+    DatasetDescriptor,
+    DatasetMember,
+    ServiceLifecycle,
+    calculate_dataset_fingerprint,
+)
+
+_PNG = b"\x89PNG\r\n\x1a\nreal-test-frame"
+
+
+def test_service_supervisor_rejects_shared_cluster_bind() -> None:
+    """The staged supervisor cannot bypass the package's loopback boundary."""
+    with pytest.raises(ValueError, match="loopback"):
+        supervisor_module.main(
+            [
+                "--service-script",
+                "service.py",
+                "--descriptor",
+                "descriptor.json",
+                "--output-dir",
+                "output",
+                "--pvpython-bin",
+                "pvpython",
+                "--bind-host",
+                "0.0.0.0",
+                "--advertise-host",
+                "compute-01.cluster.example",
+                "--port",
+                "0",
+                "--startup-timeout",
+                "30",
+                "--service-instance-id",
+                "service-test",
+            ]
+        )
+
+
+class _SupervisorProcess:
+    """Controllable child process with real stream and termination surfaces."""
+
+    def __init__(self) -> None:
+        self.stdout = io.StringIO("")
+        self.stderr = io.StringIO("")
+        self.returncode: int | None = None
+        self.terminate_calls = 0
+        self.kill_calls = 0
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        if self.returncode is None:
+            raise AssertionError("test child wait requires a terminal state")
+        return self.returncode
+
+
+class _HungSupervisorProcess(_SupervisorProcess):
+    """Ignore SIGTERM until the supervisor escalates to kill."""
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self.returncode is None:
+            raise subprocess.TimeoutExpired(
+                "pvpython",
+                0.0 if timeout is None else timeout,
+            )
+        return self.returncode
+
+
+class _RecordingReporter:
+    """Record supervisor transitions and optionally fail selected reports."""
+
+    execution_id = "exec-render"
+
+    def __init__(self, *, fail_on: set[ServiceLifecycle] | None = None) -> None:
+        self.fail_on = fail_on or set()
+        self.lifecycle_calls: list[ServiceLifecycle] = []
+
+    def report(
+        self,
+        lifecycle: ServiceLifecycle,
+        *,
+        message: str | None = None,
+    ) -> None:
+        del message
+        self.lifecycle_calls.append(lifecycle)
+        if lifecycle in self.fail_on:
+            raise OSError(f"{lifecycle.value} report failed")
+
+
+def _supervisor_descriptor(path: Path) -> Path:
+    """Write one valid intrinsic descriptor for supervisor unit tests."""
+    members = (DatasetMember(index=0, location="/cluster/input.vti"),)
+    descriptor = DatasetDescriptor(
+        dataset_id="supervisor-test",
+        kind="volume",
+        format="vtk-image-data",
+        members=members,
+        fingerprint=calculate_dataset_fingerprint(
+            dataset_id="supervisor-test",
+            kind="volume",
+            format="vtk-image-data",
+            members=members,
+        ),
+    )
+    path.write_text(descriptor.to_json(), encoding="utf-8")
+    return path
+
+
+def _supervisor_arguments(descriptor: Path, output_dir: Path) -> list[str]:
+    """Return a loopback supervisor command using no real subprocess."""
+    return [
+        "--service-script",
+        "service.py",
+        "--descriptor",
+        str(descriptor),
+        "--output-dir",
+        str(output_dir),
+        "--pvpython-bin",
+        "pvpython",
+        "--bind-host",
+        "127.0.0.1",
+        "--advertise-host",
+        "127.0.0.1",
+        "--port",
+        "18080",
+        "--startup-timeout",
+        "5",
+        "--service-instance-id",
+        "srv_0123456789abcdef0123456789abcdef",
+    ]
+
+
+def test_supervisor_termination_escalates_after_bounded_grace() -> None:
+    """A child that ignores terminate is killed after one finite timeout."""
+    process = _HungSupervisorProcess()
+
+    return_code, forced = supervisor_module._terminate_process(
+        cast(Any, process),
+        grace_seconds=0.01,
+    )
+
+    assert return_code == -9
+    assert forced is True
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 1
+
+
+class _HealthResponse:
+    """Context-managed HTTP response for exact health-contract tests."""
+
+    status = 200
+
+    def __init__(self, payload: Mapping[str, Any]) -> None:
+        self.payload = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self) -> "_HealthResponse":
+        return self
+
+    def __exit__(
+        self,
+        _exception_type: object,
+        _exception: object,
+        _traceback: object,
+    ) -> None:
+        return
+
+    def read(self, _limit: int) -> bytes:
+        return self.payload
+
+
+def test_supervisor_health_requires_exact_versioned_instance_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A different process or malformed revision cannot satisfy readiness."""
+    response_payload: dict[str, Any] = {}
+
+    def fake_urlopen(_request: object, *, timeout: float) -> _HealthResponse:
+        assert timeout == 0.5
+        return _HealthResponse(response_payload)
+
+    monkeypatch.setattr(supervisor_module.urllib.request, "urlopen", fake_urlopen)
+    expected = {
+        "schema_version": "jarvis.paraview.health.v1",
+        "status": "ready",
+        "service_instance_id": "srv_0123456789abcdef0123456789abcdef",
+        "revision": 1,
+    }
+    response_payload.update(expected)
+
+    assert supervisor_module._health_ready(
+        "127.0.0.1",
+        18080,
+        service_instance_id="srv_0123456789abcdef0123456789abcdef",
+    )
+    response_payload["revision"] = True
+    assert not supervisor_module._health_ready(
+        "127.0.0.1",
+        18080,
+        service_instance_id="srv_0123456789abcdef0123456789abcdef",
+    )
+    response_payload.update(expected)
+    response_payload["unexpected"] = "field"
+    assert not supervisor_module._health_ready(
+        "127.0.0.1",
+        18080,
+        service_instance_id="srv_0123456789abcdef0123456789abcdef",
+    )
+
+
+def test_stop_reporting_failure_does_not_prevent_owned_child_cleanup() -> None:
+    """Metadata I/O failure cannot orphan the supervised pvpython child."""
+    process = _SupervisorProcess()
+    reporter = _RecordingReporter(fail_on={ServiceLifecycle.STOPPING})
+
+    result = supervisor_module._stop_after_request(
+        cast(Any, process),
+        cast(Any, reporter),
+        ServiceLifecycle.READY,
+    )
+
+    assert result == 1
+    assert process.terminate_calls == 1
+    assert process.poll() == -15
+    assert reporter.lifecycle_calls == [
+        ServiceLifecycle.STOPPING,
+        ServiceLifecycle.STOPPED,
+    ]
+
+
+def test_supervisor_cleans_child_when_initial_reporting_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Even STARTING persistence failure enters the unconditional cleanup path."""
+    process = _SupervisorProcess()
+    reporter = _RecordingReporter(fail_on={ServiceLifecycle.STARTING})
+    descriptor = _supervisor_descriptor(tmp_path / "descriptor.json")
+
+    def fake_popen(*_args: Any, **_kwargs: Any) -> Any:
+        return process
+
+    def reporter_from_environment(**_kwargs: Any) -> _RecordingReporter:
+        return reporter
+
+    monkeypatch.setattr(supervisor_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        supervisor_module,
+        "ServiceRuntimeReporter",
+        SimpleNamespace(from_environment=reporter_from_environment),
+    )
+
+    result = supervisor_module.main(
+        _supervisor_arguments(descriptor, tmp_path / "output")
+    )
+
+    assert result == 1
+    assert process.terminate_calls == 1
+    assert process.poll() == -15
+    assert reporter.lifecycle_calls == [
+        ServiceLifecycle.STARTING,
+        ServiceLifecycle.FAILED,
+    ]
+
+
+def test_supervisor_reports_periodic_degradation_and_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Readiness remains a monitored lifecycle, not a one-time startup fact."""
+    process = _SupervisorProcess()
+    reporter = _RecordingReporter()
+    descriptor = _supervisor_descriptor(tmp_path / "descriptor.json")
+    probe_calls = 0
+
+    def fake_popen(*_args: Any, **_kwargs: Any) -> Any:
+        return process
+
+    def reporter_from_environment(**_kwargs: Any) -> _RecordingReporter:
+        return reporter
+
+    def health_ready(
+        _host: str,
+        _port: int,
+        *,
+        service_instance_id: str,
+    ) -> bool:
+        nonlocal probe_calls
+        assert service_instance_id == "srv_0123456789abcdef0123456789abcdef"
+        probe_calls += 1
+        healthy = probe_calls in {1, 5}
+        if probe_calls == 5:
+            process.returncode = 0
+        return healthy
+
+    monkeypatch.setattr(supervisor_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        supervisor_module,
+        "ServiceRuntimeReporter",
+        SimpleNamespace(from_environment=reporter_from_environment),
+    )
+    monkeypatch.setattr(supervisor_module, "_health_ready", health_ready)
+    monkeypatch.setattr(supervisor_module, "HEALTH_PROBE_INTERVAL_SECONDS", 0.001)
+
+    result = supervisor_module.main(
+        _supervisor_arguments(descriptor, tmp_path / "output")
+    )
+
+    assert result == 0
+    assert probe_calls == 5
+    assert reporter.lifecycle_calls == [
+        ServiceLifecycle.STARTING,
+        ServiceLifecycle.READY,
+        ServiceLifecycle.DEGRADED,
+        ServiceLifecycle.READY,
+        ServiceLifecycle.STOPPED,
+    ]
+
+
+class _CapturedExec:
+    """Capture a real package launch boundary without starting pvpython."""
+
+    commands: list[tuple[str, Any]] = []
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+        self.commands.append((command, exec_info))
+
+    def run(self) -> "_CapturedExec":
+        return self
+
+
+class _Backend:
+    """Deterministic real transport test backend; fakes stay in tests only."""
+
+    def __init__(self) -> None:
+        self.timestep = 0
+        self.artifacts: list[dict[str, Any]] = []
+
+    def dataset_state(self) -> dict[str, Any]:
+        return {
+            "descriptor": {
+                "schema_version": "jarvis.dataset-descriptor.v1",
+                "dataset_id": "transport-test",
+            },
+            "discovery": {
+                "arrays": [],
+                "bounds": None,
+                "timestep_values": [0.0, 1.0],
+            },
+        }
+
+    def pipeline_state(self) -> dict[str, Any]:
+        return {
+            "timestep": {
+                "index": self.timestep,
+                "value": float(self.timestep),
+                "count": 2,
+            },
+            "active_field": None,
+            "filters": [],
+            "colormap": None,
+            "camera": {
+                "position": [1.0, 1.0, 1.0],
+                "focal_point": [0.0, 0.0, 0.0],
+                "view_up": [0.0, 1.0, 0.0],
+                "parallel_scale": 1.0,
+            },
+            "selection": None,
+            "artifacts": self.artifacts,
+        }
+
+    def execute(
+        self,
+        operation: str,
+        arguments: Mapping[str, Any],
+        command_id: str,
+    ) -> dict[str, Any]:
+        del command_id
+        if operation != "set_timestep" or set(arguments) != {"index"}:
+            raise CommandError("unsupported", "test backend only accepts timestep")
+        index = arguments["index"]
+        if isinstance(index, bool) or not isinstance(index, int) or index not in {0, 1}:
+            raise CommandError("out_of_range", "test timestep is out of range")
+        self.timestep = index
+        return {"timestep": {"index": index, "value": float(index)}}
+
+    def render_png(self) -> bytes:
+        return _PNG
+
+
+class _SelectionCollection:
+    """Small vtkCollection stand-in used only at the unit-test boundary."""
+
+    def __init__(self) -> None:
+        self.items: list[Any] = []
+
+    def GetNumberOfItems(self) -> int:
+        return len(self.items)
+
+    def GetItemAsObject(self, index: int) -> Any:
+        return self.items[index]
+
+
+class _SelectionSource:
+    def __init__(self, xml_name: str, ids: list[int]) -> None:
+        self.xml_name = xml_name
+        self.proxy = SimpleNamespace(IDs=ids)
+
+    def GetXMLName(self) -> str:
+        return self.xml_name
+
+
+class _InputProperty:
+    def __init__(self, source: Any) -> None:
+        self.source = source
+
+    def GetProxy(self, _index: int) -> Any:
+        return self.source
+
+
+class _SelectionRepresentation:
+    def __init__(self, source: Any) -> None:
+        self.source = source
+
+    def GetProperty(self, name: str) -> _InputProperty:
+        assert name == "Input"
+        return _InputProperty(self.source)
+
+
+class _SelectionServerManager:
+    @staticmethod
+    def _getPyProxy(source: _SelectionSource) -> Any:
+        return source.proxy
+
+
+class _SelectionView:
+    def __init__(self, source: Any, ids: list[int]) -> None:
+        self.source = source
+        self.ids = ids
+        self.pixel_rectangle: list[int] | None = None
+
+    def SelectSurfaceCells(
+        self,
+        pixel_rectangle: list[int],
+        representations: _SelectionCollection,
+        selections: _SelectionCollection,
+        _modifier: int,
+    ) -> None:
+        self.pixel_rectangle = pixel_rectangle
+        representations.items.append(_SelectionRepresentation(self.source))
+        selections.items.append(_SelectionSource("IDSelectionSource", self.ids))
+
+
+class _SelectionSimple:
+    def __init__(self) -> None:
+        self.surface_calls: list[tuple[list[int], Any]] = []
+
+    def Render(self, _view: Any) -> None:
+        return
+
+    def SelectSurfaceCells(self, *, Rectangle: list[int], View: Any) -> None:
+        self.surface_calls.append((Rectangle, View))
+
+
+def _command(
+    *,
+    command_id: str = "cmd-1",
+    expected_revision: int | None = 1,
+    index: int = 1,
+) -> dict[str, Any]:
+    return {
+        "schema_version": COMMAND_SCHEMA,
+        "command_id": command_id,
+        "operation": "set_timestep",
+        "expected_revision": expected_revision,
+        "arguments": {"index": index},
+    }
+
+
+def test_controller_returns_authoritative_state_and_idempotent_result() -> None:
+    """Semantic commands mutate backend state once and return that exact state."""
+    controller = ServiceStateController(
+        backend=_Backend(),
+        execution_id="exec-render",
+        service_instance_id="srv_0123456789abcdef0123456789abcdef",
+    )
+
+    initial = controller.state()
+    first = controller.command(_command())
+    replay = controller.command(_command())
+
+    assert initial["schema_version"] == STATE_SCHEMA
+    assert initial["revision"] == 1
+    assert first == replay
+    assert first["schema_version"] == COMMAND_RESULT_SCHEMA
+    assert first["state"]["revision"] == 2
+    assert first["state"]["pipeline"]["timestep"]["index"] == 1
+    with pytest.raises(CommandError, match="different command"):
+        controller.command(_command(index=0))
+
+
+def test_controller_rejects_stale_revision_before_backend_mutation() -> None:
+    """Concurrent agents receive an explicit conflict instead of lost updates."""
+    controller = ServiceStateController(
+        backend=_Backend(),
+        execution_id="exec-render",
+        service_instance_id="srv_0123456789abcdef0123456789abcdef",
+    )
+    controller.command(_command())
+
+    with pytest.raises(CommandError) as captured:
+        controller.command(_command(command_id="cmd-2", expected_revision=1, index=0))
+
+    assert captured.value.code == "revision_conflict"
+    assert captured.value.details == {"expected_revision": 1, "actual_revision": 2}
+
+
+def test_controller_retains_ids_until_explicit_lifetime_limit() -> None:
+    """Old command IDs remain replayable after the bounded service fills."""
+    controller = ServiceStateController(
+        backend=_Backend(),
+        execution_id="exec-render",
+        service_instance_id="srv_0123456789abcdef0123456789abcdef",
+        max_commands=2,
+    )
+    first_command = _command(command_id="cmd-1", expected_revision=1, index=1)
+    first = controller.command(first_command)
+    controller.command(_command(command_id="cmd-2", expected_revision=2, index=0))
+
+    with pytest.raises(CommandError) as captured:
+        controller.command(_command(command_id="cmd-3", expected_revision=3, index=1))
+
+    assert captured.value.code == "command_limit"
+    assert captured.value.status is HTTPStatus.TOO_MANY_REQUESTS
+    assert captured.value.details == {"max_commands": 2}
+    assert controller.command(first_command) == first
+
+
+class _ScreenshotSimple:
+    """Write deterministic screenshot bytes at the real filesystem boundary."""
+
+    def __init__(self, payload: bytes = _PNG) -> None:
+        self.payload = payload
+        self.calls: list[tuple[Path, list[int]]] = []
+
+    def SaveScreenshot(
+        self,
+        path: str,
+        _view: object,
+        *,
+        ImageResolution: list[int],
+    ) -> None:
+        target = Path(path)
+        self.calls.append((target, ImageResolution))
+        target.write_bytes(self.payload)
+
+
+def test_unique_png_export_never_overwrites_and_rejects_invalid_output(
+    tmp_path: Path,
+) -> None:
+    """Publishing validates PNG bytes and uses create-if-absent semantics."""
+    simple = _ScreenshotSimple()
+    output = tmp_path / "frame.png"
+
+    payload = service_module._write_unique_png(
+        simple=simple,
+        view=object(),
+        output_path=output,
+        width=640,
+        height=480,
+    )
+
+    assert payload == _PNG
+    assert output.read_bytes() == _PNG
+    with pytest.raises(CommandError) as captured:
+        service_module._write_unique_png(
+            simple=simple,
+            view=object(),
+            output_path=output,
+            width=640,
+            height=480,
+        )
+    assert captured.value.code == "artifact_exists"
+    assert captured.value.status is HTTPStatus.CONFLICT
+    assert output.read_bytes() == _PNG
+    assert len(simple.calls) == 1
+
+    invalid_output = tmp_path / "invalid.png"
+    with pytest.raises(RuntimeError, match="did not produce a PNG"):
+        service_module._write_unique_png(
+            simple=_ScreenshotSimple(b"not-a-png"),
+            view=object(),
+            output_path=invalid_output,
+            width=640,
+            height=480,
+        )
+    assert not invalid_output.exists()
+
+
+def test_export_rolls_back_png_when_manifest_publication_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A failed artifact record cannot leave an untracked exported PNG."""
+    backend = cast(Any, object.__new__(service_module.ParaViewBackend))
+    backend.output_dir = tmp_path.resolve()
+    backend.simple = _ScreenshotSimple()
+    backend.view = object()
+    backend._artifacts = []
+    backend.service_instance_id = "srv_0123456789abcdef0123456789abcdef"
+
+    def fail_manifest(**_kwargs: Any) -> dict[str, Any]:
+        raise OSError("sidecar fsync failed")
+
+    monkeypatch.setattr(service_module, "_append_artifact", fail_manifest)
+
+    with pytest.raises(OSError, match="sidecar fsync failed"):
+        backend._export_artifact(
+            {"filename": "nested/frame.png", "width": 640, "height": 480},
+            "cmd-export",
+        )
+
+    assert not (tmp_path / "nested" / "frame.png").exists()
+    assert backend._artifacts == []
+
+
+class _CameraView:
+    """Mutable camera properties matching ParaView's render view surface."""
+
+    def __init__(self) -> None:
+        self.CameraPosition = [4.0, 3.0, 2.0]
+        self.CameraFocalPoint = [0.0, 0.0, 0.0]
+        self.CameraViewUp = [0.0, 1.0, 0.0]
+        self.CameraParallelScale = 5.0
+
+
+class _RenderSimple:
+    """Fail the selected render call without mutating the camera itself."""
+
+    def __init__(self, *, fail_on: set[int] | None = None) -> None:
+        self.fail_on = fail_on or set()
+        self.render_calls = 0
+
+    def Render(self, _view: object) -> None:
+        self.render_calls += 1
+        if self.render_calls in self.fail_on:
+            raise RuntimeError("render failed")
+
+
+def test_camera_validates_before_mutation_and_rolls_back_render_failure() -> None:
+    """A rejected or failed camera command leaves the prior camera exact."""
+    backend = cast(Any, object.__new__(service_module.ParaViewBackend))
+    backend.view = _CameraView()
+    backend.simple = _RenderSimple()
+    original = backend._camera_state()
+
+    with pytest.raises(CommandError, match="must be distinct"):
+        backend._set_camera(
+            {"position": [0.0, 0.0, 0.0]},
+            "cmd-invalid-camera",
+        )
+
+    assert backend._camera_state() == original
+    assert backend.simple.render_calls == 0
+
+    backend.simple = _RenderSimple(fail_on={1})
+    with pytest.raises(RuntimeError, match="render failed"):
+        backend._set_camera(
+            {"position": [8.0, 3.0, 2.0], "parallel_scale": 8.0},
+            "cmd-failed-camera",
+        )
+
+    assert backend._camera_state() == original
+    assert backend.simple.render_calls == 2
+
+
+class _FilterProxy:
+    """Minimal slice proxy used to exercise mutation ordering."""
+
+    def __init__(self) -> None:
+        self.SliceType = SimpleNamespace(Origin=None, Normal=None)
+        self.updated = False
+
+    def UpdatePipeline(self) -> None:
+        self.updated = True
+
+
+class _FilterSimple:
+    """ParaView surface intentionally omitting ResetCamera."""
+
+    def __init__(self) -> None:
+        self.slice_calls: list[object] = []
+        self.hidden: list[object] = []
+        self.proxy = _FilterProxy()
+
+    def Slice(self, *, Input: object) -> _FilterProxy:
+        self.slice_calls.append(Input)
+        return self.proxy
+
+    def Show(self, source: object, _view: object) -> object:
+        return SimpleNamespace(source=source)
+
+    def Hide(self, source: object, _view: object) -> None:
+        self.hidden.append(source)
+
+    def Delete(self, _source: object) -> None:
+        return
+
+    def Render(self, _view: object) -> None:
+        return
+
+
+def test_filter_validates_atomically_and_preserves_explicit_camera() -> None:
+    """Filters have no hidden reset and commit only after full validation."""
+    backend = cast(Any, object.__new__(service_module.ParaViewBackend))
+    previous_source = object()
+    backend.active_source = previous_source
+    backend.display = object()
+    backend.view = _CameraView()
+    backend.simple = _FilterSimple()
+    backend._filters = []
+    backend._arrays = []
+    backend._active_field = {"name": "pressure", "association": "point"}
+    backend._colormap = {"preset": "Viridis", "invert": False}
+    backend._selection = {"status": "selected"}
+    backend._discover_arrays = lambda _source=None: []
+    backend._discover_bounds = lambda _source=None: (0.0, 1.0, 0.0, 1.0, 0.0, 1.0)
+    original_camera = backend._camera_state()
+
+    with pytest.raises(CommandError, match="zero vector"):
+        backend._apply_filter(
+            {
+                "type": "slice",
+                "parameters": {
+                    "origin": [0.0, 0.0, 0.0],
+                    "normal": [0.0, 0.0, 0.0],
+                },
+            },
+            "cmd-invalid-filter",
+        )
+
+    assert backend.simple.slice_calls == []
+    result = backend._apply_filter(
+        {
+            "type": "slice",
+            "parameters": {
+                "origin": [0.0, 0.0, 0.0],
+                "normal": [0.0, 0.0, 1.0],
+            },
+        },
+        "cmd-valid-filter",
+    )
+
+    assert result["filter"]["type"] == "slice"
+    assert backend.active_source is backend.simple.proxy
+    assert backend.simple.proxy.updated is True
+    assert backend._camera_state() == original_camera
+    assert backend._active_field is None
+    assert backend._colormap is None
+    assert backend._selection is None
+
+
+class _FieldDisplay:
+    """Record transfer-function rescaling for active-field tests."""
+
+    def __init__(self) -> None:
+        self.rescale_calls = 0
+
+    def RescaleTransferFunctionToDataRange(
+        self,
+        _extend: bool,
+        _force: bool,
+    ) -> None:
+        self.rescale_calls += 1
+
+
+class _FieldSimple(_RenderSimple):
+    """Record the actual ColorBy choice applied to a display."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.color_by: tuple[str, str] | None = None
+
+    def ColorBy(self, _display: object, field: tuple[str, str]) -> None:
+        self.color_by = field
+
+
+def test_active_field_change_clears_stale_colormap_semantics() -> None:
+    """A transfer preset is never claimed for a newly selected array."""
+    backend = cast(Any, object.__new__(service_module.ParaViewBackend))
+    backend._arrays = [{"name": "temperature", "association": "point", "components": 1}]
+    backend._active_field = {
+        "name": "pressure",
+        "association": "point",
+        "components": 1,
+    }
+    backend._colormap = {"preset": "Viridis", "invert": False}
+    backend.display = _FieldDisplay()
+    backend.simple = _FieldSimple()
+    backend.view = object()
+
+    result = backend._set_active_field(
+        {"name": "temperature", "association": "point"},
+        "cmd-field",
+    )
+
+    assert result["active_field"]["name"] == "temperature"
+    assert backend.simple.color_by == ("POINTS", "temperature")
+    assert backend._colormap is None
+
+
+def test_http_health_state_command_conflict_and_frame_sse() -> None:
+    """The real stdlib server exposes all bounded transport behaviors."""
+    controller = ServiceStateController(
+        backend=_Backend(),
+        execution_id="exec-render",
+        service_instance_id="srv_0123456789abcdef0123456789abcdef",
+    )
+    server = create_server("127.0.0.1", 0, controller)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    origin = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        with urllib.request.urlopen(origin + "/healthz", timeout=2) as response:
+            health = json.load(response)
+        with urllib.request.urlopen(origin + "/state", timeout=2) as response:
+            state = json.load(response)
+        request = urllib.request.Request(
+            origin + "/commands",
+            data=json.dumps(_command()).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=2) as response:
+            result = json.load(response)
+        stale = urllib.request.Request(
+            origin + "/commands",
+            data=json.dumps(
+                _command(command_id="cmd-2", expected_revision=1, index=0)
+            ).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as captured:
+            urllib.request.urlopen(stale, timeout=2)
+        conflict = json.load(captured.value)
+        with urllib.request.urlopen(origin + "/live-data", timeout=2) as response:
+            event = response.readline().decode("ascii").strip()
+            event_id = response.readline().decode("ascii").strip()
+            data = response.readline().decode("utf-8").strip()
+
+        assert health["status"] == "ready"
+        assert state["schema_version"] == STATE_SCHEMA
+        assert result["state"]["revision"] == 2
+        assert captured.value.code == 409
+        assert conflict["error"]["code"] == "revision_conflict"
+        assert event == "event: frame"
+        assert event_id == "id: 2"
+        assert json.loads(data.removeprefix("data: "))["schema_version"] == FRAME_SCHEMA
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_missing_paraview_runtime_fails_explicitly(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A normal Python interpreter never degrades into a pretend renderer."""
+
+    def missing(_name: str) -> Any:
+        raise ImportError("paraview is not installed")
+
+    monkeypatch.setattr(service_module.importlib, "import_module", missing)
+
+    with pytest.raises(RuntimeError, match="requires pvpython"):
+        service_module.ParaViewBackend(
+            descriptor={},
+            output_dir=tmp_path,
+            service_instance_id="srv_0123456789abcdef0123456789abcdef",
+        )
+
+
+def test_normalized_viewport_maps_to_real_paraview_pixels() -> None:
+    """Browser drag boxes use top-left coordinates; ParaView uses bottom-left."""
+    viewport = service_module._viewport({"x0": 0.1, "y0": 0.2, "x1": 0.9, "y1": 0.6})
+
+    assert service_module._viewport_pixel_rectangle(viewport, (960, 540)) == [
+        95,
+        215,
+        864,
+        432,
+    ]
+    with pytest.raises(CommandError, match="positive width"):
+        service_module._viewport({"x0": 0.5, "y0": 0.2, "x1": 0.5, "y1": 0.6})
+    with pytest.raises(CommandError, match="normalized"):
+        service_module._viewport({"x0": -0.1, "y0": 0.2, "x1": 0.5, "y1": 0.6})
+
+
+def test_surface_selection_returns_real_ids_with_bounded_result() -> None:
+    """The response caps IDs while preserving ParaView's exact selected count."""
+    source = SimpleNamespace()
+    representations = _SelectionCollection()
+    representations.items.append(_SelectionRepresentation(source))
+    selections = _SelectionCollection()
+    selections.items.append(
+        _SelectionSource(
+            "IDSelectionSource",
+            [value for index in range(300) for value in (0, index)],
+        )
+    )
+
+    ids, count, reason = service_module._surface_selection_ids(
+        selected_representations=representations,
+        selection_sources=selections,
+        active_source=SimpleNamespace(SMProxy=source),
+        servermanager=_SelectionServerManager(),
+        limit=256,
+    )
+
+    assert reason is None
+    assert count == 300
+    assert len(ids) == 256
+    assert ids[0] == {"process_id": 0, "element_id": 0}
+    assert ids[-1] == {"process_id": 0, "element_id": 255}
+
+
+def test_viewport_inspection_uses_backend_selection_and_exact_result_shape() -> None:
+    """Viewport inspection delegates to ParaView and never maps pixels to world data."""
+    source = SimpleNamespace()
+    view = _SelectionView(source, [0, 41, 0, 73])
+    simple = _SelectionSimple()
+    backend = cast(Any, object.__new__(service_module.ParaViewBackend))
+    backend.active_source = SimpleNamespace(SMProxy=source)
+    backend.view = view
+    backend.simple = simple
+    backend.servermanager = _SelectionServerManager()
+    backend.vtk = SimpleNamespace(vtkCollection=_SelectionCollection)
+    backend._selection = None
+
+    result = backend._inspect_selection(
+        {"viewport": {"x0": 0.25, "y0": 0.1, "x1": 0.75, "y1": 0.9}},
+        "cmd-select",
+    )
+
+    selection = result["selection"]
+    assert selection == {
+        "selector": "viewport",
+        "status": "selected",
+        "association": "cell",
+        "viewport": {"x0": 0.25, "y0": 0.1, "x1": 0.75, "y1": 0.9},
+        "pixel_rectangle": [239, 53, 720, 486],
+        "selected_count": 2,
+        "returned_count": 2,
+        "truncated": False,
+        "ids": [
+            {"process_id": 0, "element_id": 41},
+            {"process_id": 0, "element_id": 73},
+        ],
+        "reason": None,
+    }
+    assert view.pixel_rectangle == selection["pixel_rectangle"]
+    assert simple.surface_calls == [(selection["pixel_rectangle"], view)]
+
+
+def test_viewport_inspection_reports_unsupported_without_approximation() -> None:
+    """A missing backend picker is visible to callers instead of being guessed."""
+    backend = cast(Any, object.__new__(service_module.ParaViewBackend))
+    backend.active_source = SimpleNamespace(SMProxy=object())
+    backend.view = SimpleNamespace()
+    backend.simple = _SelectionSimple()
+    backend.servermanager = _SelectionServerManager()
+    backend.vtk = SimpleNamespace(vtkCollection=_SelectionCollection)
+    backend._selection = None
+
+    result = backend._inspect_selection(
+        {"viewport": {"x0": 0.1, "y0": 0.1, "x1": 0.2, "y1": 0.2}},
+        "cmd-select",
+    )
+
+    selection = result["selection"]
+    assert selection["status"] == "unsupported"
+    assert selection["selected_count"] is None
+    assert selection["ids"] == []
+    assert selection["reason"] == "paraview_surface_selection_unavailable"
+
+
+def test_package_service_mode_stages_generic_runtime_and_owned_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The package launches a supervisor with no dataset-specific scene input."""
+    member_values = [
+        {
+            "index": index,
+            "location": f"/cluster/asteroid/frame-{index:04d}.vti",
+            "timestep": float(index),
+        }
+        for index in range(5)
+    ]
+    members = tuple(DatasetMember.from_dict(value) for value in member_values)
+    fingerprint = calculate_dataset_fingerprint(
+        dataset_id="asteroid-subset",
+        kind="temporal-volume-series",
+        format="vtk-image-data",
+        members=members,
+    )
+    descriptor = {
+        "schema_version": "jarvis.dataset-descriptor.v1",
+        "dataset_id": "asteroid-subset",
+        "kind": "temporal-volume-series",
+        "format": "vtk-image-data",
+        "members": member_values,
+        "arrays": [],
+        "bounds": None,
+        "fingerprint": {"algorithm": "sha256", "digest": fingerprint},
+        "source_artifact": None,
+    }
+    package = cast(Any, object.__new__(package_module.Paraview))
+    package.pkg_dir = str(Path(package_module.__file__).resolve().parent)
+    package.pkg_id = "viewer"
+    package.pkg_type = "builtin.paraview"
+    package.global_id = "visualization.viewer"
+    package.shared_dir = str((tmp_path / "shared" / "viewer").resolve())
+    package.private_dir = str((tmp_path / "private" / "viewer").resolve())
+    package.config = {
+        "mode": "service",
+        "nprocs": 1,
+        "ppn": 1,
+        "cwd": "",
+        "dataset_descriptor": json.dumps(descriptor),
+        "pvpython_bin": "/opt/paraview/bin/pvpython",
+        "pvpython_options": "--mesa",
+        "service_bind_host": "127.0.0.1",
+        "service_advertise_host": "127.0.0.1",
+        "service_port": 0,
+        "service_startup_timeout": 30,
+    }
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: object())
+    package.env = {}
+    package.mod_env = {
+        "JARVIS_EXECUTION_ID": "exec-render",
+        "JARVIS_PACKAGE_NAME": "builtin.paraview",
+        "JARVIS_PACKAGE_ID": "viewer",
+        "JARVIS_PROGRESS_PATH": str((tmp_path / "progress.jsonl").resolve()),
+        "JARVIS_PROGRESS_TRANSPORT": "sidecar",
+        "JARVIS_ARTIFACT_PATH": str((tmp_path / "artifacts.jsonl").resolve()),
+        "JARVIS_ARTIFACT_TRANSPORT": "sidecar",
+        "JARVIS_SERVICE_RUNTIME_PATH": str(
+            (tmp_path / "service-runtimes.jsonl").resolve()
+        ),
+    }
+    _CapturedExec.commands = []
+    monkeypatch.setattr(package_module, "Exec", _CapturedExec)
+
+    package.start()
+
+    command, exec_info = _CapturedExec.commands[0]
+    assert "service_supervisor.py" in command
+    assert "/opt/paraview/bin/pvpython" in command
+    assert "--pvpython-options --mesa" in command
+    assert "--bind-host 127.0.0.1" in command
+    assert "--advertise-host 127.0.0.1" in command
+    assert exec_info.env["JARVIS_SERVICE_RUNTIME_PATH"].endswith(
+        "service-runtimes.jsonl"
+    )
+    assert exec_info.env["JARVIS_ARTIFACT_TRANSPORT"] == "sidecar"
+    service_roots = list(
+        (Path(package.shared_dir) / ".jarvis-service" / "exec-render").iterdir()
+    )
+    assert len(service_roots) == 1
+    service_root = service_roots[0]
+    assert (service_root / "service.py").is_file()
+    assert (service_root / "service_http.py").is_file()
+    assert (service_root / "service_supervisor.py").is_file()
+    assert (service_root / "output").is_dir()
+    staged_descriptor = json.loads(
+        (service_root / "dataset-descriptor.json").read_text(encoding="utf-8")
+    )
+    assert staged_descriptor == descriptor
+
+    package.config["service_bind_host"] = "0.0.0.0"
+    with pytest.raises(ValueError, match="loopback-only"):
+        package._start_service(dict(package.mod_env))
+
+
+def test_service_export_is_immediately_queryable_through_artifact_store(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Export results are fsynced to the existing artifact API before return."""
+    sidecar = (tmp_path / "execution" / "artifacts" / "viewer.jsonl").resolve()
+    output = (tmp_path / "shared" / "output" / "frame.png").resolve()
+    output.parent.mkdir(parents=True)
+    output.write_bytes(_PNG)
+    monkeypatch.setenv("JARVIS_ARTIFACT_PATH", str(sidecar))
+    monkeypatch.setenv("JARVIS_EXECUTION_ID", "exec-render")
+    monkeypatch.setenv("JARVIS_PACKAGE_NAME", "builtin.paraview")
+    monkeypatch.setenv("JARVIS_PACKAGE_ID", "viewer")
+
+    returned = service_module._append_artifact(
+        artifact_id="art_0123456789abcdefghijklmn",
+        logical_name="frame.png",
+        path=output,
+        size_bytes=len(_PNG),
+        sha256="a" * 64,
+        service_instance_id="srv_0123456789abcdef0123456789abcdef",
+        command_id="cmd-export",
+        cluster_location="/cluster/output/frame.png",
+    )
+    persisted = ArtifactStore(sidecar).latest(returned["artifact_id"])
+
+    assert persisted is not None
+    assert persisted.artifact_id == returned["artifact_id"]
+    assert persisted.location is not None
+    assert persisted.location.value == "/cluster/output/frame.png"
+    assert persisted.checksum == "sha256:" + "a" * 64

--- a/test/unit/core/test_service_runtime.py
+++ b/test/unit/core/test_service_runtime.py
@@ -1,0 +1,272 @@
+"""Durable execution-owned service-runtime contract tests."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from jarvis_cd.core.execution import (
+    SERVICE_RUNTIME_SNAPSHOT_SCHEMA,
+    ExecutionStore,
+)
+from jarvis_cd.core.pkg import Pkg
+from jarvis_cd.service_runtime import (
+    DatasetArray,
+    DatasetDescriptor,
+    DatasetMember,
+    ServiceLifecycle,
+    ServiceProtocol,
+    ServiceRuntimeReport,
+    ServiceRuntimeReporter,
+    ServiceRuntimeStore,
+    calculate_dataset_fingerprint,
+)
+
+
+def _descriptor() -> DatasetDescriptor:
+    members = tuple(
+        DatasetMember(
+            index=index,
+            location=f"/mnt/common/asteroid/frame-{index:04d}.vti",
+            timestep=float(index * 10),
+        )
+        for index in range(5)
+    )
+    arrays = (DatasetArray("pressure", "point", 1, "Pa"),)
+    bounds = (0.0, 10.0, -2.0, 2.0, 0.0, 1.0)
+    return DatasetDescriptor(
+        dataset_id="asteroid-2018-subset",
+        kind="temporal-volume-series",
+        format="vtk-image-data",
+        members=members,
+        arrays=arrays,
+        bounds=bounds,
+        fingerprint=calculate_dataset_fingerprint(
+            dataset_id="asteroid-2018-subset",
+            kind="temporal-volume-series",
+            format="vtk-image-data",
+            members=members,
+            arrays=arrays,
+            bounds=bounds,
+        ),
+    )
+
+
+def _report(
+    *,
+    revision: int = 1,
+    lifecycle: ServiceLifecycle = ServiceLifecycle.STARTING,
+) -> ServiceRuntimeReport:
+    return ServiceRuntimeReport(
+        execution_id="exec-render",
+        package_name="builtin.paraview",
+        package_id="viewer",
+        service_instance_id="srv_0123456789abcdef0123456789abcdef",
+        revision=revision,
+        lifecycle=lifecycle,
+        host="compute-01.cluster.example",
+        port=18080,
+        protocol=ServiceProtocol.HTTP,
+        health_path="/healthz",
+        live_data_path="/live-data",
+        events_path="/events",
+        state_path="/state",
+        command_path="/commands",
+        dataset_descriptor=_descriptor(),
+    )
+
+
+def test_descriptor_round_trip_has_only_intrinsic_bounded_facts() -> None:
+    """Descriptor identity is stable and cannot absorb a hidden scene recipe."""
+    descriptor = _descriptor()
+
+    decoded = DatasetDescriptor.from_json(descriptor.to_json())
+
+    assert decoded == descriptor
+    assert decoded.canonical_digest == descriptor.canonical_digest
+    document = descriptor.to_dict()
+    assert set(document) == {
+        "schema_version",
+        "dataset_id",
+        "kind",
+        "format",
+        "members",
+        "arrays",
+        "bounds",
+        "fingerprint",
+        "source_artifact",
+    }
+    document["camera"] = {"position": [1, 2, 3]}
+    with pytest.raises(ValueError, match="unknown dataset descriptor fields"):
+        DatasetDescriptor.from_dict(document)
+    forged = descriptor.to_dict()
+    forged["members"][0]["location"] = "/mnt/common/asteroid/other.vti"
+    with pytest.raises(ValueError, match="fingerprint does not match"):
+        DatasetDescriptor.from_dict(forged)
+
+
+def test_report_requires_reachable_host_command_path_and_push_mode() -> None:
+    """A runtime report contains every relay-facing endpoint explicitly."""
+    report = _report()
+    decoded = ServiceRuntimeReport.from_json(report.to_json())
+
+    assert decoded == report
+    assert decoded.base_url == "http://compute-01.cluster.example:18080"
+    assert decoded.to_dict()["command_path"] == "/commands"
+    with pytest.raises(ValueError, match="reachable host"):
+        replace(report, host="0.0.0.0")
+
+
+def test_store_enforces_revision_identity_and_terminal_lifecycle(
+    tmp_path: Path,
+) -> None:
+    """Append-only history cannot fork identity or reopen a stopped service."""
+    store = ServiceRuntimeStore(tmp_path / "service-runtimes" / "viewer.jsonl")
+    starting = _report()
+    ready = _report(revision=2, lifecycle=ServiceLifecycle.READY)
+    stopped = _report(revision=3, lifecycle=ServiceLifecycle.STOPPED)
+
+    store.append(starting)
+    store.append(ready)
+    store.append(stopped)
+
+    assert store.latest() == stopped
+    assert store.current() == {stopped.service_instance_id: stopped}
+    with pytest.raises(ValueError, match="lifecycle transition"):
+        store.append(_report(revision=4, lifecycle=ServiceLifecycle.READY))
+
+
+def test_reporter_uses_bound_identity_and_assigns_revisions(tmp_path: Path) -> None:
+    """Packages cannot choose another execution identity through report fields."""
+    path = tmp_path / "execution" / "service-runtimes" / "viewer.jsonl"
+    reporter = ServiceRuntimeReporter.from_environment(
+        service_instance_id="srv_0123456789abcdef0123456789abcdef",
+        host="compute-01.cluster.example",
+        port=18080,
+        dataset_descriptor=_descriptor(),
+        environ={
+            "JARVIS_EXECUTION_ID": "exec-render",
+            "JARVIS_PACKAGE_NAME": "builtin.paraview",
+            "JARVIS_PACKAGE_ID": "viewer",
+            "JARVIS_SERVICE_RUNTIME_PATH": str(path.resolve()),
+        },
+    )
+
+    starting = reporter.report(ServiceLifecycle.STARTING)
+    ready = reporter.report(ServiceLifecycle.READY)
+
+    assert (starting.revision, ready.revision) == (1, 2)
+    assert ready.execution_id == "exec-render"
+    assert ServiceRuntimeStore(path).latest() == ready
+
+
+@pytest.mark.parametrize(
+    ("execution_state", "return_code", "expected_lifecycle"),
+    [
+        ("completed", 0, ServiceLifecycle.STOPPED),
+        ("failed", 7, ServiceLifecycle.FAILED),
+    ],
+)
+def test_execution_terminalization_reconciles_active_service(
+    tmp_path: Path,
+    execution_state: str,
+    return_code: int,
+    expected_lifecycle: ServiceLifecycle,
+) -> None:
+    """A killed supervisor cannot leave a terminal execution claiming ready."""
+    store = ExecutionStore(tmp_path / "executions", "visualization")
+    record = store.create("exec-render", mode="direct")
+    runtime_path = (
+        store.executions_dir / record.execution_id / "service-runtimes" / "viewer.jsonl"
+    )
+    store.update(
+        record.execution_id,
+        state="running",
+        metadata={
+            "service_runtime_files": {
+                "package-viewer": {
+                    "filename": runtime_path.name,
+                    "package_id": "viewer",
+                    "package_name": "builtin.paraview",
+                }
+            }
+        },
+    )
+    runtime_store = ServiceRuntimeStore(runtime_path)
+    runtime_store.append(_report())
+    runtime_store.append(_report(revision=2, lifecycle=ServiceLifecycle.READY))
+
+    store.update(
+        record.execution_id,
+        state=execution_state,
+        terminal=True,
+        return_code=return_code,
+        error="service failed" if return_code else None,
+    )
+
+    latest = runtime_store.latest()
+    assert latest is not None
+    assert latest.revision == 3
+    assert latest.lifecycle is expected_lifecycle
+    assert "JARVIS reconciled" in (latest.message or "")
+
+
+def test_execution_snapshot_is_exact_identity_checked_wire_document(
+    tmp_path: Path,
+) -> None:
+    """Execution handles query the stable collection expected by relay."""
+    store = ExecutionStore(tmp_path / "executions", "visualization")
+    record = store.create("exec-render", mode="direct")
+    runtime_root = store.executions_dir / record.execution_id / "service-runtimes"
+    runtime_path = runtime_root / "viewer.jsonl"
+    store.update(
+        record.execution_id,
+        state="running",
+        metadata={
+            "service_runtime_files": {
+                "package-viewer": {
+                    "filename": runtime_path.name,
+                    "package_id": "viewer",
+                    "package_name": "builtin.paraview",
+                }
+            }
+        },
+    )
+    report = _report()
+    ServiceRuntimeStore(runtime_path).append(report)
+
+    snapshot = store.get(record.execution_id).handle.service_runtimes()
+    document = snapshot.to_dict()
+
+    assert document == {
+        "schema_version": SERVICE_RUNTIME_SNAPSHOT_SCHEMA,
+        "execution_id": "exec-render",
+        "pipeline_id": "visualization",
+        "execution_state": "running",
+        "terminal": False,
+        "service_runtimes": [report.to_dict()],
+    }
+
+
+def test_package_binding_exports_only_authoritative_runtime_path(
+    tmp_path: Path,
+) -> None:
+    """Core can bind a package reporter without application-selected identity."""
+    package = cast(Any, object.__new__(Pkg))
+    package.pkg_type = "builtin.paraview"
+    package.pkg_id = "viewer"
+    package.env = {}
+    package.mod_env = {}
+    path = (tmp_path / "execution" / "service-runtimes" / "viewer.jsonl").resolve()
+
+    package.bind_execution_service_runtime("exec-render", path)
+
+    assert package.mod_env == {
+        "JARVIS_EXECUTION_ID": "exec-render",
+        "JARVIS_SERVICE_RUNTIME_PATH": str(path),
+        "JARVIS_PACKAGE_NAME": "builtin.paraview",
+        "JARVIS_PACKAGE_ID": "viewer",
+    }


### PR DESCRIPTION
## Summary
- add a durable, queryable service-runtime SPI and execution APIs
- add an interactive ParaView service runtime with structured state, commands, selection, frames, and artifacts
- harden cleanup, idempotency, export publication, atomic mutations, and health recovery

## Validation
- 49 focused pytest tests
- Ruff check and format
- Pyright: 0 errors
- wheel build and packaged-file inspection