### PR TITLE
fix: canonicalize JARVIS state roots

### DIFF
--- a/jarvis_cd/core/config.py
+++ b/jarvis_cd/core/config.py
@@ -7,6 +7,28 @@ from jarvis_cd.util.hostfile import Hostfile
 
 
 _JARVIS_ROOT_ENVIRONMENT = "JARVIS_ROOT"
+_STATE_ROOT_FIELDS = ("config_dir", "private_dir", "shared_dir")
+
+
+def _canonicalize_state_roots(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Map the OS logical-home prefix without resolving state descendants."""
+    normalized = config.copy()
+    logical_home = Path(os.path.abspath(Path.home()))
+    canonical_home = logical_home.resolve()
+    for field_name in _STATE_ROOT_FIELDS:
+        value = normalized.get(field_name)
+        if value is None:
+            continue
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"JARVIS {field_name} must be a non-empty path string")
+        absolute = Path(os.path.abspath(Path(value).expanduser()))
+        try:
+            relative = absolute.relative_to(logical_home)
+        except ValueError:
+            normalized[field_name] = str(absolute)
+        else:
+            normalized[field_name] = str(canonical_home / relative)
+    return normalized
 
 
 def load_class(import_str: str, path: str, class_name: str):
@@ -83,7 +105,7 @@ class Jarvis:
         if configured_root is None:
             configured_root = os.environ.get(_JARVIS_ROOT_ENVIRONMENT)
         if configured_root is None:
-            self.jarvis_root = Path.home() / ".ppi-jarvis"
+            self.jarvis_root = (Path.home() / ".ppi-jarvis").resolve()
         else:
             if not configured_root or any(
                 ord(character) < 32 or ord(character) == 127
@@ -105,9 +127,9 @@ class Jarvis:
         self._hostfile = None
 
         # Directory paths
-        self.config_dir = None
-        self.private_dir = None
-        self.shared_dir = None
+        self.config_dir: Optional[str] = None
+        self.private_dir: Optional[str] = None
+        self.shared_dir: Optional[str] = None
 
         # Try to automatically load configuration if it exists
         if self.is_initialized():
@@ -143,16 +165,21 @@ class Jarvis:
         # Create jarvis root directory
         self.jarvis_root.mkdir(parents=True, exist_ok=True)
 
-        # Create required directories
-        Path(config_dir).mkdir(parents=True, exist_ok=True)
-        Path(private_dir).mkdir(parents=True, exist_ok=True)
-        Path(shared_dir).mkdir(parents=True, exist_ok=True)
+        # Create required directories before canonicalizing them. This keeps
+        # administrator-managed aliases such as /home -> /mnt/common outside
+        # the private-state path boundary without relaxing its no-link checks.
+        config_path = Path(config_dir).expanduser()
+        private_path = Path(private_dir).expanduser()
+        shared_path = Path(shared_dir).expanduser()
+        config_path.mkdir(parents=True, exist_ok=True)
+        private_path.mkdir(parents=True, exist_ok=True)
+        shared_path.mkdir(parents=True, exist_ok=True)
 
         # Initialize default configuration
         default_config = {
-            "config_dir": str(Path(config_dir).absolute()),
-            "private_dir": str(Path(private_dir).absolute()),
-            "shared_dir": str(Path(shared_dir).absolute()),
+            "config_dir": str(config_path.resolve()),
+            "private_dir": str(private_path.resolve()),
+            "shared_dir": str(shared_path.resolve()),
             "current_pipeline": None,
             "hostfile": None,
         }
@@ -246,12 +273,13 @@ class Jarvis:
         return self._hostfile
 
     def load_config(self) -> Dict[str, Any]:
-        """Load jarvis configuration from file"""
+        """Load configuration and migrate legacy logical state roots in memory."""
         if not self.config_file.exists():
             raise FileNotFoundError("Jarvis not initialized. Run 'jarvis init' first.")
 
         with open(self.config_file, "r") as f:
-            return yaml.safe_load(f) or {}
+            config = yaml.safe_load(f) or {}
+        return _canonicalize_state_roots(config)
 
     def load_repos(self) -> Dict[str, Any]:
         """Load repos configuration from file"""
@@ -270,11 +298,12 @@ class Jarvis:
             return yaml.safe_load(f) or {"storage": {}, "network": {}}
 
     def save_config(self, config: Dict[str, Any]):
-        """Save jarvis configuration to file"""
+        """Save jarvis configuration with canonical state-root paths."""
+        normalized = _canonicalize_state_roots(config)
         self.jarvis_root.mkdir(parents=True, exist_ok=True)
         with open(self.config_file, "w") as f:
-            yaml.dump(config, f, default_flow_style=False)
-        self._config = config
+            yaml.dump(normalized, f, default_flow_style=False)
+        self._config = normalized
 
     def save_repos(self, repos: Dict[str, Any]):
         """Save repos configuration to file"""
@@ -423,11 +452,17 @@ class Jarvis:
 
     def get_pipeline_dir(self, pipeline_name: str) -> Path:
         """Get the config directory for a specific pipeline"""
-        return Path(self.config_dir) / "pipelines" / validate_pipeline_id(pipeline_name)
+        return (
+            self._require_state_root(self.config_dir, "config_dir")
+            / "pipelines"
+            / validate_pipeline_id(pipeline_name)
+        )
 
     def get_pipeline_shared_dir(self, pipeline_name: str) -> Path:
         """Get the shared directory for a specific pipeline"""
-        return Path(self.shared_dir) / validate_pipeline_id(pipeline_name)
+        return self._require_state_root(
+            self.shared_dir, "shared_dir"
+        ) / validate_pipeline_id(pipeline_name)
 
     def get_containers_dir(self) -> Path:
         """Centralized SIF cache shared by every pipeline.
@@ -437,11 +472,20 @@ class Jarvis:
         pipelines reuse the same image without rebuilding or
         re-pulling.
         """
-        return Path(self.shared_dir) / "containers"
+        return self._require_state_root(self.shared_dir, "shared_dir") / "containers"
 
     def get_pipeline_private_dir(self, pipeline_name: str) -> Path:
         """Get the private directory for a specific pipeline"""
-        return Path(self.private_dir) / validate_pipeline_id(pipeline_name)
+        return self._require_state_root(
+            self.private_dir, "private_dir"
+        ) / validate_pipeline_id(pipeline_name)
+
+    @staticmethod
+    def _require_state_root(value: Optional[str], field_name: str) -> Path:
+        """Return one initialized state root or fail before using the CWD."""
+        if value is None:
+            raise RuntimeError(f"JARVIS {field_name} is not initialized")
+        return Path(value)
 
     def get_current_pipeline_dir(self) -> Optional[Path]:
         """Get the config directory for the current pipeline"""

--- a/test/unit/core/test_config_state_roots.py
+++ b/test/unit/core/test_config_state_roots.py
@@ -1,0 +1,151 @@
+"""Canonical JARVIS state-root tests."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from jarvis_cd.core.config import Jarvis
+from jarvis_cd.core.execution import ExecutionStore
+from jarvis_cd.util.private_path import reject_private_path_redirection
+
+
+def _directory_link(link: Path, target: Path) -> None:
+    """Create a directory redirection supported by the current platform."""
+    if os.name == "nt":
+        import _winapi
+
+        _winapi.CreateJunction(str(target), str(link))
+        return
+    link.symlink_to(target, target_is_directory=True)
+
+
+def test_symlinked_home_is_canonicalized_before_durable_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A site-wide home alias must not enter JARVIS private execution paths."""
+    canonical_home = tmp_path / "canonical-home"
+    canonical_home.mkdir()
+    logical_home = tmp_path / "logical-home"
+    _directory_link(logical_home, canonical_home)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: logical_home))
+
+    logical_roots = {
+        "config_dir": logical_home / "config",
+        "private_dir": logical_home / "private",
+        "shared_dir": logical_home / "shared",
+    }
+    jarvis_root = logical_home / ".ppi-jarvis"
+    Jarvis._instance = None
+    try:
+        jarvis = Jarvis(jarvis_root=str(jarvis_root))
+        jarvis.initialize(
+            config_dir=str(logical_roots["config_dir"]),
+            private_dir=str(logical_roots["private_dir"]),
+            shared_dir=str(logical_roots["shared_dir"]),
+        )
+
+        expected_roots = {
+            name: str((canonical_home / path.name).resolve())
+            for name, path in logical_roots.items()
+        }
+        assert jarvis.jarvis_root == (canonical_home / ".ppi-jarvis").resolve()
+        assert {
+            name: getattr(jarvis, name) for name in expected_roots
+        } == expected_roots
+        persisted = yaml.safe_load(jarvis.config_file.read_text(encoding="utf-8"))
+        assert {name: persisted[name] for name in expected_roots} == expected_roots
+
+        legacy = persisted.copy()
+        legacy.update({name: str(path) for name, path in logical_roots.items()})
+        jarvis.config_file.write_text(
+            yaml.safe_dump(legacy, default_flow_style=False),
+            encoding="utf-8",
+        )
+
+        Jarvis._instance = None
+        reloaded = Jarvis(jarvis_root=str(jarvis_root))
+        assert {
+            name: getattr(reloaded, name) for name in expected_roots
+        } == expected_roots
+
+        executions_dir = reloaded.get_pipeline_private_dir("example") / "executions"
+        store = ExecutionStore(executions_dir, "example")
+        created = store.create("execution_canonical", mode="direct")
+        observed = store.get(created.execution_id)
+        assert observed.execution_id == created.execution_id
+        reject_private_path_redirection(executions_dir)
+    finally:
+        Jarvis._instance = None
+
+
+def test_legacy_home_migration_does_not_hide_descendant_redirection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the trusted home alias is migrated; a private-state link is rejected."""
+    canonical_home = tmp_path / "canonical-home"
+    canonical_home.mkdir()
+    logical_home = tmp_path / "logical-home"
+    _directory_link(logical_home, canonical_home)
+    redirected_target = canonical_home / "redirected-target"
+    redirected_target.mkdir()
+    redirected_private = canonical_home / "redirected-private"
+    _directory_link(redirected_private, redirected_target)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: logical_home))
+
+    jarvis_root = canonical_home / ".ppi-jarvis"
+    jarvis_root.mkdir()
+    config_file = jarvis_root / "jarvis_config.yaml"
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                "config_dir": str(logical_home / "config"),
+                "private_dir": str(logical_home / "redirected-private"),
+                "shared_dir": str(logical_home / "shared"),
+                "current_pipeline": None,
+                "hostfile": None,
+            },
+            default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+
+    Jarvis._instance = None
+    try:
+        jarvis = Jarvis(jarvis_root=str(jarvis_root))
+        expected_private = canonical_home / "redirected-private"
+        assert jarvis.private_dir == str(expected_private)
+        store = ExecutionStore(
+            jarvis.get_pipeline_private_dir("example") / "executions",
+            "example",
+        )
+        with pytest.raises(RuntimeError, match="symbolic link or reparse point"):
+            store.create("blocked", mode="direct")
+        assert not (redirected_target / "example" / "executions").exists()
+    finally:
+        Jarvis._instance = None
+
+
+def test_default_jarvis_root_canonicalizes_home_alias(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The implicit JARVIS root follows the same trusted-root boundary."""
+    canonical_home = tmp_path / "canonical-home"
+    canonical_home.mkdir()
+    logical_home = tmp_path / "logical-home"
+    _directory_link(logical_home, canonical_home)
+    monkeypatch.delenv("JARVIS_ROOT", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: logical_home))
+
+    Jarvis._instance = None
+    try:
+        jarvis = Jarvis()
+        assert jarvis.jarvis_root == (canonical_home / ".ppi-jarvis").resolve()
+    finally:
+        Jarvis._instance = None


### PR DESCRIPTION
## What changed

- Canonicalize the operating system home prefix before JARVIS persists or loads config, private, and shared state roots.
- Resolve operator-supplied roots once during `jarvis init`.
- Preserve strict symlink/reparse rejection below the canonical state boundary.
- Fail explicitly when an uninitialized root would otherwise fall back to the current directory.

## Why

Ares exposes `/home` through the administrator-managed `/home -> /mnt/common` route. Durable execution correctly rejects redirects inside private state, but JARVIS 1.3.1 persisted the logical `/home` prefix and then rejected its own execution store.

## Validation

Five focused tests pass for symlinked-home initialization, legacy migration, durable create/get, descendant-link rejection, and the existing no-redirection guard. Ruff and Pyright pass.

Live reproducer: clio-relay job `job_5e5d87e1878a477584ae0073781c867f` on Ares.