### PR TITLE
fix(release): load builtin repository in wheel smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,11 +256,11 @@ jobs:
           cd .release-smoke
           bin/python - <<'PY'
           import hashlib
+          import sys
           from importlib.metadata import entry_points
           from pathlib import Path
 
           import jarvis_cd
-          from builtin.paraview.service_http import MAX_HTTP_CONNECTIONS, STATE_SCHEMA
           from jarvis_cd.artifacts import ARTIFACT_SCHEMA_VERSION, ArtifactReporter
           from jarvis_cd.core.execution import ExecutionStore
           from jarvis_cd.progress.lammps import adapter_from_package
@@ -271,6 +271,14 @@ jobs:
           if ArtifactReporter.__module__ != 'jarvis_cd.artifacts.reporter':
               raise SystemExit('installed artifact reporter is not functional')
           distribution_root = Path(jarvis_cd.__file__).resolve().parent.parent
+          # Package implementations are repository payloads. JARVIS adds this
+          # repository root when loading them; mirror that installed-runtime
+          # boundary instead of assuming they are core-wheel subpackages.
+          sys.path.insert(0, str(distribution_root / 'builtin'))
+          from builtin.paraview.service_http import (  # noqa: E402
+              MAX_HTTP_CONNECTIONS,
+              STATE_SCHEMA,
+          )
           required_providers = [
               distribution_root / 'builtin' / 'builtin' / package / filename
               for package, filename in (

--- a/test/unit/test_release_workflow.py
+++ b/test/unit/test_release_workflow.py
@@ -359,6 +359,7 @@ def test_exact_release_request_gates_artifact_build() -> None:
     assert "'private_schema': 'jarvis.service-runtime.private.v1'" in WORKFLOW
     assert "resolve-service-runtime-authority" in WORKFLOW
     assert "MAX_HTTP_CONNECTIONS" in WORKFLOW
+    assert "sys.path.insert(0, str(distribution_root / 'builtin'))" in WORKFLOW
     build_block = WORKFLOW[build_index : WORKFLOW.index("  release:")]
     assert "    needs: release-preflight" in build_block
     assert "release_request" in build_block


### PR DESCRIPTION
## What changed

Makes the installed-wheel release smoke load JARVIS package implementations through the shipped builtin repository root, matching production package discovery.

## Root cause

The v1.4.0 build contained the ParaView payload, but the new smoke test imported it as though it were a core wheel subpackage. Package implementations intentionally live beneath the separately loaded builtin repository.

## Validation

- Reproduced against a clean exact-tag wheel
- Verified the installed ParaView service contract from an unrelated working directory
- 7 release-workflow tests pass
- Ruff and diff checks pass