### PR TITLE
fix(release): accept operator request BOM

### DIFF
--- a/ci/release_request.py
+++ b/ci/release_request.py
@@ -54,6 +54,11 @@ def validate_release_request(
     """Return an exact release request after validating every field."""
     if len(raw.encode("utf-8")) > MAX_REQUEST_BYTES:
         raise ReleaseRequestError("release request exceeds its byte limit")
+    # PowerShell can prepend a UTF-8 BOM when an operator pipes JSON into
+    # ``gh``. RFC 8259 permits parsers to ignore that marker for
+    # interoperability; remove only a single leading marker so malformed
+    # content elsewhere remains invalid.
+    raw = raw.removeprefix("\ufeff")
     if STABLE_TAG_PATTERN.fullmatch(tag) is None:
         raise ReleaseRequestError("release tag must be a stable vX.Y.Z tag")
     if COMMIT_PATTERN.fullmatch(commit) is None:

--- a/test/unit/test_release_request.py
+++ b/test/unit/test_release_request.py
@@ -67,6 +67,21 @@ def test_valid_request_is_canonicalized() -> None:
     assert _validate(record) == record
 
 
+def test_valid_request_accepts_single_leading_utf8_bom() -> None:
+    record = _record()
+
+    canonical = canonical_release_request(
+        "\ufeff" + json.dumps(record),
+        repository=REPOSITORY,
+        tag=TAG,
+        commit=COMMIT,
+        now_epoch=NOW,
+        max_age_seconds=3_600,
+    )
+
+    assert canonical == json.dumps(record, separators=(",", ":"), sort_keys=True)
+
+
 @pytest.mark.parametrize(
     ("mutate", "message"),
     [


### PR DESCRIPTION
Accept a single leading UTF-8 BOM in the exact release-request validator. This preserves strict field, commit, tag, and freshness validation while allowing PowerShell-authored GitHub variables to be parsed consistently.\n\nFocused verification: 17 release-request tests, Ruff, Pyright, and diff checks pass.