### PR TITLE
fix: make LAMMPS runtime outputs portable

### DIFF
--- a/builtin/builtin/lammps/artifacts.py
+++ b/builtin/builtin/lammps/artifacts.py
@@ -282,6 +282,7 @@ def adapter_from_package(package: dict[str, Any]) -> LammpsArtifactAdapter | Non
         return None
     output_dir = _configured_output_dir(
         package.get("out"),
+        shared_dir=package.get("shared_dir"),
         runtime_cwd=package.get("runtime_cwd"),
     )
     deploy_mode = str(package.get("effective_deploy_mode") or "default").casefold()
@@ -308,21 +309,28 @@ def adapter_from_package(package: dict[str, Any]) -> LammpsArtifactAdapter | Non
 def _configured_output_dir(
     value: object,
     *,
+    shared_dir: object = None,
     runtime_cwd: object,
 ) -> PurePosixPath:
     """Return one normalized absolute POSIX output directory."""
     raw = os.path.expandvars(str(value or "."))
     path = PurePosixPath(raw)
     if not path.is_absolute():
-        if not isinstance(runtime_cwd, str) or not runtime_cwd:
+        shared_path = _optional_absolute_path(shared_dir)
+        if shared_path is not None:
+            path = shared_path / path
+            raw = path.as_posix()
+        elif not isinstance(runtime_cwd, str) or not runtime_cwd:
             raise ValueError(
-                "relative LAMMPS artifact output requires a runtime working directory"
+                "relative LAMMPS artifact output requires a package shared "
+                "directory or runtime working directory"
             )
-        runtime_path = PurePosixPath(runtime_cwd)
-        if not runtime_path.is_absolute():
-            raise ValueError("LAMMPS runtime working directory must be absolute")
-        path = runtime_path / path
-        raw = path.as_posix()
+        else:
+            runtime_path = PurePosixPath(runtime_cwd)
+            if not runtime_path.is_absolute():
+                raise ValueError("LAMMPS runtime working directory must be absolute")
+            path = runtime_path / path
+            raw = path.as_posix()
     if not path.is_absolute() or path.as_posix() != raw or ".." in path.parts:
         raise ValueError("LAMMPS artifacts require a normalized absolute output path")
     return path

