### PR TITLE
feat: containerized-benchmark support — builtin.fio/redis merge, per-host overlay + fakeroot, scheduler Mode A fix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,10 +40,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Apptainer
 # -----------------------------------------------------------------------
 ARG APPTAINER_VERSION=1.4.1
-RUN wget -qO /tmp/apptainer.deb \
+RUN apt-get update \
+    && wget -qO /tmp/apptainer.deb \
         "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VERSION}/apptainer_${APPTAINER_VERSION}_amd64.deb" \
     && apt-get install -y /tmp/apptainer.deb \
-    && rm /tmp/apptainer.deb
+    && rm /tmp/apptainer.deb \
+    && rm -rf /var/lib/apt/lists/*
 
 # -----------------------------------------------------------------------
 # SSH server setup (required by jarvis multi-node tests)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,6 +38,7 @@
   "forwardPorts": [2222],
 
   "remoteEnv": {
-    "PYTHONPATH": "${containerWorkspaceFolder}"
+    "PYTHONPATH": "${containerWorkspaceFolder}",
+    "IS_SANDBOX": "1"
   }
 }

--- a/builtin/builtin/ior/README.md
+++ b/builtin/builtin/ior/README.md
@@ -59,3 +59,22 @@ Clean produced data
 ```bash
 jarvis pipeline clean
 ```
+## v3 options (#526 regression pipelines)
+
+- `num_nodes` (default `0` = all hosts) — launch on the first N hosts of the
+  pipeline hostfile. Enables node-count sweeps ({1,2,4} nodes) inside one
+  allocation without changing the pipeline hostfile.
+- `single_instance` (default `false`) — pin ior to the FIRST host: the
+  single-client baseline (e.g. NFS) on multi-node pipelines. Applied after
+  `num_nodes` subsetting (it wins in the degenerate combination).
+- `stonewall` (default `0` = off) — ior `-D <seconds>`: cap each write/read
+  phase at a fixed number of seconds.
+- `log` defaults to `<shared_dir>/ior.log`. Pipelines with MORE THAN ONE ior
+  package must set a distinct `log:` per package or their stats overwrite
+  each other.
+
+In containerized pipelines (`base_deploy_mode: container` + a prebuilt SIF)
+ior and mpiexec come from the image and run inside the per-node apptainer
+instance; multi-node ranks spawn over the instance sshd on
+`container_ssh_port`. The package passes an inline `--host` list in container
+mode so the hostfile file itself need not be visible inside the instance.

--- a/builtin/builtin/ior/pkg.py
+++ b/builtin/builtin/ior/pkg.py
@@ -10,6 +10,8 @@ import re
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo, Rm, Mkdir
 from jarvis_cd.shell.process import GdbServer
+from jarvis_cd.util.container_utils import (
+    container_kwargs, eff_hostfile, single_instance_menu_opt)
 
 
 class Ior(Application):
@@ -104,7 +106,28 @@ class Ior(Application):
                 'msg': 'Use direct I/O (O_DIRECT) for POSIX API, bypassing I/O buffers',
                 'type': bool,
                 'default': False,
-            }
+            },
+            {
+                'name': 'num_nodes',
+                'msg': 'Number of nodes to launch on (first N hosts of the '
+                       'pipeline hostfile). 0 means all hosts. Enables '
+                       'node-count sweeps inside one allocation without '
+                       'changing the pipeline hostfile.',
+                'type': int,
+                'default': 0,
+            },
+            {
+                'name': 'stonewall',
+                'msg': 'Stonewalling deadline in seconds (ior -D): cap each '
+                       'write/read phase at this many seconds. 0 disables.',
+                'type': int,
+                'default': 0,
+            },
+            single_instance_menu_opt(
+                msg='Pin ior to the FIRST host even when the pipeline '
+                    'hostfile has >1 host - the single-client baseline '
+                    '(e.g. NFS) on multi-node pipelines. Applied after '
+                    'num_nodes subsetting.'),
         ]
 
     # ------------------------------------------------------------------
@@ -166,9 +189,49 @@ class Ior(Application):
     # Lifecycle
     # ------------------------------------------------------------------
 
+    def _eff_hostfile(self):
+        """The hostfile this ior run actually launches on.
+
+        Order matters: ``num_nodes`` subsets to the first N hosts (the
+        node-count sweep axis), then the ``single_instance`` collapse pins
+        to host[0] (the single-client baseline; it wins in the degenerate
+        combination). In container mode the result is stripped of its
+        backing file path so mpiexec (running inside the instance) gets an
+        inline ``--host`` list instead of a path the instance may not see.
+        """
+        hf = self.hostfile
+        if hf is not None and self.config.get('num_nodes', 0) > 0:
+            hf = hf.subset(self.config['num_nodes'])
+        hf = eff_hostfile(self, hostfile=hf)
+        if (hf is not None and hf.path is not None
+                and self._container_engine != 'none'):
+            hf = hf.copy()
+        return hf
+
     def start(self):
         """Launch IOR via MpiExecInfo; Exec handles container wrapping transparently."""
         cfg = self.config
+
+        # Stale-log guard: a partial/failed run must never report the
+        # previous combo's bandwidths. shared_dir is bound at an identical
+        # path in the container, so a host-side remove is sufficient.
+        log_path = cfg.get('log')
+        if log_path and os.path.isfile(log_path):
+            try:
+                os.remove(log_path)
+            except OSError:
+                pass
+
+        hostfile = self._eff_hostfile()
+
+        # Ensure the output parent dir exists in the deployment context:
+        # inside the container instance when containerized (the path may be
+        # an in-container-only mount), a harmless mkdir -p bare-metal.
+        out = os.path.expandvars(cfg['out'])
+        parent_dir = str(pathlib.Path(out).parent)
+        Mkdir(parent_dir,
+              PsshExecInfo(env=self.mod_env, hostfile=hostfile,
+                           **container_kwargs(self))).run()
 
         cmd = [
             'ior',
@@ -188,6 +251,8 @@ class Ior(Application):
             cmd.append(f'-i {cfg["reps"]}')
         if cfg.get('direct'):
             cmd.append('-O useO_DIRECT=1')
+        if cfg.get('stonewall', 0) > 0:
+            cmd.append(f'-D {cfg["stonewall"]}')
 
         ior_cmd = ' '.join(cmd)
         if cfg.get('log'):
@@ -201,14 +266,56 @@ class Ior(Application):
         Exec(cmd_list, MpiExecInfo(
             nprocs=cfg['nprocs'],
             ppn=cfg['ppn'],
-            hostfile=self.hostfile,
+            hostfile=hostfile,
             port=self.ssh_port,
-            container=self._container_engine,
-            container_image=self.deploy_image_name(),
-            shared_dir=self.shared_dir,
-            private_dir=self.private_dir,
             env=self.mod_env,
+            **container_kwargs(self),
         )).run()
+
+        # Fail loudly on a silent MPI/ior failure. A hard mpiexec abort
+        # (e.g. "PRTE has lost communication with a remote daemon" when the
+        # cross-node spawn fails) or an ior that never reached its results
+        # block leaves no summary in the log, yet Exec does not always raise.
+        # Without this gate the pipeline marks the combination success with
+        # blank bandwidths -- a false green that would let a daily regression
+        # report healthy while multi-node is broken.
+        self._assert_ior_completed()
+
+    def _assert_ior_completed(self):
+        """Raise if the just-finished ior run produced no results summary.
+
+        Reads the log (same file _get_stat parses) and requires a Max
+        Write/Read line for each requested operation. A missing summary
+        means ior aborted or never ran the measured I/O -- surface it as a
+        failed combination instead of a success with empty stats.
+        """
+        wrote = self.config.get('write', True)
+        read = self.config.get('read', False)
+        if not wrote and not read:
+            return  # no workload requested; nothing to validate
+
+        log_path = self.config.get('log')
+        text = ''
+        if log_path and os.path.isfile(log_path):
+            try:
+                with open(log_path, 'r') as f:
+                    text = f.read()
+            except OSError:
+                text = ''
+        stats = self.parse_log(text)
+
+        missing = []
+        if wrote and f'{self.pkg_id}.write_max_mibs' not in stats:
+            missing.append('write')
+        if read and f'{self.pkg_id}.read_max_mibs' not in stats:
+            missing.append('read')
+        if missing:
+            raise RuntimeError(
+                f'ior[{self.pkg_id}]: no IOR {"/".join(missing)} summary in '
+                f'{log_path!r} -- the run failed (mpiexec abort or no '
+                f'cross-node spawn) and produced no bandwidth. Failing this '
+                f'combination rather than reporting a false success; inspect '
+                f'the log for the mpiexec/PRTE error.')
 
     def stop(self):
         """Stop IOR (no-op — IOR runs to completion)."""
@@ -218,7 +325,8 @@ class Ior(Application):
         """Remove IOR output files."""
         Rm(self.config['out'] + '*',
            PsshExecInfo(env=self.env,
-                        hostfile=self.hostfile)).run()
+                        hostfile=self._eff_hostfile(),
+                        **container_kwargs(self))).run()
 
     # ------------------------------------------------------------------
     # Output parsing

--- a/builtin/builtin/juicefs/Dockerfile.deploy
+++ b/builtin/builtin/juicefs/Dockerfile.deploy
@@ -1,0 +1,17 @@
+FROM ##DEPLOY_BASE##
+
+# JuiceFS ships as a single static binary (no apt package); fuse3 provides
+# the FUSE userspace the mount needs. Version is inlined (not an ARG) so the
+# content also converts cleanly on the apptainer-native build path.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        fuse3 libfuse3-3 \
+        curl ca-certificates \
+        openssh-server openssh-client \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/run/sshd \
+    && curl -fsSL "https://github.com/juicedata/juicefs/releases/download/v1.2.3/juicefs-1.2.3-linux-amd64.tar.gz" \
+       | tar -xz -C /usr/local/bin juicefs \
+    && juicefs version
+
+EXPOSE 22
+CMD ["/bin/bash"]

--- a/builtin/builtin/juicefs/README.md
+++ b/builtin/builtin/juicefs/README.md
@@ -1,0 +1,56 @@
+JuiceFS is a POSIX-compatible distributed filesystem: file data lives in an
+object store, file metadata in a transactional engine (here Redis).
+
+# Installation
+
+JuiceFS ships as a single static binary:
+
+```bash
+curl -fsSL https://github.com/juicedata/juicefs/releases/download/v1.2.3/juicefs-1.2.3-linux-amd64.tar.gz \
+  | tar -xz -C /usr/local/bin juicefs
+```
+
+# Juicefs
+
+Formats a JuiceFS volume (idempotent) and FUSE-mounts it in `start`;
+unmounts in `stop`; removes the local cache/bucket dirs in `clean`.
+
+The expected pipeline order is `redis -> juicefs -> <benchmark driver>` so
+the Redis metadata engine accepts connections before `juicefs format` runs.
+Pair it with `builtin.redis` (use redis `single_instance: true` on
+multi-node pipelines — the default `meta_url` selects DB 1, which cluster
+mode cannot serve).
+
+## Options
+
+- `meta_url` (default `redis://127.0.0.1:6379/1`) — metadata engine URL
+- `meta_use_head` (default `false`) — rewrite `meta_url`'s host to the
+  pipeline hostfile's FIRST host at start. For multi-node pipelines where
+  every node mounts JuiceFS but redis is head-pinned (`single_instance`):
+  keep the loopback `meta_url` and set this true (redis must accept
+  non-loopback connections; the shipped `redis.conf` binds `0.0.0.0`)
+- `storage` (default `file`) — object backend: `file` (local dir) or `gs`
+- `bucket` — bucket URL for non-file storage (e.g. `gs://my-bucket`)
+- `gcs_credentials` — path to a GCS service-account JSON key; exported as
+  `GOOGLE_APPLICATION_CREDENTIALS` at start/stop, never stored in config
+- `data_dir` (default `${HOME}/juicefs_data`) — local object-store dir
+  (`--bucket` when `storage=file`)
+- `mountpoint` (default `${HOME}/juicefs_mnt`) — FUSE mountpoint
+- `name` (default `jfsbench`) — volume name passed to `juicefs format`
+- `cache_dir` / `cache_size_mb` (default 512) — local cache; JuiceFS's own
+  default cap is 100 GiB, which can ENOSPC a small node-local scratch
+- `format_fresh` (default true) — wipe the local bucket dir before format
+  (`storage=file` only; never wipes a cloud bucket)
+- `mount_wait` (default 20) — seconds to wait for mount readiness
+- `extra_mount_opts` — appended verbatim to `juicefs mount`
+- `single_instance` (default false) — pin format/mount to the FIRST host on
+  a multi-node hostfile (JuiceFS here is a head-node-only mount whose redis
+  metadata lives on the head node)
+
+## Container deploys
+
+All lifecycle commands are container-wrapped via
+`jarvis_cd.util.container_utils`, so the FUSE mount lives in the pipeline's
+apptainer/container instance namespace and directory setup happens there
+too (host-side `os.makedirs` of in-container paths would fail). Rootless
+apptainer needs `container_fakeroot: true` at the pipeline level for FUSE.

--- a/builtin/builtin/juicefs/pkg.py
+++ b/builtin/builtin/juicefs/pkg.py
@@ -1,0 +1,402 @@
+"""
+This module provides classes and methods to deploy JuiceFS as a Jarvis
+service package.
+
+JuiceFS is a POSIX-compatible distributed filesystem that stores file
+*data* in an object store (here a local directory via ``--storage file``)
+and file *metadata* in a transactional engine (here Redis). This package
+formats the filesystem once, mounts it via FUSE, and unmounts it on stop --
+mirroring the lifecycle style of the ``redis`` service package.
+
+The expected deployment order is: redis -> juicefs -> <benchmark driver>,
+so the Redis metadata engine is already accepting connections before
+``juicefs format`` runs.
+"""
+import os
+import time
+import urllib.parse
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.util.logger import Color
+from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
+from jarvis_cd.util.container_utils import (
+    container_kwargs, flatten_stdout, eff_hostfile, single_instance_menu_opt)
+
+
+class Juicefs(Application):
+    """
+    Format and FUSE-mount a JuiceFS filesystem (Redis metadata +
+    local-file object backend) for single-node benchmarking.
+    """
+
+    def _init(self):
+        """
+        Initialize paths. Concrete (env-expanded) paths are resolved in
+        ``_configure`` and recomputed on demand via ``_paths``.
+        """
+        pass
+
+    def _configure_menu(self):
+        """
+        Create a CLI menu for the configurator method.
+
+        :return: List(dict)
+        """
+        return [
+            {
+                'name': 'meta_url',
+                'msg': 'Metadata engine URL (Redis) for format/mount',
+                'type': str,
+                'default': 'redis://127.0.0.1:6379/1',
+            },
+            {
+                'name': 'meta_use_head',
+                'msg': 'Rewrite meta_url\'s host to the pipeline hostfile\'s '
+                       'FIRST host at start. Use on multi-node pipelines '
+                       'where every node mounts JuiceFS but the Redis '
+                       'metadata store is pinned to the head node '
+                       '(single_instance redis): keep meta_url on '
+                       '127.0.0.1 and set this true.',
+                'type': bool,
+                'default': False,
+            },
+            {
+                'name': 'storage',
+                'msg': "Object storage backend type ('file' local dir, or 'gs' for Google Cloud Storage)",
+                'type': str,
+                'default': 'file',
+            },
+            {
+                'name': 'bucket',
+                'msg': "Object bucket URL for non-file storage, e.g. gs://my-bucket (required when storage='gs')",
+                'type': str,
+                'default': '',
+            },
+            {
+                'name': 'gcs_credentials',
+                'msg': 'Path to a GCS service-account JSON key (exported as GOOGLE_APPLICATION_CREDENTIALS; never stored in config)',
+                'type': str,
+                'default': '',
+            },
+            {
+                'name': 'data_dir',
+                'msg': "Local object-store dir (used as --bucket only when storage='file')",
+                'type': str,
+                'default': '${HOME}/juicefs_data',
+            },
+            {
+                'name': 'mountpoint',
+                'msg': 'FUSE mountpoint directory',
+                'type': str,
+                'default': '${HOME}/juicefs_mnt',
+            },
+            {
+                'name': 'name',
+                'msg': 'JuiceFS volume name (passed to juicefs format)',
+                'type': str,
+                'default': 'jfsbench',
+            },
+            {
+                'name': 'cache_dir',
+                'msg': 'Local cache directory for the mount',
+                'type': str,
+                'default': '${HOME}/juicefs_cache',
+            },
+            {
+                'name': 'cache_size_mb',
+                'msg': 'Local cache size cap in MiB (juicefs --cache-size). '
+                       'JuiceFS defaults to 100 GiB, which can exhaust a small '
+                       'node-local scratch device; bound it well under free '
+                       'space on the cache_dir filesystem.',
+                'type': int,
+                'default': 512,
+            },
+            {
+                'name': 'juicefs_bin',
+                'msg': 'Path to the juicefs binary',
+                'type': str,
+                'default': 'juicefs',
+            },
+            {
+                'name': 'format_fresh',
+                'msg': "Wipe the local bucket dir before formatting (storage='file' only; no-op for cloud)",
+                'type': bool,
+                'default': True,
+            },
+            {
+                'name': 'mount_wait',
+                'msg': 'Seconds to wait for the mount to become ready',
+                'type': int,
+                'default': 20,
+            },
+            {
+                'name': 'extra_mount_opts',
+                'msg': 'Extra options appended to juicefs mount',
+                'type': str,
+                'default': '',
+            },
+            # Head-node-only pinning: JuiceFS is a single mount here (its redis
+            # metadata store lives only on the first host), so on a multi-node
+            # pipeline it must NOT fan format/mount/rm out to every node.
+            single_instance_menu_opt(),
+        ]
+
+    def _build_deploy_phase(self):
+        if self.config.get('deploy_mode') != 'container':
+            return None
+        base = getattr(self.pipeline, 'container_base', 'ubuntu:24.04')
+        content = self._read_dockerfile('Dockerfile.deploy', {
+            'DEPLOY_BASE': base,
+        })
+        return content, 'default'
+
+    def _paths(self):
+        """
+        Resolve env-expanded, user-expanded absolute paths from config.
+
+        :return: tuple(data_dir, mountpoint, cache_dir)
+        """
+        def fix(p):
+            return os.path.expanduser(os.path.expandvars(str(p)))
+        return (fix(self.config['data_dir']),
+                fix(self.config['mountpoint']),
+                fix(self.config['cache_dir']))
+
+    def _effective_meta_url(self):
+        """
+        ``meta_url``, with its host swapped to the pipeline hostfile's FIRST
+        host when ``meta_use_head`` is set. Lets a multi-node YAML keep the
+        loopback default while the head-pinned (single_instance) redis serves
+        metadata to JuiceFS mounts on every node. Credentials and port in the
+        URL are preserved; only the hostname changes.
+
+        :return: str (the meta URL to pass to juicefs format/mount)
+        """
+        meta_url = self.config['meta_url']
+        if not self.config.get('meta_use_head'):
+            return meta_url
+        hf = self.hostfile
+        if hf is None or not hf.hosts:
+            return meta_url
+        parsed = urllib.parse.urlsplit(meta_url)
+        if not parsed.netloc:
+            return meta_url
+        creds, sep, hostport = parsed.netloc.rpartition('@')
+        _, colon, port = hostport.partition(':')
+        new_netloc = f'{creds}{sep}{hf.hosts[0]}{colon}{port}'
+        return urllib.parse.urlunsplit(parsed._replace(netloc=new_netloc))
+
+    def _bucket_arg(self):
+        """
+        The value passed to ``juicefs format --bucket``. For storage='file'
+        this is the local data_dir; for cloud backends (e.g. 'gs') it is the
+        configured bucket URL (gs://...).
+
+        :return: str
+        """
+        if self.config['storage'] == 'file':
+            data_dir, _, _ = self._paths()
+            return data_dir
+        return str(self.config['bucket'])
+
+    def _inject_cloud_env(self):
+        """
+        Populate ``self.mod_env`` with object-store credentials for the
+        spawned juicefs subprocesses. Secrets are never read from config: the
+        JSON key stays on disk and only its *path* (``gcs_credentials``) is
+        turned into ``GOOGLE_APPLICATION_CREDENTIALS``. Any ``GCS_*`` already
+        in the parent environment is passed through verbatim (env-based
+        credential chain).
+
+        Must run in ``start``/``stop`` -- ``_configure`` runs in a separate
+        process, so mod_env mutations there would not survive to the Exec
+        (the pipeline rebuilds mod_env from the persisted env each invocation).
+
+        :return: None
+        """
+        if self.config['storage'] != 'gs':
+            return
+        cred = os.path.expanduser(os.path.expandvars(
+            str(self.config.get('gcs_credentials', ''))))
+        if cred:
+            self.mod_env['GOOGLE_APPLICATION_CREDENTIALS'] = cred
+        # Pass through pre-set GCS_* (e.g. a short-lived GCS_ACCESS_TOKEN, or
+        # GCS_PROJECT_ID) that the env allowlist would otherwise drop.
+        for key in ('GCS_ACCESS_TOKEN', 'GCS_PROJECT_ID'):
+            if key not in self.mod_env and key in os.environ:
+                self.mod_env[key] = os.environ[key]
+
+    def _configure(self, **kwargs):
+        """
+        Validate config. The mount/cache/bucket directories are NOT created
+        here: ``_configure`` runs host-side in the jarvis process BEFORE the
+        apptainer instance exists, so a host ``os.makedirs`` of an in-container
+        path like ``/mnt/jfs_mnt`` would hit the host's root-owned ``/mnt`` and
+        fail (Errno 13). The dirs are instead created in ``start`` via a
+        (container-wrapped) Exec. Harmless host mkdir in a bare-metal deploy.
+
+        :param kwargs: Configuration parameters for this pkg.
+        :return: None
+        """
+        if not self.config['meta_url']:
+            raise ValueError('juicefs: meta_url must be set')
+
+        storage = self.config['storage']
+        if storage == 'gs':
+            if not str(self.config.get('bucket', '')).startswith('gs://'):
+                raise ValueError(
+                    "juicefs: storage='gs' requires bucket=gs://<bucket>")
+            if not str(self.config.get('gcs_credentials', '')) \
+                    and 'GCS_ACCESS_TOKEN' not in os.environ:
+                self.log("juicefs: storage='gs' with no gcs_credentials and no "
+                         "GCS_ACCESS_TOKEN; relying on Google's ADC chain (e.g. "
+                         "`gcloud auth application-default login`, or a GCE "
+                         "attached service account). Valid if ADC is configured; "
+                         "fails only if the chain resolves no credentials.",
+                         color=Color.YELLOW)
+        elif storage != 'file':
+            self.log(f"juicefs: storage='{storage}' is configured but only "
+                     f"'file' and 'gs' are exercised by this package",
+                     color=Color.YELLOW)
+
+    def _is_mounted(self, mountpoint):
+        """
+        Report whether ``mountpoint`` has a filesystem mounted *in the
+        deployment context* (the apptainer instance's mount namespace for a
+        container deploy, or the host for bare-metal). Uses a container-wrapped
+        Exec probe rather than host-side ``os.path.ismount``: the JuiceFS FUSE
+        mount lives inside the instance, which the host can't see.
+
+        :param mountpoint: Absolute mountpoint path.
+        :return: bool
+        """
+        probe = Exec(
+            f'mountpoint -q {mountpoint} && echo __JFS_MOUNTED__ || true',
+            PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                         collect_output=True, **container_kwargs(self))).run()
+        return '__JFS_MOUNTED__' in flatten_stdout(probe)
+
+    def start(self):
+        """
+        Format (idempotent) and FUSE-mount the JuiceFS filesystem, then
+        block until the mount is ready.
+
+        :return: None
+        """
+        jfs = self.config['juicefs_bin']
+        data_dir, mountpoint, cache_dir = self._paths()
+        meta_url = self._effective_meta_url()
+
+        # Make object-store credentials available to BOTH subprocesses below
+        # (same process as the Exec -- see _inject_cloud_env docstring).
+        self._inject_cloud_env()
+
+        # Create the mount/cache (and, for storage='file', bucket) dirs in the
+        # deployment context. Under a non-setuid apptainer these are container
+        # paths (e.g. /mnt/jfs_mnt), so they must be made via a container-wrapped
+        # Exec, NOT host-side os.makedirs (which would hit the host's root-owned
+        # /mnt). Bare-metal: a harmless local mkdir -p.
+        mkdirs = [mountpoint, cache_dir]
+        if self.config['storage'] == 'file':
+            mkdirs.append(data_dir)
+        Exec(f'mkdir -p {" ".join(mkdirs)}',
+             PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+
+        # Fresh slate: drop any orphaned chunks from a previous run. This is a
+        # LOCAL operation, only meaningful for storage='file' (the Redis
+        # metadata is wiped per-run by the redis package, so stale chunks here
+        # would only be dead bytes). For cloud backends, wiping the bucket is
+        # destructive re-init and is out of scope -- log and skip.
+        if self.config['format_fresh']:
+            if self.config['storage'] == 'file':
+                self.log(f'Clearing bucket dir {data_dir}', color=Color.YELLOW)
+                # Container-wrapped (see mkdir rationale above): host-side
+                # shutil.rmtree on /mnt/jfs_data would fail / hit the wrong fs.
+                Exec(f'rm -rf {data_dir} && mkdir -p {data_dir}',
+                     PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+            else:
+                self.log(f"format_fresh: skipping bucket wipe for "
+                         f"storage='{self.config['storage']}' (no-op; "
+                         f"destructive bucket re-init is out of scope)",
+                         color=Color.YELLOW)
+
+        # Format the volume (safe to re-run against fresh metadata).
+        fmt = [
+            jfs, 'format',
+            '--storage', self.config['storage'],
+            '--bucket', self._bucket_arg(),
+            meta_url,
+            self.config['name'],
+        ]
+        self.log(f"Formatting JuiceFS: {' '.join(fmt)}", color=Color.YELLOW)
+        Exec(' '.join(fmt), PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+
+        # Mount via FUSE. --background daemonizes and returns once the
+        # mount is registered.
+        mnt = [
+            jfs, 'mount',
+            meta_url,
+            mountpoint,
+            '--cache-dir', cache_dir,
+            # Cap the local cache: JuiceFS defaults to 100 GiB, which can fill a
+            # small node-local scratch device (e.g. a compute-node /tmp on a
+            # ~2 GiB-free root fs) and tip a high-thread combo into ENOSPC.
+            '--cache-size', str(self.config['cache_size_mb']),
+            '--background',
+        ]
+        if self.config['extra_mount_opts']:
+            mnt.append(self.config['extra_mount_opts'])
+        self.log(f"Mounting JuiceFS: {' '.join(mnt)}", color=Color.YELLOW)
+        Exec(' '.join(mnt), PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+
+        # Wait for the mount to actually be ready before downstream I/O.
+        deadline = int(self.config['mount_wait'])
+        for _ in range(deadline):
+            if self._is_mounted(mountpoint):
+                self.log(f'JuiceFS mounted at {mountpoint}', color=Color.GREEN)
+                return
+            time.sleep(1)
+        raise RuntimeError(
+            f'juicefs: mountpoint {mountpoint} not ready after '
+            f'{deadline}s (check redis connectivity and /dev/fuse access)')
+
+    def stop(self):
+        """
+        Unmount the JuiceFS filesystem.
+
+        :return: None
+        """
+        _, mountpoint, _ = self._paths()
+        jfs = self.config['juicefs_bin']
+        Exec(f'{jfs} umount {mountpoint}',
+             PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+        # Fallback for a wedged mount; ignore failure if already gone.
+        if self._is_mounted(mountpoint):
+            Exec(f'fusermount -u {mountpoint}',
+                 PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+
+    def clean(self):
+        """
+        Unmount (if needed) and delete the local cache (and, for
+        storage='file', the local bucket) directories. A cloud bucket is
+        never deleted here -- teardown is left to the storage provider /
+        its lifecycle rules.
+
+        :return: None
+        """
+        data_dir, mountpoint, cache_dir = self._paths()
+        if self._is_mounted(mountpoint):
+            self.stop()
+        dirs = [cache_dir]
+        if self.config['storage'] == 'file':
+            dirs.append(data_dir)
+        # Container-wrapped removal (see start()'s mkdir rationale): host-side
+        # shutil.rmtree can't reach the in-container paths.
+        Exec(f'rm -rf {" ".join(dirs)}',
+             PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()

--- a/builtin/builtin/redis-benchmark/README.md
+++ b/builtin/builtin/redis-benchmark/README.md
@@ -5,3 +5,19 @@ LabStor is a distributed semi-microkernel for building data processing services.
 ```bash
 spack install redis
 ```
+
+## v3 options (#526 regression pipelines)
+
+- `clients` (default `50` = tool default) — parallel client connections
+  (`-c`). For a "threads" sweep, zip with `nthreads` so a row means N
+  connections driven by N threads.
+- `nthreads` — I/O-issuing threads (`--threads`); `count` — total requests
+  (`-n`); `req_size` — request size in integer bytes (`-d`).
+- `single_instance` (default `false`) — run the benchmark on the FIRST host
+  (next to a head-pinned `single_instance` redis) and skip cluster
+  addressing.
+
+Output is captured with `--csv` (replacing the human-readable report) and
+teed to `<shared_dir>/<pkg_id>_redis_bench.csv`. results.csv columns:
+`{pkg_id}.set_rps`, `.get_rps`, `.set_p50_ms`, `.get_p50_ms`, `.set_p99_ms`,
+`.get_p99_ms`, `.runtime`.

--- a/builtin/builtin/redis-benchmark/pkg.py
+++ b/builtin/builtin/redis-benchmark/pkg.py
@@ -1,13 +1,22 @@
 """
 This module provides classes and methods to launch the Redis benchmark tool.
 """
+import csv
+import io
+import os
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.shell import Exec, LocalExecInfo
+from jarvis_cd.util.container_utils import (
+    container_kwargs, eff_hostfile, single_instance_menu_opt)
 
 
 class RedisBenchmark(Application):
     """
     Redis benchmark — supports default (host) and container deployment modes.
+
+    Output is captured in ``--csv`` mode (one row per test with rps and
+    latency percentiles) and teed to ``<shared_dir>/<pkg_id>_redis_bench.csv``
+    so ``_get_stat`` can populate results.csv columns from disk.
     """
 
     def _configure_menu(self):
@@ -20,7 +29,7 @@ class RedisBenchmark(Application):
             },
             {
                 'name': 'count',
-                'msg': 'Number of requests to generate',
+                'msg': 'Number of requests to generate (-n)',
                 'type': int,
                 'default': 100000,
             },
@@ -38,19 +47,28 @@ class RedisBenchmark(Application):
             },
             {
                 'name': 'nthreads',
-                'msg': 'Number of threads',
+                'msg': 'Number of I/O-issuing threads (--threads)',
                 'type': int,
                 'default': 1,
             },
             {
+                'name': 'clients',
+                'msg': 'Number of parallel client connections (-c). 50 is '
+                       'the tool default. For a "threads" sweep, zip this '
+                       'with nthreads so a row means N connections driven '
+                       'by N threads.',
+                'type': int,
+                'default': 50,
+            },
+            {
                 'name': 'pipeline',
-                'msg': 'Number of requests to pipeline',
+                'msg': 'Number of requests to pipeline (-P)',
                 'type': int,
                 'default': 1,
             },
             {
                 'name': 'req_size',
-                'msg': 'Size of requests in bytes',
+                'msg': 'Size of requests in bytes (-d, integer bytes)',
                 'type': int,
                 'default': 3,
             },
@@ -60,6 +78,11 @@ class RedisBenchmark(Application):
                 'type': int,
                 'default': 0,
             },
+            single_instance_menu_opt(
+                msg='Run the benchmark on the FIRST host (next to a '
+                    'single_instance redis) instead of the driver node, '
+                    'and skip cluster addressing. For multi-node '
+                    'pipelines with a head-pinned standalone redis.'),
         ]
 
     def _build_deploy_phase(self):
@@ -74,8 +97,22 @@ class RedisBenchmark(Application):
     def _configure(self, **kwargs):
         super()._configure(**kwargs)
 
+    def _csv_path(self):
+        """Where the raw ``--csv`` output lands (shared_dir is bound at an
+        identical path inside the container, so host-side reads work)."""
+        return os.path.join(self.shared_dir,
+                            f'{self.pkg_id}_redis_bench.csv')
+
     def start(self):
-        hostfile = self.hostfile
+        # Stale-output guard: a failed run must not report the previous
+        # combo's numbers.
+        csv_path = self._csv_path()
+        if os.path.isfile(csv_path):
+            try:
+                os.remove(csv_path)
+            except OSError:
+                pass
+
         bench_type = ','.join(filter(None, [
             'set' if self.config.get('write', True) else '',
             'get' if self.config.get('read', True) else '',
@@ -86,22 +123,108 @@ class RedisBenchmark(Application):
             f'-t {bench_type}',
             f'-P {self.config["pipeline"]}',
             f'--threads {self.config["nthreads"]}',
+            f'-c {self.config["clients"]}',
             f'-d {self.config["req_size"]}',
             f'-p {self.config["port"]}',
         ]
-        if len(hostfile) > 1:
-            cmd += [f'-h {hostfile.hosts[self.config["node"]]}', '--cluster']
 
-        Exec(' '.join(cmd), LocalExecInfo(
-            env=self.mod_env,
-            container=self._container_engine,
-            container_image=self.deploy_image_name(),
-            shared_dir=self.shared_dir,
-                private_dir=self.private_dir,
-        )).run()
+        exec_kwargs = dict(env=self.mod_env, **container_kwargs(self))
+        if self.config.get('single_instance'):
+            # Run next to the head-pinned standalone redis (LocalExecInfo
+            # with a remote hostfile promotes to SSH on host[0]); loopback
+            # addressing, no cluster flags.
+            exec_kwargs['hostfile'] = eff_hostfile(self)
+        else:
+            # Legacy behavior: run on the driver node; address a cluster
+            # node explicitly when the pipeline spans hosts.
+            hostfile = self.hostfile
+            if len(hostfile) > 1:
+                cmd += [f'-h {hostfile.hosts[self.config["node"]]}',
+                        '--cluster']
+
+        cmd += ['--csv', f'2>&1 | tee {csv_path}']
+
+        Exec(' '.join(cmd), LocalExecInfo(**exec_kwargs)).run()
 
     def stop(self):
         pass
 
     def clean(self):
-        pass
+        csv_path = self._csv_path()
+        if os.path.isfile(csv_path):
+            try:
+                os.remove(csv_path)
+            except OSError:
+                pass
+
+    # ------------------------------------------------------------------
+    # Output parsing
+    # ------------------------------------------------------------------
+
+    def _parse_output(self, text):
+        """Parse ``redis-benchmark --csv`` output into stat entries.
+
+        Handles the redis 6/7 8-column form
+        (``"test","rps","avg_latency_ms",...,"p50_latency_ms",...``) and
+        falls back to the legacy 2-column ``"test","rps"`` form. Never
+        raises; unparseable text yields an empty dict.
+        """
+        stats = {}
+        prefix = self.pkg_id
+        try:
+            rows = list(csv.reader(io.StringIO(text)))
+        except csv.Error:
+            return stats
+        if not rows:
+            return stats
+
+        header = [h.strip().lower() for h in rows[0]]
+        col = {name: i for i, name in enumerate(header)}
+        # Legacy 2-column output has no header row; detect by first cell.
+        has_header = 'test' in col
+        data_rows = rows[1:] if has_header else rows
+
+        def field(row, name, legacy_idx=None):
+            idx = col.get(name, legacy_idx if not has_header else None)
+            if idx is None or idx >= len(row):
+                return None
+            try:
+                return float(row[idx])
+            except (TypeError, ValueError):
+                return None
+
+        for row in data_rows:
+            if not row:
+                continue
+            test = row[0].strip().strip('"').lower()
+            if test not in ('set', 'get'):
+                continue
+            rps = field(row, 'rps', legacy_idx=1)
+            if rps is not None:
+                stats[f'{prefix}.{test}_rps'] = rps
+            p50 = field(row, 'p50_latency_ms')
+            if p50 is not None:
+                stats[f'{prefix}.{test}_p50_ms'] = p50
+            p99 = field(row, 'p99_latency_ms')
+            if p99 is not None:
+                stats[f'{prefix}.{test}_p99_ms'] = p99
+        return stats
+
+    def _get_stat(self, stat_dict):
+        """Populate ``stat_dict`` from the teed ``--csv`` file on disk.
+
+        Called on a freshly-loaded instance after the run; missing or
+        unparseable file → only runtime is recorded.
+        """
+        stat_dict[f'{self.pkg_id}.runtime'] = getattr(
+            self, 'start_time', None)
+
+        csv_path = self._csv_path()
+        if not os.path.isfile(csv_path):
+            return
+        try:
+            with open(csv_path, 'r') as f:
+                text = f.read()
+        except OSError:
+            return
+        stat_dict.update(self._parse_output(text))

--- a/builtin/builtin/redis/README.md
+++ b/builtin/builtin/redis/README.md
@@ -5,3 +5,40 @@ Redis is a key-value store
 ```bash
 spack install redis
 ```
+
+# Redis
+
+Runs a standalone server on a single-host hostfile, or a redis cluster when
+the hostfile has >1 host.
+
+## Options
+
+- `port` (default 6379)
+- `single_instance` (default false) — force ONE standalone server on the
+  FIRST host even when the hostfile has >1 host, skipping the cluster
+  branch. Use when redis is a metadata singleton: cluster mode is DB0-only,
+  so clients that `SELECT` a non-zero DB (e.g. a JuiceFS `meta_url` of
+  `redis://.../1`) break against a cluster, and N servers sharing one
+  `nodes.conf` on a shared filesystem collide. Default keeps the legacy
+  behaviour (cluster iff >1 host).
+
+## Startup/teardown hardening
+
+- The server runs with `--dir <private_dir>` and any stale `dump.rdb` there
+  is removed pre-launch: redis loads `./dump.rdb` from its CWD at startup,
+  and a stale dump from a prior run (or a newer redis version) either
+  crashes startup ("Can't handle RDB format version N") or leaks old keys.
+  The shipped `redis.conf` also sets `save ""` (no snapshotting — this is
+  an ephemeral service) and `pidfile ""` (`/var/run` is not writable in
+  unprivileged containers; the pidfile is unused since redis is
+  non-daemonized and tracked directly).
+- After launch, `start()` waits for `redis-cli ping` → `PONG` (30 × 1s,
+  warn-only) before returning, so dependent packages don't race a server
+  that is still binding; standalone servers are then `flushall`'d for a
+  fresh slate per run.
+- `stop()` shuts down gracefully (`redis-cli shutdown nosave`), falls back
+  to a force-kill, then waits for the port to be free so a back-to-back
+  restart doesn't race the dying server.
+
+All redis-cli probes run in the deployment context (inside the container
+instance for a container deploy), so `redis-cli` need not exist host-side.

--- a/builtin/builtin/redis/config/redis.conf
+++ b/builtin/builtin/redis/config/redis.conf
@@ -338,7 +338,10 @@ daemonize no
 #
 # Note that on modern Linux systems "/run/redis.pid" is more conforming
 # and should be used instead.
-pidfile /var/run/redis_6379.pid
+# #526: empty => no pidfile. /var/run is not writable inside the unprivileged
+# apptainer container ("Failed to write PID file: Permission denied"); the pid
+# file is unused here (non-daemonized; jarvis tracks the process directly).
+pidfile ""
 
 # Specify the server verbosity level.
 # This can be one of:
@@ -476,6 +479,12 @@ rdbchecksum yes
 # resharding via MIGRATE, it is temporarily set to 'no' by default.
 #
 # sanitize-dump-payload no
+
+# #526: disable RDB snapshotting. This is an ephemeral in-memory metadata engine
+# (JuiceFS meta in DB1) + benchmark target (DB0); persistence is undesirable and
+# a stale dump.rdb loaded across runs/sweep-combos leaked 83 keys + old JuiceFS
+# meta. With save "" no dump.rdb is written; the pkg also flushall's on start.
+save ""
 
 # The filename where to dump the DB
 dbfilename dump.rdb

--- a/builtin/builtin/redis/pkg.py
+++ b/builtin/builtin/redis/pkg.py
@@ -2,9 +2,14 @@
 This module provides classes and methods to launch Redis.
 Redis cluster is used if the hostfile has many hosts.
 """
+import time
+
 from jarvis_cd.core.pkg import Service
 from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Kill
+from jarvis_cd.util.container_utils import (
+    all_hosts_ok, container_kwargs, eff_hostfile, single_instance_menu_opt)
+from jarvis_cd.util.logger import Color
 
 
 class Redis(Service):
@@ -20,6 +25,13 @@ class Redis(Service):
                 'type': int,
                 'default': 6379,
             },
+            single_instance_menu_opt(
+                msg='Force ONE redis server on the first host even when '
+                    'the hostfile has >1 host (skip the cluster branch). '
+                    'Use when redis is a metadata singleton — e.g. '
+                    'JuiceFS meta over redis://.../1, which needs SELECT '
+                    'and so cannot use DB0-only cluster mode. Default '
+                    'keeps the legacy behaviour (cluster iff >1 host).'),
         ]
 
     def _build_deploy_phase(self):
@@ -39,12 +51,50 @@ class Redis(Service):
             {'PORT': self.config['port']},
         )
 
+    def _redis_cli(self, args, expect=None, timeout_s=2):
+        """Run ``redis-cli <args>`` in the deployment context (inside the
+        container instance for a container deploy — redis-cli need not exist
+        host-side). ``timeout N`` bounds each attempt; callers keep their
+        own retry loops.
+
+        :param args: redis-cli argument string (e.g. ``-p 6379 ping``)
+        :param expect: optional substring required in every host's stdout
+        :param timeout_s: per-attempt timeout in seconds
+        :return: True iff every host exited 0 (and printed ``expect``)
+        """
+        res = Exec(f'timeout {timeout_s} redis-cli {args}',
+                   PsshExecInfo(env=self.mod_env,
+                                hostfile=eff_hostfile(self),
+                                collect_output=True,
+                                **container_kwargs(self))).run()
+        return all_hosts_ok(res, expect)
+
     def start(self):
-        hostfile = self.hostfile
-        host_str = ' '.join(f'{h}:{self.config["port"]}' for h in hostfile.hosts)
+        # single_instance pins to the first host (see eff_hostfile), keeping
+        # redis a plain non-cluster server: cluster mode is DB0-only and
+        # breaks clients that SELECT a non-zero DB (e.g. a JuiceFS meta_url
+        # of redis://.../1), and N servers sharing one nodes.conf on a
+        # shared filesystem collide anyway.
+        hostfile = eff_hostfile(self)
+        port = self.config['port']
+        host_str = ' '.join(f'{h}:{port}' for h in hostfile.hosts)
         cluster_config_file = f'{self.private_dir}/nodes.conf'
 
-        cmd = ['redis-server', f'{self.shared_dir}/redis.conf']
+        # Redis loads ./dump.rdb from its working directory at startup. The
+        # conf sets `dir ./`, which resolves to whatever CWD redis starts in —
+        # and a stale dump.rdb left there by a prior run or a newer redis
+        # crashes startup ("Can't handle RDB format version N / Fatal error
+        # loading the DB. Exiting."). Pin --dir to THIS run's private dir and
+        # wipe any leftover dump so startup is clean.
+        Exec(f'rm -f {self.private_dir}/dump.rdb',
+             PsshExecInfo(env=self.mod_env, hostfile=hostfile,
+                          **container_kwargs(self))).run()
+
+        cmd = [
+            'redis-server',
+            f'{self.shared_dir}/redis.conf',
+            f'--dir {self.private_dir}',
+        ]
         if len(hostfile) > 1:
             cmd += [
                 '--cluster-enabled yes',
@@ -56,29 +106,41 @@ class Redis(Service):
             env=self.mod_env,
             hostfile=hostfile,
             exec_async=True,
-            container=self._container_engine,
-            container_image=self.deploy_image_name(),
-            shared_dir=self.shared_dir,
-            private_dir=self.private_dir,
             bind_mounts=self.container_mounts,
+            **container_kwargs(self),
         )).run()
 
         self.sleep()
 
+        # Wait for redis to actually accept connections before dependents
+        # (benchmarks, JuiceFS format) connect. Warn-only: a slow-but-alive
+        # server still comes up; a dead one fails loudly downstream.
+        self.log(f'Waiting for Redis to accept connections on port {port}',
+                 color=Color.YELLOW)
+        for _ in range(30):
+            if self._redis_cli(f'-p {port} ping', expect='PONG'):
+                break
+            time.sleep(1)
+        else:
+            self.log('WARNING: Redis did not respond to PING after 30s',
+                     color=Color.RED)
+
+        # Standalone hygiene — wipe ALL DBs so each run/sweep combo starts
+        # from an empty server, regardless of any dump.rdb a prior run left
+        # behind. The cluster branch below already flushall's per host.
+        if len(hostfile) <= 1:
+            self.log('Flushing all DBs (fresh slate for this run)',
+                     color=Color.YELLOW)
+            self._redis_cli(f'-p {port} flushall', timeout_s=5)
+
         if len(hostfile) > 1:
             for host in hostfile.hosts:
-                Exec(f'redis-cli -p {self.config["port"]} -h {host} flushall',
+                Exec(f'redis-cli -p {port} -h {host} flushall',
                      LocalExecInfo(env=self.mod_env,
-                                   container=self._container_engine,
-                                   container_image=self.deploy_image_name(),
-                                   shared_dir=self.shared_dir,
-                                   private_dir=self.private_dir)).run()
-                Exec(f'redis-cli -p {self.config["port"]} -h {host} cluster reset',
+                                   **container_kwargs(self))).run()
+                Exec(f'redis-cli -p {port} -h {host} cluster reset',
                      LocalExecInfo(env=self.mod_env,
-                                   container=self._container_engine,
-                                   container_image=self.deploy_image_name(),
-                                   shared_dir=self.shared_dir,
-                                   private_dir=self.private_dir)).run()
+                                   **container_kwargs(self))).run()
 
             cmd = ' '.join([
                 'redis-cli',
@@ -88,15 +150,34 @@ class Redis(Service):
             ])
             Exec(cmd, LocalExecInfo(
                 env=self.mod_env,
-                container=self._container_engine,
-                container_image=self.deploy_image_name(),
-                shared_dir=self.shared_dir,
-                private_dir=self.private_dir,
+                **container_kwargs(self),
             )).run()
             self.sleep()
 
     def stop(self):
-        Kill('redis-server', PsshExecInfo(env=self.env, hostfile=self.hostfile)).run()
+        port = self.config['port']
+        hostfile = eff_hostfile(self)
+        # Graceful shutdown via redis-cli on the SAME hosts redis was started
+        # on (single_instance => first host only), else stop tries to reach
+        # servers that were never launched.
+        Exec(f'redis-cli -p {port} shutdown nosave',
+             PsshExecInfo(env=self.mod_env,
+                          hostfile=hostfile,
+                          **container_kwargs(self))).run()
+        # Fallback: force-kill any remaining redis-server processes.
+        Kill('redis-server',
+             PsshExecInfo(env=self.mod_env,
+                          hostfile=hostfile,
+                          **container_kwargs(self))).run()
+        # Wait for the port to be free before returning so the next combo's
+        # server doesn't race a dying one. If the deployment context is
+        # already gone the probe fails -> treated as "port free", the right
+        # best-effort answer at teardown.
+        for _ in range(10):
+            if not self._redis_cli(f'-p {port} ping', expect='PONG'):
+                break
+            time.sleep(1)
+        time.sleep(1)
 
     def clean(self):
         pass

--- a/docker/build_regression_image.sh
+++ b/docker/build_regression_image.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Build the #526 regression APPTAINER SIF — this IS the automated
+# "installation" for the containerized single_node/distributed pipelines
+# (which live in clio-core under jarvis_clio_core/pipelines/ares/).
+# Two stages, docker-only:
+#   1. `docker build` docker/regression.Dockerfile -> a local OCI image (it
+#      bakes spack iowarp(+fuse) and ior@3.3.0, juicefs, redis, THIS
+#      jarvis-cd checkout, and clio-core at a pinned ref; its final RUN
+#      fails if any required binary is missing — the install-cleanliness
+#      gate).
+#   2. `apptainer build <sif> docker-daemon://<image>` -> a portable .sif.
+#      No Docker Hub round-trip, no apptainer --fakeroot needed at build time.
+#
+# Source trees:
+#   - jarvis-cd enters via the docker build CONTEXT (this repo's root): the
+#     image always matches the checkout you run this script from.
+#   - clio-core enters via a git fetch inside the Dockerfile at
+#     CLIO_REPO_URL @ CLIO_REF. When CLIO_REF is a branch, this script
+#     resolves it to a commit SHA first (git ls-remote) so docker's layer
+#     cache busts exactly when clio-core pushes — a raw branch-name build
+#     arg would silently reuse a stale cached clone. The resolved SHA is
+#     echoed: record it, it is the exact clio-core commit baked in.
+#
+# The SIF is written to the jarvis containers cache so the pipeline YAMLs
+# find it by basename (container_image: "iowarp-regression-526-v3"):
+#     <jarvis shared_dir>/containers/iowarp-regression-526-v3.sif
+# On Ares shared_dir is on /mnt/common (shared FS) -> the SIF is visible on
+# every compute node automatically (no per-node copy).
+#
+# Re-run daily so #526 tracks the latest IOWarp.
+#
+# Usage (from anywhere, on a host with docker + apptainer):
+#   bash docker/build_regression_image.sh
+#
+# Common overrides (env):
+#   IMAGE=iowarp-regression:526-v3          # local docker image tag to build
+#   SIF_BASENAME=iowarp-regression-526-v3   # must match YAML container_image
+#   SIF_PATH=/abs/path/iowarp-regression-526-v3.sif  # override the SIF location
+#   IOWARP_SPEC='iowarp@dev +fuse'          # upstream dev + FUSE (v3: no +redis)
+#   IOR_SPEC='ior@3.3.0'                    # pinned; builtin.ior parses 3.3.0 output
+#   BASE_IMAGE=iowarp/iowarp-build:latest
+#   CLIO_REPO_URL=https://github.com/eDoggo3779/clio-core-fork.git
+#   CLIO_REF=jarvis-pipelines-526           # branch (resolved to SHA) or SHA
+#   SKIP_DOCKER_BUILD=1                     # reuse an existing local docker image
+set -euo pipefail
+
+IMAGE="${IMAGE:-iowarp-regression:526-v3}"
+SIF_BASENAME="${SIF_BASENAME:-iowarp-regression-526-v3}"
+IOWARP_SPEC="${IOWARP_SPEC:-iowarp@dev +fuse}"
+IOR_SPEC="${IOR_SPEC:-ior@3.3.0}"
+BASE_IMAGE="${BASE_IMAGE:-iowarp/iowarp-build:latest}"
+CLIO_REPO_URL="${CLIO_REPO_URL:-https://github.com/eDoggo3779/clio-core-fork.git}"
+CLIO_REF="${CLIO_REF:-jarvis-pipelines-526}"
+SKIP_DOCKER_BUILD="${SKIP_DOCKER_BUILD:-0}"
+
+# Build context = the jarvis-cd repo root (parent of docker/), so the
+# Dockerfile's `COPY . /opt/jarvis-cd` bakes in this checkout.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_ROOT="$( cd "${SCRIPT_DIR}/.." && pwd )"
+DOCKERFILE="${SCRIPT_DIR}/regression.Dockerfile"
+
+# ---- resolve the SIF destination (jarvis containers cache) ----------------
+# Derive shared_dir from the jarvis config so the SIF lands where the YAMLs
+# look for it by basename. Allow a full SIF_PATH override for non-standard
+# setups.
+if [ -z "${SIF_PATH:-}" ]; then
+  SHARED_DIR="$(grep -hE '^[[:space:]]*shared_dir:' "$HOME"/.ppi-jarvis/*.yaml 2>/dev/null \
+                | head -1 | sed -E 's/^[[:space:]]*shared_dir:[[:space:]]*//; s/["'"'"']//g')"
+  if [ -z "$SHARED_DIR" ]; then
+    echo "ERROR: could not read shared_dir from ~/.ppi-jarvis/*.yaml." >&2
+    echo "       Run 'jarvis init' first, or pass SIF_PATH=/abs/path.sif." >&2
+    exit 1
+  fi
+  SIF_PATH="$SHARED_DIR/containers/$SIF_BASENAME.sif"
+fi
+mkdir -p "$(dirname "$SIF_PATH")"
+
+# ---- resolve CLIO_REF branch/tag -> commit SHA (docker cache-bust) --------
+# docker caches the clio fetch layer on the ARG *value*; a branch name would
+# silently reuse a stale clone after clio-core pushes. Resolving to a SHA
+# makes every clio push produce a fresh value (and records provenance). If
+# CLIO_REF is already a SHA (or the remote is unreachable), pass it through.
+RESOLVED_REF="$(git ls-remote "$CLIO_REPO_URL" "refs/heads/$CLIO_REF" "refs/tags/$CLIO_REF" 2>/dev/null \
+                | head -1 | cut -f1)"
+if [ -n "$RESOLVED_REF" ]; then
+  echo "CLIO_REF '$CLIO_REF' resolved to commit $RESOLVED_REF"
+  CLIO_REF="$RESOLVED_REF"
+else
+  echo "WARNING: could not resolve CLIO_REF '$CLIO_REF' as a branch/tag on" >&2
+  echo "         $CLIO_REPO_URL (already a SHA, or remote unreachable);"    >&2
+  echo "         passing it through as-is. Note docker may reuse a cached"  >&2
+  echo "         clone layer for a previously-seen value."                  >&2
+fi
+
+echo "=== #526 regression SIF build ==="
+echo "  docker image : $IMAGE"
+echo "  IOWARP_SPEC  : $IOWARP_SPEC"
+echo "  IOR_SPEC     : $IOR_SPEC"
+echo "  BASE_IMAGE   : $BASE_IMAGE"
+echo "  CLIO_REPO_URL: $CLIO_REPO_URL"
+echo "  CLIO_REF     : $CLIO_REF"
+echo "  SIF_PATH     : $SIF_PATH"
+
+# ---- tool presence --------------------------------------------------------
+command -v apptainer >/dev/null || {
+  echo "ERROR: apptainer not on PATH. Install it (e.g. spack install" >&2
+  echo "       apptainer) and 'spack load apptainer' first."          >&2
+  exit 1
+}
+
+# ---- stage 1: docker build ------------------------------------------------
+if [ "$SKIP_DOCKER_BUILD" = "1" ]; then
+  echo "=== SKIP_DOCKER_BUILD=1 — reusing existing local image $IMAGE ==="
+else
+  command -v docker >/dev/null || {
+    echo "ERROR: docker not on PATH — it is required (the docker build is" >&2
+    echo "       the only supported build path for this image)."           >&2
+    exit 1
+  }
+  echo "=== docker build $IMAGE ==="
+  docker build -f "$DOCKERFILE" \
+    --build-arg BASE_IMAGE="$BASE_IMAGE" \
+    --build-arg IOWARP_SPEC="$IOWARP_SPEC" \
+    --build-arg IOR_SPEC="$IOR_SPEC" \
+    --build-arg CLIO_REPO_URL="$CLIO_REPO_URL" \
+    --build-arg CLIO_REF="$CLIO_REF" \
+    -t "$IMAGE" "$PROJECT_ROOT"
+  echo "=== docker build OK: $IMAGE ==="
+fi
+
+# ---- stage 2: convert the local docker image to a SIF ---------------------
+echo "=== apptainer build $SIF_PATH  (docker-daemon://$IMAGE) ==="
+apptainer build --force "$SIF_PATH" "docker-daemon://$IMAGE"
+
+echo "=== SIF ready: $SIF_PATH ==="
+ls -lh "$SIF_PATH"
+echo "The pipeline YAMLs reference this by basename: container_image: \"$SIF_BASENAME\""

