### PR TITLE
fix(paraview): own runtime discovery in package

### DIFF
--- a/builtin/builtin/paraview/README.md
+++ b/builtin/builtin/paraview/README.md
@@ -24,13 +24,21 @@ location from browser coordinates.
 jarvis ppl append paraview \
   mode=service \
   dataset_descriptor=/site/descriptors/asteroid-subset.json \
-  pvpython_bin=/opt/ParaView/bin/pvpython \
   service_bind_host=127.0.0.1 \
   service_advertise_host=127.0.0.1 \
   nprocs=1
 jarvis ppl submit +no_wait +json
 jarvis execution service-runtimes <execution-id> +json
 ```
+
+The package resolves `pvpython`, `pvbatch`, or `pvserver` (according to mode)
+from the JARVIS pipeline execution environment. Service mode is intrinsically
+headless: the package probes the selected launcher and chooses one supported
+backend, preferring `--mesa` and otherwise using
+`--force-offscreen-rendering`. Executable paths and raw launcher flags are
+intentionally not package parameters. If the selected environment does not
+provide the mode-specific ParaView executable, the package fails before
+application launch with an explicit dependency error.
 
 JARVIS reports the actual service host/port and lifecycle through the durable
 execution handle. A relay owns authenticated desktop routing; direct SSH

--- a/builtin/builtin/paraview/pkg.py
+++ b/builtin/builtin/paraview/pkg.py
@@ -5,13 +5,40 @@ import shlex
 import sys
 import tempfile
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, ExecInfo, LocalExecInfo, MpiExecInfo
+from jarvis_cd.shell import Exec, ExecInfo, LocalExecInfo, MpiExecInfo, Which
 
 _EXEC_FAILURE_STDERR_LIMIT = 4096
+_MODE_EXECUTABLES = {
+    "batch": "pvbatch",
+    "server": "pvserver",
+    "service": "pvpython",
+}
+_HEADLESS_ARGUMENTS = ("--mesa", "--force-offscreen-rendering")
+
+
+@dataclass(frozen=True)
+class _ParaViewRuntime:
+    """One ParaView launcher resolved inside the package execution environment."""
+
+    executable: str
+    capabilities: frozenset[str]
+
+    def arguments(self, *, force_offscreen: bool) -> tuple[str, ...]:
+        """Return package-selected launcher arguments for semantic headless mode."""
+        if not force_offscreen:
+            return ()
+        for argument in _HEADLESS_ARGUMENTS:
+            if argument in self.capabilities:
+                return (argument,)
+        raise RuntimeError(
+            f"ParaView launcher {self.executable!r} does not advertise a supported "
+            "headless rendering capability (--mesa or --force-offscreen-rendering)"
+        )
 
 
 class Paraview(Application):
@@ -63,7 +90,10 @@ class Paraview(Application):
             },
             {
                 "name": "force_offscreen_rendering",
-                "msg": "Useful for headless environments (no display)",
+                "msg": (
+                    "Use a detected headless backend in server or batch mode; "
+                    "service mode is always headless"
+                ),
                 "type": bool,
                 "default": False,
             },
@@ -76,18 +106,6 @@ class Paraview(Application):
             {
                 "name": "script",
                 "msg": "Generic Python script passed to pvbatch in batch mode",
-                "type": str,
-                "default": "",
-            },
-            {
-                "name": "pvbatch_bin",
-                "msg": "Path or command used to launch pvbatch",
-                "type": str,
-                "default": "pvbatch",
-            },
-            {
-                "name": "pvbatch_options",
-                "msg": "Options passed to pvbatch (for example --mesa)",
                 "type": str,
                 "default": "",
             },
@@ -109,18 +127,6 @@ class Paraview(Application):
                     "Live-view dataset descriptor JSON or JSON file path; "
                     "requires mode=service"
                 ),
-                "type": str,
-                "default": "",
-            },
-            {
-                "name": "pvpython_bin",
-                "msg": "Path or command used to launch the ParaView service",
-                "type": str,
-                "default": "pvpython",
-            },
-            {
-                "name": "pvpython_options",
-                "msg": "Options passed to pvpython in service mode",
                 "type": str,
                 "default": "",
             },
@@ -159,7 +165,10 @@ class Paraview(Application):
         :return: None
         """
         del kwargs
+        self._validate_legacy_runtime_configuration()
         mode = self.config.get("mode", "server")
+        if mode not in _MODE_EXECUTABLES:
+            raise ValueError(f"Unsupported ParaView mode: {mode!r}")
         configured = self.config.get("dataset_descriptor")
         if mode != "service":
             if configured not in (None, ""):
@@ -184,6 +193,7 @@ class Paraview(Application):
 
         :return: None
         """
+        self._validate_legacy_runtime_configuration()
         mode = self.config.get("mode", "server")
         environment = dict(self.mod_env)
         environment.setdefault("JARVIS_PACKAGE_NAME", "builtin.paraview")
@@ -214,17 +224,16 @@ class Paraview(Application):
             script = os.path.expandvars(cast(str, self.config.get("script") or ""))
             if not script:
                 raise ValueError("ParaView batch mode requires a script")
-            pvbatch_bin = os.path.expandvars(
-                cast(str, self.config.get("pvbatch_bin") or "pvbatch")
+            runtime = self._resolve_runtime("batch", environment)
+            command = [shlex.quote(runtime.executable)]
+            command.extend(
+                shlex.quote(item)
+                for item in runtime.arguments(
+                    force_offscreen=bool(
+                        self.config.get("force_offscreen_rendering", False)
+                    )
+                )
             )
-            command = [shlex.quote(pvbatch_bin)]
-            pvbatch_options = cast(
-                str,
-                self.config.get("pvbatch_options") or "",
-            )
-            command.extend(shlex.quote(item) for item in shlex.split(pvbatch_options))
-            if self.config["force_offscreen_rendering"]:
-                command.append("--force-offscreen-rendering")
             command.append(shlex.quote(script))
             script_args = cast(str, self.config.get("script_args") or "")
             if script_args:
@@ -235,13 +244,24 @@ class Paraview(Application):
         if mode != "server":
             raise ValueError(f"Unsupported ParaView mode: {mode!r}")
 
+        runtime = self._resolve_runtime("server", environment)
         port_id = self.config["port_id"]
         time_out = self.config["time_out"]
-        condition = ""
-        if self.config["force_offscreen_rendering"]:
-            condition += " --force-offscreen-rendering"
+        command = [
+            shlex.quote(runtime.executable),
+            f"--server-port={port_id}",
+            f"--timeout={time_out}",
+        ]
+        command.extend(
+            shlex.quote(item)
+            for item in runtime.arguments(
+                force_offscreen=bool(
+                    self.config.get("force_offscreen_rendering", False)
+                )
+            )
+        )
         result = Exec(
-            f"pvserver --server-port={port_id} --timeout={time_out}{condition}",
+            " ".join(command),
             exec_info,
         ).run()
         self._raise_for_exec_failure(result, operation="ParaView server")
@@ -275,6 +295,9 @@ class Paraview(Application):
             raise RuntimeError(
                 "ParaView service mode requires a durable JARVIS execution binding"
             )
+        runtime = self._resolve_runtime("service", environment)
+        pvpython_arguments = runtime.arguments(force_offscreen=True)
+        pvpython_options = shlex.join(pvpython_arguments)
         descriptor_value = cast(
             str,
             self.config.get("dataset_descriptor") or "",
@@ -319,18 +342,6 @@ class Paraview(Application):
         if not 0 <= service_port <= 65535:
             raise ValueError("service_port must be between 0 and 65535")
         startup_timeout = self._configured_int("service_startup_timeout", 120)
-        pvpython_bin = os.path.expandvars(
-            cast(str, self.config.get("pvpython_bin") or "pvpython")
-        )
-        pvpython_arguments = shlex.split(
-            cast(str, self.config.get("pvpython_options") or "")
-        )
-        if (
-            self.config.get("force_offscreen_rendering", False)
-            and "--force-offscreen-rendering" not in pvpython_arguments
-        ):
-            pvpython_arguments.append("--force-offscreen-rendering")
-        pvpython_options = shlex.join(pvpython_arguments)
         command = [
             sys.executable,
             str(supervisor),
@@ -341,7 +352,7 @@ class Paraview(Application):
             "--output-dir",
             str(output_dir),
             "--pvpython-bin",
-            pvpython_bin,
+            runtime.executable,
             "--pvpython-options",
             pvpython_options,
             "--bind-host",
@@ -369,6 +380,155 @@ class Paraview(Application):
             self._execution_info(environment, line_callback),
         ).run()
         self._raise_for_exec_failure(result, operation="ParaView service")
+
+    def _validate_legacy_runtime_configuration(self) -> None:
+        """Reject implementation overrides while accepting old no-op defaults."""
+        for field, executable in (
+            ("pvbatch_bin", "pvbatch"),
+            ("pvpython_bin", "pvpython"),
+        ):
+            configured = self.config.get(field)
+            if configured in (None, "", executable):
+                continue
+            raise ValueError(
+                f"ParaView {field} is no longer configurable; make {executable} "
+                "available through the JARVIS pipeline execution environment PATH"
+            )
+        for field, executable in (
+            ("pvbatch_options", "pvbatch"),
+            ("pvpython_options", "pvpython"),
+        ):
+            configured = self.config.get(field)
+            if configured in (None, ""):
+                continue
+            raise ValueError(
+                f"ParaView {field} is no longer configurable; builtin.paraview "
+                f"detects supported headless arguments from {executable}"
+            )
+
+    def _resolve_runtime(
+        self,
+        mode: str,
+        environment: dict[str, str],
+    ) -> _ParaViewRuntime:
+        """Resolve and probe the mode-specific launcher from ``self.mod_env``."""
+        executable_name = _MODE_EXECUTABLES.get(mode)
+        if executable_name is None:
+            raise ValueError(f"Unsupported ParaView mode: {mode!r}")
+        exec_info = self._runtime_probe_info(environment)
+        resolver = Which(executable_name, exec_info)
+        resolver.run()
+        failures = self._failed_exit_codes(resolver)
+        resolved = self._first_output_line(resolver.stdout)
+        if failures or not resolved:
+            path = environment.get("PATH")
+            path_context = "the configured PATH" if path else "PATH"
+            raise RuntimeError(
+                f"builtin.paraview mode={mode!r} requires {executable_name!r} "
+                f"in the JARVIS execution environment {path_context}; install "
+                "ParaView or select a pipeline environment that provides it"
+            )
+
+        help_result = Exec(
+            f"{shlex.quote(resolved)} --help",
+            exec_info,
+        ).run()
+        help_failures = self._failed_exit_codes(help_result)
+        if help_failures:
+            details = ", ".join(f"{host}={code!r}" for host, code in help_failures)
+            diagnostic = self._bounded_stderr(help_result, help_failures)
+            raise RuntimeError(
+                f"ParaView capability probe failed for {resolved!r}: {details}"
+                f"{diagnostic}"
+            )
+        help_text = "\n".join(
+            value
+            for output in (help_result.stdout, help_result.stderr)
+            if isinstance(output, dict)
+            for value in output.values()
+            if isinstance(value, str)
+        )
+        capabilities = frozenset(
+            argument for argument in _HEADLESS_ARGUMENTS if argument in help_text
+        )
+        return _ParaViewRuntime(
+            executable=resolved,
+            capabilities=capabilities,
+        )
+
+    def _runtime_probe_info(self, environment: dict[str, str]) -> LocalExecInfo:
+        """Use the same host, container, environment, and cwd as package launch."""
+        common: dict[str, Any] = {
+            "env": environment,
+            "cwd": os.path.expandvars(cast(str, self.config.get("cwd") or "")) or None,
+            "hostfile": self.hostfile,
+            "hide_output": True,
+            "timeout": 30,
+        }
+        if self.config.get("deploy_mode") == "container":
+            common.update(
+                {
+                    "container": self._container_engine,
+                    "container_image": self.deploy_image_name(),
+                    "shared_dir": self.shared_dir,
+                    "private_dir": self.private_dir,
+                    "bind_mounts": self.container_mounts,
+                }
+            )
+        return LocalExecInfo(**common)
+
+    @staticmethod
+    def _first_output_line(output: Any) -> str:
+        """Return the first printable non-empty line from executor output."""
+        if not isinstance(output, dict):
+            return ""
+        for host in sorted(output, key=str):
+            value = output[host]
+            if not isinstance(value, str):
+                continue
+            for line in value.splitlines():
+                candidate = line.strip()
+                if candidate and all(ord(character) >= 32 for character in candidate):
+                    return candidate
+        return ""
+
+    @staticmethod
+    def _failed_exit_codes(result: Any) -> list[tuple[Any, Any]]:
+        """Return deterministic nonzero or malformed executor statuses."""
+        exit_codes = getattr(result, "exit_code", None)
+        if not isinstance(exit_codes, dict) or not exit_codes:
+            return [("runtime", "missing")]
+        return sorted(
+            (
+                (host, code)
+                for host, code in exit_codes.items()
+                if isinstance(code, bool) or not isinstance(code, int) or code != 0
+            ),
+            key=lambda item: str(item[0]),
+        )
+
+    @staticmethod
+    def _bounded_stderr(
+        result: Any,
+        failures: list[tuple[Any, Any]],
+    ) -> str:
+        """Return bounded stderr for a failed runtime capability probe."""
+        stderr_by_host = getattr(result, "stderr", None)
+        if not isinstance(stderr_by_host, dict):
+            return ""
+        messages = []
+        for host, _code in failures:
+            stderr = stderr_by_host.get(host)
+            if stderr is None:
+                stderr = stderr_by_host.get(str(host))
+            if isinstance(stderr, str) and stderr.strip():
+                messages.append(f"{host}: {' '.join(stderr.split())}")
+        if not messages:
+            return ""
+        bounded = "; ".join(messages)
+        if len(bounded) > _EXEC_FAILURE_STDERR_LIMIT:
+            bounded = bounded[: _EXEC_FAILURE_STDERR_LIMIT - 3] + "..."
+        return f"; stderr: {bounded}"
 
     @staticmethod
     def _load_dataset_descriptor(

--- a/docs/package-progress.md
+++ b/docs/package-progress.md
@@ -51,8 +51,10 @@ so they never need direct access to a host-only execution path.
 ## ParaView
 
 `builtin.paraview` supports both `server` and generic `batch` modes. Batch mode
-accepts a user or site-owned script, `pvbatch_bin`, and `pvbatch_options` (for
-example `--mesa` on a compatible installation). The bundled
+accepts a user or site-owned script and semantic script arguments. It resolves
+`pvbatch` from the pipeline execution environment and detects supported
+headless launcher arguments itself, selecting one backend rather than stacking
+backend-selection flags. The bundled
 `progress_reporter.py` is intentionally Python 3.10-compatible and imports no
 JARVIS modules because ParaView may bundle an older Python than JARVIS. It emits
 structured stdout only; the JARVIS parent validates identity and sequence, then

--- a/docs/service-runtimes.md
+++ b/docs/service-runtimes.md
@@ -190,14 +190,20 @@ pkg_type: builtin.paraview
 pkg_name: viewer
 mode: service
 dataset_descriptor: /site/descriptors/asteroid-subset.json
-pvpython_bin: /opt/ParaView/bin/pvpython
-pvpython_options: --mesa
 service_bind_host: 127.0.0.1
 service_advertise_host: 127.0.0.1
 service_port: 0
 service_startup_timeout: 120
 nprocs: 1
 ```
