### PR TITLE
fix(paraview): preserve physical runtime semantics

### DIFF
--- a/builtin/builtin/paraview/service.py
+++ b/builtin/builtin/paraview/service.py
@@ -31,6 +31,7 @@ MAX_SELECTION_RESULTS = 256
 MAX_EXPORTED_ARTIFACT_BYTES = 128 * 1024 * 1024
 LIVE_VIEW_SIZE = (960, 540)
 ARTIFACT_PREFIX = "JARVIS_ARTIFACT "
+DEFAULT_COLORMAP_PRESET = "Cool to Warm"
 
 
 class ParaViewBackend:
@@ -85,7 +86,8 @@ class ParaViewBackend:
         self._artifacts: List[Dict[str, Any]] = []
         self._arrays = self._discover_arrays()
         self._bounds = self._discover_bounds()
-        self._timesteps = self._discover_timesteps()
+        self._reader_timesteps = self._discover_reader_timesteps()
+        self._timesteps = self._resolve_timesteps(self._reader_timesteps)
         self._dataset_arrays = _json_copy_list(self._arrays)
         self._dataset_bounds = tuple(self._bounds) if self._bounds is not None else None
         self._dataset_timesteps = list(self._timesteps)
@@ -189,9 +191,12 @@ class ParaViewBackend:
                     "timestep index exceeds the discovered series",
                 )
             value = self._timesteps[index]
-            self.view.ViewTime = value
-            self.reader.UpdatePipeline(value)
-            self.active_source.UpdatePipeline(value)
+            if self._reader_timesteps:
+                reader_value = self._reader_timesteps[index]
+                self.view.ViewTime = reader_value
+                self.reader.UpdatePipeline(reader_value)
+                self.active_source.UpdatePipeline(reader_value)
+            self._refresh_active_field_range()
         self._timestep_index = index
         self.simple.Render(self.view)
         return {"timestep": {"index": index, "value": value}}
@@ -217,19 +222,27 @@ class ParaViewBackend:
                 "field_not_found",
                 "active field is not present in discovered ParaView arrays",
             )
+        scalar_range = self._array_range(name, association, match["components"])
+        lookup = self.simple.GetColorTransferFunction(name)
+        if not lookup.ApplyPreset(DEFAULT_COLORMAP_PRESET, True):
+            raise CommandError(
+                "preset_not_found",
+                "ParaView's default generic colormap preset was not found",
+            )
         paraview_association = "POINTS" if association == "point" else "CELLS"
         self.simple.ColorBy(self.display, (paraview_association, name))
         self.display.RescaleTransferFunctionToDataRange(True, False)
+        lookup.RescaleTransferFunction(*scalar_range)
         active_field = {
             "name": name,
             "association": association,
             "components": match["components"],
+            "range": scalar_range,
+            "units": match.get("units"),
         }
         self.simple.Render(self.view)
         self._active_field = active_field
-        # A transfer-function preset is bound to the previously active array.
-        # Changing arrays must not claim that preset is still applied.
-        self._colormap = None
+        self._colormap = {"preset": DEFAULT_COLORMAP_PRESET, "invert": False}
         return {"active_field": dict(self._active_field)}
 
     def _set_camera(
@@ -434,6 +447,7 @@ class ParaViewBackend:
         if invert:
             lookup.InvertTransferFunction()
         self.display.RescaleTransferFunctionToDataRange(True, False)
+        lookup.RescaleTransferFunction(*self._active_field["range"])
         self._colormap = {"preset": preset, "invert": invert}
         self.simple.Render(self.view)
         return {"colormap": dict(self._colormap)}
@@ -517,15 +531,17 @@ class ParaViewBackend:
                 servermanager=self.servermanager,
                 limit=MAX_SELECTION_RESULTS,
             )
-            self.simple.SelectSurfaceCells(
-                Rectangle=pixel_rectangle,
-                View=self.view,
-            )
-            self.simple.Render(self.view)
         except (AttributeError, RuntimeError, TypeError, ValueError):
             ids = []
             selected_count = None
             unsupported_reason = "paraview_surface_selection_unavailable"