--- a/docker/regression.Dockerfile
+++ b/docker/regression.Dockerfile
@@ -1,0 +1,179 @@
+# =============================================================================
+# regression.Dockerfile — prebuilt image for the #526 CONTAINER pipelines
+# (clio-core's single_node.yaml / distributed.yaml with
+#  base_deploy_mode: container).
+# =============================================================================
+#
+# The #526 pipelines deploy with APPTAINER, but this Dockerfile is the ONLY
+# build path: docker/build_regression_image.sh does the docker build here and
+# then converts the result to a portable .sif with
+#   apptainer build <sif> docker-daemon://iowarp-regression:526-v3
+# (jarvis then starts ONE apptainer instance per node and runs the WHOLE
+# pipeline inside it via apptainer exec instance://...). Every package —
+# redis, juicefs, ior, clio_* — runs bare-metal inside the container, so a
+# FUSE mount made by juicefs/CTE is visible to ior in the same mount
+# namespace. Multi-node MPI runs launch mpiexec INSIDE the head instance
+# and spawn remote ranks over the instance sshd (container_ssh_port).
+#
+# THE BUILD IS THE "installs run cleanly" GATE: the final RUN fails the build
+# if any required binary is missing (this is how #526 "includes the
+# installation").
+#
+# The image combines TWO source trees:
+#   - jarvis-cd: COPY'd from the docker build CONTEXT (this repo's root), so
+#     the image always matches the local checkout under validation — no ref
+#     pin to bump. Build from the repo root (build_regression_image.sh does).
+#   - clio-core: fetched at build time from CLIO_REPO_URL @ CLIO_REF. The
+#     fetch-by-ref form below accepts a branch name OR a commit SHA;
+#     build_regression_image.sh resolves branches to SHAs first so docker's
+#     layer cache busts exactly when clio-core pushes new commits (a raw
+#     branch-name ARG would silently reuse a stale cached clone).
+#     It supplies (a) the EXTENDED spack recipe — installers/spack adds a
+#     `redis` variant the upstream recipe lacks — and (b) the
+#     jarvis_clio_core package repo (clio_* pkg_types).
+#
+# Tailored to the IOWarp build base: it runs as the non-root user `iowarp`,
+# ships spack at /home/iowarp/spack, and has NO clio_* built — so system
+# installs run as root, the IOWarp build runs as `iowarp` (it owns spack),
+# and the runtime user is root (the jarvis compose entrypoint uses /root).
+#
+# WHY register clio-core's recipe: clio-core owns the iowarp recipe used by
+# this image (namespace `iowarp` overrides the builtin), so recipe changes
+# ship with the clio branch instead of waiting on a spack upstream. v3
+# builds `iowarp@dev +fuse` — the v2-only `+redis` variant (it gated
+# clio_redis_bench, which v3 does not ship) is gone from the v3 recipe, so
+# a `+redis` spec would fail to concretize. `ior@3.3.0` is installed in the
+# same spack invocation so it links against the same MPI stack whose
+# `mpiexec` the view puts on PATH (an apt-linked ior would be launched by a
+# different MPI — classic version-mismatch breakage). No `+hdf5`: the
+# regression sweeps use posix/mpiio.
+
+ARG BASE_IMAGE=iowarp/iowarp-build:latest
+FROM ${BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+# IOWarp spec — built with clio-core's recipe (see header). `@dev` is
+# upstream dev; +fuse builds clio_cte_fuse. (v3: no +redis — the variant
+# left the recipe along with clio_redis_bench.)
+ARG IOWARP_SPEC=iowarp@dev +fuse
+# IOR pinned: builtin.ior's log parser was written against 3.3.0 output.
+ARG IOR_SPEC=ior@3.3.0
+ARG JUICEFS_VERSION=1.2.3
+# clio-core source: URL + ref (branch or SHA; SHA preferred — see header).
+ARG CLIO_REPO_URL=https://github.com/eDoggo3779/clio-core-fork.git
+ARG CLIO_REF=jarvis-pipelines-526
+ARG SPACK_SETUP=/home/iowarp/spack/share/spack/setup-env.sh
+ARG SPACK_USER=iowarp
+
+# 1) System deps as ROOT (the base defaults to USER iowarp -> apt is denied).
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        fuse3 libfuse3-3 \
+        openmpi-bin libopenmpi-dev \
+        redis-server redis-tools \
+        git curl ca-certificates \
+        python3 python3-pip python3-venv \
+        openssh-server openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# 2) JuiceFS — official single static binary (to a root-owned PATH dir).
+RUN curl -fsSL "https://github.com/juicedata/juicefs/releases/download/v${JUICEFS_VERSION}/juicefs-${JUICEFS_VERSION}-linux-amd64.tar.gz" \
+      | tar -xz -C /usr/local/bin juicefs \
+    && juicefs version
+
+# 3) clio-core at the pinned ref (shallow fetch-by-ref: works for branch
+#    names AND commit SHAs, unlike `git clone --branch`), plus a spack
+#    "view" dir the iowarp user can populate and root can read at runtime.
+#    Only the recipe + jarvis packages are needed from the tree;
+#    `spack install` fetches the `@dev` SOURCE from upstream GitHub.
+RUN git init -q /opt/clio-core \
+    && git -C /opt/clio-core fetch -q --depth 1 ${CLIO_REPO_URL} ${CLIO_REF} \
+    && git -C /opt/clio-core checkout -q FETCH_HEAD \
+    && mkdir -p /opt/iowarp-view && chown ${SPACK_USER}:${SPACK_USER} /opt/iowarp-view
+
+# 4) IOWarp (+FUSE) and IOR via spack, as the user that OWNS spack. Register
+#    clio-core's recipe FIRST so `iowarp@dev +fuse` resolves to clio's
+#    recipe (its namespace `iowarp` overrides the base image's builtin
+#    iowarp pkg). ior is installed in the SAME invocation so it links
+#    against the same MPI whose mpiexec ends up on the view PATH.
+#
+#    The base image's site-scope packages.yaml has external stubs for cmake,
+#    python, openmpi, hdf5, and boost that lack concrete versions — spack
+#    0.22+ rejects them during concretization. Override them in the user
+#    scope (user scope wins over site/system) so spack builds from source
+#    instead.
+USER ${SPACK_USER}
+RUN mkdir -p ~/.spack && cat > ~/.spack/packages.yaml <<'EOF'
+packages:
+  cmake:
+    buildable: true
+    externals: []
+  python:
+    buildable: true
+    externals: []
+  openmpi:
+    buildable: true
+    externals: []
+  hdf5:
+    buildable: true
+    externals: []
+  boost:
+    buildable: true
+    externals: []
+EOF
+RUN . "${SPACK_SETUP}" \
+    && spack repo add /opt/clio-core/installers/spack \
+    && spack install --fail-fast ${IOWARP_SPEC} ${IOR_SPEC} \
+    && spack view --dependencies yes symlink -i /opt/iowarp-view \
+         ${IOWARP_SPEC} ${IOR_SPEC}
+
+# 5) Back to root: put the view on PATH, install jarvis-cd from the build
+#    context (the local checkout — kept LATE so jarvis-only edits do not
+#    rebuild the spack layer), register the clio jarvis repo, prepare sshd.
+#    Runtime user stays root (compose /root).
+USER root
+ENV PATH=/opt/iowarp-view/bin:${PATH}
+ENV LD_LIBRARY_PATH=/opt/iowarp-view/lib:/opt/iowarp-view/lib64:${LD_LIBRARY_PATH}
+
+COPY . /opt/jarvis-cd
+RUN { pip3 install -e /opt/jarvis-cd \
+      || pip3 install --break-system-packages -e /opt/jarvis-cd; } \
+    && jarvis init \
+    && jarvis repo add /opt/clio-core/jarvis_clio_core \
+    && jarvis repo list
+
+RUN mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh
+
+# 5b) Multi-node MPI over the instance sshd needs two image-side fixes:
+#     - Remote prted spawn: sshd child sessions get the compiled-in default
+#       PATH (the image ENV does not survive an sshd login), so the MPI
+#       launch chain must resolve from /usr/local/bin. Spack binaries are
+#       rpath'd, so bare symlinks suffice. The [ -e ] guard tolerates
+#       OMPI4 (orted) vs OMPI5 (prted) daemon naming.
+#     - First-contact host keys: the in-instance `ssh -p <port>` hop to a
+#       peer instance would fail interactive host-key verification
+#       (instance keys != node keys; no port entries in known_hosts). We
+#       PREPEND the Host * block to the system-wide /etc/ssh/ssh_config, not
+#       only a drop-in: the base image's ssh_config may lack an
+#       `Include ssh_config.d/*.conf` line, so the drop-in alone was silently
+#       ignored on Ares (ssh is first-match-wins, so top-of-file always wins).
+RUN for b in mpiexec mpirun prted orted orterun ior; do \
+        [ -e "/opt/iowarp-view/bin/$b" ] \
+            && ln -sf "/opt/iowarp-view/bin/$b" "/usr/local/bin/$b"; \
+    done; \
+    mkdir -p /etc/ssh/ssh_config.d \
+    && printf 'Host *\n    StrictHostKeyChecking no\n    UserKnownHostsFile /dev/null\n    LogLevel ERROR\n' \
+         > /etc/ssh/ssh_config.d/instance.conf \
+    && touch /etc/ssh/ssh_config \
+    && { printf 'Host *\n    StrictHostKeyChecking no\n    UserKnownHostsFile /dev/null\n    LogLevel ERROR\n\n'; \
+         cat /etc/ssh/ssh_config; } > /etc/ssh/ssh_config.new \
+    && mv /etc/ssh/ssh_config.new /etc/ssh/ssh_config
+
+# 6) GATE — fail the build if a REQUIRED binary is missing. v3 list: ior
+#    replaces fio; clio_cte_bench and clio_redis_bench left the project
+#    (the redis experiment now uses builtin.redis-benchmark).
+RUN for b in clio_run clio_cte_fuse \
+             juicefs ior redis-server redis-cli redis-benchmark mpiexec jarvis; do \
+        command -v "$b" >/dev/null || { echo "MISSING REQUIRED BINARY: $b"; exit 1; }; \
+    done \
+    && echo "iowarp-regression image: required binaries present"

--- a/docs/pipeline_tests.md
+++ b/docs/pipeline_tests.md
@@ -139,6 +139,28 @@ The directory where results are stored. You can use environment variables:
 - `${CONFIG_DIR}` - Pipeline's config directory
 - `${HOME}` - User's home directory
 
+### run_timeout (optional)
+
+A wall-clock budget, in seconds, for a single combination. Omitted (the
+default), a run is unbounded.
+
+Set it when any package can wedge. The per-run error handling only catches
+exceptions, and a hang is not an exception -- so without a budget one stuck
+package blocks the sweep forever, and under a scheduler it consumes the
+whole allocation and you lose every result, including the combinations that
+would have passed.
+
+On expiry the run is torn down (bounded, best-effort, so a wedged `stop()`
+cannot re-hang the sweep), that row is recorded as `failed` with the reason
+in the `error` column, and the next combination starts.
+
+```yaml
+run_timeout: 1800   # 30 minutes per combination
+```
+
+Pick a value comfortably above the slowest healthy run -- it is a
+deadlock backstop, not a performance bound.
+
 ### scheduler (optional)
 
 A top-level `scheduler:` block plays one of two roles depending on

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -307,7 +307,7 @@ file the job script populates inside the allocation.
 
 ### Container Configuration
 
-Pipelines can be configured to run packages inside Docker or Podman containers. Set `base_deploy_mode: container` and provide container configuration. Containers act as SSH compute nodes — the host-side jarvis orchestrates everything by exec-ing commands into the running containers via `docker exec` and MPI over SSH. No jarvis installation is needed inside the containers.
+Pipelines can be configured to run packages inside Docker, Podman, or Apptainer containers. Set `base_deploy_mode: container` and provide container configuration. Containers act as SSH compute nodes — the host-side jarvis orchestrates everything by exec-ing commands into the running containers via `docker exec` (or `apptainer exec`) and MPI over SSH. No jarvis installation is needed inside the containers. Apptainer has its own start model and additional keys — see [Apptainer Pipelines](#apptainer-pipelines).
 
 #### Container Pipeline Parameters
 
@@ -353,6 +353,48 @@ pkgs:
 | `container_host_path` | string | `""` | Docker host path prefix for DinD environments |
 | `container_workspace` | string | `""` | Workspace root path for DinD path remapping |
 | `container_extensions` | dict | `{}` | Custom Docker Compose config merged into service definition |
+
+#### Apptainer Pipelines
+
+Set `container_engine: apptainer` to use Apptainer (typical on HPC clusters where Docker is unavailable). The model differs from Docker/Podman: there is no compose file. Jarvis starts a persistent **instance** (with an sshd inside, on `container_ssh_port`) from the pipeline's SIF on **every host in the hostfile**, then runs each package via `apptainer exec instance://<pipeline>`. The SIF defaults to `<pipeline_name>.sif` in the centralized containers directory; `container_image` overrides it with another SIF basename or an absolute path.
+
+Apptainer silently ignores per-exec `--bind` / `--add-caps` / `--fakeroot` flags on a running instance, so everything the workload needs must be declared at the pipeline level — the following keys bake into `apptainer instance start`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `container_overlay` | bool | `true` | Mount a writable `--overlay` upper dir. `false` drops the overlay entirely: the container filesystem is read-only outside bind mounts, and the host `/tmp` mounts normally |
+| `container_overlay_root` | string | `null` | Node-local root for the overlay upper dir: each host uses `<root>/<pipeline>/overlay`, created on every host automatically. `$VAR`s are expanded. **Required for multi-node pipelines** (see below) |
+| `container_caps` | list | `[]` | Capabilities added via `--add-caps` (e.g. `SYS_ADMIN` for FUSE mounts) |
+| `container_fakeroot` | bool | `false` | Start the instance under `--fakeroot`. Rootless (non-setuid) apptainer only grants a FUSE-capable user namespace this way |
+| `container_binds` | list | `[]` | Extra `host:container` bind mounts (e.g. `/dev/fuse:/dev/fuse`). The pipeline shared/private dirs are always bound at identical paths |
+| `container_gpu` | bool | `false` | GPU passthrough (`--nv`) |
+| `tmp_bind_root` | string | `null` | Per-host `/tmp` redirect: binds `<root>/<pipeline>/tmp` (created on every host automatically) into the container at `/tmp`, so parallel hosts don't collide on `/tmp` paths that would otherwise land in a shared overlay. `$VAR`s are expanded |
+
+**Important — multi-node pipelines must relocate the overlay.** By default the overlay upper dir lives under the pipeline's shared directory, which on a real cluster is a shared filesystem (NFS). That layout only works single-node: overlayfs cannot use a shared/NFS directory as its upper layer, and concurrent `apptainer instance start`s on N nodes race each other on the same directory. A pipeline whose hostfile spans more than one host must set `container_overlay_root` to a node-local path (e.g. `/mnt/nvme/$USER`) or set `container_overlay: false` — jarvis refuses to start the known-broken combination rather than hang.
+
+Example 4-node apptainer pipeline:
+
+```yaml
+name: distributed_bench
+base_deploy_mode: container
+container_engine: apptainer
+hostfile: /path/to/hostfile.txt           # 4 compute nodes
+
+container_fakeroot: true                  # rootless FUSE-capable userns
+container_binds: []                       # optional; FUSE needs no /dev/fuse bind under --fakeroot
+container_overlay_root: /mnt/nvme/$USER   # per-host overlay upper dir
+tmp_bind_root: /mnt/nvme/$USER            # per-host /tmp
+
+pkgs:
+  - pkg_type: builtin.ior
+    nprocs: 8
+    ppn: 2
+```
+
+Notes:
+- Jarvis never cleans the per-host overlay/tmp directories; their contents persist per node across runs (the default shared-dir overlay has the same persistence, just centralized).
+- A workload that installs software at runtime (apt/conda/pip inside the container) needs a writable overlay — with `container_overlay: false` the container filesystem is read-only outside bind mounts.
+- If `apptainer instance start` fails on any host, the pipeline aborts immediately naming that host instead of continuing with partial instances.
 
 #### How Container Pipelines Work
 

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -45,9 +45,12 @@ class Pipeline:
         self.container_host_path = ""  # Docker host path prefix for DinD remapping
         self.container_workspace = ""  # Container workspace root for DinD remapping
         self.container_caps = []  # Apptainer --add-caps (e.g. SYS_ADMIN)
+        self.container_fakeroot = False  # Apptainer --fakeroot at instance start
         self.container_binds = []  # Pipeline-level bind mounts (host:container)
         self.container_gpu = False  # --nv / GPU passthrough
         self.tmp_bind_root = None  # Per-host /tmp redirect root (apptainer)
+        self.container_overlay = True  # Apptainer --overlay writable layer
+        self.container_overlay_root = None  # Per-host overlay upper dir root (apptainer)
 
         # Default deploy_mode propagated to packages that don't set
         # their own. None means no default ('default' deploy_mode).
@@ -319,8 +322,20 @@ class Pipeline:
             pipeline_config['container_workspace'] = self.container_workspace
         if self.container_caps:
             pipeline_config['container_caps'] = self.container_caps
+        if self.container_fakeroot:
+            pipeline_config['container_fakeroot'] = self.container_fakeroot
         if self.container_binds:
             pipeline_config['container_binds'] = self.container_binds
+        # container_overlay defaults to True: persist only a non-default
+        # False (the `if truthy` idiom above would drop it silently).
+        if not self.container_overlay:
+            pipeline_config['container_overlay'] = False
+        if self.container_overlay_root:
+            pipeline_config['container_overlay_root'] = self.container_overlay_root
+        if self.container_gpu:
+            pipeline_config['container_gpu'] = self.container_gpu
+        if self.tmp_bind_root:
+            pipeline_config['tmp_bind_root'] = self.tmp_bind_root
 
         # Add base_deploy_mode (default deploy_mode propagated to pkgs).
         if self.base_deploy_mode:
@@ -972,8 +987,22 @@ class Pipeline:
         self.container_host_path = pipeline_config.get('container_host_path', '')
         self.container_workspace = pipeline_config.get('container_workspace', '')
         self.container_caps = pipeline_config.get('container_caps', [])
+        self.container_fakeroot = pipeline_config.get(
+            'container_fakeroot', False)
         self.container_binds = Pipeline._expand_env_in_config(
             pipeline_config.get('container_binds', []) or [])
+        self.container_overlay = pipeline_config.get('container_overlay', True)
+        overlay_root_raw = pipeline_config.get('container_overlay_root', None)
+        self.container_overlay_root = (
+            os.path.expandvars(overlay_root_raw)
+            if overlay_root_raw else None
+        )
+        self.container_gpu = pipeline_config.get('container_gpu', False)
+        tmp_bind_root_raw = pipeline_config.get('tmp_bind_root', None)
+        self.tmp_bind_root = (
+            os.path.expandvars(tmp_bind_root_raw)
+            if tmp_bind_root_raw else None
+        )
 
         # Launcher overrides (top-level YAML keys). None = use built-in
         # defaults (ssh / pssh / mpiexec). Typical override pattern:
@@ -1135,6 +1164,13 @@ class Pipeline:
         # the workload needs (e.g., SYS_ADMIN + /dev/fuse for FUSE mounts)
         # has to be declared at the pipeline level here.
         self.container_caps = pipeline_def.get('container_caps', [])
+        # Apptainer-only: run the instance under --fakeroot. Rootless
+        # apptainer grants a FUSE-capable user namespace (CAP_SYS_ADMIN
+        # inside the userns) only via --fakeroot; per-exec flags are
+        # ignored on a running instance, so like caps/binds above it must
+        # bake into `apptainer instance start`.
+        self.container_fakeroot = pipeline_def.get('container_fakeroot',
+                                                   False)
         self.container_binds = Pipeline._expand_env_in_config(
             pipeline_def.get('container_binds', []) or [])
 
@@ -1154,6 +1190,24 @@ class Pipeline:
         self.tmp_bind_root = (
             os.path.expandvars(tmp_bind_root_raw)
             if tmp_bind_root_raw else None
+        )
+
+        # Apptainer-only: writable-overlay controls. The default overlay
+        # upper dir lives under the pipeline's shared_dir, which is
+        # single-node only: overlayfs cannot use a shared/NFS directory
+        # as its upper layer, and concurrent `apptainer instance start`s
+        # across nodes race on the same session/overlay setup. Setting
+        # `container_overlay_root: /mnt/nvme/$USER` (or any per-host
+        # path) puts the upper dir at <root>/<pipeline_name>/overlay on
+        # every host instead — required for multi-node pipelines.
+        # `container_overlay: false` drops --overlay entirely: the
+        # container FS is read-only outside bind mounts and the host
+        # /tmp mounts normally.
+        self.container_overlay = pipeline_def.get('container_overlay', True)
+        overlay_root_raw = pipeline_def.get('container_overlay_root', None)
+        self.container_overlay_root = (
+            os.path.expandvars(overlay_root_raw)
+            if overlay_root_raw else None
         )
 
         # Launcher overrides (top-level YAML keys). None = use built-in
@@ -1781,21 +1835,59 @@ class Pipeline:
             if self.container_caps:
                 cap_flag = f'--add-caps {",".join(self.container_caps)} '
 
-            # Per-pipeline writable layer backed by NFS, not RAM.
+            fakeroot_flag = '--fakeroot ' if self.container_fakeroot else ''
+
+            # The effective hostfile decides both where instances start
+            # (exec_info below) and whether the default shared overlay
+            # is even legal (guard below). Fetch it once, up front.
+            hostfile = self.get_hostfile()
+
+            # Per-pipeline writable layer backed by disk, not RAM.
             # `--writable-tmpfs` is RAM-only (capped at ~50% of system
             # RAM); workloads that apt-/conda-install at runtime
             # (snakemake conda envs, deferred pip installs, …) blow past
-            # that even though the host has terabytes free. An overlay
-            # directory under shared_dir lives on the same NFS mount as
-            # the SIF, so the container has effectively unlimited
-            # writable space and the data persists across runs.
+            # that even though the host has terabytes free.
+            #
+            # The default overlay dir under shared_dir lives on the same
+            # (typically NFS) mount as the SIF — effectively unlimited
+            # writable space, persists across runs — but is single-node
+            # only: overlayfs cannot use a shared/NFS directory as its
+            # upper layer, and N nodes mounting the same upper dir race
+            # each other's session setup (guarded below).
+            # `container_overlay_root` relocates the upper dir to
+            # <root>/<pipeline_name>/overlay on node-local disk instead;
+            # that dir is created on every host via exec_info further
+            # down, since a head-side mkdir only exists on this node.
             #
             # `--no-mount tmp` keeps the host's small /tmp out of the
-            # picture; in-container /tmp lands in the overlay (NFS).
-            overlay_dir = shared_dir / 'overlay'
-            overlay_dir.mkdir(parents=True, exist_ok=True)
-            overlay_flag = f'--overlay {overlay_dir} '
-            no_mount_flag = '--no-mount tmp '
+            # picture; in-container /tmp lands in the overlay. With
+            # `container_overlay: false` there is no overlay for /tmp to
+            # land in, so the host /tmp stays mounted (apptainer
+            # default).
+            overlay_flag = ''
+            no_mount_flag = ''
+            if self.container_overlay:
+                if self.container_overlay_root:
+                    overlay_dir = (
+                        f"{self.container_overlay_root}/{self.name}/overlay")
+                else:
+                    if (len(hostfile) > 1 and
+                            not self._hostfile_is_local_only(hostfile)):
+                        raise RuntimeError(
+                            f"Pipeline '{self.name}' spans multiple hosts "
+                            f"but uses the default shared apptainer overlay "
+                            f"({shared_dir / 'overlay'}). overlayfs cannot "
+                            "use a shared/NFS directory as its upper layer, "
+                            "and concurrent instance starts race on it. Set "
+                            "`container_overlay_root: <node-local path>` "
+                            "(e.g. /mnt/nvme/$USER) or `container_overlay: "
+                            "false` in the pipeline YAML.")
+                    overlay_dir = shared_dir / 'overlay'
+                    # Head-side mkdir suffices only because this path is
+                    # on the shared FS (single-node guaranteed above).
+                    overlay_dir.mkdir(parents=True, exist_ok=True)
+                overlay_flag = f'--overlay {overlay_dir} '
+                no_mount_flag = '--no-mount tmp '
 
             # When tmp_bind_root is set in the pipeline YAML, replace the
             # overlay-backed /tmp with a per-host bind mount so workloads
@@ -1808,7 +1900,7 @@ class Pipeline:
                 no_mount_flag = ''
 
             start_cmd = (
-                f"apptainer instance start {nv_flag}{cap_flag}{bind_flags}"
+                f"apptainer instance start {fakeroot_flag}{nv_flag}{cap_flag}{bind_flags}"
                 f"{tmp_bind_flag}{no_mount_flag}{overlay_flag}{sif_path} {instance_name}"
                 f" && apptainer exec {nv_flag}instance://{instance_name}"
                 f" /usr/sbin/sshd -p {ssh_port}"
@@ -1828,7 +1920,6 @@ class Pipeline:
             # adopted by pam_slurm_adopt automatically; the pipeline's
             # own ssh_cmd override (e.g. env -u LD_LIBRARY_PATH ssh)
             # neutralizes the conda libcrypto/OpenSSL mismatch.
-            hostfile = self.get_hostfile()
             if self._hostfile_is_local_only(hostfile):
                 logger.info("Hostfile is local-only, deploying to localhost directly")
                 exec_info = LocalExecInfo()
@@ -1837,6 +1928,21 @@ class Pipeline:
                     f"Hostfile has {len(hostfile)} hosts; starting "
                     "apptainer instance on every host via PsshExecInfo")
                 exec_info = PsshExecInfo(hostfile=hostfile)
+
+            # A per-host overlay upper dir must exist on every node
+            # before `apptainer instance start` tries to mount it,
+            # otherwise apptainer aborts with "mount source X doesn't
+            # exist". (The default shared overlay was mkdir'd head-side
+            # above — being on the shared FS, every node sees it.)
+            if self.container_overlay and self.container_overlay_root:
+                overlay_mkdir = (
+                    f"mkdir -p "
+                    f"{self.container_overlay_root}/{self.name}/overlay")
+                logger.info(
+                    f"container_overlay_root set; ensuring "
+                    f"{self.container_overlay_root}/{self.name}/overlay "
+                    "exists on every host")
+                Exec(overlay_mkdir, exec_info).run()
 
             # Per-host bind source for tmp_bind_root must exist on every
             # node before the apptainer instance start tries to mount it,
@@ -1849,7 +1955,15 @@ class Pipeline:
                     f"{self.name}/tmp exists on every host")
                 Exec(tmp_mkdir, exec_info).run()
 
-            Exec(start_cmd, exec_info).run()
+            start = Exec(start_cmd, exec_info).run()
+            # A partial instance start must not go unnoticed: the
+            # workload's own clustering layer would wait forever on the
+            # node whose instance never came up.
+            for host, code in start.exit_code.items():
+                if code != 0:
+                    raise RuntimeError(
+                        f"apptainer instance start failed on {host} "
+                        f"(exit {code})")
             logger.success("Apptainer instances started (SSH ready)")
         else:
             # Docker/Podman: start containers via compose

--- a/jarvis_cd/core/pipeline_test.py
+++ b/jarvis_cd/core/pipeline_test.py
@@ -8,6 +8,7 @@ import csv
 import yaml
 import copy
 import itertools
+from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Any, List, Optional, Tuple
@@ -44,6 +45,73 @@ def is_pipeline_test(yaml_data: Dict[str, Any]) -> bool:
     return has_config
 
 
+# Wall-clock budget for the teardown that follows a timed-out run. The same
+# hang that tripped the deadline can wedge stop() too, so the cleanup is
+# bounded as well -- otherwise the recovery path reintroduces the hang.
+TEARDOWN_TIMEOUT = 300
+
+
+class Deadline:
+    """
+    Records whether an :func:`alarm_timeout` budget actually expired.
+
+    The TimeoutError raised by the alarm does not necessarily reach the
+    caller: ``Pipeline.start`` catches whatever a package raises and
+    re-raises it as ``RuntimeError("Pipeline startup failed at package
+    ...")``. Keying recovery off the exception *type* therefore misses the
+    timeout and skips teardown, which leaks the run's redis, container
+    instances and mounts into the next combination. This flag is set in the
+    signal handler itself, so it survives any downstream re-wrapping.
+    """
+
+    def __init__(self):
+        self.expired = False
+
+
+@contextmanager
+def alarm_timeout(seconds: Optional[int], message: str,
+                  deadline: Optional['Deadline'] = None):
+    """
+    Bound a blocking call with SIGALRM, raising TimeoutError on expiry.
+
+    A wedged package blocks forever inside ``pipeline.start()``. The sweep
+    runner's per-run ``try/except`` only catches exceptions, and a hang is
+    not an exception -- so one bad combination silently consumes the entire
+    grid and, under a scheduler, the entire allocation. Converting the hang
+    into a TimeoutError lets the runner record that combination as failed
+    and move on to the next one.
+
+    Arms only in the main thread, since Python delivers signals there; in a
+    worker thread this is a no-op so threaded/library callers still work.
+
+    :param seconds: Budget in seconds; falsy or <= 0 disables the alarm
+    :param message: Text carried by the raised TimeoutError
+    :param deadline: Optional Deadline marked ``expired`` when the alarm
+        fires, so callers can detect the timeout even if the TimeoutError
+        is re-wrapped as another exception type further up the stack
+    """
+    import signal
+    import threading
+
+    if not seconds or seconds <= 0 or \
+            threading.current_thread() is not threading.main_thread():
+        yield
+        return
+
+    def _on_alarm(signum, frame):
+        if deadline is not None:
+            deadline.expired = True
+        raise TimeoutError(message)
+
+    previous = signal.signal(signal.SIGALRM, _on_alarm)
+    signal.alarm(int(seconds))
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous)
+
+
 class PipelineTest:
     """
     Pipeline test runner for experiment sets using grid search.
@@ -63,6 +131,9 @@ class PipelineTest:
         self.loop = []  # Loop structure
         self.repeat = 1
         self.output = None
+        # Wall-clock budget for a single combination, in seconds. None (the
+        # default) preserves the historical unbounded behaviour.
+        self.run_timeout = None
         self.combinations = []  # Generated test combinations
         self.results = []  # Collected results
         # Top-level scheduler block (one job wraps the whole test run).
@@ -245,6 +316,7 @@ class PipelineTest:
         self.loop = test_def.get('loop', [])
         self.repeat = test_def.get('repeat', 1)
         self.output = test_def.get('output', None)
+        self.run_timeout = test_def.get('run_timeout', None)
         self.scheduler = test_def.get('scheduler', None)
         self.source_path = str(pipeline_file.absolute())
 
@@ -261,6 +333,8 @@ class PipelineTest:
         logger.info(f"  Total combinations: {len(self.combinations)}")
         logger.info(f"  Repeat count: {self.repeat}")
         logger.info(f"  Total runs: {len(self.combinations) * self.repeat}")
+        if self.run_timeout:
+            logger.info(f"  Run timeout: {self.run_timeout}s per combination")
 
     def _build_combinations(self):
         """
