### PR TITLE
fix: tolerate shared record replacement churn

### DIFF
--- a/jarvis_cd/core/execution.py
+++ b/jarvis_cd/core/execution.py
@@ -96,6 +96,7 @@ _UNSET = object()
 _TRANSACTION_LOCK_PREFIX = ".jarvis-execution-lock-"
 _DIRECT_STARTUP_GRACE_SECONDS = 60.0
 _SECURE_RECORD_READ_ATTEMPTS = 16
+_SECURE_RECORD_READ_RETRY_SECONDS = 0.01
 
 
 @dataclass(frozen=True)
@@ -647,6 +648,15 @@ def _validate_private_regular_file(
         raise PrivatePathIdentityChangedError(
             f"private path changed during secure open: {path}"
         )
+    if descriptor_status.st_nlink == 0:
+        # Atomic replacement unlinks the descriptor's old inode. On a shared
+        # filesystem, pathname metadata can briefly remain cached at that same
+        # inode, so identity equality alone does not make the zero-link view a
+        # corrupt record. Classify it as replacement churn and let the bounded
+        # secure-read loop reopen the current pathname.
+        raise PrivatePathIdentityChangedError(
+            f"private path changed during secure open: {path}"
+        )
     if descriptor_status.st_nlink != 1 or descriptor_status.st_size > maximum_size:
         raise RuntimeError(f"invalid execution record: {path}")
     if os.name != "nt" and (
@@ -714,6 +724,7 @@ def read_execution_record(
         except PrivatePathIdentityChangedError:
             if attempt + 1 == _SECURE_RECORD_READ_ATTEMPTS:
                 raise
+            sleep(_SECURE_RECORD_READ_RETRY_SECONDS)
             continue
         finally:
             os.close(descriptor)

--- a/jarvis_cd/util/private_path.py
+++ b/jarvis_cd/util/private_path.py
@@ -115,6 +115,13 @@ def ensure_private_descriptor(
         raise PrivatePathIdentityChangedError(
             f"private path changed during secure open: {target}"
         )
+    if not directory and descriptor_information.st_nlink == 0:
+        # A descriptor pinned before an atomic pathname replacement can be
+        # unlinked while pathname metadata still resolves to a cached view of
+        # that inode. Callers may safely reopen only this typed churn signal.
+        raise PrivatePathIdentityChangedError(
+            f"private path changed during secure open: {target}"
+        )
     if not directory and descriptor_information.st_nlink != 1:
         raise RuntimeError(f"private file must have exactly one link: {target}")
     if os.name == "nt":

--- a/test/unit/core/test_execution_record_replacement.py
+++ b/test/unit/core/test_execution_record_replacement.py
@@ -1,0 +1,154 @@
+"""Focused execution-record replacement coherence tests."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import jarvis_cd.core.execution as execution_module
+import jarvis_cd.util.private_path as private_path_module
+import pytest
+
+from jarvis_cd.core.execution import MAX_RECORD_BYTES, RECORD_NAME, ExecutionStore
+
+
+def _record_status(*, links: int) -> os.stat_result:
+    """Return a regular-file status for one stable synthetic inode."""
+    return cast(
+        os.stat_result,
+        SimpleNamespace(
+            st_mode=stat.S_IFREG | 0o600,
+            st_ino=101,
+            st_dev=7,
+            st_nlink=links,
+            st_uid=1,
+            st_gid=1,
+            st_size=3,
+            st_file_attributes=0,
+        ),
+    )
+
+
+def test_record_validator_retries_zero_link_with_stale_same_inode_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shared-filesystem stale inode view remains replacement churn."""
+    record_path = tmp_path / RECORD_NAME
+    record_path.write_text("{}\n", encoding="utf-8")
+    unlinked_descriptor = _record_status(links=0)
+    stale_path_view = _record_status(links=1)
+
+    def descriptor_already_validated(
+        _path: Path,
+        _descriptor: int,
+        *,
+        directory: bool,
+    ) -> None:
+        assert directory is False
+
+    monkeypatch.setattr(
+        execution_module,
+        "ensure_private_descriptor",
+        descriptor_already_validated,
+    )
+    monkeypatch.setattr(
+        execution_module.os,
+        "fstat",
+        lambda _descriptor: unlinked_descriptor,
+    )
+    monkeypatch.setattr(Path, "lstat", lambda _path: stale_path_view)
+
+    with pytest.raises(
+        execution_module.PrivatePathIdentityChangedError,
+        match="changed during secure open",
+    ):
+        execution_module._validate_private_regular_file(
+            19,
+            record_path,
+            maximum_size=MAX_RECORD_BYTES,
+        )
+
+
+def test_private_descriptor_classifies_zero_link_as_replacement_churn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The descriptor guard exposes the same typed retry signal."""
+    record_path = tmp_path / RECORD_NAME
+    record_path.write_text("{}\n", encoding="utf-8")
+    unlinked_descriptor = _record_status(links=0)
+    stale_path_view = _record_status(links=1)
+
+    monkeypatch.setattr(
+        private_path_module,
+        "reject_private_path_redirection",
+        lambda _path: None,
+    )
+    monkeypatch.setattr(
+        private_path_module.os,
+        "fstat",
+        lambda _descriptor: unlinked_descriptor,
+    )
+    monkeypatch.setattr(Path, "lstat", lambda _path: stale_path_view)
+
+    with pytest.raises(
+        private_path_module.PrivatePathIdentityChangedError,
+        match="changed during secure open",
+    ):
+        private_path_module.ensure_private_descriptor(
+            record_path,
+            19,
+            directory=False,
+        )
+
+
+def test_post_submit_record_read_retries_after_metadata_settles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An accepted scheduler identity survives transient replacement churn."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create("accepted", mode="scheduler", scheduler_provider="slurm")
+    store.update("accepted", state="submitting")
+    store.update(
+        "accepted",
+        state="submitted",
+        submitted=True,
+        native_id="21948",
+    )
+    real_validate = execution_module._validate_private_regular_file
+    validation_attempts = 0
+    retry_delays: list[float] = []
+
+    def transient_replacement(
+        descriptor: int,
+        path: Path,
+        *,
+        maximum_size: int,
+    ) -> os.stat_result:
+        nonlocal validation_attempts
+        validation_attempts += 1
+        if validation_attempts == 1:
+            raise execution_module.PrivatePathIdentityChangedError(
+                f"private path changed during secure open: {path}"
+            )
+        return real_validate(descriptor, path, maximum_size=maximum_size)
+
+    monkeypatch.setattr(
+        execution_module,
+        "_validate_private_regular_file",
+        transient_replacement,
+    )
+    monkeypatch.setattr(execution_module, "sleep", retry_delays.append)
+
+    record = store.get("accepted")
+
+    assert record.state == "submitted"
+    assert record.submitted is True
+    assert record.scheduler_native_id == "21948"
+    assert validation_attempts == 2
+    assert retry_delays == [execution_module._SECURE_RECORD_READ_RETRY_SECONDS]


### PR DESCRIPTION
## Summary
- treat a zero-link execution-record descriptor as bounded atomic replacement churn
- pause briefly before secure reopen attempts on shared filesystems
- preserve fail-closed behavior for hard links, symlinks, and non-identity security failures

## Production evidence
Ares accepted SLURM job `21948`, but the immediate post-submit record read observed an unlinked old inode while pathname metadata was stale and reported `invalid execution record`. The replacement record was valid on the next read.

## Validation
- `uv run pytest -q test/unit/core/test_execution_record_replacement.py` (3 passed)
- six focused existing execution-record tests plus the new file (9 passed total)
- `uv run ruff check ...`
- `uv run pyright ...` (0 errors)