### PR TITLE
fix: refresh managed builtin repository

### DIFF
--- a/jarvis_cd/core/config.py
+++ b/jarvis_cd/core/config.py
@@ -282,12 +282,24 @@ class Jarvis:
         return _canonicalize_state_roots(config)
 
     def load_repos(self) -> Dict[str, Any]:
-        """Load repos configuration from file"""
+        """Load repositories and bind the legacy builtin slot to this install.
+
+        Older installations copied the distribution's ``builtin`` repository
+        into ``<JARVIS_ROOT>/builtin`` once and then kept using that mutable
+        snapshot across package upgrades.  The exact legacy path is owned by
+        JARVIS, so it is safe to rebind that one entry in memory to the builtin
+        repository shipped beside the running ``jarvis_cd`` package.  Other
+        repository entries, including operator-provided repositories named
+        ``builtin``, remain untouched.
+        """
         if not self.repos_file.exists():
             return {"repos": []}
 
         with open(self.repos_file, "r") as f:
-            return yaml.safe_load(f) or {"repos": []}
+            repositories = yaml.safe_load(f) or {"repos": []}
+        if not isinstance(repositories, dict):
+            return repositories
+        return self._bind_distribution_builtin_repository(repositories)
 
     def load_resource_graph(self) -> Dict[str, Any]:
         """Load resource graph from file"""
@@ -306,11 +318,11 @@ class Jarvis:
         self._config = normalized
 
     def save_repos(self, repos: Dict[str, Any]):
-        """Save repos configuration to file"""
+        """Save repository config and bind its managed builtin view."""
         self.jarvis_root.mkdir(parents=True, exist_ok=True)
         with open(self.repos_file, "w") as f:
             yaml.dump(repos, f, default_flow_style=False)
-        self._repos = repos
+        self._repos = self._bind_distribution_builtin_repository(repos)
 
     def save_resource_graph(self, resource_graph: Dict[str, Any]):
         """Save resource graph to file"""
@@ -534,27 +546,31 @@ class Jarvis:
         return config_dir / "pipelines"
 
     def get_builtin_repo_path(self) -> Path:
-        """Get path to builtin repository"""
+        """Get the active builtin repository for this JARVIS installation."""
         # First check if builtin repo is registered in repos
         for repo_path_str in self.repos["repos"]:
             repo_path = Path(repo_path_str)
             if repo_path.name == "builtin" and repo_path.exists():
                 return repo_path
 
-        # Fall back to builtin repo installed to ~/.ppi-jarvis/builtin
+        # Bind builtins to the running source tree or installed distribution.
+        # This must precede the legacy copied tree so a wheel upgrade cannot
+        # continue loading an older package contract from JARVIS_ROOT.
+        distribution_builtin = self._distribution_builtin_repository()
+        if distribution_builtin is not None:
+            return distribution_builtin
+
+        # Compatibility fallback for installations whose distribution did not
+        # include builtins.  This path is never overwritten here.
         user_builtin = self.jarvis_root / "builtin"
         if user_builtin.exists():
             return user_builtin
 
-        # Fall back to builtin repo in the same directory as this file (development)
-        dev_builtin = Path(__file__).parent.parent.parent / "builtin"
-        if dev_builtin.exists():
-            return dev_builtin
-
-        # Fall back to installed package location
+        # Preserve compatibility with non-standard installations where the
+        # builtin top-level package is not adjacent to jarvis_cd.
         try:
-            import importlib.util
             import importlib.metadata
+            import importlib.util
             import site
 
             # Method 1: Try to find builtin package directly
@@ -601,6 +617,52 @@ class Jarvis:
 
         # Default fallback
         return user_builtin
