### PR TITLE
fix: validate ParaView descriptors during configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,7 @@ jobs:
             test/unit/core/test_lammps_progress.py \
             test/unit/core/test_lammps_package_runtime.py \
             test/unit/core/test_paraview_artifacts.py \
+            test/unit/core/test_paraview_service.py::test_package_validates_dataset_descriptor_during_configuration \
             test/unit/core/test_scheduler_submission.py \
             test/unit/core/test_pipeline_hostfile.py \
             test/unit/util/test_pkg_argparse.py \

--- a/builtin/builtin/paraview/pkg.py
+++ b/builtin/builtin/paraview/pkg.py
@@ -142,7 +142,7 @@ class Paraview(Application):
             },
         ]
 
-    def _configure(self, **kwargs):
+    def _configure(self, **kwargs: Any) -> None:
         """
         Converts the Jarvis configuration to application-specific configuration.
         E.g., OrangeFS produces an orangefs.xml file.
@@ -150,8 +150,18 @@ class Paraview(Application):
         :param kwargs: Configuration parameters for this pkg.
         :return: None
         """
+        del kwargs
+        if self.config.get("mode", "server") != "service":
+            return
 
-        pass
+        from jarvis_cd.service_runtime import DatasetDescriptor
+
+        configured = self.config.get("dataset_descriptor")
+        if not isinstance(configured, str):
+            raise ValueError(
+                "ParaView dataset_descriptor must be JSON text or a file path"
+            )
+        self._load_dataset_descriptor(configured, DatasetDescriptor)
 
     def start(self):
         """

--- a/test/unit/core/test_paraview_service.py
+++ b/test/unit/core/test_paraview_service.py
@@ -1176,6 +1176,41 @@ def test_package_service_mode_stages_generic_runtime_and_owned_output(
         package._start_service(dict(package.mod_env))
 
 
+def test_package_validates_dataset_descriptor_during_configuration(
+    tmp_path: Path,
+) -> None:
+    """A malformed catalog copy cannot persist until an execution is launched."""
+    package = cast(Any, object.__new__(package_module.Paraview))
+    package.config = {
+        "mode": "service",
+        "dataset_descriptor": json.dumps(
+            {
+                "schema_version": "jarvis.dataset-descriptor.v1",
+                "dataset_id": "asteroid-subset",
+                "kind": "temporal-volume-series",
+                "format": "vtk-image-data",
+                "members": [
+                    {
+                        "index": 0,
+                        "location": "/cluster/asteroid/frame-0000.vti",
+                        "timestep": 0.0,
+                    }
+                ],
+                "arrays": [],
+                "bounds": None,
+            }
+        ),
+    }
+
+    with pytest.raises(ValueError, match="fingerprint must be an object"):
+        package._configure()
+
+    package.config["dataset_descriptor"] = str(
+        _supervisor_descriptor(tmp_path / "valid-descriptor.json")
+    )
+    package._configure()
+
+
 def test_service_export_is_immediately_queryable_through_artifact_store(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/test/unit/test_release_workflow.py
+++ b/test/unit/test_release_workflow.py
@@ -343,6 +343,10 @@ def test_exact_release_request_gates_artifact_build() -> None:
     assert "test/unit/core/test_progress_spi.py" in WORKFLOW
     assert "test/unit/core/test_pipeline_coverage.py" in WORKFLOW
     assert "test/unit/ci/test_live_ares_gray_scott_probe.py" in WORKFLOW
+    assert (
+        "test/unit/core/test_paraview_service.py::"
+        "test_package_validates_dataset_descriptor_during_configuration"
+    ) in WORKFLOW
     assert "test/unit/shell/test_local_exec.py" in WORKFLOW
     assert "test/unit/shell/test_mpi_exec.py" in WORKFLOW
     assert "test/unit/util/test_pkg_argparse.py" in WORKFLOW


### PR DESCRIPTION
## What changed
- validate service-mode ParaView dataset descriptors during package configuration
- reject incomplete catalog copies before a durable execution is created
- include the regression in the focused release workflow

## Root cause
The ParaView package accepted an incomplete descriptor at `jarvis_add_step` and deferred validation until service startup. A real agent omitted the catalog fingerprint while copying the descriptor, so JARVIS created an execution that failed before scheduler submission.

## Impact
Malformed descriptors now fail at the configuration boundary with the existing strict descriptor error. Valid JSON text and file-backed descriptors keep the same interface.

## Validation
- 9 focused tests passed
- Ruff check and format check passed
- Pyright passed with 0 errors
- `git diff --check` passed