### PR TITLE
fix: require service mode for ParaView datasets

### DIFF
--- a/builtin/builtin/paraview/pkg.py
+++ b/builtin/builtin/paraview/pkg.py
@@ -11,6 +11,8 @@ from typing import Any, cast
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.shell import Exec, ExecInfo, LocalExecInfo, MpiExecInfo
 
+_EXEC_FAILURE_STDERR_LIMIT = 4096
+
 
 class Paraview(Application):
     """
@@ -34,7 +36,10 @@ class Paraview(Application):
         return [
             {
                 "name": "mode",
-                "msg": "ParaView mode: server, service, or batch",
+                "msg": (
+                    "ParaView mode: service for a live dataset view, server for "
+                    "a plain pvserver, or batch for a script"
+                ),
                 "type": str,
                 "default": "server",
             },
@@ -100,7 +105,10 @@ class Paraview(Application):
             },
             {
                 "name": "dataset_descriptor",
-                "msg": "Service-mode dataset descriptor JSON or JSON file path",
+                "msg": (
+                    "Live-view dataset descriptor JSON or JSON file path; "
+                    "requires mode=service"
+                ),
                 "type": str,
                 "default": "",
             },
@@ -151,12 +159,18 @@ class Paraview(Application):
         :return: None
         """
         del kwargs
-        if self.config.get("mode", "server") != "service":
+        mode = self.config.get("mode", "server")
+        configured = self.config.get("dataset_descriptor")
+        if mode != "service":
+            if configured not in (None, ""):
+                raise ValueError(
+                    "ParaView dataset_descriptor requires mode='service' for "
+                    "live dataset viewing"
+                )
             return
 
         from jarvis_cd.service_runtime import DatasetDescriptor
 
-        configured = self.config.get("dataset_descriptor")
         if not isinstance(configured, str):
             raise ValueError(
                 "ParaView dataset_descriptor must be JSON text or a file path"
@@ -495,20 +509,38 @@ class Paraview(Application):
 
     @staticmethod
     def _raise_for_exec_failure(result: Any, *, operation: str) -> None:
-        """Raise when an execution has no status or any host exits nonzero."""
+        """Raise with bounded stderr when an execution exits unsuccessfully."""
         exit_codes = getattr(result, "exit_code", None)
         if not isinstance(exit_codes, dict) or not exit_codes:
             raise RuntimeError(f"{operation} returned no process exit status")
-        failures = {
-            str(host): code
+        failures = [
+            (host, code)
             for host, code in exit_codes.items()
             if isinstance(code, bool) or not isinstance(code, int) or code != 0
-        }
+        ]
         if failures:
             details = ", ".join(
-                f"{host}={code!r}" for host, code in sorted(failures.items())
+                f"{host}={code!r}"
+                for host, code in sorted(failures, key=lambda item: str(item[0]))
             )
-            raise RuntimeError(f"{operation} failed with exit status: {details}")
+            diagnostic = ""
+            stderr_by_host = getattr(result, "stderr", None)
+            if isinstance(stderr_by_host, dict):
+                messages: list[str] = []
+                for host, _code in sorted(failures, key=lambda item: str(item[0])):
+                    stderr = stderr_by_host.get(host)
+                    if stderr is None:
+                        stderr = stderr_by_host.get(str(host))
+                    if isinstance(stderr, str) and stderr.strip():
+                        messages.append(f"{host}: {' '.join(stderr.split())}")
+                if messages:
+                    bounded = "; ".join(messages)
+                    if len(bounded) > _EXEC_FAILURE_STDERR_LIMIT:
+                        bounded = bounded[: _EXEC_FAILURE_STDERR_LIMIT - 3] + "..."
+                    diagnostic = f"; stderr: {bounded}"
+            raise RuntimeError(
+                f"{operation} failed with exit status: {details}{diagnostic}"
+            )
 
     def stop(self):
         """

--- a/test/unit/core/test_paraview_service.py
+++ b/test/unit/core/test_paraview_service.py
@@ -1211,6 +1211,73 @@ def test_package_validates_dataset_descriptor_during_configuration(
     package._configure()
 
 
+@pytest.mark.parametrize("mode", ["server", "batch"])
+def test_package_requires_service_mode_for_live_dataset_descriptor(mode: str) -> None:
+    """A live-view descriptor cannot silently launch a non-service mode."""
+    package = cast(Any, object.__new__(package_module.Paraview))
+    package.config = {
+        "mode": mode,
+        "dataset_descriptor": '{"dataset_id":"asteroid-subset"}',
+    }
+
+    with pytest.raises(ValueError) as error:
+        package._configure()
+
+    assert "mode='service'" in str(error.value)
+    assert "live dataset viewing" in str(error.value)
+
+    package.config["dataset_descriptor"] = ""
+    package._configure()
+
+
+def test_package_parameters_describe_live_view_service_mode() -> None:
+    """Agent-facing parameter help explains the live-view mode contract."""
+    package = cast(Any, object.__new__(package_module.Paraview))
+    parameters = {
+        parameter["name"]: parameter for parameter in package._configure_menu()
+    }
+
+    assert "service for a live dataset view" in parameters["mode"]["msg"]
+    assert "requires mode=service" in parameters["dataset_descriptor"]["msg"]
+
+
+def test_package_exec_failure_preserves_bounded_stderr() -> None:
+    """A failed remote launch reports its actionable process diagnostic."""
+    result = SimpleNamespace(
+        exit_code={"localhost": 127},
+        stderr={"localhost": "/bin/sh: pvserver: command not found\n"},
+    )
+
+    with pytest.raises(RuntimeError) as error:
+        package_module.Paraview._raise_for_exec_failure(
+            result,
+            operation="ParaView server",
+        )
+
+    message = str(error.value)
+    assert "localhost=127" in message
+    assert "pvserver: command not found" in message
+
+
+def test_package_exec_failure_truncates_oversized_stderr() -> None:
+    """Remote stderr cannot make the raised execution error unbounded."""
+    result = SimpleNamespace(
+        exit_code={"localhost": 1},
+        stderr={"localhost": "actionable-prefix " + ("x" * 5000)},
+    )
+
+    with pytest.raises(RuntimeError) as error:
+        package_module.Paraview._raise_for_exec_failure(
+            result,
+            operation="ParaView service",
+        )
+
+    message = str(error.value)
+    assert "actionable-prefix" in message
+    assert message.endswith("...")
+    assert len(message) < 4200
+
+
 def test_service_export_is_immediately_queryable_through_artifact_store(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
﻿## Summary
- require `mode='service'` whenever ParaView receives a live dataset descriptor
- teach agents the live-view/service distinction in package parameter help
- preserve bounded process stderr in actionable ParaView launch failures

## Focused validation
- `uv run pytest test/unit/core/test_paraview_service.py -k service-mode-focused-tests -q`
- `uv run ruff check builtin/builtin/paraview/pkg.py test/unit/core/test_paraview_service.py`
- `uv run pyright builtin/builtin/paraview/pkg.py`