--- a/builtin/builtin/lammps/pkg.py
+++ b/builtin/builtin/lammps/pkg.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
 
 
@@ -68,15 +68,19 @@ class Lammps(Application):
             },
             {
                 "name": "out",
-                "msg": "Output directory for results",
+                "msg": (
+                    "Output directory for results. Relative paths resolve under "
+                    "the JARVIS package shared directory; '.' uses that durable "
+                    "execution-owned root."
+                ),
                 "type": str,
-                "default": "/tmp/lammps_out",
+                "default": ".",
             },
             {
                 "name": "kokkos_gpu",
                 "msg": "Enable Kokkos GPU (CUDA) acceleration",
                 "type": bool,
-                "default": True,
+                "default": False,
             },
             {
                 "name": "num_gpus",
@@ -115,7 +119,7 @@ class Lammps(Application):
         if self.config.get("deploy_mode") != "container":
             return None
         base = self.config.get("base_image", "sci-hpc-base")
-        use_gpu = self.config.get("kokkos_gpu", True)
+        use_gpu = self.config.get("kokkos_gpu", False)
         cuda_arch = self.config.get("cuda_arch", 80)
         if use_gpu:
             cmake_extra = (
@@ -139,7 +143,7 @@ class Lammps(Application):
     def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
         if self.config.get("deploy_mode") != "container":
             return None
-        use_gpu = self.config.get("kokkos_gpu", True)
+        use_gpu = self.config.get("kokkos_gpu", False)
         deploy_base = (
             "nvidia/cuda:12.6.0-runtime-ubuntu24.04" if use_gpu else "ubuntu:24.04"
         )
@@ -169,14 +173,7 @@ class Lammps(Application):
         super()._configure(**kwargs)
 
         if self.config.get("deploy_mode") == "default":
-            output_dir: object = self.config.get("out")
-            if output_dir:
-                if not isinstance(output_dir, str):
-                    raise TypeError("out must be a path string")
-                Mkdir(
-                    output_dir,
-                    PsshExecInfo(hostfile=self.hostfile, env=self.env),
-                ).run()
+            self._ensure_output_dir()
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -188,19 +185,31 @@ class Lammps(Application):
 
     def _output_dir(self) -> str:
         """Return the normalized package output directory."""
-        configured: object = self.config.get("out")
-        if configured is None or configured == "":
-            configured = "."
-        if not isinstance(configured, str):
-            raise TypeError("out must be a path string")
-        return os.path.abspath(os.path.expanduser(os.path.expandvars(configured)))
+        return str(self.resolve_shared_path(self.config.get("out"), field="out"))
+
+    def _ensure_output_dir(self) -> None:
+        """Create the resolved output directory on every participating host."""
+        created = Mkdir(
+            self._output_dir(),
+            self._node_exec_info(env=self.env),
+        ).run()
+        failures = {host: code for host, code in created.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to create LAMMPS output directory {self._output_dir()}: "
+                f"{failures}"
+            )
+
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        """Return local or parallel-SSH execution according to the hostfile."""
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
 
     def _remove_stale_log(self) -> None:
         """Remove the previous log before relay polling and LAMMPS startup."""
-        exec_args: dict[str, Any] = {
-            "hostfile": self.hostfile,
-            "env": self.mod_env,
-        }
+        exec_args: dict[str, Any] = {"env": self.mod_env}
         if self.config.get("deploy_mode") == "container":
             exec_args.update(
                 {
@@ -213,7 +222,7 @@ class Lammps(Application):
             )
         cleanup = Exec(
             f"rm -f {shlex.quote(self._log_path())}",
-            PsshExecInfo(**exec_args),
+            self._node_exec_info(**exec_args),
         ).run()
         failures = {host: code for host, code in cleanup.exit_code.items() if code != 0}
         if failures:
@@ -315,6 +324,7 @@ class Lammps(Application):
         container mode, MpiExecInfo with hostfile for default mode.
         """
         script_path = self._generated_input_script()
+        self._ensure_output_dir()
         self._remove_stale_log()
         line_callback = self.progress_line_callback()
         if self.config.get("deploy_mode") == "container":
@@ -364,7 +374,7 @@ class Lammps(Application):
                     ppn=self.config["ppn"],
                     hostfile=self.hostfile,
                     env=self.mod_env,
-                    cwd=self.config.get("out"),
+                    cwd=self._output_dir(),
                     line_callback=line_callback,
                 ),
             ).run()
@@ -378,11 +388,17 @@ class Lammps(Application):
 
     def clean(self) -> None:
         """Remove LAMMPS output directory."""
-        output_dir: object = self.config.get("out")
-        if output_dir:
-            if not isinstance(output_dir, str):
-                raise TypeError("out must be a path string")
-            Rm(
-                output_dir + "*",
-                PsshExecInfo(hostfile=self.hostfile, env=self.env),
-            ).run()
+        output_dir = self._output_dir()
+        output_path = Path(output_dir)
+        if output_path == Path(output_path.anchor):
+            raise ValueError("refusing to clean a filesystem root as LAMMPS output")
+        removed = Rm(
+            output_dir,
+            self._node_exec_info(env=self.env),
+            recursive=True,
+        ).run()
+        failures = {host: code for host, code in removed.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to clean LAMMPS output directory {output_dir}: {failures}"
+            )

--- a/builtin/builtin/lammps/progress.py
+++ b/builtin/builtin/lammps/progress.py
@@ -384,15 +384,15 @@ def adapter_from_package(
     output = package.get("out")
     deploy_mode = package.get("effective_deploy_mode") or package.get("deploy_mode")
     progress = package.get("progress")
-    shared_log = _nested_progress_value(progress, "log_visibility") == "shared"
-    output_dir = (
-        Path(os.path.expandvars(output))
-        if deploy_mode != "container"
-        and shared_log
-        and isinstance(output, str)
-        and output.strip()
-        else None
+    shared_root = _optional_absolute_path(package.get("shared_dir"))
+    output_dir = _resolved_output_dir(output, shared_root=shared_root)
+    shared_log = _nested_progress_value(progress, "log_visibility") == "shared" or (
+        output_dir is not None
+        and shared_root is not None
+        and output_dir.is_relative_to(shared_root)
     )
+    if deploy_mode == "container" or not shared_log:
+        output_dir = None
     return LammpsThermoProgressAdapter(
         package_name=str(package_type),
         package_id=str(package.get("pkg_id") or "lammps"),
@@ -410,6 +410,37 @@ def adapter_from_package(
         ),
         output_dir=output_dir,
     )
+
+
+def _optional_absolute_path(value: object) -> Path | None:
+    """Return one normalized absolute package path when available."""
+    if not isinstance(value, (str, os.PathLike)) or not os.fspath(value):
+        return None
+    path = Path(os.path.expandvars(os.fspath(value))).expanduser()
+    if not path.is_absolute() or ".." in path.parts:
+        return None
+    return path.resolve(strict=False)
+
+
+def _resolved_output_dir(
+    value: object,
+    *,
+    shared_root: Path | None,
+) -> Path | None:
+    """Resolve LAMMPS output using the package shared-path contract."""
+    if value is None:
+        raw = "."
+    elif isinstance(value, str):
+        raw = os.path.expandvars(value or ".")
+    else:
+        return None
+    path = Path(raw).expanduser()
+    if path.is_absolute():
+        return path.resolve(strict=False)
+    if shared_root is None:
+        return None
+    resolved = (shared_root / path).resolve(strict=False)
+    return resolved if resolved.is_relative_to(shared_root) else None
 
 
 def _nested_progress_total(value: object) -> object:

--- a/jarvis_cd/core/config.py
+++ b/jarvis_cd/core/config.py
@@ -622,14 +622,20 @@ class Jarvis:
         self,
         repositories: Dict[str, Any],
     ) -> Dict[str, Any]:
-        """Return repository config with only the managed legacy slot rebound."""
+        """Return repository config with only managed legacy slots rebound.
+
+        Ownership is path-based: JARVIS owns ``builtin`` directly beneath the
+        active ``JARVIS_ROOT`` and beneath its historical default
+        ``~/.ppi-jarvis`` root. A repository is never treated as managed merely
+        because its basename is ``builtin``.
+        """
         entries = repositories.get("repos")
         if not isinstance(entries, list):
             return repositories
         distribution_builtin = self._distribution_builtin_repository()
         if distribution_builtin is None:
             return repositories
-        legacy_builtin = self._absolute_lexical_path(self.jarvis_root / "builtin")
+        managed_builtin_slots = self._managed_builtin_repository_slots()
         rebound_path = str(distribution_builtin)
         changed = False
         rebound_entries: list[Any] = []
@@ -637,7 +643,7 @@ class Jarvis:
             rebound: Any = entry
             if (
                 isinstance(entry, str)
-                and self._absolute_lexical_path(entry) == legacy_builtin
+                and self._absolute_lexical_path(entry) in managed_builtin_slots
             ):
                 rebound = rebound_path
                 changed = rebound != entry
@@ -648,6 +654,15 @@ class Jarvis:
         if not changed:
             return repositories
         return {**repositories, "repos": rebound_entries}
+
+    def _managed_builtin_repository_slots(self) -> set[Path]:
+        """Return exact legacy paths reserved for JARVIS-managed builtins."""
+        historical_default = Path.home() / ".ppi-jarvis" / "builtin"
+        return {
+            self._absolute_lexical_path(self.jarvis_root / "builtin"),
+            self._absolute_lexical_path(historical_default),
+            self._absolute_lexical_path(historical_default.resolve(strict=False)),
+        }
 
     @staticmethod
     def _absolute_lexical_path(path: str | os.PathLike[str]) -> Path:

--- a/jarvis_cd/core/pkg.py
+++ b/jarvis_cd/core/pkg.py
@@ -459,6 +459,49 @@ class Pkg:
         # Fall back to global jarvis hostfile
         return self.jarvis.hostfile
 
+    def resolve_shared_path(
+        self,
+        value: object,
+        *,
+        field: str = "path",
+        default: str = ".",
+    ) -> Path:
+        """Resolve a package-owned path against this package's shared root.
+
+        Absolute paths remain operator-selected. Relative paths are scoped to
+        ``shared_dir`` so package defaults stay portable across sites and, for
+        scheduler runs, resolve inside the immutable execution snapshot rather
+        than the process working directory.
+
+        :param value: Configured string or path-like value.
+        :param field: Configuration field name used in validation errors.
+        :param default: Relative path used when ``value`` is unset or empty.
+        :return: A normalized absolute path.
+        :raises TypeError: If the configured value is not path-like.
+        :raises ValueError: If a relative value escapes the package shared root.
+        """
+        configured = default if value is None or value == "" else value
+        if not isinstance(configured, (str, os.PathLike)):
+            raise TypeError(f"{field} must be a path string")
+        raw = os.path.expanduser(os.path.expandvars(os.fspath(configured)))
+        if not raw or any(ord(character) < 32 for character in raw):
+            raise ValueError(f"{field} must be a non-empty printable path")
+
+        path = Path(raw)
+        if path.is_absolute():
+            return path.resolve(strict=False)
+
+        shared_dir = self.shared_dir
+        if not isinstance(shared_dir, (str, os.PathLike)) or not os.fspath(shared_dir):
+            raise RuntimeError(
+                f"relative {field} requires a JARVIS package shared directory"
+            )
+        shared_root = Path(shared_dir).expanduser().resolve(strict=False)
+        resolved = (shared_root / path).resolve(strict=False)
+        if not resolved.is_relative_to(shared_root):
+            raise ValueError(f"relative {field} cannot escape package shared directory")
+        return resolved
+
     def get_progress_provider(self) -> Optional["PackageProgressProvider"]:
         """Load this package's optional sibling ``progress.py`` provider.
 

--- a/test/unit/core/test_config_state_roots.py
+++ b/test/unit/core/test_config_state_roots.py
@@ -246,3 +246,50 @@ def test_explicit_operator_builtin_repository_is_not_rebound(
         assert marker.read_text(encoding="utf-8") == "# operator-owned package\n"
     finally:
         Jarvis._instance = None
+
+
+def test_default_managed_builtin_rebinds_after_jarvis_root_migration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Moving JARVIS_ROOT cannot leave the old default builtin contract active."""
+    canonical_home = tmp_path / "canonical-home"
+    canonical_home.mkdir()
+    logical_home = tmp_path / "logical-home"
+    _directory_link(logical_home, canonical_home)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: logical_home))
+    legacy_builtin = canonical_home / ".ppi-jarvis" / "builtin"
+    legacy_package = legacy_builtin / "builtin" / "paraview" / "pkg.py"
+    legacy_package.parent.mkdir(parents=True)
+    legacy_package.write_text("# stale default JARVIS copy\n", encoding="utf-8")
+    operator_builtin = canonical_home / "operator-repositories" / "builtin"
+    operator_marker = operator_builtin / "builtin" / "site_package" / "pkg.py"
+    operator_marker.parent.mkdir(parents=True)
+    operator_marker.write_text("# operator owned\n", encoding="utf-8")
+    migrated_root = canonical_home / ".local" / "share" / "relay" / "jarvis"
+
+    Jarvis._instance = None
+    try:
+        jarvis = Jarvis(jarvis_root=str(migrated_root))
+        jarvis.initialize(
+            config_dir=str(migrated_root / "config"),
+            private_dir=str(migrated_root / "private"),
+            shared_dir=str(migrated_root / "shared"),
+        )
+        persisted = {"repos": [str(legacy_builtin), str(operator_builtin)]}
+        jarvis.save_repos(persisted)
+
+        distribution_builtin = jarvis._distribution_builtin_repository()
+        assert distribution_builtin is not None
+        assert jarvis.repos == {
+            "repos": [str(distribution_builtin), str(operator_builtin)]
+        }
+        assert yaml.safe_load(jarvis.repos_file.read_text(encoding="utf-8")) == (
+            persisted
+        )
+        assert legacy_package.read_text(encoding="utf-8") == (
+            "# stale default JARVIS copy\n"
+        )
+        assert operator_marker.read_text(encoding="utf-8") == "# operator owned\n"
+    finally:
+        Jarvis._instance = None

--- a/test/unit/core/test_lammps_artifacts.py
+++ b/test/unit/core/test_lammps_artifacts.py
@@ -147,6 +147,23 @@ def test_lammps_factory_rejects_unscoped_output_authority() -> None:
     assert adapter.script_path == Path("/work/relative/output/in.lj")
 
 
+def test_lammps_default_artifacts_resolve_to_execution_package_shared_root() -> None:
+    """The portable output default must yield exact durable artifact locations."""
+    module = _module()
+
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.lammps",
+            "out": ".",
+            "shared_dir": "/execution/shared/lammps",
+            "runtime_cwd": "/execution/runtime",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.output_dir.as_posix() == "/execution/shared/lammps"
+
+
 def test_container_lammps_reports_only_host_visible_output() -> None:
     """Container-private paths are not claimed as durable cluster artifacts."""
     module = _module()

--- a/test/unit/core/test_lammps_package_runtime.py
+++ b/test/unit/core/test_lammps_package_runtime.py
@@ -10,6 +10,9 @@ from typing import Any
 
 import pytest
 
+from jarvis_cd.shell import LocalExecInfo, PsshExecInfo
+from jarvis_cd.util.hostfile import Hostfile
+
 
 def _load_lammps_package() -> ModuleType:
     """Load the package implementation without changing JARVIS repo imports."""
@@ -54,6 +57,150 @@ class _FailedCleanupExec(_CapturedExec):
         super().__init__(command, exec_info)
         if command.startswith("rm -f "):
             self.exit_code = {"node1": 1}
+
+
+class _CapturedMkdir:
+    """Accept package output creation without touching remote execution."""
+
+    paths: list[str] = []
+
+    def __init__(self, path: str, exec_info: Any) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedMkdir:
+        """Record the resolved directory and report successful creation."""
+        self.paths.append(self.path)
+        return self
+
+
+class _CapturedRm:
+    """Capture one exact package-owned cleanup request."""
+
+    calls: list[tuple[str, bool]] = []
+
+    def __init__(
+        self,
+        path: str,
+        exec_info: Any,
+        *,
+        recursive: bool = False,
+    ) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.recursive = recursive
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedRm:
+        """Record the cleanup target and report successful removal."""
+        self.calls.append((self.path, self.recursive))
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _capture_output_directory_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep package launch tests isolated from PSSH output creation."""
+    _CapturedMkdir.paths = []
+    _CapturedRm.calls = []
+    monkeypatch.setattr(lammps_package, "Mkdir", _CapturedMkdir)
+    monkeypatch.setattr(lammps_package, "Rm", _CapturedRm)
+
+
+def test_portable_defaults_use_package_shared_output_and_cpu() -> None:
+    """The agent-visible defaults must not assume a site path or accelerator."""
+    package = object.__new__(lammps_package.Lammps)
+    menu = {item["name"]: item for item in package._configure_menu()}
+
+    assert menu["out"]["default"] == "."
+    assert "JARVIS package shared directory" in menu["out"]["msg"]
+    assert menu["kokkos_gpu"]["default"] is False
+
+
+def test_default_output_resolves_inside_execution_package_shared_root(
+    tmp_path: Path,
+) -> None:
+    """Queued executions resolve the portable default using their owned root."""
+    package = object.__new__(lammps_package.Lammps)
+    package.config = {"out": "."}
+    package.shared_dir = tmp_path / "execution" / "shared" / "lammps"
+
+    assert Path(package._output_dir()) == package.shared_dir.resolve()
+
+    package.config["out"] = "trajectory"
+    assert Path(package._output_dir()) == (package.shared_dir / "trajectory").resolve()
+
+    package.config["out"] = "../escape"
+    with pytest.raises(ValueError, match="cannot escape package shared directory"):
+        package._output_dir()
+
+
+def test_output_directory_creation_uses_local_execution_for_default_hostfile(
+    tmp_path: Path,
+) -> None:
+    """A local pipeline must not require PSSH merely to create its output root."""
+    package = object.__new__(lammps_package.Lammps)
+    package.config = {"out": "."}
+    package.env = {}
+    package.shared_dir = tmp_path / "shared"
+    default_hostfile = Hostfile(find_ips=False)
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: default_hostfile)
+
+    package._ensure_output_dir()
+
+    assert _CapturedMkdir.paths == [str(package.shared_dir.resolve())]
+    assert _CapturedMkdir.paths[0] == package._output_dir()
+    assert isinstance(package._node_exec_info(), LocalExecInfo)
+
+
+def test_remote_hostfile_uses_parallel_ssh_for_output_lifecycle(tmp_path: Path) -> None:
+    """A genuinely remote host set still fans package lifecycle operations out."""
+    package = object.__new__(lammps_package.Lammps)
+    package.config = {"out": "."}
+    package.shared_dir = tmp_path / "shared"
+    package.pipeline = SimpleNamespace(
+        get_hostfile=lambda: Hostfile(
+            hosts=["compute-01", "compute-02"],
+            find_ips=False,
+        )
+    )
+
+    assert isinstance(package._node_exec_info(), PsshExecInfo)
+
+
+def test_clean_removes_only_resolved_owned_output_without_wildcard(
+    tmp_path: Path,
+) -> None:
+    """Cleanup cannot target the process cwd or prefix-matching sibling paths."""
+    package = object.__new__(lammps_package.Lammps)
+    package.config = {"out": "results"}
+    package.env = {}
+    package.shared_dir = tmp_path / "execution" / "shared" / "lammps"
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: Hostfile(find_ips=False))
+
+    package.clean()
+
+    expected = str((package.shared_dir / "results").resolve())
+    assert _CapturedRm.calls == [(expected, True)]
+    assert "*" not in _CapturedRm.calls[0][0]
+    assert _CapturedRm.calls[0][0] not in {".", ".*"}
+
+
+def test_clean_refuses_filesystem_root() -> None:
+    """Even an explicit absolute output cannot authorize root deletion."""
+    package = object.__new__(lammps_package.Lammps)
+    filesystem_root = Path.cwd().anchor
+    package.config = {"out": filesystem_root}
+    package.env = {}
+    package.shared_dir = Path.cwd()
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: Hostfile(find_ips=False))
+
+    with pytest.raises(ValueError, match="filesystem root"):
+        package.clean()
+
+    assert _CapturedRm.calls == []
 
 
 def test_default_launch_owns_deterministic_lammps_log(

--- a/test/unit/core/test_lammps_progress.py
+++ b/test/unit/core/test_lammps_progress.py
@@ -75,6 +75,28 @@ def test_adapter_is_owned_by_builtin_lammps(tmp_path: Path) -> None:
     assert node_local_adapter.log_visibility == "scoped_stdout"
 
 
+def test_default_output_progress_uses_execution_package_shared_log(
+    tmp_path: Path,
+) -> None:
+    """The portable default exposes the execution-owned log without stdout scraping."""
+    shared_dir = (tmp_path / "execution" / "shared" / "lammps").resolve()
+
+    adapter = adapter_from_package(
+        {
+            "pkg_type": "builtin.lammps",
+            "out": ".",
+            "shared_dir": str(shared_dir),
+            "io_dump_interval": 100,
+            "io_run_steps": 5000,
+        }
+    )
+
+    assert isinstance(adapter, LammpsThermoProgressAdapter)
+    assert adapter.log_visibility == "shared"
+    assert adapter.progress_log_paths() == [shared_dir / "log.lammps"]
+    assert adapter.total_steps == 5000
+
+
 def test_adapter_observes_only_lammps_jarvis_scope() -> None:
     """Unscoped or unrelated stdout must not create trusted progress."""
     adapter = LammpsThermoProgressAdapter(total_steps=100, run_id="job_1")


### PR DESCRIPTION
## Summary
- resolve relative package paths under the execution-owned JARVIS shared root
- make LAMMPS CPU-safe and site-neutral by default while aligning launch, progress, artifacts, and cleanup
- rebind only exact JARVIS-managed legacy builtin repositories to the running distribution
- use local lifecycle execution for local hostfiles and refuse unsafe cleanup targets

## Validation
- 41 focused tests passed
- Ruff passed
- focused Pyright passed
- git diff --check passed