+
+    def _bind_distribution_builtin_repository(
+        self,
+        repositories: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Return repository config with only the managed legacy slot rebound."""
+        entries = repositories.get("repos")
+        if not isinstance(entries, list):
+            return repositories
+        distribution_builtin = self._distribution_builtin_repository()
+        if distribution_builtin is None:
+            return repositories
+        legacy_builtin = self._absolute_lexical_path(self.jarvis_root / "builtin")
+        rebound_path = str(distribution_builtin)
+        changed = False
+        rebound_entries: list[Any] = []
+        for entry in entries:
+            rebound: Any = entry
+            if (
+                isinstance(entry, str)
+                and self._absolute_lexical_path(entry) == legacy_builtin
+            ):
+                rebound = rebound_path
+                changed = rebound != entry
+            if rebound not in rebound_entries:
+                rebound_entries.append(rebound)
+            elif rebound != entry:
+                changed = True
+        if not changed:
+            return repositories
+        return {**repositories, "repos": rebound_entries}
+
+    @staticmethod
+    def _absolute_lexical_path(path: str | os.PathLike[str]) -> Path:
+        """Normalize a path without following operator-managed redirections."""
+        return Path(os.path.abspath(Path(path).expanduser()))
+
+    @staticmethod
+    def _distribution_builtin_repository() -> Optional[Path]:
+        """Locate the builtin repository shipped with the running package."""
+        candidate = Path(__file__).resolve().parents[2] / "builtin"
+        if (candidate / "__init__.py").is_file() and (
+            candidate / "builtin" / "__init__.py"
+        ).is_file():
+            return candidate
+        return None
 
     def find_package(self, pkg_name: str) -> Optional[str]:
         """

--- a/test/unit/core/test_config_state_roots.py
+++ b/test/unit/core/test_config_state_roots.py
@@ -10,6 +10,7 @@ import yaml
 
 from jarvis_cd.core.config import Jarvis
 from jarvis_cd.core.execution import ExecutionStore
+from jarvis_cd.core.pkg import Pkg
 from jarvis_cd.util.private_path import reject_private_path_redirection
 
 
@@ -147,5 +148,101 @@ def test_default_jarvis_root_canonicalizes_home_alias(
     try:
         jarvis = Jarvis()
         assert jarvis.jarvis_root == (canonical_home / ".ppi-jarvis").resolve()
+    finally:
+        Jarvis._instance = None
+
+
+def test_stale_managed_builtin_repo_binds_to_running_distribution(
+    tmp_path: Path,
+) -> None:
+    """A wheel upgrade must not keep describing an old copied builtin tree."""
+    jarvis_root = tmp_path / ".ppi-jarvis"
+    legacy_builtin = jarvis_root / "builtin"
+    legacy_package = legacy_builtin / "builtin" / "paraview" / "pkg.py"
+    legacy_package.parent.mkdir(parents=True)
+    legacy_package.write_text(
+        "# stale managed copy intentionally lacks pvpython_bin\n",
+        encoding="utf-8",
+    )
+    operator_repo = tmp_path / "operator-packages"
+    operator_repo.mkdir()
+
+    Jarvis._instance = None
+    try:
+        jarvis = Jarvis(jarvis_root=str(jarvis_root))
+        jarvis.initialize(
+            config_dir=str(tmp_path / "config"),
+            private_dir=str(tmp_path / "private"),
+            shared_dir=str(tmp_path / "shared"),
+        )
+        persisted_repositories = {"repos": [str(operator_repo), str(legacy_builtin)]}
+        jarvis.save_repos(persisted_repositories)
+        active_distribution_builtin = jarvis._distribution_builtin_repository()
+        assert active_distribution_builtin is not None
+        assert jarvis.repos == {
+            "repos": [str(operator_repo), str(active_distribution_builtin)]
+        }
+
+        Jarvis._instance = None
+        reloaded = Jarvis(jarvis_root=str(jarvis_root))
+        distribution_builtin = reloaded._distribution_builtin_repository()
+        assert distribution_builtin is not None
+        assert reloaded.repos == {
+            "repos": [str(operator_repo), str(distribution_builtin)]
+        }
+        assert yaml.safe_load(reloaded.repos_file.read_text(encoding="utf-8")) == (
+            persisted_repositories
+        )
+        assert legacy_package.read_text(encoding="utf-8").startswith(
+            "# stale managed copy"
+        )
+
+        package = Pkg.load_standalone("builtin.paraview")
+        setting = next(
+            item
+            for item in package.configure_menu()
+            if item.get("name") == "pvpython_bin"
+        )
+        assert setting == {
+            "name": "pvpython_bin",
+            "msg": "Path or command used to launch the ParaView service",
+            "type": str,
+            "default": "pvpython",
+        }
+        assert (
+            Path(package.pkg_dir)
+            .resolve()
+            .is_relative_to(distribution_builtin.resolve())
+        )
+    finally:
+        Jarvis._instance = None
+
+
+def test_explicit_operator_builtin_repository_is_not_rebound(
+    tmp_path: Path,
+) -> None:
+    """Only JARVIS's exact legacy copy path is distribution-managed."""
+    jarvis_root = tmp_path / ".ppi-jarvis"
+    operator_builtin = tmp_path / "operator" / "builtin"
+    marker = operator_builtin / "builtin" / "site_package" / "pkg.py"
+    marker.parent.mkdir(parents=True)
+    marker.write_text("# operator-owned package\n", encoding="utf-8")
+
+    Jarvis._instance = None
+    try:
+        jarvis = Jarvis(jarvis_root=str(jarvis_root))
+        jarvis.initialize(
+            config_dir=str(tmp_path / "config"),
+            private_dir=str(tmp_path / "private"),
+            shared_dir=str(tmp_path / "shared"),
+        )
+        repositories = {"repos": [str(operator_builtin)]}
+        jarvis.save_repos(repositories)
+
+        Jarvis._instance = None
+        reloaded = Jarvis(jarvis_root=str(jarvis_root))
+        assert reloaded.repos == repositories
+        assert reloaded.get_builtin_repo_path() == operator_builtin
+        assert marker.read_text(encoding="utf-8") == "# operator-owned package\n"
     finally:
         Jarvis._instance = None

--- a/test/unit/core/test_paraview_service.py
+++ b/test/unit/core/test_paraview_service.py
@@ -312,6 +312,39 @@ def test_supervisor_cleans_child_when_initial_reporting_fails(
     ]
 
 
+def test_supervisor_missing_configured_pvpython_fails_loudly(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A configured launcher that does not exist is a recorded hard failure."""
+    reporter = _RecordingReporter()
+    descriptor = _supervisor_descriptor(tmp_path / "descriptor.json")
+    missing_launcher = str(tmp_path / "missing-pvpython")
+    arguments = _supervisor_arguments(descriptor, tmp_path / "output")
+    arguments[arguments.index("--pvpython-bin") + 1] = missing_launcher
+
+    def missing_popen(command: list[str], **_kwargs: Any) -> Any:
+        assert command[0] == missing_launcher
+        raise FileNotFoundError(f"configured launcher not found: {missing_launcher}")
+
+    def reporter_from_environment(**_kwargs: Any) -> _RecordingReporter:
+        return reporter
+
+    monkeypatch.setattr(supervisor_module.subprocess, "Popen", missing_popen)
+    monkeypatch.setattr(
+        supervisor_module,
+        "ServiceRuntimeReporter",
+        SimpleNamespace(from_environment=reporter_from_environment),
+    )
+
+    assert supervisor_module.main(arguments) == 1
+    assert reporter.lifecycle_calls == [ServiceLifecycle.FAILED]
+    diagnostic = capsys.readouterr().err
+    assert "ParaView service supervisor failed" in diagnostic
+    assert missing_launcher in diagnostic
+
+
 def test_supervisor_reports_periodic_degradation_and_recovery(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- bind the exact legacy JARVIS-managed builtin repository slot to the builtin tree shipped by the running distribution
- preserve operator repositories and leave the stale managed copy untouched
- prove released ParaView settings remain discoverable after an upgrade and fail loudly for an invalid configured launcher

## Focused validation
- 28 focused pytest tests passed
- Ruff passed
- targeted Pyright passed
- clean installed-wheel smoke passed