### PR TITLE
refactor(paraview): separate dataset and pipeline discovery

### DIFF
--- a/builtin/builtin/paraview/service.py
+++ b/builtin/builtin/paraview/service.py
@@ -86,6 +86,9 @@ class ParaViewBackend:
         self._arrays = self._discover_arrays()
         self._bounds = self._discover_bounds()
         self._timesteps = self._discover_timesteps()
+        self._dataset_arrays = _json_copy_list(self._arrays)
+        self._dataset_bounds = tuple(self._bounds) if self._bounds is not None else None
+        self._dataset_timesteps = list(self._timesteps)
         self._timestep_index = 0
 
     def dataset_state(self) -> Dict[str, Any]:
@@ -93,9 +96,13 @@ class ParaViewBackend:
         return {
             "descriptor": _json_copy(self.descriptor),
             "discovery": {
-                "arrays": _json_copy_list(self._arrays),
-                "bounds": list(self._bounds) if self._bounds is not None else None,
-                "timestep_values": list(self._timesteps),
+                "arrays": _json_copy_list(self._dataset_arrays),
+                "bounds": (
+                    list(self._dataset_bounds)
+                    if self._dataset_bounds is not None
+                    else None
+                ),
+                "timestep_values": list(self._dataset_timesteps),
             },
         }
 
@@ -373,12 +380,8 @@ class ParaViewBackend:
                 proxy.LowerThreshold = threshold_lower
                 proxy.UpperThreshold = threshold_upper
             proxy.UpdatePipeline()
-            # Inspect the derived output while keeping ``dataset.discovery`` bound to
-            # the opened source descriptor. Filter state belongs to ``pipeline``;
-            # replacing source arrays or bounds here makes dataset identity drift and
-            # turns a geometric slice into an apparent dataset mutation.
-            self._discover_arrays(proxy)
-            self._discover_bounds(proxy)
+            new_arrays = self._discover_arrays(proxy)
+            new_bounds = self._discover_bounds(proxy)
             new_display = self.simple.Show(proxy, self.view)
             self.simple.Hide(previous_source, self.view)
             _apply_camera_state(self.view, previous_camera)
@@ -401,6 +404,8 @@ class ParaViewBackend:
         self.active_source = proxy
         self.display = new_display
         self._filters.append(record)
+        self._arrays = new_arrays
+        self._bounds = new_bounds
         self._active_field = None
         self._colormap = None
         self._selection = None

--- a/test/unit/core/test_paraview_service.py
+++ b/test/unit/core/test_paraview_service.py
@@ -868,6 +868,14 @@ def test_filter_preserves_dataset_discovery_and_explicit_camera() -> None:
     backend._filters = []
     backend._arrays = [{"name": "pressure", "association": "point", "components": 1}]
     backend._bounds = (-10.0, 10.0, -20.0, 20.0, -30.0, 30.0)
+    backend._timesteps = [0.0, 1.0]
+    backend._dataset_arrays = list(backend._arrays)
+    backend._dataset_bounds = backend._bounds
+    backend._dataset_timesteps = list(backend._timesteps)
+    backend.descriptor = {
+        "schema_version": "jarvis.dataset-descriptor.v1",
+        "dataset_id": "source-volume",
+    }
     backend._active_field = {"name": "pressure", "association": "point"}
     backend._colormap = {"preset": "Viridis", "invert": False}
     backend._selection = {"status": "selected"}
@@ -876,8 +884,7 @@ def test_filter_preserves_dataset_discovery_and_explicit_camera() -> None:
     ]
     backend._discover_bounds = lambda _source=None: (0.0, 1.0, 0.0, 1.0, 0.0, 1.0)
     original_camera = backend._camera_state()
-    original_arrays = list(backend._arrays)
-    original_bounds = backend._bounds
+    original_discovery = backend.dataset_state()
 
     with pytest.raises(CommandError, match="zero vector"):
         backend._apply_filter(
@@ -907,8 +914,11 @@ def test_filter_preserves_dataset_discovery_and_explicit_camera() -> None:
     assert backend.active_source is backend.simple.proxy
     assert backend.simple.proxy.updated is True
     assert backend._camera_state() == original_camera
-    assert backend._arrays == original_arrays
-    assert backend._bounds == original_bounds
+    assert backend.dataset_state() == original_discovery
+    assert backend._arrays == [
+        {"name": "slice-pressure", "association": "point", "components": 1}
+    ]
+    assert backend._bounds == (0.0, 1.0, 0.0, 1.0, 0.0, 1.0)
     assert backend._active_field is None
     assert backend._colormap is None
     assert backend._selection is None


### PR DESCRIPTION
## What changed

- snapshot source arrays, bounds, and timesteps when the dataset opens
- publish that immutable snapshot as dataset.discovery
- continue tracking derived arrays and bounds for chained pipeline operations
- strengthen the filter regression to prove both sides of the boundary

## Why

The first focused fix stopped source-discovery drift, but simply retaining the old active arrays/bounds would weaken later field and threshold validation. This follow-up keeps dataset identity immutable without discarding derived pipeline knowledge.

## Verification

- focused ParaView discovery/filter regression passes
- Ruff clean/formatted
- production module Pyright: 0 errors