@@ -351,6 +425,15 @@ class PipelineTest:
             template, then any nested ``config.scheduler`` overrides it,
             then the ``scheduler.X`` variable values override that.
 
+        When NO ``scheduler.X`` variables are swept, the test's top-level
+        ``scheduler:`` block is NOT copied into iteration configs: in that
+        mode the block describes the single job that ``ppl submit`` wraps
+        around the WHOLE test run, and iterations must run in-process
+        inside that allocation (stamping the block onto every iteration
+        made ``_run_single`` re-submit each one as a nested sbatch job
+        from inside the allocation). A ``scheduler:`` nested inside
+        ``config:`` still requests per-iteration submission explicitly.
+
         :param base_config: Base pipeline configuration
         :param variables: Variable values to apply
         :return: Modified configuration
@@ -363,7 +446,7 @@ class PipelineTest:
         pkg_vars = {k: v for k, v in variables.items()
                     if k.split('.', 1)[0] != 'scheduler'}
 
-        if scheduler_vars or self.scheduler:
+        if scheduler_vars:
             merged = copy.deepcopy(self.scheduler) if self.scheduler else {}
             existing = config.get('scheduler') or {}
             merged.update(existing)
@@ -597,14 +680,43 @@ class PipelineTest:
             # template + scheduler.X vars), submit it as its own job and
             # block until it finishes via ``sbatch --wait``. Otherwise
             # run the pipeline in-process.
