### PR TITLE
fix: retry atomic execution record replacement

### DIFF
--- a/jarvis_cd/core/execution.py
+++ b/jarvis_cd/core/execution.py
@@ -30,6 +30,7 @@ from jarvis_cd.service_runtime import (
     ServiceRuntimeStore,
 )
 from jarvis_cd.util.private_path import (
+    PrivatePathIdentityChangedError,
     ensure_private_descriptor,
     ensure_private_path,
     reject_private_path_redirection,
@@ -94,6 +95,7 @@ _TRANSITIONS = {
 _UNSET = object()
 _TRANSACTION_LOCK_PREFIX = ".jarvis-execution-lock-"
 _DIRECT_STARTUP_GRACE_SECONDS = 60.0
+_SECURE_RECORD_READ_ATTEMPTS = 16
 
 
 @dataclass(frozen=True)
@@ -639,12 +641,17 @@ def _validate_private_regular_file(
     if (
         not stat.S_ISREG(descriptor_status.st_mode)
         or stat.S_ISLNK(path_status.st_mode)
-        or (descriptor_status.st_dev, descriptor_status.st_ino)
-        != (path_status.st_dev, path_status.st_ino)
         or descriptor_status.st_nlink != 1
         or descriptor_status.st_size > maximum_size
     ):
         raise RuntimeError(f"invalid execution record: {path}")
+    if (descriptor_status.st_dev, descriptor_status.st_ino) != (
+        path_status.st_dev,
+        path_status.st_ino,
+    ):
+        raise PrivatePathIdentityChangedError(
+            f"private path changed during secure open: {path}"
+        )
     if os.name != "nt" and (
         descriptor_status.st_uid != _effective_uid()
         or stat.S_IMODE(descriptor_status.st_mode) & 0o077
@@ -681,18 +688,41 @@ def read_execution_record(
         raise RuntimeError(f"execution root is not owner-controlled: {execution_root}")
     record_path = execution_root / RECORD_NAME
     flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
-    descriptor = os.open(record_path, flags)
-    try:
-        _validate_private_regular_file(
-            descriptor,
-            record_path,
-            maximum_size=MAX_RECORD_BYTES,
-        )
-        payload = os.read(descriptor, MAX_RECORD_BYTES + 1)
-        if len(payload) > MAX_RECORD_BYTES:
-            raise RuntimeError(f"execution record is too large: {record_path}")
-    finally:
-        os.close(descriptor)
+    payload: Optional[bytes] = None
+    for attempt in range(_SECURE_RECORD_READ_ATTEMPTS):
+        descriptor = os.open(record_path, flags)
+        try:
+            _validate_private_regular_file(
+                descriptor,
+                record_path,
+                maximum_size=MAX_RECORD_BYTES,
+            )
+            payload = os.read(descriptor, MAX_RECORD_BYTES + 1)
+            if len(payload) > MAX_RECORD_BYTES:
+                raise RuntimeError(f"execution record is too large: {record_path}")
+            descriptor_status = os.fstat(descriptor)
+            reject_private_path_redirection(record_path)
+            path_status = record_path.lstat()
+            if stat.S_ISLNK(path_status.st_mode):
+                raise RuntimeError(
+                    f"private path changed during secure open: {record_path}"
+                )
+            if (descriptor_status.st_dev, descriptor_status.st_ino) != (
+                path_status.st_dev,
+                path_status.st_ino,
+            ):
+                raise PrivatePathIdentityChangedError(
+                    f"private path changed during secure open: {record_path}"
+                )
+        except PrivatePathIdentityChangedError:
+            if attempt + 1 == _SECURE_RECORD_READ_ATTEMPTS:
+                raise
+            continue
+        finally:
+            os.close(descriptor)
+        break
+    if payload is None:
+        raise RuntimeError(f"secure execution record read failed: {record_path}")
     try:
         document = json.loads(
             payload.decode("utf-8", errors="strict"),

--- a/jarvis_cd/util/private_path.py
+++ b/jarvis_cd/util/private_path.py
@@ -8,6 +8,10 @@ from pathlib import Path
 from typing import Any
 
 
+class PrivatePathIdentityChangedError(RuntimeError):
+    """Report that a pathname stopped identifying an open descriptor."""
+
+
 def reject_private_path_redirection(path: Path) -> None:
     """Reject symbolic links and Windows reparse points in a path ancestry.
 
@@ -102,10 +106,15 @@ def ensure_private_descriptor(
         not expected_type
         or _is_path_redirection(descriptor_information)
         or _is_path_redirection(path_information)
-        or (descriptor_information.st_dev, descriptor_information.st_ino)
-        != (path_information.st_dev, path_information.st_ino)
     ):
         raise RuntimeError(f"private path changed during secure open: {target}")
+    if (descriptor_information.st_dev, descriptor_information.st_ino) != (
+        path_information.st_dev,
+        path_information.st_ino,
+    ):
+        raise PrivatePathIdentityChangedError(
+            f"private path changed during secure open: {target}"
+        )
     if not directory and descriptor_information.st_nlink != 1:
         raise RuntimeError(f"private file must have exactly one link: {target}")
     if os.name == "nt":
@@ -124,11 +133,15 @@ def ensure_private_descriptor(
             raise RuntimeError(f"private path permissions are too broad: {target}")
     final_path_information = target.lstat()
     final_descriptor_information = os.fstat(descriptor)
-    if _is_path_redirection(final_path_information) or (
+    if _is_path_redirection(final_path_information):
+        raise RuntimeError(f"private path changed during secure open: {target}")
+    if (
         final_descriptor_information.st_dev,
         final_descriptor_information.st_ino,
     ) != (final_path_information.st_dev, final_path_information.st_ino):
-        raise RuntimeError(f"private path changed during secure open: {target}")
+        raise PrivatePathIdentityChangedError(
+            f"private path changed during secure open: {target}"
+        )
 
 
 def _ensure_private_windows_path(path: Path, *, directory: bool) -> None:

--- a/test/unit/core/test_execution.py
+++ b/test/unit/core/test_execution.py
@@ -288,6 +288,119 @@ def test_record_reader_does_not_block_atomic_replacement(
             os.close(descriptor)
 
 
+def test_record_reader_retries_its_own_atomic_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A secure read retries when a JARVIS writer replaces its open inode."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create("replaceable", mode="direct")
+    real_validate = execution_module._validate_private_regular_file
+    reader_attempts = 0
+    replaced = False
+
+    def replace_during_validation(
+        descriptor: int,
+        path: Path,
+        *,
+        maximum_size: int,
+    ) -> os.stat_result:
+        nonlocal reader_attempts, replaced
+        reader_attempts += 1
+        if not replaced:
+            replaced = True
+            if os.name == "nt":
+                # MoveFileEx cannot replace a path held by Python's os.open.
+                # Exercise the same typed kernel-identity signal directly;
+                # the POSIX branch below performs the real atomic replacement.
+                raise execution_module.PrivatePathIdentityChangedError(
+                    f"private path changed during secure open: {path}"
+                )
+            store.update("replaceable", state="running")
+        return real_validate(descriptor, path, maximum_size=maximum_size)
+
+    monkeypatch.setattr(
+        execution_module,
+        "_validate_private_regular_file",
+        replace_during_validation,
+    )
+
+    record = store.get("replaceable")
+
+    assert record.state == ("preparing" if os.name == "nt" else "running")
+    assert reader_attempts >= 2
+
+
+def test_record_reader_does_not_retry_non_identity_security_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Symlink and type validation failures remain immediately fatal."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create("blocked", mode="direct")
+    validations = 0
+
+    def reject_redirection(
+        _descriptor: int,
+        _path: Path,
+        *,
+        maximum_size: int,
+    ) -> os.stat_result:
+        nonlocal validations
+        validations += 1
+        assert maximum_size == MAX_RECORD_BYTES
+        raise RuntimeError("private path cannot traverse a symbolic link")
+
+    monkeypatch.setattr(
+        execution_module,
+        "_validate_private_regular_file",
+        reject_redirection,
+    )
+
+    with pytest.raises(RuntimeError, match="symbolic link"):
+        store.get("blocked")
+    assert validations == 1
+
+
+def test_record_reader_bounds_identity_retries_and_closes_descriptors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Continuous pathname churn fails closed after a bounded descriptor loop."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create("churning", mode="direct")
+    descriptors: list[int] = []
+
+    def reject_changed_identity(
+        descriptor: int,
+        path: Path,
+        *,
+        maximum_size: int,
+    ) -> os.stat_result:
+        descriptors.append(descriptor)
+        assert maximum_size == MAX_RECORD_BYTES
+        raise execution_module.PrivatePathIdentityChangedError(
+            f"private path changed during secure open: {path}"
+        )
+
+    monkeypatch.setattr(
+        execution_module,
+        "_validate_private_regular_file",
+        reject_changed_identity,
+    )
+
+    with pytest.raises(
+        execution_module.PrivatePathIdentityChangedError,
+        match="changed during secure open",
+    ):
+        store.get("churning")
+
+    assert len(descriptors) == execution_module._SECURE_RECORD_READ_ATTEMPTS
+    for descriptor in descriptors:
+        with pytest.raises(OSError):
+            os.fstat(descriptor)
+
+
 def test_store_rejects_non_json_metadata_and_terminal_regression(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What changed

- distinguish benign file-descriptor/path identity churn from non-retryable private-path security violations
- retry the complete no-follow, owner-private execution-record read up to a fixed bound when JARVIS atomically replaces its own record
- revalidate ancestry and descriptor/path identity after reading before parsing the payload
- cover real POSIX atomic replacement, non-retryable redirection failures, bounded exhaustion, and descriptor closure

## Root cause

Execution readers opened `.jarvis-execution.json` without the writer transaction lock. A concurrent JARVIS lifecycle update atomically replaced that path, so the reader's pinned descriptor and the current pathname correctly had different inodes. The private-path guard reported that normal writer race as a fatal security error.

## Validation

- `uv run pytest -q test/unit/core/test_execution.py test/unit/util/test_private_path.py` (58 passed on Windows)
- `uv run --isolated pytest -q test/unit/core/test_execution.py -k record_reader_` (6 passed on Linux/WSL, including the real POSIX replacement path)
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run pyright jarvis_cd/util/private_path.py jarvis_cd/core/execution.py` (0 errors)
- `git diff --check`