### PR TITLE
fix: retry late execution record replacement

### DIFF
--- a/jarvis_cd/core/execution.py
+++ b/jarvis_cd/core/execution.py
@@ -638,12 +638,7 @@ def _validate_private_regular_file(
     ensure_private_descriptor(path, descriptor, directory=False)
     descriptor_status = os.fstat(descriptor)
     path_status = path.lstat()
-    if (
-        not stat.S_ISREG(descriptor_status.st_mode)
-        or stat.S_ISLNK(path_status.st_mode)
-        or descriptor_status.st_nlink != 1
-        or descriptor_status.st_size > maximum_size
-    ):
+    if not stat.S_ISREG(descriptor_status.st_mode) or stat.S_ISLNK(path_status.st_mode):
         raise RuntimeError(f"invalid execution record: {path}")
     if (descriptor_status.st_dev, descriptor_status.st_ino) != (
         path_status.st_dev,
@@ -652,6 +647,8 @@ def _validate_private_regular_file(
         raise PrivatePathIdentityChangedError(
             f"private path changed during secure open: {path}"
         )
+    if descriptor_status.st_nlink != 1 or descriptor_status.st_size > maximum_size:
+        raise RuntimeError(f"invalid execution record: {path}")
     if os.name != "nt" and (
         descriptor_status.st_uid != _effective_uid()
         or stat.S_IMODE(descriptor_status.st_mode) & 0o077

--- a/test/unit/core/test_execution.py
+++ b/test/unit/core/test_execution.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from pathlib import Path
@@ -329,6 +330,51 @@ def test_record_reader_retries_its_own_atomic_replacement(
 
     assert record.state == ("preparing" if os.name == "nt" else "running")
     assert reader_attempts >= 2
+
+
+def test_record_validator_classifies_unlinked_replaced_inode_for_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unlinked old inode is replacement churn, not a corrupt hardlink."""
+    record_path = tmp_path / RECORD_NAME
+    record_path.write_text("{}\n", encoding="utf-8")
+    old_inode = os.stat_result((stat.S_IFREG | 0o600, 101, 7, 0, 1, 1, 3, 0, 0, 0))
+    replacement_inode = os.stat_result(
+        (stat.S_IFREG | 0o600, 102, 7, 1, 1, 1, 3, 0, 0, 0)
+    )
+
+    def descriptor_already_validated(
+        _path: Path,
+        _descriptor: int,
+        *,
+        directory: bool,
+    ) -> None:
+        assert directory is False
+
+    def stat_open_inode(_descriptor: int) -> os.stat_result:
+        return old_inode
+
+    def stat_replacement_path(_path: Path) -> os.stat_result:
+        return replacement_inode
+
+    monkeypatch.setattr(
+        execution_module,
+        "ensure_private_descriptor",
+        descriptor_already_validated,
+    )
+    monkeypatch.setattr(execution_module.os, "fstat", stat_open_inode)
+    monkeypatch.setattr(Path, "lstat", stat_replacement_path)
+
+    with pytest.raises(
+        execution_module.PrivatePathIdentityChangedError,
+        match="changed during secure open",
+    ):
+        execution_module._validate_private_regular_file(
+            19,
+            record_path,
+            maximum_size=MAX_RECORD_BYTES,
+        )
 
 
 def test_record_reader_does_not_retry_non_identity_security_failure(


### PR DESCRIPTION
## What changed

- classify descriptor/path identity replacement before enforcing the steady-state link-count invariant
- retry the remaining late atomic-replacement window instead of treating it as durable-record corruption
- retain fail-closed behavior for stable hardlinks, symlinks, oversized records, and non-private files

## Root cause

JARVIS 1.3.6 retried replacement during the first secure descriptor check, but a writer could still atomically replace `.jarvis-execution.json` immediately afterward. In that window the opened old inode has zero links while the path names the new inode. The validator checked link count before identity and raised a non-retryable `RuntimeError`, which failed a live Ares MCP discovery even though the execution completed successfully.

## Validation

- `uv run pytest -q test/unit/core/test_execution.py -k "record_reader or record_validator"` (7 passed)
- `uv run ruff check jarvis_cd/core/execution.py test/unit/core/test_execution.py`
- `uv run ruff format --check jarvis_cd/core/execution.py test/unit/core/test_execution.py`
- `uv run pyright jarvis_cd/core/execution.py` (0 errors)
- `git diff --check`