-            if pipeline.scheduler:
-                logger.pipeline(
-                    f"Submitting iteration as scheduler job "
-                    f"({pipeline.scheduler.get('name')})")
-                pipeline.submit(submit=True, wait=True)
-            else:
-                pipeline.start()
-                pipeline.stop()
+            deadline = Deadline()
+            try:
+                with alarm_timeout(
+                        self.run_timeout,
+                        f"run exceeded run_timeout of {self.run_timeout}s",
+                        deadline):
+                    if pipeline.scheduler:
+                        logger.pipeline(
+                            f"Submitting iteration as scheduler job "
+                            f"({pipeline.scheduler.get('name')})")
+                        pipeline.submit(submit=True, wait=True)
+                    else:
+                        pipeline.start()
+                        pipeline.stop()
+            except Exception:
+                # Keyed off the Deadline, not the exception type:
+                # Pipeline.start re-raises whatever a package raised as
+                # RuntimeError, so the TimeoutError does not survive to
+                # here. Without teardown the run's redis, container
+                # instances and mounts leak into the next combination --
+                # which then silently benchmarks the previous run's
+                # processes.
+                if not deadline.expired:
+                    raise
+                logger.error(
+                    f"Run exceeded run_timeout of {self.run_timeout}s; "
+                    f"tearing down and continuing to the next combination")
+                try:
+                    with alarm_timeout(
+                            TEARDOWN_TIMEOUT,
+                            f"teardown exceeded {TEARDOWN_TIMEOUT}s"):
+                        pipeline.stop()
+                except Exception as stop_error:
+                    logger.warning(
+                        f"Teardown after timeout did not complete cleanly: "
+                        f"{stop_error}")
+                raise
 
             end_time = time.time()
             result['runtime'] = end_time - start_time

