### PR TITLE
test: scope execution record retry assertion

### DIFF
--- a/test/unit/core/test_execution_record_replacement.py
+++ b/test/unit/core/test_execution_record_replacement.py
@@ -121,7 +121,7 @@ def test_post_submit_record_read_retries_after_metadata_settles(
         native_id="21948",
     )
     real_validate = execution_module._validate_private_regular_file
-    validation_attempts = 0
+    replacement_injected = False
     retry_delays: list[float] = []
 
     def transient_replacement(
@@ -130,9 +130,9 @@ def test_post_submit_record_read_retries_after_metadata_settles(
         *,
         maximum_size: int,
     ) -> os.stat_result:
-        nonlocal validation_attempts
-        validation_attempts += 1
-        if validation_attempts == 1:
+        nonlocal replacement_injected
+        if path.name == RECORD_NAME and not replacement_injected:
+            replacement_injected = True
             raise execution_module.PrivatePathIdentityChangedError(
                 f"private path changed during secure open: {path}"
             )
@@ -150,5 +150,5 @@ def test_post_submit_record_read_retries_after_metadata_settles(
     assert record.state == "submitted"
     assert record.submitted is True
     assert record.scheduler_native_id == "21948"
-    assert validation_attempts == 2
+    assert replacement_injected is True
     assert retry_delays == [execution_module._SECURE_RECORD_READ_RETRY_SECONDS]


### PR DESCRIPTION
## Summary

- Scope the synthetic replacement-churn injection to the execution record rather than every private file validation.
- Assert that one replacement was injected and that the secure read performed exactly one retry delay.
- Preserve the scheduler identity assertions that exercise the public `ExecutionStore.get()` path.

## Root cause

This test was added before scheduler-cluster reconciliation. It monkeypatched the shared `_validate_private_regular_file` helper and assumed the complete `ExecutionStore.get()` call would perform exactly two validations.

Scheduler reconciliation now intentionally validates four times in this scenario: the initial record open fails once and succeeds on retry, the transaction lock is validated, and the record is read again while holding that lock to avoid a time-of-check/time-of-use race. CI therefore observed four validations even though the execution-record retry behaved correctly.

This changes only the stale test assumption. Production validation, locking, and reconciliation behavior remain unchanged.

## Validation

- `python -m pytest -q test/unit/core/test_execution_record_replacement.py::test_post_submit_record_read_retries_after_metadata_settles` - 1 passed
- `ruff check test/unit/core/test_execution_record_replacement.py`
- `ruff format --check test/unit/core/test_execution_record_replacement.py`
- `git diff --check`