+        try:
+            self.simple.ClearSelection(self.active_source)
+            self.simple.Render(self.view)
+        except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+            raise RuntimeError(
+                "ParaView could not clear the viewport selection highlight"
+            ) from exc
 
         if unsupported_reason is not None:
             status = "unsupported"
@@ -630,6 +646,72 @@ class ParaViewBackend:
                 )
         return arrays
 
+    def _array_range(
+        self,
+        name: str,
+        association: str,
+        components: int,
+    ) -> List[float]:
+        """Return the finite scalar or vector-magnitude range for one live array."""
+
+        information = self.active_source.GetDataInformation()
+        attribute_information = (
+            information.GetPointDataInformation()
+            if association == "point"
+            else information.GetCellDataInformation()
+        )
+        array_information = None
+        for index in range(min(attribute_information.GetNumberOfArrays(), 256)):
+            candidate = attribute_information.GetArrayInformation(index)
+            if candidate is not None and str(candidate.GetName()) == name:
+                array_information = candidate
+                break
+        if array_information is None:
+            raise CommandError(
+                "field_not_found",
+                "active field is not present in current ParaView array information",
+            )
+        current_components = int(array_information.GetNumberOfComponents())
+        if current_components != components:
+            raise CommandError(
+                "field_shape_changed",
+                "active field component count changed in current ParaView data",
+            )
+        component = 0 if components == 1 else -1
+        for method_name in ("GetComponentFiniteRange", "GetComponentRange"):
+            method = getattr(array_information, method_name, None)
+            if not callable(method):
+                continue
+            try:
+                values = cast(Sequence[Any], method(component))
+                scalar_range = [float(values[0]), float(values[1])]
+            except (IndexError, TypeError, ValueError, OverflowError):
+                continue
+            if (
+                all(math.isfinite(value) for value in scalar_range)
+                and scalar_range[0] <= scalar_range[1]
+            ):
+                return scalar_range
+        raise CommandError(
+            "field_range_unavailable",
+            "ParaView did not expose a finite range for the active field",
+        )
+
+    def _refresh_active_field_range(self) -> None:
+        """Refresh range semantics and the transfer function for the displayed data."""
+
+        if self._active_field is None:
+            return
+        scalar_range = self._array_range(
+            self._active_field["name"],
+            self._active_field["association"],
+            self._active_field["components"],
+        )
+        self.display.RescaleTransferFunctionToDataRange(True, False)
+        lookup = self.simple.GetColorTransferFunction(self._active_field["name"])
+        lookup.RescaleTransferFunction(*scalar_range)
+        self._active_field["range"] = scalar_range
+
     def _discover_bounds(
         self,
         source: Any = None,
@@ -643,16 +725,45 @@ class ParaViewBackend:
             return None
         return cast(Tuple[float, float, float, float, float, float], bounds)
 
-    def _discover_timesteps(self) -> List[float]:
+    def _discover_reader_timesteps(self) -> List[float]:
+        """Return ParaView's internal clock for the opened reader or file series."""
+
         values = getattr(self.reader, "TimestepValues", None)
         if values:
-            return [float(value) for value in values]
-        descriptor_values = [
-            member.get("timestep")
-            for member in self.descriptor["members"]
-            if member.get("timestep") is not None
-        ]
-        return [float(value) for value in descriptor_values]
+            parsed = [float(value) for value in values]
+            if not all(math.isfinite(value) for value in parsed):
+                raise RuntimeError("ParaView reader exposed a non-finite timestep")
+            return parsed
+        return []
+
+    def _resolve_timesteps(self, reader_values: Sequence[float]) -> List[float]:
+        """Resolve user-facing physical times without changing ParaView's reader clock.
+
+        Multi-file readers commonly synthesize ``0, 1, ...`` even when the catalog descriptor
+        carries physical simulation times. Descriptor values therefore label the public runtime,
+        while ``reader_values`` remain the clock used to drive ``ViewTime`` and ``UpdatePipeline``.
+        Partial or cardinality-mismatched metadata is rejected rather than silently mislabelled.
+        """
+
+        members = self.descriptor["members"]
+        configured = [member.get("timestep") for member in members]
+        present = [value is not None for value in configured]
+        if any(present) and not all(present):
+            raise ValueError(
+                "dataset descriptor timestep metadata must cover every member or no members"
+            )
+        if all(present):
+            physical = [float(cast(float, value)) for value in configured]
+            if reader_values and len(reader_values) != len(physical):
+                raise RuntimeError(
+                    "ParaView reader timestep count differs from the dataset descriptor"
+                )
+            if len(physical) > 1 and not reader_values:
+                raise RuntimeError(
+                    "ParaView did not expose a time axis for the descriptor member series"
+                )
+            return physical
+        return [float(value) for value in reader_values]
 
     def _camera_state(self) -> Dict[str, Any]:
         return {
@@ -740,6 +851,13 @@ def _validate_descriptor(value: Mapping[str, Any]) -> Dict[str, Any]:
         if member.get("index") != expected_index:
             raise ValueError("dataset member indexes must be contiguous")
         _normalized_absolute_path(member.get("location"))
+        timestep = member.get("timestep")
+        if timestep is not None and (
+            isinstance(timestep, bool)
+            or not isinstance(timestep, (int, float))
+            or not math.isfinite(float(timestep))
+        ):
+            raise ValueError("dataset member timestep must be a finite number")
     fingerprint = value.get("fingerprint")
     if (
         not isinstance(fingerprint, dict)

--- a/docs/service-runtimes.md
+++ b/docs/service-runtimes.md
@@ -145,6 +145,16 @@ ID returns HTTP 429 with `command_limit`, while every previously accepted ID
 remains replayable. Restarting the service creates a new service instance and
 a new command-ID lifetime.
 
+`set_active_field` reports the exact array `name`, `association`, component
+count, finite scalar (or vector-magnitude) `range`, and nullable `units`.
+JARVIS never infers missing units; when the runtime has no authoritative unit
+metadata the field reports `units: null`. Selecting a field applies the generic
+`Cool to Warm` preset and records it in `pipeline.colormap`; a later
+`set_colormap` remains explicit.
+Changing timesteps refreshes both the reported range and the transfer-function
+range for the displayed data. Applying a filter invalidates the active field
+and colormap, so a range from the pre-filter source cannot remain in state.
+
 `inspect_selection` accepts exactly one of two selector forms. A known element
 uses `{"association":"point|cell","index":N}`. A human drag box uses
 `{"viewport":{"x0":0.1,"y0":0.2,"x1":0.9,"y1":0.8}}`, with finite
@@ -157,7 +167,10 @@ also include the normalized `viewport` and exact `pixel_rectangle`. At most 256
 real IDs are returned while `selected_count` preserves the full count. A
 backend that cannot expose real selection IDs returns `status=unsupported`; an
 area with no visible cells returns `status=empty`. JARVIS never approximates a
-screen selection as world coordinates.
+screen selection as world coordinates. After collecting the IDs and count,
+the service clears ParaView's opaque selection highlight and renders the clean
+data view; clients can display the authoritative viewport as a non-obscuring
+overlay from the returned normalized rectangle.
 
 The `jarvis.paraview.command-result.v1` response contains the resulting full
 authoritative state and the real operation result. `/events` pushes those state

--- a/test/unit/core/test_paraview_service.py
+++ b/test/unit/core/test_paraview_service.py
@@ -599,14 +599,22 @@ class _SelectionView:
 
 
 class _SelectionSimple:
-    def __init__(self) -> None:
+    def __init__(self, *, fail_clear: bool = False) -> None:
         self.surface_calls: list[tuple[list[int], Any]] = []
+        self.cleared_sources: list[Any] = []
+        self.render_calls = 0
+        self.fail_clear = fail_clear
 
     def Render(self, _view: Any) -> None:
-        return
+        self.render_calls += 1
 
     def SelectSurfaceCells(self, *, Rectangle: list[int], View: Any) -> None:
         self.surface_calls.append((Rectangle, View))
+
+    def ClearSelection(self, source: Any) -> None:
+        self.cleared_sources.append(source)
+        if self.fail_clear:
+            raise RuntimeError("selection clear failed")
 
 
 def _command(
@@ -779,6 +787,7 @@ class _CameraView:
         self.CameraFocalPoint = [0.0, 0.0, 0.0]
         self.CameraViewUp = [0.0, 1.0, 0.0]
         self.CameraParallelScale = 5.0
+        self.ViewTime: float | None = None
 
 
 class _RenderSimple:
@@ -943,25 +952,122 @@ class _FieldDisplay:
         self.rescale_calls += 1
 
 
+class _FieldArrayInformation:
+    """Expose exact ParaView array identity and finite component ranges."""
+
+    def __init__(
+        self,
+        name: str,
+        components: int,
+        scalar_range: tuple[float, float],
+    ) -> None:
+        self.name = name
+        self.components = components
+        self.scalar_range = scalar_range
+        self.requested_components: list[int] = []
+
+    def GetName(self) -> str:
+        return self.name
+
+    def GetNumberOfComponents(self) -> int:
+        return self.components
+
+    def GetComponentFiniteRange(self, component: int) -> tuple[float, float]:
+        self.requested_components.append(component)
+        return self.scalar_range
+
+
+class _FieldAttributesInformation:
+    def __init__(self, arrays: list[_FieldArrayInformation]) -> None:
+        self.arrays = arrays
+
+    def GetNumberOfArrays(self) -> int:
+        return len(self.arrays)
+
+    def GetArrayInformation(self, index: int) -> _FieldArrayInformation:
+        return self.arrays[index]
+
+
+class _FieldDataInformation:
+    def __init__(
+        self,
+        *,
+        point_arrays: list[_FieldArrayInformation] | None = None,
+        cell_arrays: list[_FieldArrayInformation] | None = None,
+    ) -> None:
+        self.point_arrays = _FieldAttributesInformation(point_arrays or [])
+        self.cell_arrays = _FieldAttributesInformation(cell_arrays or [])
+
+    def GetPointDataInformation(self) -> _FieldAttributesInformation:
+        return self.point_arrays
+
+    def GetCellDataInformation(self) -> _FieldAttributesInformation:
+        return self.cell_arrays
+
+
+class _FieldSource:
+    def __init__(self, information: _FieldDataInformation) -> None:
+        self.information = information
+        self.update_times: list[float] = []
+
+    def GetDataInformation(self) -> _FieldDataInformation:
+        return self.information
+
+    def UpdatePipeline(self, value: float) -> None:
+        self.update_times.append(value)
+
+
+class _FieldLookup:
+    def __init__(self) -> None:
+        self.preset_calls: list[tuple[str, bool]] = []
+        self.rescale_calls: list[tuple[float, float]] = []
+        self.invert_calls = 0
+
+    def ApplyPreset(self, preset: str, rescale: bool) -> bool:
+        self.preset_calls.append((preset, rescale))
+        return True
+
+    def RescaleTransferFunction(self, lower: float, upper: float) -> None:
+        self.rescale_calls.append((lower, upper))
+
+    def InvertTransferFunction(self) -> None:
+        self.invert_calls += 1
+
+
 class _FieldSimple(_RenderSimple):
     """Record the actual ColorBy choice applied to a display."""
 
     def __init__(self) -> None:
         super().__init__()
         self.color_by: tuple[str, str] | None = None
+        self.lookup = _FieldLookup()
 
     def ColorBy(self, _display: object, field: tuple[str, str]) -> None:
         self.color_by = field
 
+    def GetColorTransferFunction(self, _name: str) -> _FieldLookup:
+        return self.lookup
 
-def test_active_field_change_clears_stale_colormap_semantics() -> None:
-    """A transfer preset is never claimed for a newly selected array."""
+
+def test_active_field_reports_exact_range_units_and_generic_colormap() -> None:
+    """Field state and transfer-function state come from the displayed ParaView data."""
     backend = cast(Any, object.__new__(service_module.ParaViewBackend))
-    backend._arrays = [{"name": "temperature", "association": "point", "components": 1}]
+    array = _FieldArrayInformation("temperature", 1, (-12.5, 38.25))
+    backend.active_source = _FieldSource(_FieldDataInformation(point_arrays=[array]))
+    backend._arrays = [
+        {
+            "name": "temperature",
+            "association": "point",
+            "components": 1,
+            "units": None,
+        }
+    ]
     backend._active_field = {
         "name": "pressure",
         "association": "point",
         "components": 1,
+        "range": [0.0, 1.0],
+        "units": "Pa",
     }
     backend._colormap = {"preset": "Viridis", "invert": False}
     backend.display = _FieldDisplay()
@@ -973,9 +1079,132 @@ def test_active_field_change_clears_stale_colormap_semantics() -> None:
         "cmd-field",
     )
 
-    assert result["active_field"]["name"] == "temperature"
+    assert result == {
+        "active_field": {
+            "name": "temperature",
+            "association": "point",
+            "components": 1,
+            "range": [-12.5, 38.25],
+            "units": None,
+        }
+    }
     assert backend.simple.color_by == ("POINTS", "temperature")
+    assert array.requested_components == [0]
+    assert backend.display.rescale_calls == 1
+    assert backend.simple.lookup.preset_calls == [
+        (service_module.DEFAULT_COLORMAP_PRESET, True)
+    ]
+    assert backend.simple.lookup.rescale_calls == [(-12.5, 38.25)]
+    assert backend._colormap == {
+        "preset": service_module.DEFAULT_COLORMAP_PRESET,
+        "invert": False,
+    }
+
+
+def test_timestep_refreshes_active_field_and_transfer_function_range() -> None:
+    """Physical timestep changes cannot leave the previous scalar range in state or color."""
+    backend = cast(Any, object.__new__(service_module.ParaViewBackend))
+    array = _FieldArrayInformation("pressure", 1, (2.5, 91.75))
+    source = _FieldSource(_FieldDataInformation(cell_arrays=[array]))
+    backend.active_source = source
+    backend.reader = _TimedPipelineProxy()
+    backend.view = SimpleNamespace(ViewTime=None)
+    backend.display = _FieldDisplay()
+    backend.simple = _FieldSimple()
+    backend._reader_timesteps = [0.0, 1.0]
+    backend._timesteps = [0.0, 1141.0]
+    backend._timestep_index = 0
+    backend._active_field = {
+        "name": "pressure",
+        "association": "cell",
+        "components": 1,
+        "range": [-1.0, 1.0],
+        "units": None,
+    }
+    backend._colormap = {
+        "preset": service_module.DEFAULT_COLORMAP_PRESET,
+        "invert": False,
+    }
+
+    result = backend._set_timestep({"index": 1}, "cmd-time")
+
+    assert result == {"timestep": {"index": 1, "value": 1141.0}}
+    assert backend.view.ViewTime == 1.0
+    assert backend.reader.update_times == [1.0]
+    assert source.update_times == [1.0]
+    assert backend._active_field == {
+        "name": "pressure",
+        "association": "cell",
+        "components": 1,
+        "range": [2.5, 91.75],
+        "units": None,
+    }
+    assert backend._colormap == {
+        "preset": service_module.DEFAULT_COLORMAP_PRESET,
+        "invert": False,
+    }
+    assert backend.display.rescale_calls == 1
+    assert backend.simple.lookup.rescale_calls == [(2.5, 91.75)]
+
+
+def test_active_field_rejects_non_finite_paraview_range() -> None:
+    """The service never publishes a guessed legend range for invalid array data."""
+    backend = cast(Any, object.__new__(service_module.ParaViewBackend))
+    array = _FieldArrayInformation("pressure", 1, (float("nan"), float("inf")))
+    backend.active_source = _FieldSource(_FieldDataInformation(point_arrays=[array]))
+    backend._arrays = [
+        {
+            "name": "pressure",
+            "association": "point",
+            "components": 1,
+            "units": None,
+        }
+    ]
+    backend._active_field = None
+    backend._colormap = None
+    backend.display = _FieldDisplay()
+    backend.simple = _FieldSimple()
+    backend.view = object()
+
+    with pytest.raises(CommandError) as captured:
+        backend._set_active_field(
+            {"name": "pressure", "association": "point"},
+            "cmd-field",
+        )
+
+    assert captured.value.code == "field_range_unavailable"
+    assert backend._active_field is None
     assert backend._colormap is None
+    assert backend.simple.color_by is None
+
+
+def test_explicit_colormap_preserves_authoritative_scalar_range() -> None:
+    """Changing only the preset cannot decouple its transfer range from field state."""
+    backend = cast(Any, object.__new__(service_module.ParaViewBackend))
+    backend._active_field = {
+        "name": "pressure",
+        "association": "point",
+        "components": 1,
+        "range": [-8.0, 144.0],
+        "units": None,
+    }
+    backend._colormap = {
+        "preset": service_module.DEFAULT_COLORMAP_PRESET,
+        "invert": False,
+    }
+    backend.display = _FieldDisplay()
+    backend.simple = _FieldSimple()
+    backend.view = object()
+
+    result = backend._set_colormap(
+        {"preset": "Viridis (matplotlib)", "invert": True},
+        "cmd-colormap",
+    )
+
+    assert result == {"colormap": {"preset": "Viridis (matplotlib)", "invert": True}}
+    assert backend.simple.lookup.preset_calls == [("Viridis (matplotlib)", True)]
+    assert backend.simple.lookup.rescale_calls == [(-8.0, 144.0)]
+    assert backend.simple.lookup.invert_calls == 1
 
 
 def test_http_health_state_command_conflict_and_frame_sse() -> None:
@@ -1049,6 +1278,101 @@ def test_missing_paraview_runtime_fails_explicitly(
             output_dir=tmp_path,
             service_instance_id="srv_0123456789abcdef0123456789abcdef",
         )
+
+
+class _TimedPipelineProxy:
+    """Capture the exact internal ParaView clock used for a timestep mutation."""
+
+    def __init__(self) -> None:
+        self.update_times: list[float] = []
+
+    def UpdatePipeline(self, value: float) -> None:
+        self.update_times.append(value)
+
+
+def test_descriptor_physical_timesteps_override_synthetic_reader_labels() -> None:
+    """Public state keeps catalog times while ParaView advances on its internal clock."""
+
+    backend = cast(Any, object.__new__(service_module.ParaViewBackend))
+    physical = [0.0, 1141.0, 2286.0, 3429.0, 4565.0]
+    backend.descriptor = {
+        "members": [
+            {
+                "index": index,
+                "location": f"/cluster/frame-{index}.vti",
+                "timestep": value,
+            }
+            for index, value in enumerate(physical)
+        ]
+    }
+    reader_clock = [0.0, 1.0, 2.0, 3.0, 4.0]
+
+    assert backend._resolve_timesteps(reader_clock) == physical
+
+    backend._reader_timesteps = reader_clock
+    backend._timesteps = physical
+    backend._timestep_index = 0
+    backend._active_field = None
+    backend._filters = []
+    backend._colormap = None
+    backend._selection = None
+    backend._artifacts = []
+    backend.view = _CameraView()
+    backend.view.ViewTime = None
+    backend.reader = _TimedPipelineProxy()
+    backend.active_source = _TimedPipelineProxy()
+    backend.simple = SimpleNamespace(Render=lambda _view: None)
+
+    result = backend._set_timestep({"index": 4}, "cmd-final")
+
+    assert result == {"timestep": {"index": 4, "value": 4565.0}}
+    assert backend.pipeline_state()["timestep"] == {
+        "index": 4,
+        "value": 4565.0,
+        "count": 5,
+    }
+    assert backend.view.ViewTime == 4.0
+    assert backend.reader.update_times == [4.0]
+    assert backend.active_source.update_times == [4.0]
+
+
+def test_descriptor_timestep_mapping_rejects_partial_or_mismatched_series() -> None:
+    backend = cast(Any, object.__new__(service_module.ParaViewBackend))
+    backend.descriptor = {
+        "members": [
+            {"index": 0, "location": "/cluster/frame-0.vti", "timestep": 0.0},
+            {"index": 1, "location": "/cluster/frame-1.vti"},
+        ]
+    }
+    with pytest.raises(ValueError, match="cover every member"):
+        backend._resolve_timesteps([0.0, 1.0])
+
+    backend.descriptor["members"][1]["timestep"] = 1141.0
+    with pytest.raises(RuntimeError, match="count differs"):
+        backend._resolve_timesteps([0.0])
+    with pytest.raises(RuntimeError, match="did not expose a time axis"):
+        backend._resolve_timesteps([])
+
+
+@pytest.mark.parametrize("invalid", [True, float("nan"), float("inf")])
+def test_package_descriptor_rejects_invalid_member_timestep(invalid: object) -> None:
+    members = (DatasetMember(index=0, location="/cluster/input.vti"),)
+    descriptor = DatasetDescriptor(
+        dataset_id="invalid-time",
+        kind="volume",
+        format="vtk-image-data",
+        members=members,
+        fingerprint=calculate_dataset_fingerprint(
+            dataset_id="invalid-time",
+            kind="volume",
+            format="vtk-image-data",
+            members=members,
+        ),
+    ).to_dict()
+    descriptor["members"][0]["timestep"] = invalid
+
+    with pytest.raises(ValueError, match="finite number"):
+        service_module._validate_descriptor(descriptor)
 
 
 def test_normalized_viewport_maps_to_real_paraview_pixels() -> None:
@@ -1130,7 +1454,9 @@ def test_viewport_inspection_uses_backend_selection_and_exact_result_shape() -> 
         "reason": None,
     }
     assert view.pixel_rectangle == selection["pixel_rectangle"]
-    assert simple.surface_calls == [(selection["pixel_rectangle"], view)]
+    assert simple.surface_calls == []
+    assert simple.cleared_sources == [backend.active_source]
+    assert simple.render_calls == 2
 
 
 def test_viewport_inspection_reports_unsupported_without_approximation() -> None:
@@ -1153,6 +1479,28 @@ def test_viewport_inspection_reports_unsupported_without_approximation() -> None
     assert selection["selected_count"] is None
     assert selection["ids"] == []
     assert selection["reason"] == "paraview_surface_selection_unavailable"
+    assert backend.simple.cleared_sources == [backend.active_source]
+
+
+def test_viewport_inspection_fails_if_selection_highlight_cannot_be_cleared() -> None:
+    """A successful ID query cannot leave an obscuring ParaView highlight behind."""
+    source = SimpleNamespace()
+    backend = cast(Any, object.__new__(service_module.ParaViewBackend))
+    backend.active_source = SimpleNamespace(SMProxy=source)
+    backend.view = _SelectionView(source, [0, 41])
+    backend.simple = _SelectionSimple(fail_clear=True)
+    backend.servermanager = _SelectionServerManager()
+    backend.vtk = SimpleNamespace(vtkCollection=_SelectionCollection)
+    backend._selection = None
+
+    with pytest.raises(RuntimeError, match="could not clear"):
+        backend._inspect_selection(
+            {"viewport": {"x0": 0.1, "y0": 0.1, "x1": 0.2, "y1": 0.2}},
+            "cmd-select",
+        )
+
+    assert backend.simple.cleared_sources == [backend.active_source]
+    assert backend._selection is None
 
 
 def test_package_service_mode_stages_generic_runtime_and_owned_output(


### PR DESCRIPTION
## What changed

- preserve catalog-provided physical timesteps while driving ParaView with its reader clock
- expose finite per-frame scalar ranges and nullable units with a generic recorded colormap
- clear opaque viewport highlights after capturing authoritative selection evidence
- document the runtime contract and cover it with focused unit tests

## Why

The live five-timestep acceptance run exposed misleading `t=0..4` labels, no machine-readable scalar range, and a selection highlight that obscured the scientific feature. These semantics belong to the JARVIS ParaView package, not relay bootstrap or a site/demo profile.

## Validation

- `uv run pytest test/unit/core/test_paraview_service.py -q` (45 passed)
- `uv run ruff check builtin/builtin/paraview/service.py test/unit/core/test_paraview_service.py`
- `uv run ruff format --check builtin/builtin/paraview/service.py test/unit/core/test_paraview_service.py`
- `uv run pyright builtin/builtin/paraview/service.py`
- `git diff --check`