--- a/jarvis_cd/core/scheduler.py
+++ b/jarvis_cd/core/scheduler.py
@@ -164,9 +164,16 @@ class SlurmScheduler(Scheduler):
             if value is True:
                 lines.append(f"#SBATCH {flag}")
             else:
-                lines.append(f"#SBATCH {flag}={value}")
+                # Expand ${VAR} host-side: slurm does NOT expand env vars in
+                # #SBATCH directives, so an unexpanded ${HOME} in output:/error:
+                # is taken literally (relative to WorkDir), the file can't be
+                # opened, and the job fails at launch with no logs. os.path.
+                # expandvars leaves slurm patterns (%j, %x, ...) and unset vars
+                # untouched. This mirrors how the rest of jarvis expands env
+                # vars in YAML paths (container_binds, tmp_bind_root).
+                lines.append(f"#SBATCH {flag}={os.path.expandvars(str(value))}")
         for raw in self.spec.get('sbatch_args', []) or []:
-            lines.append(f"#SBATCH {raw}")
+            lines.append(f"#SBATCH {os.path.expandvars(str(raw))}")
         return lines
 
     def render(self) -> str:

--- a/jarvis_cd/shell/exec_factory.py
+++ b/jarvis_cd/shell/exec_factory.py
@@ -165,9 +165,16 @@ class Exec(CoreExec):
                 # sshd running inside apptainer instances on remote nodes.
                 # Export PATH so remote orted finds application binaries
                 # (the remote SSH login shell may override the container PATH).
