### PR TITLE
fix: honor offscreen rendering for ParaView services

### DIFF
--- a/builtin/builtin/paraview/pkg.py
+++ b/builtin/builtin/paraview/pkg.py
@@ -298,7 +298,15 @@ class Paraview(Application):
         pvpython_bin = os.path.expandvars(
             cast(str, self.config.get("pvpython_bin") or "pvpython")
         )
-        pvpython_options = cast(str, self.config.get("pvpython_options") or "")
+        pvpython_arguments = shlex.split(
+            cast(str, self.config.get("pvpython_options") or "")
+        )
+        if (
+            self.config.get("force_offscreen_rendering", False)
+            and "--force-offscreen-rendering" not in pvpython_arguments
+        ):
+            pvpython_arguments.append("--force-offscreen-rendering")
+        pvpython_options = shlex.join(pvpython_arguments)
         command = [
             sys.executable,
             str(supervisor),

--- a/test/unit/core/test_paraview_service.py
+++ b/test/unit/core/test_paraview_service.py
@@ -1117,6 +1117,7 @@ def test_package_service_mode_stages_generic_runtime_and_owned_output(
         "dataset_descriptor": json.dumps(descriptor),
         "pvpython_bin": "/opt/paraview/bin/pvpython",
         "pvpython_options": "--mesa",
+        "force_offscreen_rendering": True,
         "service_bind_host": "127.0.0.1",
         "service_advertise_host": "127.0.0.1",
         "service_port": 0,
@@ -1144,7 +1145,7 @@ def test_package_service_mode_stages_generic_runtime_and_owned_output(
     command, exec_info = _CapturedExec.commands[0]
     assert "service_supervisor.py" in command
     assert "/opt/paraview/bin/pvpython" in command
-    assert "--pvpython-options --mesa" in command
+    assert "--pvpython-options '--mesa --force-offscreen-rendering'" in command
     assert "--bind-host 127.0.0.1" in command
     assert "--advertise-host 127.0.0.1" in command
     assert exec_info.env["JARVIS_SERVICE_RUNTIME_PATH"].endswith(
@@ -1164,6 +1165,11 @@ def test_package_service_mode_stages_generic_runtime_and_owned_output(
         (service_root / "dataset-descriptor.json").read_text(encoding="utf-8")
     )
     assert staged_descriptor == descriptor
+
+    package.config["pvpython_options"] = "--mesa --force-offscreen-rendering"
+    package._start_service(dict(package.mod_env))
+    deduplicated_command, _ = _CapturedExec.commands[1]
+    assert deduplicated_command.count("--force-offscreen-rendering") == 1
 
     package.config["service_bind_host"] = "0.0.0.0"
     with pytest.raises(ValueError, match="loopback-only"):


### PR DESCRIPTION
## Summary
- honor `force_offscreen_rendering` when launching ParaView service mode through `pvpython`
- preserve and safely quote operator-provided `pvpython_options`
- avoid duplicating the offscreen option when a site profile already supplied it

## Validation
- `uv run --no-sync pytest -q test/unit/core/test_paraview_service.py` (23 passed)
- `uv run --no-sync ruff check builtin/builtin/paraview/pkg.py test/unit/core/test_paraview_service.py`
- `uv run --no-sync ruff format --check builtin/builtin/paraview/pkg.py test/unit/core/test_paraview_service.py`
- `uv run --no-sync pyright builtin/builtin/paraview/pkg.py`
- live Ares Slurm probes: default and offscreen-only reproduced the site launcher failure; the site-bound `--mesa` variants rendered, and the exact five-member JARVIS service reached READY in job 21942