### PR TITLE
fix: reconcile scheduler cluster activation

### DIFF
--- a/jarvis_cd/core/execution.py
+++ b/jarvis_cd/core/execution.py
@@ -1895,6 +1895,44 @@ class ExecutionStore:
             merged_metadata = dict(current.metadata)
             if metadata:
                 merged_metadata.update(metadata)
+            if _script_activation:
+                submission_value = merged_metadata.get("submission")
+                if isinstance(submission_value, Mapping):
+                    submission = dict(submission_value)
+                    submission_provider = submission.get("provider")
+                    submission_native_id = submission.get("scheduler_job_id")
+                    submission_cluster = submission.get("scheduler_cluster")
+                    if submission_provider not in (None, next_provider):
+                        raise RuntimeError(
+                            "scheduler activation provider conflicts with submission"
+                        )
+                    if submission_native_id not in (None, next_native_id):
+                        raise RuntimeError(
+                            "scheduler activation native identity conflicts with submission"
+                        )
+                    if submission_cluster not in (None, next_cluster):
+                        raise RuntimeError(
+                            "scheduler activation cluster conflicts with submission"
+                        )
+                    complete_submit_receipt = (
+                        submission.get("schema_version")
+                        == "jarvis.scheduler.submission.v1"
+                        and submission.get("execution_id") == current.execution_id
+                        and submission_provider == next_provider
+                        and submission_native_id == next_native_id
+                        and submission.get("submitted") is True
+                        and submission.get("identity_source") == "scheduler_submit_api"
+                    )
+                    if (
+                        complete_submit_receipt
+                        and submission_cluster is None
+                        and next_cluster is not None
+                    ):
+                        submission["scheduler_cluster"] = next_cluster
+                        submission["cluster_identity_source"] = (
+                            "scheduler_runtime_environment"
+                        )
+                    merged_metadata["submission"] = submission
             next_return_code = cast(
                 Optional[int],
                 current.return_code if return_code is _UNSET else return_code,

--- a/test/unit/core/test_execution.py
+++ b/test/unit/core/test_execution.py
@@ -529,6 +529,115 @@ def test_scheduler_activation_is_identity_bound_and_scripted_only(
         )
 
 
+def test_scheduler_activation_backfills_submitted_cluster_projection(
+    tmp_path: Path,
+) -> None:
+    """Allocation identity keeps the durable submission projection coherent."""
+
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create("submitted", mode="scheduler", scheduler_provider="slurm")
+    store.update("submitted", state="submitting")
+    store.update(
+        "submitted",
+        state="submitted",
+        submitted=True,
+        native_id="42",
+        metadata={
+            "submission": {
+                "schema_version": "jarvis.scheduler.submission.v1",
+                "execution_id": "submitted",
+                "provider": "slurm",
+                "scheduler_job_id": "42",
+                "scheduler_cluster": None,
+                "identity_source": "scheduler_submit_api",
+                "submitted": True,
+            }
+        },
+    )
+
+    activated = store.activate_scheduler(
+        "submitted",
+        provider="slurm",
+        native_id="42",
+        cluster="linux",
+    )
+
+    assert activated.cluster == "linux"
+    submission = activated.metadata["submission"]
+    assert submission["scheduler_cluster"] == "linux"
+    assert submission["cluster_identity_source"] == "scheduler_runtime_environment"
+    assert submission["identity_source"] == "scheduler_submit_api"
+
+
+def test_scheduler_activation_rejects_conflicting_submission_cluster(
+    tmp_path: Path,
+) -> None:
+    """An allocation cannot rewrite an already-bound submission cluster."""
+
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create("conflict", mode="scheduler", scheduler_provider="slurm")
+    store.update("conflict", state="submitting")
+    store.update(
+        "conflict",
+        state="submitted",
+        submitted=True,
+        native_id="42",
+        metadata={
+            "submission": {
+                "provider": "slurm",
+                "scheduler_job_id": "42",
+                "scheduler_cluster": "other",
+            }
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="cluster conflicts"):
+        store.activate_scheduler(
+            "conflict",
+            provider="slurm",
+            native_id="42",
+            cluster="ares",
+        )
+
+
+def test_scheduler_activation_does_not_promote_incomplete_submission_receipt(
+    tmp_path: Path,
+) -> None:
+    """Runtime identity cannot make a manual/script-only projection look submitted."""
+
+    store = ExecutionStore(tmp_path / "executions", "example")
+    store.create(
+        "manual-projection",
+        mode="scheduler",
+        scheduler_provider="slurm",
+        metadata={
+            "submission": {
+                "schema_version": "jarvis.scheduler.submission.v1",
+                "execution_id": "manual-projection",
+                "provider": "slurm",
+                "scheduler_job_id": None,
+                "scheduler_cluster": None,
+                "identity_source": None,
+                "submitted": False,
+            }
+        },
+    )
+    store.update("manual-projection", state="scripted", terminal=True)
+
+    activated = store.activate_scheduler(
+        "manual-projection",
+        provider="slurm",
+        native_id="42",
+        cluster="linux",
+    )
+
+    submission = activated.metadata["submission"]
+    assert submission["scheduler_cluster"] is None
+    assert "cluster_identity_source" not in submission
+    assert submission["scheduler_job_id"] is None
+    assert submission["submitted"] is False
+
+
 def test_record_reader_rejects_unknown_fields_and_symlink_roots(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- reconcile a complete scheduler submission receipt when allocation startup later discovers the scheduler-native cluster identity
- fail closed on provider, native-job, or cluster conflicts without confusing the relay routing alias with the scheduler cluster
- keep incomplete/manual projections unchanged so runtime activation cannot make them look scheduler-submitted

## Live evidence
Ares execution `jarvis_c62b5d8cc37d4a80a57dfae638288d6d` was submitted as SLURM job `21950`. `sbatch --parsable` returned no cluster, then the allocation reported `SLURM_CLUSTER_NAME=linux`; the durable execution handle updated to `linux` while `metadata.submission.scheduler_cluster` remained null, causing clio-kit to fail its consistency check before structured runtime/log retrieval.

## Validation
- 5 focused scheduler identity/order tests passed
- Ruff check/format clean
- Pyright: 0 errors, 0 warnings for the changed source
- `git diff --check`