-                if '--mca plm rsh' not in mpi_cmd:
+                #
+                # Exclude the slurm plm rather than naming the ssh launcher:
+                # OpenMPI <=4 (ORTE) calls the ssh launcher 'rsh', OpenMPI 5
+                # (PRRTE) renamed it 'ssh'. '^slurm' defeats slurm's srun-based
+                # launch (which would spawn prted OUTSIDE the container) and
+                # lets PRRTE/ORTE auto-select its ssh launcher under either
+                # name -- no in-container version probe needed.
+                if '--mca plm ' not in mpi_cmd:
                     mpi_cmd = mpi_cmd.replace(
-                        'mpiexec ', 'mpiexec --mca plm rsh ', 1)
+                        'mpiexec ', 'mpiexec --mca plm ^slurm ', 1)
                 mpi_cmd = mpi_cmd.replace(
                     'mpiexec ', 'mpiexec -x PATH -x LD_LIBRARY_PATH ', 1)
                 wrapped_cmd, local_info = self._prepare_container(mpi_cmd)

--- a/jarvis_cd/shell/mpi_exec.py
+++ b/jarvis_cd/shell/mpi_exec.py
@@ -112,10 +112,16 @@ class OpenMpiExec(LocalMpiExec):
         params = self.mpi_cmd.split() if self.mpi_cmd else ['mpiexec']
         params.append('--oversubscribe')
         params.append('--allow-run-as-root')  # For docker
-        # Forward the pipeline-level ssh_cmd to OpenMPI's rsh agent
-        # so prted spawns remote daemons via the wrapped ssh.
+        # Forward the pipeline-level ssh_cmd to OpenMPI's ssh launch agent
+        # so prted spawns remote daemons via the wrapped ssh. OpenMPI <=4
+        # (ORTE) names this plm_rsh_agent; OpenMPI 5 (PRRTE) renamed it to
+        # plm_ssh_agent. The command is assembled on the host but runs inside
+        # the container, so the in-container OMPI version isn't reliably known
+        # here -- emit both names; each runtime honors the one it knows and
+        # ignores the other (an unknown --mca name warns, it is not fatal).
         if self.ssh_cmd:
             params.append(f'--mca plm_rsh_agent "{self.ssh_cmd}"')
+            params.append(f'--mca plm_ssh_agent "{self.ssh_cmd}"')
 
         # Derive --prefix from PATH so remote nodes can find prted
         env_path = self.mpi_env.get('PATH', '')
@@ -127,9 +133,11 @@ class OpenMpiExec(LocalMpiExec):
                     params.append(f'--prefix {prefix}')
                     break
 
-        # Set SSH port if explicitly specified (SSH config will be used otherwise)
+        # Set SSH port if explicitly specified (SSH config used otherwise).
+        # Same rsh(<=4)/ssh(5) launcher rename as the agent above -- emit both.
         if self.ssh_port and self.ssh_port != 22:
             params.append(f'--mca plm_rsh_args "-p {self.ssh_port}"')
+            params.append(f'--mca plm_ssh_args "-p {self.ssh_port}"')
 
 
         if self.ppn is not None:

--- a/jarvis_cd/util/container_utils.py
+++ b/jarvis_cd/util/container_utils.py
@@ -1,0 +1,135 @@
+"""Shared helpers for routing package commands into the pipeline's running
+container instance.
+
+jarvis-cd wraps a command as ``apptainer exec ... instance://<name> bash -c
+'<cmd>'`` only when the ExecInfo passed to Exec carries a container engine
+(``ExecFactory._prepare_container`` gates on ``exec_info.container``). The
+framework never injects this automatically: every package must thread the
+kwargs into each ExecInfo it builds.
+
+These helpers are the shared implementation of that pattern for any package
+(builtin or from an external registered repo) that must behave correctly in
+both bare-metal and containerized pipelines: :func:`container_kwargs` routes
+Execs into the deploy context, :func:`eff_hostfile` +
+:func:`single_instance_menu_opt` implement head-node-only pinning, and
+:func:`flatten_stdout` / :func:`all_hosts_ok` normalize multi-host Exec
+results.
+"""
+from jarvis_cd.util.hostfile import Hostfile
+
+
+def eff_hostfile(pkg, hostfile=None):
+    """The hostfile a *head-node-only* service should actually run on.
+
+    Some packages in a multi-node pipeline are single-client baselines or
+    metadata singletons, NOT distributed workloads: redis (e.g. as JuiceFS's
+    metadata store), the JuiceFS format+FUSE mount, and single-client ior
+    baselines are all meant to run on ONE host even though the pipeline hands
+    every package the full N-node hostfile. Left unpinned they fan out over
+    Pssh to all N nodes and (a) race on shared filesystems (concurrent
+    ``rm -rf``/``mkdir`` of a data dir -> "Directory not empty" and a
+    half-torn state that breaks the next sweep combo), and (b) on the
+    non-head nodes hit services that aren't there ("connection refused") and
+    leave broken FUSE mounts behind.
+
+    When this package sets ``single_instance`` and the (effective) hostfile
+    has >1 host, collapse to just the FIRST host; otherwise return the
+    hostfile unchanged (single-node pipelines and genuinely-distributed
+    packages are unaffected).
+
+    :param pkg: the jarvis package instance (``self``)
+    :param hostfile: optional base hostfile overriding ``pkg.hostfile`` —
+        for packages that pre-slice their hostfile (e.g. ior's ``num_nodes``
+        subset) before the single_instance collapse
+    :return: a Hostfile (possibly sliced to its first host)
+    """
+    hf = hostfile if hostfile is not None else pkg.hostfile
+    if pkg.config.get('single_instance') and hf is not None \
+            and len(hf.hosts) > 1:
+        return Hostfile(hosts=hf.hosts[:1],
+                        hosts_ip=hf.hosts_ip[:1] if hf.hosts_ip else None)
+    return hf
+
+
+def single_instance_menu_opt(msg=None):
+    """The ``single_instance`` config menu entry shared by every
+    head-node-only service. Off by default so single-node pipelines and
+    distributed workloads are unchanged; set true in a multi-node YAML to pin
+    the service to the first host. See :func:`eff_hostfile`.
+
+    :param msg: optional package-specific help text overriding the generic
+        message (semantics must stay those of :func:`eff_hostfile`)
+    :return: dict (a _configure_menu entry)
+    """
+    return {
+        'name': 'single_instance',
+        'msg': msg or (
+            'Pin this service to the FIRST host even when the pipeline '
+            'hostfile has >1 host (skip fanning out over Pssh). Use for '
+            'head-node-only baselines/singletons (e.g. a JuiceFS mount or '
+            'a single-client ior baseline) so they do not race on shared '
+            'filesystems or hit a service that only runs on the head node. '
+            'Default keeps the legacy run-on-every-host behaviour.'),
+        'type': bool,
+        'default': False,
+    }
+
+
+def container_kwargs(pkg):
+    """ExecInfo kwargs that make jarvis's ``Exec._prepare_container`` wrap the
+    command to run inside the pipeline's container instance.
+
+    ``pkg._container_engine`` returns the pipeline's engine (e.g.
+    ``apptainer``) only when this package's ``deploy_mode`` is ``container``
+    (propagated from the pipeline's ``base_deploy_mode``); otherwise it is
+    ``'none'`` and ``_prepare_container`` no-ops, so the result is always
+    safe to splat into any ExecInfo.
+
+    ``pkg.deploy_image_name()`` is the pipeline RUN name (e.g.
+    ``single_node_run1``) — the apptainer instance name — NOT the SIF
+    basename from the YAML's ``container_image``.
+
+    :param pkg: the jarvis package instance (``self``)
+    :return: dict of ExecInfo kwargs
+    """
+    return {
+        'container': pkg._container_engine,
+        'container_image': pkg.deploy_image_name(),
+    }
+
+
+def flatten_stdout(exec_result):
+    """Return an Exec result's stdout as one string.
+
+    Pssh/Local Exec results carry stdout either as ``{host: str}`` or as a
+    plain string depending on the exec type.
+
+    :param exec_result: the object returned by ``Exec(...).run()``
+    :return: stdout joined across hosts
+    """
+    out = getattr(exec_result, 'stdout', '')
+    if isinstance(out, dict):
+        return '\n'.join(str(v) for v in out.values())
+    return str(out)
+
+
+def all_hosts_ok(exec_result, expect=None):
+    """True iff every host exited 0 and, when ``expect`` is given, every
+    host's stdout contains it. Handles dict-or-scalar exit_code/stdout.
+
+    :param exec_result: the object returned by ``Exec(...).run()``
+    :param expect: optional substring required in each host's stdout
+    :return: bool
+    """
+    codes = getattr(exec_result, 'exit_code', 1)
+    if isinstance(codes, dict):
+        if any(c != 0 for c in codes.values()):
+            return False
+    elif codes != 0:
+        return False
+    if expect is None:
+        return True
+    out = getattr(exec_result, 'stdout', '')
+    if isinstance(out, dict):
+        return all(expect in str(v) for v in out.values())
+    return expect in str(out)