+
+`builtin.paraview` resolves `pvpython` from the pipeline execution
+environment's `PATH`. Service mode is intrinsically headless, so the package
+probes the installed launcher and selects one supported backend itself:
+`--mesa` when advertised, otherwise `--force-offscreen-rendering`. Site paths
+and raw ParaView launcher flags are not part of the semantic package contract.
+A missing or unusable `pvpython` dependency fails the package explicitly
+before the service supervisor starts.
 
 The ParaView backend is deliberately loopback-only. The relay connector must
 run inside the execution's owned allocation and dial `127.0.0.1`; JARVIS

--- a/test/unit/core/test_config_state_roots.py
+++ b/test/unit/core/test_config_state_roots.py
@@ -198,17 +198,12 @@ def test_stale_managed_builtin_repo_binds_to_running_distribution(
         )
 
         package = Pkg.load_standalone("builtin.paraview")
-        setting = next(
-            item
-            for item in package.configure_menu()
-            if item.get("name") == "pvpython_bin"
-        )
-        assert setting == {
-            "name": "pvpython_bin",
-            "msg": "Path or command used to launch the ParaView service",
-            "type": str,
-            "default": "pvpython",
-        }
+        settings = {str(item.get("name")): item for item in package.configure_menu()}
+        assert "pvpython_bin" not in settings
+        assert "pvpython_options" not in settings
+        assert "pvbatch_bin" not in settings
+        assert "pvbatch_options" not in settings
+        assert settings["mode"]["default"] == "server"
         assert (
             Path(package.pkg_dir)
             .resolve()

--- a/test/unit/core/test_paraview_progress.py
+++ b/test/unit/core/test_paraview_progress.py
@@ -181,22 +181,46 @@ def _load_paraview_package() -> ModuleType:
 class _CapturedExec:
     commands: list[tuple[str, Any]] = []
     exit_codes: dict[str, int] = {"localhost": 0}
+    help_text = "--mesa\n--force-offscreen-rendering\n"
 
     def __init__(self, command: str, exec_info: Any) -> None:
         self.command = command
         self.exec_info = exec_info
-        self.exit_code = dict(self.exit_codes)
-        self.commands.append((command, exec_info))
+        self.stdout = {"localhost": ""}
+        self.stderr = {"localhost": ""}
+        if command.endswith(" --help"):
+            self.exit_code = {"localhost": 0}
+            self.stdout["localhost"] = self.help_text
+        else:
+            self.exit_code = dict(self.exit_codes)
+            self.commands.append((command, exec_info))
 
     def run(self) -> "_CapturedExec":
         return self
 
 
-def test_generic_paraview_batch_honors_binary_options_and_hostfile(
+class _ResolvedWhich:
+    """Resolve the requested launcher inside a deterministic package PATH."""
+
+    calls: list[tuple[str, Any]] = []
+
+    def __init__(self, executable: str, exec_info: Any) -> None:
+        self.executable = executable
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+        self.stdout = {"localhost": f"/runtime/paraview/bin/{executable}\n"}
+        self.stderr = {"localhost": ""}
+        self.calls.append((executable, exec_info))
+
+    def run(self) -> "_ResolvedWhich":
+        return self
+
+
+def test_generic_paraview_batch_resolves_runtime_and_hostfile(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Ares can select pvbatch, --mesa, and the allocated hostfile generically."""
+    """The package resolves pvbatch and headless flags in its execution context."""
     module = _load_paraview_package()
     package = object.__new__(module.Paraview)
     assert module.__file__ is not None
@@ -213,8 +237,6 @@ def test_generic_paraview_batch_honors_binary_options_and_hostfile(
         "mode": "batch",
         "nprocs": 2,
         "ppn": 2,
-        "pvbatch_bin": "/opt/paraview/bin/pvbatch",
-        "pvbatch_options": "--mesa --verbosity INFO",
         "script": str(tmp_path / "asteroid script.py"),
         "script_args": "--frames 2",
     }
@@ -227,17 +249,21 @@ def test_generic_paraview_batch_honors_binary_options_and_hostfile(
     }
     _CapturedExec.commands = []
     _CapturedExec.exit_codes = {"localhost": 0}
+    _ResolvedWhich.calls = []
     monkeypatch.setattr(module, "Exec", _CapturedExec)
+    monkeypatch.setattr(module, "Which", _ResolvedWhich)
 
     package.start()
 
     command, exec_info = _CapturedExec.commands[0]
-    assert command.startswith("/opt/paraview/bin/pvbatch --mesa --verbosity INFO")
-    assert "--force-offscreen-rendering" in command
+    assert command.startswith("/runtime/paraview/bin/pvbatch --mesa")
+    assert "--force-offscreen-rendering" not in command
     assert exec_info.hostfile is hostfile
     assert exec_info.env["JARVIS_PACKAGE_NAME"] == "builtin.paraview"
     assert exec_info.env["JARVIS_PACKAGE_ID"] == "asteroid_render"
     assert exec_info.env["JARVIS_PROGRESS_TRANSPORT"] == "stdout"
+    assert [call[0] for call in _ResolvedWhich.calls] == ["pvbatch"]
+    assert _ResolvedWhich.calls[0][1].hostfile is hostfile
     reporter_path = Path(exec_info.env["JARVIS_PARAVIEW_REPORTER"])
     assert reporter_path.parent == Path(package.shared_dir) / ".jarvis-progress"
     assert module.__file__ is not None
@@ -277,8 +303,6 @@ def test_single_process_container_stages_reporter_and_uses_local_exec(
         "mode": "batch",
         "nprocs": 1,
         "ppn": 1,
-        "pvbatch_bin": "pvbatch",
-        "pvbatch_options": "--mesa",
         "script": str(tmp_path / "render.py"),
         "script_args": "--frames 2",
     }
@@ -297,7 +321,9 @@ def test_single_process_container_stages_reporter_and_uses_local_exec(
     }
     _CapturedExec.commands = []
     _CapturedExec.exit_codes = {"localhost": 0}
+    _ResolvedWhich.calls = []
     monkeypatch.setattr(module, "Exec", _CapturedExec)
+    monkeypatch.setattr(module, "Which", _ResolvedWhich)
 
     package.start()
 
@@ -314,6 +340,9 @@ def test_single_process_container_stages_reporter_and_uses_local_exec(
     assert reporter_path.is_file()
     assert reporter_path.parent == Path(package.shared_dir) / ".jarvis-progress"
     assert exec_info.env["PYTHONPATH"].split(os.pathsep)[0] == str(reporter_path.parent)
+    probe_info = _ResolvedWhich.calls[0][1]
+    assert probe_info.container == "apptainer"
+    assert probe_info.container_image == "paraview-progress-exec"
 
 
 @pytest.mark.parametrize(
@@ -340,8 +369,6 @@ def test_paraview_exit_failure_propagates_to_pipeline(
         "nprocs": 1,
         "ppn": 1,
         "port_id": 11111,
-        "pvbatch_bin": "pvbatch",
-        "pvbatch_options": "--mesa",
         "script": str(tmp_path / "render.py"),
         "script_args": "",
         "time_out": 10,
@@ -351,7 +378,9 @@ def test_paraview_exit_failure_propagates_to_pipeline(
     package.mod_env = {}
     _CapturedExec.commands = []
     _CapturedExec.exit_codes = {"compute-1": 7}
+    _ResolvedWhich.calls = []
     monkeypatch.setattr(module, "Exec", _CapturedExec)
+    monkeypatch.setattr(module, "Which", _ResolvedWhich)
 
     with pytest.raises(RuntimeError, match=rf"{operation} failed.*compute-1=7"):
         package.start()

--- a/test/unit/core/test_paraview_service.py
+++ b/test/unit/core/test_paraview_service.py
@@ -403,15 +403,47 @@ class _CapturedExec:
     """Capture a real package launch boundary without starting pvpython."""
 
     commands: list[tuple[str, Any]] = []
+    help_text = "--mesa\n--force-offscreen-rendering\n"
 
     def __init__(self, command: str, exec_info: Any) -> None:
         self.command = command
         self.exec_info = exec_info
         self.exit_code = {"localhost": 0}
-        self.commands.append((command, exec_info))
+        self.stdout = {"localhost": ""}
+        self.stderr = {"localhost": ""}
+        if command.endswith(" --help"):
+            self.stdout["localhost"] = self.help_text
+        else:
+            self.commands.append((command, exec_info))
 
     def run(self) -> "_CapturedExec":
         return self
+
+
+class _ResolvedWhich:
+    """Resolve package launchers without depending on host ParaView installs."""
+
+    calls: list[tuple[str, Any]] = []
+
+    def __init__(self, executable: str, exec_info: Any) -> None:
+        self.executable = executable
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+        self.stdout = {"localhost": f"/runtime/paraview/bin/{executable}\n"}
+        self.stderr = {"localhost": ""}
+        self.calls.append((executable, exec_info))
+
+    def run(self) -> "_ResolvedWhich":
+        return self
+
+
+class _MissingWhich(_ResolvedWhich):
+    """Represent one absent mode-specific ParaView launcher."""
+
+    def __init__(self, executable: str, exec_info: Any) -> None:
+        super().__init__(executable, exec_info)
+        self.exit_code = {"localhost": 1}
+        self.stdout = {"localhost": ""}
 
 
 class _Backend:
@@ -1115,8 +1147,6 @@ def test_package_service_mode_stages_generic_runtime_and_owned_output(
         "ppn": 1,
         "cwd": "",
         "dataset_descriptor": json.dumps(descriptor),
-        "pvpython_bin": "/opt/paraview/bin/pvpython",
-        "pvpython_options": "--mesa",
         "force_offscreen_rendering": True,
         "service_bind_host": "127.0.0.1",
         "service_advertise_host": "127.0.0.1",
@@ -1126,6 +1156,7 @@ def test_package_service_mode_stages_generic_runtime_and_owned_output(
     package.pipeline = SimpleNamespace(get_hostfile=lambda: object())
     package.env = {}
     package.mod_env = {
+        "PATH": "/runtime/paraview/bin",
         "JARVIS_EXECUTION_ID": "exec-render",
         "JARVIS_PACKAGE_NAME": "builtin.paraview",
         "JARVIS_PACKAGE_ID": "viewer",
@@ -1138,14 +1169,17 @@ def test_package_service_mode_stages_generic_runtime_and_owned_output(
         ),
     }
     _CapturedExec.commands = []
+    _ResolvedWhich.calls = []
     monkeypatch.setattr(package_module, "Exec", _CapturedExec)
+    monkeypatch.setattr(package_module, "Which", _ResolvedWhich)
 
     package.start()
 
     command, exec_info = _CapturedExec.commands[0]
     assert "service_supervisor.py" in command
-    assert "/opt/paraview/bin/pvpython" in command
-    assert "--pvpython-options '--mesa --force-offscreen-rendering'" in command
+    assert "/runtime/paraview/bin/pvpython" in command
+    assert "--pvpython-options --mesa" in command
+    assert "--force-offscreen-rendering" not in command
     assert "--bind-host 127.0.0.1" in command
     assert "--advertise-host 127.0.0.1" in command
     assert exec_info.env["JARVIS_SERVICE_RUNTIME_PATH"].endswith(
@@ -1166,10 +1200,12 @@ def test_package_service_mode_stages_generic_runtime_and_owned_output(
     )
     assert staged_descriptor == descriptor
 
-    package.config["pvpython_options"] = "--mesa --force-offscreen-rendering"
     package._start_service(dict(package.mod_env))
     deduplicated_command, _ = _CapturedExec.commands[1]
-    assert deduplicated_command.count("--force-offscreen-rendering") == 1
+    assert deduplicated_command.count("--mesa") == 1
+    assert "--force-offscreen-rendering" not in deduplicated_command
+    assert [call[0] for call in _ResolvedWhich.calls] == ["pvpython", "pvpython"]
+    assert _ResolvedWhich.calls[0][1].env["PATH"] == "/runtime/paraview/bin"
 
     package.config["service_bind_host"] = "0.0.0.0"
     with pytest.raises(ValueError, match="loopback-only"):
@@ -1230,6 +1266,15 @@ def test_package_requires_service_mode_for_live_dataset_descriptor(mode: str) ->
     package._configure()
 
 
+def test_package_rejects_unknown_mode_during_configuration() -> None:
+    """An invalid mode cannot survive configuration until package startup."""
+    package = cast(Any, object.__new__(package_module.Paraview))
+    package.config = {"mode": "site-wrapper", "dataset_descriptor": ""}
+
+    with pytest.raises(ValueError, match="Unsupported ParaView mode"):
+        package._configure()
+
+
 def test_package_parameters_describe_live_view_service_mode() -> None:
     """Agent-facing parameter help explains the live-view mode contract."""
     package = cast(Any, object.__new__(package_module.Paraview))
@@ -1239,6 +1284,82 @@ def test_package_parameters_describe_live_view_service_mode() -> None:
 
     assert "service for a live dataset view" in parameters["mode"]["msg"]
     assert "requires mode=service" in parameters["dataset_descriptor"]["msg"]
+    assert (
+        "service mode is always headless"
+        in parameters["force_offscreen_rendering"]["msg"]
+    )
+    assert "pvpython_bin" not in parameters
+    assert "pvpython_options" not in parameters
+    assert "pvbatch_bin" not in parameters
+    assert "pvbatch_options" not in parameters
+
+
+def test_package_selects_one_deterministic_headless_backend() -> None:
+    """Mesa is preferred when available, with force-offscreen as fallback."""
+    both = package_module._ParaViewRuntime(
+        executable="/runtime/bin/pvpython",
+        capabilities=frozenset({"--force-offscreen-rendering", "--mesa"}),
+    )
+    fallback = package_module._ParaViewRuntime(
+        executable="/runtime/bin/pvpython",
+        capabilities=frozenset({"--force-offscreen-rendering"}),
+    )
+
+    assert both.arguments(force_offscreen=True) == ("--mesa",)
+    assert fallback.arguments(force_offscreen=True) == ("--force-offscreen-rendering",)
+    assert both.arguments(force_offscreen=False) == ()
+
+
+@pytest.mark.parametrize(
+    ("mode", "executable"),
+    [
+        ("service", "pvpython"),
+        ("batch", "pvbatch"),
+        ("server", "pvserver"),
+    ],
+)
+def test_package_fails_clearly_when_mode_runtime_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+    executable: str,
+) -> None:
+    """Each mode checks its own dependency in the JARVIS execution PATH."""
+    package = cast(Any, object.__new__(package_module.Paraview))
+    package.config = {"cwd": ""}
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: object())
+    _MissingWhich.calls = []
+    monkeypatch.setattr(package_module, "Which", _MissingWhich)
+
+    with pytest.raises(RuntimeError) as error:
+        package._resolve_runtime(mode, {"PATH": "/jarvis/environment/bin"})
+
+    message = str(error.value)
+    assert f"mode={mode!r}" in message
+    assert repr(executable) in message
+    assert "JARVIS execution environment" in message
+    assert _MissingWhich.calls[0][1].env == {"PATH": "/jarvis/environment/bin"}
+
+
+def test_package_rejects_legacy_launcher_overrides() -> None:
+    """Executable paths and raw launcher flags are not semantic parameters."""
+    package = cast(Any, object.__new__(package_module.Paraview))
+    package.config = {
+        "mode": "server",
+        "dataset_descriptor": "",
+        "pvpython_bin": "/site/ParaView/bin/pvpython",
+    }
+
+    with pytest.raises(ValueError, match="execution environment PATH"):
+        package._configure()
+
+    package.config = {
+        "mode": "server",
+        "dataset_descriptor": "",
+        "pvpython_bin": "pvpython",
+        "pvpython_options": "--mesa",
+    }
+    with pytest.raises(ValueError, match="detects supported headless arguments"):
+        package._configure()
 
 
 def test_package_exec_failure_preserves_bounded_stderr() -> None:


### PR DESCRIPTION
## Summary
- keep bootstrap package-agnostic and move ParaView dependency discovery into `builtin.paraview`
- resolve `pvpython`, `pvbatch`, or `pvserver` from the JARVIS execution environment by mode
- make service mode intrinsically headless with package-owned capability selection
- remove executable paths and raw launcher flags from the agent-facing package menu
- fail explicitly when the selected environment does not provide a usable ParaView runtime

## Focused validation
- 50 focused ParaView/config/progress tests passed
- Ruff clean
- package Pyright clean
- git diff check clean