### PR TITLE
fix(paraview): preserve source discovery across filters

### DIFF
--- a/builtin/builtin/paraview/service.py
+++ b/builtin/builtin/paraview/service.py
@@ -373,8 +373,12 @@ class ParaViewBackend:
                 proxy.LowerThreshold = threshold_lower
                 proxy.UpperThreshold = threshold_upper
             proxy.UpdatePipeline()
-            new_arrays = self._discover_arrays(proxy)
-            new_bounds = self._discover_bounds(proxy)
+            # Inspect the derived output while keeping ``dataset.discovery`` bound to
+            # the opened source descriptor. Filter state belongs to ``pipeline``;
+            # replacing source arrays or bounds here makes dataset identity drift and
+            # turns a geometric slice into an apparent dataset mutation.
+            self._discover_arrays(proxy)
+            self._discover_bounds(proxy)
             new_display = self.simple.Show(proxy, self.view)
             self.simple.Hide(previous_source, self.view)
             _apply_camera_state(self.view, previous_camera)
@@ -397,8 +401,6 @@ class ParaViewBackend:
         self.active_source = proxy
         self.display = new_display
         self._filters.append(record)
-        self._arrays = new_arrays
-        self._bounds = new_bounds
         self._active_field = None
         self._colormap = None
         self._selection = None

--- a/test/unit/core/test_paraview_service.py
+++ b/test/unit/core/test_paraview_service.py
@@ -857,8 +857,8 @@ class _FilterSimple:
         return
 
 
-def test_filter_validates_atomically_and_preserves_explicit_camera() -> None:
-    """Filters have no hidden reset and commit only after full validation."""
+def test_filter_preserves_dataset_discovery_and_explicit_camera() -> None:
+    """Filters mutate pipeline state without rewriting source dataset discovery."""
     backend = cast(Any, object.__new__(service_module.ParaViewBackend))
     previous_source = object()
     backend.active_source = previous_source
@@ -866,13 +866,18 @@ def test_filter_validates_atomically_and_preserves_explicit_camera() -> None:
     backend.view = _CameraView()
     backend.simple = _FilterSimple()
     backend._filters = []
-    backend._arrays = []
+    backend._arrays = [{"name": "pressure", "association": "point", "components": 1}]
+    backend._bounds = (-10.0, 10.0, -20.0, 20.0, -30.0, 30.0)
     backend._active_field = {"name": "pressure", "association": "point"}
     backend._colormap = {"preset": "Viridis", "invert": False}
     backend._selection = {"status": "selected"}
-    backend._discover_arrays = lambda _source=None: []
+    backend._discover_arrays = lambda _source=None: [
+        {"name": "slice-pressure", "association": "point", "components": 1}
+    ]
     backend._discover_bounds = lambda _source=None: (0.0, 1.0, 0.0, 1.0, 0.0, 1.0)
     original_camera = backend._camera_state()
+    original_arrays = list(backend._arrays)
+    original_bounds = backend._bounds
 
     with pytest.raises(CommandError, match="zero vector"):
         backend._apply_filter(
@@ -902,6 +907,8 @@ def test_filter_validates_atomically_and_preserves_explicit_camera() -> None:
     assert backend.active_source is backend.simple.proxy
     assert backend.simple.proxy.updated is True
     assert backend._camera_state() == original_camera
+    assert backend._arrays == original_arrays
+    assert backend._bounds == original_bounds
     assert backend._active_field is None
     assert backend._colormap is None
     assert backend._selection is None


### PR DESCRIPTION
## What changed

- keep source dataset arrays and bounds immutable after ParaView filters
- retain filter output validation and explicit camera preservation
- add a focused regression proving derived slice geometry cannot rewrite dataset.discovery

## Why

The live Ares asteroid run successfully applied one center slice, but JARVIS v1.3.16 republished the slice proxy bounds as source dataset discovery. VIGIL correctly rejected that dataset-identity drift. Runtime identity, timestep, and camera were unchanged.

## Verification

- reproducer failed against current v1.3.16 behavior
- focused ParaView regression passes after the fix
- Ruff clean/formatted
- production module Pyright: 0 errors
- live failure captured through released clio-relay 1.3.33, clio-kit 2.5.13, and JARVIS 1.3.16 on Ares