--- a/test/unit/core/test_builtin_526.py
+++ b/test/unit/core/test_builtin_526.py
@@ -1,0 +1,207 @@
+"""Unit tests for the #526 v3 builtin-package logic:
+
+- ior's effective-hostfile resolution (num_nodes subset, single_instance
+  collapse, container-mode path stripping)
+- redis-benchmark's --csv output parsing
+- juicefs's meta_use_head URL rewrite
+
+These test the pure logic only; the MPI-in-container launch chain itself is
+exercised on Ares by the smoke pipelines.
+"""
+import importlib.util
+import os
+import pathlib
+import tempfile
+import unittest
+
+from jarvis_cd.util.hostfile import Hostfile
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+
+def _load_pkg_module(name, rel_path):
+    spec = importlib.util.spec_from_file_location(
+        name, str(_REPO_ROOT / rel_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_ior_mod = _load_pkg_module('ior_pkg', 'builtin/builtin/ior/pkg.py')
+_rb_mod = _load_pkg_module('rb_pkg', 'builtin/builtin/redis-benchmark/pkg.py')
+_jfs_mod = _load_pkg_module('jfs_pkg', 'builtin/builtin/juicefs/pkg.py')
+
+
+def _stub(cls, config, hostfile=None, engine='none'):
+    """Instance of ``cls`` bypassing Pkg.__init__, with the hostfile /
+    _container_engine properties shadowed by fixed values."""
+    shadow = type('Stub' + cls.__name__, (cls,), {
+        'hostfile': property(lambda self: self._stub_hf),
+        '_container_engine': property(lambda self: self._stub_engine),
+    })
+    obj = object.__new__(shadow)
+    obj.config = config
+    obj._stub_hf = hostfile
+    obj._stub_engine = engine
+    return obj
+
+
+class TestIorEffHostfile(unittest.TestCase):
+    HOSTS = ['n1', 'n2', 'n3', 'n4']
+
+    def _hf(self, path='/tmp/hf.txt'):
+        hf = Hostfile(hosts=list(self.HOSTS), find_ips=False)
+        hf.path = path
+        return hf
+
+    def test_defaults_are_noop(self):
+        pkg = _stub(_ior_mod.Ior, {'num_nodes': 0, 'single_instance': False},
+                    self._hf())
+        hf = pkg._eff_hostfile()
+        self.assertEqual(hf.hosts, self.HOSTS)
+        self.assertEqual(hf.path, '/tmp/hf.txt')  # bare-metal keeps the file
+
+    def test_num_nodes_subsets_first_n(self):
+        pkg = _stub(_ior_mod.Ior, {'num_nodes': 2}, self._hf())
+        self.assertEqual(pkg._eff_hostfile().hosts, ['n1', 'n2'])
+
+    def test_single_instance_collapses_to_head(self):
+        pkg = _stub(_ior_mod.Ior, {'single_instance': True}, self._hf())
+        self.assertEqual(pkg._eff_hostfile().hosts, ['n1'])
+
+    def test_single_instance_wins_over_num_nodes(self):
+        pkg = _stub(_ior_mod.Ior,
+                    {'num_nodes': 3, 'single_instance': True}, self._hf())
+        self.assertEqual(pkg._eff_hostfile().hosts, ['n1'])
+
+    def test_container_mode_strips_hostfile_path(self):
+        pkg = _stub(_ior_mod.Ior, {'num_nodes': 0}, self._hf(),
+                    engine='apptainer')
+        hf = pkg._eff_hostfile()
+        self.assertEqual(hf.hosts, self.HOSTS)
+        self.assertIsNone(hf.path)  # forces an inline --host list
+
+    def test_stonewall_flag_in_menu(self):
+        names = [o['name'] for o in _ior_mod.Ior._configure_menu(
+            object.__new__(_ior_mod.Ior))]
+        for key in ('num_nodes', 'stonewall', 'single_instance'):
+            self.assertIn(key, names)
+
+
+class TestIorCompletionGate(unittest.TestCase):
+    """_assert_ior_completed converts a silent MPI/ior failure (no summary
+    in the log) into a failed combination instead of a false-green success."""
+
+    WRITE_SUMMARY = (
+        'access    bw(MiB/s)\n'
+        'write     112.92     113.96     0.017 65536 1024.0 0.03 1.12 0.0 1.13 0\n'
+        'Max Write: 112.92 MiB/sec (118.40 MB/sec)\n')
+    # A hard multi-node abort: header/options only, no results block.
+    ABORTED = ('PRTE has lost communication with a remote daemon.\n'
+               'Host key verification failed.\n')
+
+    def _pkg(self, config, log_text=None):
+        pkg = object.__new__(_ior_mod.Ior)
+        pkg.pkg_id = 'cte_ior'
+        pkg.config = dict(config)
+        if log_text is not None:
+            fd, path = tempfile.mkstemp(suffix='.log')
+            with os.fdopen(fd, 'w') as f:
+                f.write(log_text)
+            self.addCleanup(os.remove, path)
+            pkg.config['log'] = path
+        return pkg
+
+    def test_passes_when_write_summary_present(self):
+        pkg = self._pkg({'write': True, 'read': False}, self.WRITE_SUMMARY)
+        pkg._assert_ior_completed()  # must not raise
+
+    def test_raises_on_aborted_run(self):
+        pkg = self._pkg({'write': True, 'read': False}, self.ABORTED)
+        with self.assertRaises(RuntimeError):
+            pkg._assert_ior_completed()
+
+    def test_raises_when_log_missing(self):
+        pkg = self._pkg({'write': True, 'read': False})
+        pkg.config['log'] = '/nonexistent/ior.log'
+        with self.assertRaises(RuntimeError):
+            pkg._assert_ior_completed()
+
+    def test_raises_when_read_requested_but_absent(self):
+        # write-only summary but the combo also asked for a read phase.
+        pkg = self._pkg({'write': True, 'read': True}, self.WRITE_SUMMARY)
+        with self.assertRaises(RuntimeError):
+            pkg._assert_ior_completed()
+
+    def test_noop_when_no_workload_requested(self):
+        pkg = self._pkg({'write': False, 'read': False}, self.ABORTED)
+        pkg._assert_ior_completed()  # nothing requested -> nothing to validate
+
+
+class TestRedisBenchmarkParse(unittest.TestCase):
+    V7 = ('"test","rps","avg_latency_ms","min_latency_ms","p50_latency_ms",'
+          '"p95_latency_ms","p99_latency_ms","max_latency_ms"\n'
+          '"SET","95238.10","0.263","0.084","0.255","0.407","0.495","1.351"\n'
+          '"GET","98039.22","0.256","0.084","0.247","0.399","0.479","1.079"\n')
+    LEGACY = '"SET","95238.10"\n"GET","98039.22"\n'
+
+    def _pkg(self):
+        pkg = object.__new__(_rb_mod.RedisBenchmark)
+        pkg.pkg_id = 'redis_bench'
+        return pkg
+
+    def test_v7_eight_column(self):
+        stats = self._pkg()._parse_output(self.V7)
+        self.assertEqual(stats['redis_bench.set_rps'], 95238.10)
+        self.assertEqual(stats['redis_bench.get_rps'], 98039.22)
+        self.assertEqual(stats['redis_bench.set_p50_ms'], 0.255)
+        self.assertEqual(stats['redis_bench.get_p99_ms'], 0.479)
+
+    def test_legacy_two_column(self):
+        stats = self._pkg()._parse_output(self.LEGACY)
+        self.assertEqual(stats['redis_bench.set_rps'], 95238.10)
+        self.assertNotIn('redis_bench.set_p50_ms', stats)
+
+    def test_junk_never_raises(self):
+        self.assertEqual(
+            self._pkg()._parse_output('redis: Connection refused\n'), {})
+        self.assertEqual(self._pkg()._parse_output(''), {})
+
+    def test_clients_flag_in_menu(self):
+        names = [o['name'] for o in _rb_mod.RedisBenchmark._configure_menu(
+            object.__new__(_rb_mod.RedisBenchmark))]
+        self.assertIn('clients', names)
+        self.assertIn('single_instance', names)
+
+
+class TestJuicefsMetaUseHead(unittest.TestCase):
+    def _pkg(self, meta_url, use_head=True, hosts=('head', 'n2')):
+        hf = Hostfile(hosts=list(hosts), find_ips=False) if hosts else None
+        return _stub(_jfs_mod.Juicefs,
+                     {'meta_url': meta_url, 'meta_use_head': use_head}, hf)
+
+    def test_rewrites_host_keeps_port_and_db(self):
+        self.assertEqual(
+            self._pkg('redis://127.0.0.1:6379/1')._effective_meta_url(),
+            'redis://head:6379/1')
+
+    def test_preserves_credentials(self):
+        self.assertEqual(
+            self._pkg('redis://:pw@127.0.0.1:6379/1')._effective_meta_url(),
+            'redis://:pw@head:6379/1')
+
+    def test_disabled_is_identity(self):
+        self.assertEqual(
+            self._pkg('redis://127.0.0.1:6379/1',
+                      use_head=False)._effective_meta_url(),
+            'redis://127.0.0.1:6379/1')
+
+    def test_no_hostfile_is_identity(self):
+        self.assertEqual(
+            self._pkg('redis://127.0.0.1:6379/1',
+                      hosts=None)._effective_meta_url(),
+            'redis://127.0.0.1:6379/1')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/core/test_container_apptainer.py
+++ b/test/unit/core/test_container_apptainer.py
@@ -1,0 +1,302 @@
+"""
+Unit tests for the apptainer branch of Pipeline._start_containerized_pipeline.
+Verifies the `apptainer instance start` command construction:
+  - Back-compat golden: defaults produce the exact current command string
+  - container_overlay_root relocates the overlay upper dir per host and
+    fans a mkdir to every node
+  - container_overlay: false omits --overlay (and --no-mount tmp)
+  - Multi-node + default shared overlay raises instead of racing NFS
+  - Per-host instance-start failures raise naming the host
+  - Both keys round-trip save() -> load-from-config and YAML load
+"""
+import unittest
+import sys
+import os
+import tempfile
+import shutil
+import yaml
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+from jarvis_cd.core.config import Jarvis
+from jarvis_cd.core.pipeline import Pipeline
+from jarvis_cd.util.hostfile import Hostfile
+from jarvis_cd.shell import LocalExecInfo, PsshExecInfo
+
+
+def initialize_jarvis_for_test(config_dir, private_dir, shared_dir):
+    jarvis = Jarvis.get_instance()
+    # Save original config so we can restore it after the test
+    saved_config = None
+    if jarvis.config_file.exists():
+        import yaml
+        with open(jarvis.config_file, 'r') as f:
+            saved_config = yaml.safe_load(f)
+    jarvis.initialize(config_dir, private_dir, shared_dir, force=False)
+    return jarvis, saved_config
+
+
+class ApptainerStartTestBase(unittest.TestCase):
+    """Base class with shared setUp/tearDown for apptainer start tests."""
+
+    REMOTE_HOSTS = ['node-01', 'node-02', 'node-03', 'node-04']
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_apptainer_')
+        self.config_dir = os.path.join(self.test_dir, 'config')
+        self.private_dir = os.path.join(self.test_dir, 'private')
+        self.shared_dir = os.path.join(self.test_dir, 'shared')
+        os.makedirs(self.config_dir, exist_ok=True)
+        os.makedirs(self.private_dir, exist_ok=True)
+        os.makedirs(self.shared_dir, exist_ok=True)
+
+        os.environ['JARVIS_CONFIG'] = self.config_dir
+        os.environ['JARVIS_PRIVATE'] = self.private_dir
+        os.environ['JARVIS_SHARED'] = self.shared_dir
+
+        self.jarvis, self._saved_config = initialize_jarvis_for_test(
+            self.config_dir, self.private_dir, self.shared_dir
+        )
+
+    def tearDown(self):
+        # Restore the original jarvis config so tests don't clobber the user's setup
+        if self._saved_config:
+            import yaml
+            jarvis = Jarvis.get_instance()
+            jarvis.save_config(self._saved_config)
+            jarvis.config_dir = self._saved_config.get('config_dir', jarvis.config_dir)
+            jarvis.private_dir = self._saved_config.get('private_dir', jarvis.private_dir)
+            jarvis.shared_dir = self._saved_config.get('shared_dir', jarvis.shared_dir)
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+    def _create_pipeline(self, name, hosts=None, **attrs):
+        """Create an apptainer container pipeline; hosts=None keeps the
+        default (local-only) jarvis hostfile."""
+        pipeline = Pipeline()
+        pipeline.create(name)
+        pipeline.base_deploy_mode = 'container'
+        pipeline.container_engine = 'apptainer'
+        if hosts is not None:
+            pipeline.hostfile = Hostfile(hosts=hosts, find_ips=False)
+        for key, value in attrs.items():
+            setattr(pipeline, key, value)
+        pipeline.save()
+        return pipeline
+
+    def _start(self, pipeline, exit_codes=None):
+        """Run _start_containerized_pipeline with Exec mocked; returns the
+        mock. exit_codes is the per-host dict every Exec().run() reports."""
+        with patch('jarvis_cd.shell.Exec') as MockExec:
+            result = MockExec.return_value.run.return_value
+            result.exit_code = exit_codes if exit_codes is not None else {}
+            pipeline._start_containerized_pipeline()
+        return MockExec
+
+    @staticmethod
+    def _cmds(MockExec):
+        """Command strings passed to Exec, in call order."""
+        return [c.args[0] for c in MockExec.call_args_list]
+
+
+class TestApptainerStartCmd(ApptainerStartTestBase):
+
+    def test_default_single_host_golden(self):
+        """Back-compat: with neither overlay key set and a local-only
+        hostfile, the start command is byte-identical to the historical
+        one (shared-dir overlay, --no-mount tmp, LocalExecInfo)."""
+        pipeline = self._create_pipeline('apt_golden')
+        MockExec = self._start(pipeline)
+
+        shared = self.jarvis.get_pipeline_shared_dir('apt_golden')
+        private = self.jarvis.get_pipeline_private_dir('apt_golden')
+        sif = self.jarvis.get_containers_dir() / 'apt_golden.sif'
+        expected = (
+            f"apptainer instance start "
+            f"--bind {shared}:{shared} --bind {private}:{private} "
+            f"--no-mount tmp --overlay {shared / 'overlay'} "
+            f"{sif} apt_golden"
+            f" && apptainer exec instance://apt_golden"
+            f" /usr/sbin/sshd -p 2222 -o StrictModes=no -o UsePAM=no"
+        )
+        self.assertEqual(MockExec.call_count, 1)
+        cmd, exec_info = MockExec.call_args.args
+        self.assertEqual(cmd, expected)
+        self.assertIsInstance(exec_info, LocalExecInfo)
+        self.assertTrue((shared / 'overlay').is_dir())
+
+    def test_overlay_root_relocates_overlay_and_fans_mkdir(self):
+        """container_overlay_root moves the overlay upper dir to a
+        per-host path and fans a mkdir to every node before start."""
+        pipeline = self._create_pipeline('apt_root', hosts=self.REMOTE_HOSTS,
+                                         container_overlay_root='/tmp')
+        MockExec = self._start(
+            pipeline, exit_codes={h: 0 for h in self.REMOTE_HOSTS})
+
+        cmds = self._cmds(MockExec)
+        self.assertIn('mkdir -p /tmp/apt_root/overlay', cmds)
+        mkdir_idx = cmds.index('mkdir -p /tmp/apt_root/overlay')
+        start_idx = next(i for i, c in enumerate(cmds)
+                         if c.startswith('apptainer instance start'))
+        self.assertLess(mkdir_idx, start_idx)
+
+        start_cmd = cmds[start_idx]
+        self.assertIn('--overlay /tmp/apt_root/overlay ', start_cmd)
+        shared = self.jarvis.get_pipeline_shared_dir('apt_root')
+        self.assertNotIn(str(shared / 'overlay'), start_cmd)
+        # Shared overlay dir must NOT be created head-side in this mode
+        self.assertFalse((shared / 'overlay').exists())
+        # Both the mkdir and the start are fanned to all hosts
+        for call in MockExec.call_args_list:
+            self.assertIsInstance(call.args[1], PsshExecInfo)
+
+    def test_overlay_disabled_omits_flag_and_mounts_host_tmp(self):
+        """container_overlay: false drops --overlay entirely and lets the
+        host /tmp mount normally (no --no-mount tmp)."""
+        pipeline = self._create_pipeline('apt_nool', container_overlay=False)
+        MockExec = self._start(pipeline)
+
+        self.assertEqual(MockExec.call_count, 1)
+        cmd = MockExec.call_args.args[0]
+        self.assertNotIn('--overlay', cmd)
+        self.assertNotIn('--no-mount', cmd)
+        shared = self.jarvis.get_pipeline_shared_dir('apt_nool')
+        self.assertFalse((shared / 'overlay').exists())
+
+    def test_overlay_disabled_keeps_tmp_bind(self):
+        """tmp_bind_root still applies when the overlay is disabled."""
+        pipeline = self._create_pipeline('apt_notmp', container_overlay=False,
+                                         tmp_bind_root='/scratch')
+        MockExec = self._start(pipeline)
+
+        cmds = self._cmds(MockExec)
+        self.assertIn('mkdir -p /scratch/apt_notmp/tmp', cmds)
+        start_cmd = cmds[-1]
+        self.assertIn('--bind /scratch/apt_notmp/tmp:/tmp ', start_cmd)
+        self.assertNotIn('--overlay', start_cmd)
+        self.assertNotIn('--no-mount', start_cmd)
+
+    def test_overlay_false_wins_over_overlay_root(self):
+        """container_overlay: false gates the whole overlay feature,
+        including the per-host mkdir fan-out for container_overlay_root."""
+        pipeline = self._create_pipeline('apt_both', container_overlay=False,
+                                         container_overlay_root='/tmp')
+        MockExec = self._start(pipeline)
+
+        for cmd in self._cmds(MockExec):
+            self.assertNotIn('--overlay', cmd)
+            self.assertNotIn('/overlay', cmd)
+
+    def test_multi_node_default_overlay_raises(self):
+        """A multi-host hostfile with the default shared overlay is the
+        known-broken configuration: refuse to start, before any command
+        runs or the overlay dir is created."""
+        pipeline = self._create_pipeline('apt_guard', hosts=self.REMOTE_HOSTS)
+
+        with patch('jarvis_cd.shell.Exec') as MockExec:
+            with self.assertRaises(RuntimeError) as ctx:
+                pipeline._start_containerized_pipeline()
+
+        msg = str(ctx.exception)
+        self.assertIn('container_overlay_root', msg)
+        self.assertIn('container_overlay', msg)
+        MockExec.assert_not_called()
+        shared = self.jarvis.get_pipeline_shared_dir('apt_guard')
+        self.assertFalse((shared / 'overlay').exists())
+
+    def test_multi_node_overlay_disabled_no_raise(self):
+        """Multi-host is fine once the shared overlay is out of the
+        picture; the start command fans out via PsshExecInfo."""
+        pipeline = self._create_pipeline('apt_mnool', hosts=self.REMOTE_HOSTS,
+                                         container_overlay=False)
+        MockExec = self._start(
+            pipeline, exit_codes={h: 0 for h in self.REMOTE_HOSTS})
+
+        self.assertEqual(MockExec.call_count, 1)
+        cmd, exec_info = MockExec.call_args.args
+        self.assertNotIn('--overlay', cmd)
+        self.assertIsInstance(exec_info, PsshExecInfo)
+
+    def test_partial_start_failure_raises_naming_host(self):
+        """An instance start that fails on a subset of hosts raises
+        immediately, naming the failed host, instead of hanging later."""
+        pipeline = self._create_pipeline('apt_fail', hosts=self.REMOTE_HOSTS,
+                                         container_overlay_root='/tmp')
+        codes = {'node-01': 0, 'node-02': 255, 'node-03': 0, 'node-04': 0}
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self._start(pipeline, exit_codes=codes)
+
+        self.assertIn('node-02', str(ctx.exception))
+        self.assertIn('255', str(ctx.exception))
+
+
+class TestApptainerConfigRoundTrip(ApptainerStartTestBase):
+
+    def test_overlay_keys_roundtrip_config(self):
+        """Non-default values survive save() -> load-from-config. The
+        default-True container_overlay needs an inverted save idiom: a
+        truthy-only save would silently drop False."""
+        self._create_pipeline('apt_rt', container_overlay=False,
+                              container_overlay_root='/mnt/nvme/me')
+
+        p2 = Pipeline('apt_rt')
+        self.assertIs(p2.container_overlay, False)
+        self.assertEqual(p2.container_overlay_root, '/mnt/nvme/me')
+
+    def test_overlay_defaults_roundtrip_config(self):
+        """Defaults survive a round trip and stay out of the saved file."""
+        self._create_pipeline('apt_rtdef')
+
+        p2 = Pipeline('apt_rtdef')
+        self.assertIs(p2.container_overlay, True)
+        self.assertIsNone(p2.container_overlay_root)
+
+        config_file = self.jarvis.get_pipeline_dir('apt_rtdef') / 'pipeline.yaml'
+        with open(config_file) as f:
+            saved = yaml.safe_load(f)
+        self.assertNotIn('container_overlay', saved)
+        self.assertNotIn('container_overlay_root', saved)
+
+    def test_tmp_bind_root_roundtrip_config(self):
+        """tmp_bind_root survives save() -> load-from-config, so a
+        pipeline rebuilt from its saved config (ppl start/stop/run)
+        keeps its per-host /tmp bind."""
+        self._create_pipeline('apt_tbr', tmp_bind_root='/mnt/nvme/me')
+
+        p2 = Pipeline('apt_tbr')
+        self.assertEqual(p2.tmp_bind_root, '/mnt/nvme/me')
+
+    def test_container_gpu_roundtrip_config(self):
+        """container_gpu survives save() -> load-from-config."""
+        self._create_pipeline('apt_gpu', container_gpu=True)
+
+        p2 = Pipeline('apt_gpu')
+        self.assertIs(p2.container_gpu, True)
+
+    def test_yaml_load_overlay_keys_expandvars(self):
+        """YAML load honors both keys and expands env vars in the root
+        path, mirroring the tmp_bind_root contract."""
+        os.environ['JARVIS_TEST_OVERLAY'] = '/mnt/testnvme'
+        try:
+            yaml_path = os.path.join(self.test_dir, 'apt_yaml.yaml')
+            with open(yaml_path, 'w') as f:
+                f.write(
+                    'name: apt_yaml\n'
+                    'container_engine: apptainer\n'
+                    'container_overlay: false\n'
+                    'container_overlay_root: $JARVIS_TEST_OVERLAY/root\n'
+                    'pkgs: []\n'
+                )
+            pipeline = Pipeline()
+            pipeline.load('yaml', yaml_path)
+            self.assertIs(pipeline.container_overlay, False)
+            self.assertEqual(pipeline.container_overlay_root,
+                             '/mnt/testnvme/root')
+        finally:
+            del os.environ['JARVIS_TEST_OVERLAY']
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/core/test_pipeline_test.py
+++ b/test/unit/core/test_pipeline_test.py
@@ -4,6 +4,7 @@ Tests for pipeline test functionality (grid search experiments).
 import os
 import csv
 import sys
+import time
 import yaml
 import tempfile
 import shutil
@@ -13,8 +14,12 @@ from pathlib import Path
 # Add the project root to the path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 
+from unittest.mock import patch
+
 from jarvis_cd.core.pipeline_test import (
     is_pipeline_test,
+    alarm_timeout,
+    Deadline,
     PipelineTest,
     load_yaml_auto,
 )
@@ -437,8 +442,10 @@ class TestPipelineTestVariableApplication(unittest.TestCase):
 
         self.assertEqual(result['scheduler'], {'nodes': 4})
 
-    def test_apply_top_level_scheduler_propagates_with_no_vars(self):
-        """Top-level scheduler propagates to config even when no vars touch it."""
+    def test_apply_top_level_scheduler_not_stamped_without_vars(self):
+        """A top-level scheduler describes the ONE job wrapping the whole
+        test (Mode A); without scheduler.X vars it must NOT be stamped onto
+        each iteration config, or every combo would submit a nested sbatch."""
         test = PipelineTest()
         test.scheduler = {'name': 'slurm', 'nodes': 2}
         base_config = {
@@ -448,7 +455,7 @@ class TestPipelineTestVariableApplication(unittest.TestCase):
 
         result = test._apply_variables(base_config, {})
 
-        self.assertEqual(result['scheduler'], {'name': 'slurm', 'nodes': 2})
+        self.assertNotIn('scheduler', result)
 
 
 class TestPipelineTestLoading(unittest.TestCase):
@@ -895,6 +902,197 @@ class TestPipelineTestCsvLog(unittest.TestCase):
 
         # Should not raise any errors
         test._write_csv_log()
+
+
+class TestPipelineTestRunTimeout(unittest.TestCase):
+    """Tests for the per-combination run_timeout guard."""
+
+    def test_alarm_timeout_fires_on_hang(self):
+        """A call that outlives the budget raises TimeoutError."""
+        with self.assertRaises(TimeoutError):
+            with alarm_timeout(1, 'budget exceeded'):
+                time.sleep(30)
+
+    def test_alarm_timeout_allows_fast_call(self):
+        """A call that finishes in time is untouched."""
+        with alarm_timeout(30, 'budget exceeded'):
+            result = 'finished'
+        self.assertEqual(result, 'finished')
+
+    def test_alarm_timeout_disabled_when_unset(self):
+        """None preserves the historical unbounded behaviour."""
+        with alarm_timeout(None, 'never'):
+            result = 'finished'
+        self.assertEqual(result, 'finished')
+
+    def test_alarm_timeout_does_not_leak_alarm(self):
+        """No stray SIGALRM is delivered after the block exits."""
+        with alarm_timeout(1, 'budget exceeded'):
+            pass
+        # Outliving the former budget must not raise.
+        time.sleep(1.5)
+
+    def test_run_timeout_parsed_from_yaml(self):
+        """run_timeout is read off the test definition."""
+        temp_dir = tempfile.mkdtemp()
+        try:
+            yaml_path = os.path.join(temp_dir, 'test.yaml')
+            with open(yaml_path, 'w') as f:
+                yaml.dump({
+                    'config': {
+                        'name': 'demo',
+                        'pkgs': [{'pkg_type': 'builtin.ior',
+                                  'pkg_name': 'ior'}],
+                    },
+                    'repeat': 1,
+                    'run_timeout': 1800,
+                }, f)
+
+            test = PipelineTest()
+            test.load(yaml_path)
+
+            self.assertEqual(test.run_timeout, 1800)
+        finally:
+            shutil.rmtree(temp_dir)
+
+    def test_run_timeout_defaults_to_none(self):
+        """Omitting run_timeout leaves the sweep unbounded as before."""
+        test = PipelineTest()
+        self.assertIsNone(test.run_timeout)
+
+    def test_deadline_records_expiry(self):
+        """The Deadline flag is set from inside the signal handler."""
+        deadline = Deadline()
+        self.assertFalse(deadline.expired)
+        with self.assertRaises(TimeoutError):
+            with alarm_timeout(1, 'budget exceeded', deadline):
+                time.sleep(30)
+        self.assertTrue(deadline.expired)
+
+    def test_deadline_not_marked_when_call_completes(self):
+        """A run that finishes in time leaves the Deadline untouched."""
+        deadline = Deadline()
+        with alarm_timeout(30, 'budget exceeded', deadline):
+            pass
+        self.assertFalse(deadline.expired)
+
+    def test_teardown_runs_when_timeout_is_rewrapped(self):
+        """Teardown must fire even though start() re-wraps TimeoutError.
+
+        Pipeline.start catches whatever a package raises and re-raises it as
+        RuntimeError, so the TimeoutError never reaches the sweep runner.
+        Keying recovery off the exception type silently skipped teardown and
+        leaked redis / container instances into the next combination.
+        """
+        stopped = []
+
+        class HangingPipeline:
+            scheduler = None
+            packages = []
+
+            def load(self, *args, **kwargs):
+                pass
+
+            def configure_all_packages(self, *args, **kwargs):
+                pass
+
+            def start(self):
+                try:
+                    time.sleep(30)
+                except TimeoutError as e:
+                    # Mirrors jarvis_cd/core/pipeline.py:510
+                    raise RuntimeError(
+                        f"Pipeline startup failed at package 'bench': {e}"
+                    ) from e
+
+            def stop(self):
+                stopped.append(True)
+
+        test = PipelineTest()
+        test.name = 'demo'
+        test.combinations = [{'ior.nprocs': 1}]
+        test.run_timeout = 1
+
+        with patch('jarvis_cd.core.pipeline_test.Pipeline', HangingPipeline):
+            with self.assertRaises(RuntimeError):
+                test._run_single({'name': 'demo', 'pkgs': []},
+                                 {'ior.nprocs': 1}, 0)
+
+        self.assertEqual(len(stopped), 1,
+                         'teardown did not run after a re-wrapped timeout')
+
+    def test_no_teardown_for_ordinary_failure(self):
+        """A non-timeout failure is re-raised without the timeout teardown."""
+        stopped = []
+
+        class FailingPipeline:
+            scheduler = None
+            packages = []
+
+            def load(self, *args, **kwargs):
+                pass
+
+            def configure_all_packages(self, *args, **kwargs):
+                pass
+
+            def start(self):
+                raise RuntimeError('package blew up immediately')
+
+            def stop(self):
+                stopped.append(True)
+
+        test = PipelineTest()
+        test.name = 'demo'
+        test.combinations = [{'ior.nprocs': 1}]
+        test.run_timeout = 600
+
+        with patch('jarvis_cd.core.pipeline_test.Pipeline', FailingPipeline):
+            with self.assertRaises(RuntimeError):
+                test._run_single({'name': 'demo', 'pkgs': []},
+                                 {'ior.nprocs': 1}, 0)
+
+        self.assertEqual(stopped, [])
+
+    def test_timed_out_run_is_recorded_failed_and_sweep_continues(self):
+        """A hung combination fails that row only; later rows still run."""
+        temp_dir = tempfile.mkdtemp()
+        try:
+            test = PipelineTest()
+            test.name = 'demo'
+            test.output = temp_dir
+            test.config = {
+                'name': 'demo',
+                'pkgs': [{'pkg_type': 'builtin.ior', 'pkg_name': 'ior'}],
+            }
+            test.combinations = [{'ior.nprocs': 1},
+                                 {'ior.nprocs': 2},
+                                 {'ior.nprocs': 3}]
+            test.run_timeout = 1
+
+            calls = []
+
+            def fake_run_single(config, variables, repeat_idx):
+                nprocs = variables['ior.nprocs']
+                calls.append(nprocs)
+                if nprocs == 1:
+                    raise TimeoutError('run exceeded run_timeout of 1s')
+                return {'combination_idx': nprocs,
+                        'repeat_idx': repeat_idx,
+                        'variables': variables.copy(),
+                        'runtime': 1.0}
+
+            test._run_single = fake_run_single
+            test.run()
+
+            # Every combination was attempted despite the first hanging.
+            self.assertEqual(calls, [1, 2, 3])
+            self.assertEqual(len(test.results), 3)
+            self.assertEqual(test.results[0]['status'], 'failed')
+            self.assertIn('run_timeout', test.results[0]['error'])
+            self.assertEqual(test.results[1]['status'], 'success')
+            self.assertEqual(test.results[2]['status'], 'success')
+        finally:
+            shutil.rmtree(temp_dir)
 
 
 if __name__ == '__main__':

--- a/test/unit/core/test_scheduler_directives.py
+++ b/test/unit/core/test_scheduler_directives.py
@@ -1,0 +1,70 @@
+"""Unit tests for SBATCH directive rendering in jarvis_cd.core.scheduler.
+
+Regression guard for the #526 smoke failure: slurm does NOT expand env vars
+in #SBATCH directives, so an unexpanded ``${HOME}`` in output:/error: was
+taken literally (relative to WorkDir), the log file could not be opened, and
+the job failed at launch with no logs. jarvis must expand ${VAR} host-side
+while leaving slurm patterns (%j, %x) and unset vars untouched.
+"""
+import os
+import unittest
+
+from jarvis_cd.core.scheduler import make_scheduler
+
+
+def _render(spec, tmp_path='/tmp/jarvis-sched-test'):
+    sched = make_scheduler(spec, tmp_path, pipeline_yaml='/x/ppl.yaml')
+    return sched.render()
+
+
+class TestSchedulerDirectiveExpansion(unittest.TestCase):
+    def setUp(self):
+        os.environ['JARVIS_SCHED_TEST_HOME'] = '/home/tester'
+
+    def tearDown(self):
+        os.environ.pop('JARVIS_SCHED_TEST_HOME', None)
+
+    def test_expands_env_var_in_output_error(self):
+        text = _render({
+            'name': 'slurm',
+            'job_name': 'smoke',
+            'output': '${JARVIS_SCHED_TEST_HOME}/smoke-%j.out',
+            'error': '${JARVIS_SCHED_TEST_HOME}/smoke-%j.err',
+        })
+        # ${VAR} expanded to an absolute path...
+        self.assertIn('#SBATCH --output=/home/tester/smoke-%j.out', text)
+        self.assertIn('#SBATCH --error=/home/tester/smoke-%j.err', text)
+        # ...and the literal (broken) form is gone.
+        self.assertNotIn('${JARVIS_SCHED_TEST_HOME}', text)
+
+    def test_preserves_slurm_patterns(self):
+        text = _render({
+            'name': 'slurm',
+            'output': '/logs/%x-%j.out',
+        })
+        self.assertIn('#SBATCH --output=/logs/%x-%j.out', text)
+
+    def test_unset_var_left_literal_not_blanked(self):
+        # os.path.expandvars leaves unknown vars untouched rather than
+        # blanking them (so a user's ${SLURM_JOB_ID} typo stays visible
+        # instead of silently collapsing the path).
+        text = _render({
+            'name': 'slurm',
+            'output': '${DEFINITELY_UNSET_XYZ}/o-%j.out',
+        })
+        self.assertIn('#SBATCH --output=${DEFINITELY_UNSET_XYZ}/o-%j.out', text)
+
+    def test_expands_in_sbatch_args_passthrough(self):
+        text = _render({
+            'name': 'slurm',
+            'sbatch_args': ['--comment=${JARVIS_SCHED_TEST_HOME}/note'],
+        })
+        self.assertIn('#SBATCH --comment=/home/tester/note', text)
+
+    def test_partition_value_without_var_unchanged(self):
+        text = _render({'name': 'slurm', 'partition': 'compute'})
+        self.assertIn('#SBATCH --partition=compute', text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/shell/test_openmpi_launcher.py
+++ b/test/unit/shell/test_openmpi_launcher.py
@@ -1,0 +1,58 @@
+"""Unit tests for OpenMPI launcher MCA injection (#526 distributed).
+
+OpenMPI 5 (PRRTE) renamed the ssh launch plm and its params: OMPI <=4 uses
+plm/rsh + plm_rsh_agent/plm_rsh_args; OMPI 5 uses plm/ssh + plm_ssh_agent/
+plm_ssh_args. jarvis assembles the command on the host but it runs inside the
+container, so it can't detect the in-container version -- it emits both param
+names (each runtime honors the one it knows). The plm component itself is
+selected version-agnostically via '--mca plm ^slurm' in exec_factory.
+"""
+import unittest
+
+from jarvis_cd.shell.mpi_exec import OpenMpiExec
+from jarvis_cd.util.hostfile import Hostfile
+
+
+def _mpicmd(ssh_cmd=None, ssh_port=None, mpi_cmd=None, hosts=('n1', 'n2')):
+    """Call OpenMpiExec.mpicmd() without running LocalExec.__init__."""
+    obj = object.__new__(OpenMpiExec)
+    obj.nprocs = 4
+    obj.ppn = 2
+    obj.hostfile = Hostfile(hosts=list(hosts), find_ips=False)
+    obj.mpi_env = {'PATH': '/nonexistent/bin'}
+    obj.ssh_port = ssh_port
+    obj.mpi_cmd = mpi_cmd
+    obj.ssh_cmd = ssh_cmd
+    obj.original_cmd = 'ior -w'
+    obj.cmd_list = None
+    return obj.mpicmd()
+
+
+class TestOpenMpiLauncherParams(unittest.TestCase):
+    def test_ssh_agent_emits_both_rsh_and_ssh_names(self):
+        cmd = _mpicmd(ssh_cmd='env -u LD_LIBRARY_PATH ssh')
+        self.assertIn('--mca plm_rsh_agent "env -u LD_LIBRARY_PATH ssh"', cmd)
+        self.assertIn('--mca plm_ssh_agent "env -u LD_LIBRARY_PATH ssh"', cmd)
+
+    def test_port_emits_both_rsh_and_ssh_args(self):
+        cmd = _mpicmd(ssh_port=2222)
+        self.assertIn('--mca plm_rsh_args "-p 2222"', cmd)
+        self.assertIn('--mca plm_ssh_args "-p 2222"', cmd)
+
+    def test_port_22_not_injected(self):
+        cmd = _mpicmd(ssh_port=22)
+        self.assertNotIn('plm_ssh_args', cmd)
+        self.assertNotIn('plm_rsh_args', cmd)
+
+    def test_no_ssh_cmd_no_agent(self):
+        cmd = _mpicmd(ssh_cmd=None)
+        self.assertNotIn('plm_ssh_agent', cmd)
+        self.assertNotIn('plm_rsh_agent', cmd)
+
+    def test_inline_host_list_from_pathless_hostfile(self):
+        cmd = _mpicmd(ssh_port=2222)
+        self.assertIn('--host n1,n2', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Upstream half of a two-PR pair enabling containerized (Apptainer) benchmark
pipelines. **clio-core #526 is the consumer**; the source pipelines that
exercise this live in clio-core's `migration/README.md`. Three separable,
independently reviewable payloads.

## 1. builtin.fio / builtin.redis feature merge

**fio** — container-aware driver:
- **Directory mode** (`target_dir` → `--directory`) for FUSE mountpoints whose
  mount only exists inside the container instance's namespace; filename mode
  (`out` → `--filename`) unchanged.
- **JSON metrics**: when `output_file` is set, fio runs `--output-format=json`
  and parses per-op columns into results.csv (`agg_bw_mbps`, `iops`,
  `lat_mean_us`, `lat_p99_us`, `total_io_mb`).
- `single_instance` (pin to first host), plus `fallocate`/`use_thread`/
  `runtime`/`exec_mode` knobs.

**redis**:
- `single_instance` forces one standalone server on the first host even on a
  multi-host hostfile (metadata singleton — cluster mode is DB0-only, which
  breaks a JuiceFS `meta_url` that `SELECT`s a non-zero DB).
- Startup/teardown hardening: stale `dump.rdb` removal, `redis-cli ping` wait
  before returning, graceful `shutdown nosave` + wait-for-port-free, ephemeral
  `redis.conf` (`save ""`, `pidfile ""`). All probes run in the deployment
  context so `redis-cli` need not exist host-side.

**Back-compat:** existing yamls are unaffected — with the new options unset,
both packages reproduce the previous command line byte-for-byte.

## 2. pipeline.py container additions

- **`container_fakeroot`** — rootless Apptainer needs `--fakeroot` baked into
  `instance start` for FUSE user-namespace mounts.
- **`container_overlay` / `container_overlay_root`** — fixes the shared-NFS
  multi-node overlay bug. Jarvis fanned one identical `--overlay <shared_dir>`
  to every host; overlayfs cannot use NFS as an upper layer and N nodes race
  the same directory, so the 4-node `distributed` pipeline **hung until the 2h
  Slurm limit**. Fix:
  - per-host node-local overlay at `<container_overlay_root>/<name>/overlay`
    (with a per-host `mkdir` fan-out);
  - a **guard that fails fast** — naming both escape hatches — instead of
    hanging when a multi-node pipeline keeps the default shared overlay;
  - a per-host `instance start` **exit-code check**;
  - `container_overlay: false` omits `--overlay` and auto-clears
    `--no-mount tmp`.
  Defaults yield a **byte-identical single-host `start_cmd`**.
- Also persists `tmp_bind_root` and `container_gpu` across save/load-config
  (previously silently dropped when a pipeline was rebuilt from saved config).

## 3. pipeline_test.py scheduler Mode A fix

Only copy the test's top-level `scheduler:` block into per-iteration configs
when `scheduler.X` variables are actually swept (`if scheduler_vars:`).
Otherwise that block describes the single job `ppl submit` wraps around the
whole run, and stamping it onto every iteration made `_run_single` re-submit
each iteration as a **nested sbatch job from inside the allocation**. A
`scheduler:` nested under `config:` still requests per-iteration submission
explicitly.

## Tests

New `test/unit/core/test_container_apptainer.py` (13 cases): golden single-host
`start_cmd` byte-identity, overlay relocation + `mkdir` fan-out, disabled-overlay
tmp handling, the multi-node guard, per-host start-failure, and save/load
round-trips.

## Validation (Ares, 4-node Slurm)

- `distributed` **3/3 green** with `container_overlay_root=/tmp` — no 2h hang;
  per-node overlay confirmed (one instance PID stopped per node).
- `single_node` **24/24** — back-compat intact in production.
- Unedited multi-node run **fails immediately on the guard** as intended
  (replaces the old 2-hour hang).
