### PR TITLE
fix(lammps): finalize progress from process exit

### DIFF
--- a/builtin/builtin/lammps/progress.py
+++ b/builtin/builtin/lammps/progress.py
@@ -43,18 +43,131 @@ class LammpsThermoProgressAdapter:
     stdout_fragment: str = ""
     jarvis_stdout_fragment: str = ""
     last_emitted_key: tuple[float, float, float, float | None] | None = None
+    _last_observation: ProgressObservation | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
+    _terminal_state: ProgressState | None = field(default=None, init=False, repr=False)
 
     def observe_progress(self, text: str) -> list[ProgressObservation]:
         """Interpret application stdout for the JARVIS-owned typed SPI."""
-        return [_record_to_observation(record) for record in self.observe_stdout(text)]
+        if self._terminal_state is not None:
+            return []
+        return self._remember_observations(
+            [_record_to_observation(record) for record in self.observe_stdout(text)]
+        )
 
     def finalize_progress(self) -> list[ProgressObservation]:
         """Flush the final application-output fragment for JARVIS core."""
-        return [_record_to_observation(record) for record in self.finalize_stdout()]
+        if self._terminal_state is not None:
+            return []
+        return self._remember_observations(
+            [_record_to_observation(record) for record in self.finalize_stdout()]
+        )
+
+    def finalize_progress_for_exit(self, return_code: int) -> list[ProgressObservation]:
+        """Finalize LAMMPS progress from its authoritative process exit status."""
+        if isinstance(return_code, bool) or not isinstance(return_code, int):
+            raise TypeError("process return code must be an integer")
+        if self._terminal_state is not None:
+            return []
+
+        observations = self.finalize_progress()
+        terminal = self._process_exit_observation(return_code)
+        if terminal is not None:
+            observations.append(terminal)
+            self._last_observation = terminal
+            self._terminal_state = terminal.state
+        return observations
 
     def reset_progress(self) -> None:
         """Reset the JARVIS-owned application stream parser."""
         self.reset_stdout()
+
+    def _remember_observations(
+        self,
+        observations: list[ProgressObservation],
+    ) -> list[ProgressObservation]:
+        """Retain the last typed observation for truthful process finalization."""
+        if observations:
+            self._last_observation = observations[-1]
+        return observations
+
+    def _process_exit_observation(
+        self,
+        return_code: int,
+    ) -> ProgressObservation | None:
+        """Return one terminal event without inventing unobserved progress."""
+        latest = self._last_observation
+        if return_code == 0:
+            total_steps = self.total_steps
+            if (
+                latest is None
+                or total_steps is None
+                or latest.current != total_steps
+                or latest.total != total_steps
+            ):
+                return None
+            completed_steps = latest.current
+            if completed_steps is None:
+                return None
+            metadata = dict(latest.metadata)
+            metadata.update(
+                {
+                    "completion_signal": "process_exit_zero_after_final_timestep",
+                    "return_code": return_code,
+                }
+            )
+            return ProgressObservation(
+                label=latest.label,
+                state=ProgressState.COMPLETED,
+                current=completed_steps,
+                total=total_steps,
+                unit=latest.unit,
+                message=(
+                    f"LAMMPS completed {int(completed_steps)} of "
+                    f"{int(total_steps)} steps"
+                ),
+                metadata=metadata,
+            )
+
+        current = latest.current if latest is not None else 0.0
+        total = latest.total if latest is not None else self.total_steps
+        metadata = (
+            dict(latest.metadata)
+            if latest is not None
+            else self._base_progress_metadata()
+        )
+        metadata.update(
+            {
+                "completion_signal": "process_exit_nonzero",
+                "return_code": return_code,
+            }
+        )
+        return ProgressObservation(
+            label=latest.label if latest is not None else "timestep",
+            state=ProgressState.FAILED,
+            current=current,
+            total=total,
+            unit=latest.unit if latest is not None else "step",
+            message=f"LAMMPS failed with exit status {return_code}",
+            metadata=metadata,
+        )
+
+    def _base_progress_metadata(self) -> dict[str, JsonValue]:
+        """Return bounded package provenance when no thermo row was observed."""
+        return {
+            "adapter": self.adapter_name,
+            "source": "jarvis_package",
+            "progress_source": self.authoritative_source or "process_exit",
+            "log_visibility": self.log_visibility,
+            "package_name": self.package_name,
+            "package_id": self.package_id,
+            "package_version": self.package_version,
+            "run_id": self.run_id,
+            "execution_id": self.run_id,
+        }
 
     def observe_stdout(self, text: str) -> list[dict[str, object]]:
         """Extract progress from an already trusted package-owned log."""
@@ -80,6 +193,8 @@ class LammpsThermoProgressAdapter:
         self.active_run_steps = None
         self.active_run_start_step = None
         self.last_emitted_key = None
+        self._last_observation = None
+        self._terminal_state = None
 
     def _observe_stdout(
         self,

--- a/test/unit/core/test_lammps_progress.py
+++ b/test/unit/core/test_lammps_progress.py
@@ -9,7 +9,9 @@ import pytest
 
 from jarvis_cd.progress import (
     PackageProgressProvider,
+    ProcessExitProgressProvider,
     ProgressObservation,
+    ProgressState,
     RelayProgressAdapter,
 )
 from jarvis_cd.progress.lammps import (
@@ -40,6 +42,7 @@ def test_adapter_is_owned_by_builtin_lammps(tmp_path: Path) -> None:
     assert adapter.total_steps == 100
     assert adapter.progress_log_paths() == [tmp_path / "log.lammps"]
     assert isinstance(adapter, PackageProgressProvider)
+    assert isinstance(adapter, ProcessExitProgressProvider)
     assert isinstance(adapter, RelayProgressAdapter)
 
     container_adapter = adapter_from_package(
@@ -136,6 +139,73 @@ def test_lammps_provider_exposes_typed_jarvis_observations() -> None:
     assert all(isinstance(item, ProgressObservation) for item in observations)
     assert [item.current for item in observations] == [0.0, 5.0]
     assert [item.total for item in observations] == [10, 10]
+
+
+def test_lammps_successful_exit_completes_observed_final_timestep() -> None:
+    """A zero process exit commits an observed final thermo row exactly once."""
+    provider = LammpsThermoProgressAdapter(
+        total_steps=100,
+        package_version="test-version",
+    )
+    observed = provider.observe_progress(
+        "run 100\nStep Temp CPU\n0 1.0 0.0\n50 1.1 1.0\n100 1.2 2.0"
+    )
+
+    terminal = provider.finalize_progress_for_exit(0)
+
+    assert [item.current for item in observed] == [0.0, 50.0]
+    assert [item.current for item in terminal] == [100.0, 100.0]
+    assert terminal[-1].state is ProgressState.COMPLETED
+    assert terminal[-1].total == 100.0
+    assert terminal[-1].unit == "step"
+    assert terminal[-1].metadata["source"] == "jarvis_package"
+    assert terminal[-1].metadata["package_version"] == "test-version"
+    assert terminal[-1].metadata["completion_signal"] == (
+        "process_exit_zero_after_final_timestep"
+    )
+    assert terminal[-1].metadata["return_code"] == 0
+    assert provider.finalize_progress_for_exit(0) == []
+
+
+def test_lammps_successful_exit_does_not_invent_unobserved_progress() -> None:
+    """Process success alone cannot fabricate a missing final thermo step."""
+    provider = LammpsThermoProgressAdapter(total_steps=100)
+    observed = provider.observe_progress(
+        "run 100\nStep Temp CPU\n0 1.0 0.0\n50 1.1 1.0\n"
+    )
+
+    terminal = provider.finalize_progress_for_exit(0)
+
+    assert [item.current for item in observed] == [0.0, 50.0]
+    assert terminal == []
+    assert all(item.state is ProgressState.RUNNING for item in observed)
+
+
+def test_lammps_failed_exit_terminates_at_last_observed_timestep() -> None:
+    """A nonzero process exit records failure without advancing progress."""
+    provider = LammpsThermoProgressAdapter(total_steps=100)
+    observed = provider.observe_progress(
+        "run 100\nStep Temp CPU\n0 1.0 0.0\n25 1.1 1.0\n"
+    )
+
+    terminal = provider.finalize_progress_for_exit(7)
+
+    assert [item.current for item in observed] == [0.0, 25.0]
+    assert len(terminal) == 1
+    assert terminal[0].state is ProgressState.FAILED
+    assert terminal[0].current == 25.0
+    assert terminal[0].total == 100.0
+    assert terminal[0].metadata["completion_signal"] == "process_exit_nonzero"
+    assert terminal[0].metadata["return_code"] == 7
+    assert provider.finalize_progress_for_exit(7) == []
+
+
+def test_lammps_process_exit_rejects_non_integer_status() -> None:
+    """The package provider accepts only an actual integer process result."""
+    provider = LammpsThermoProgressAdapter(total_steps=100)
+
+    with pytest.raises(TypeError, match="process return code must be an integer"):
+        provider.finalize_progress_for_exit(True)
 
 
 def test_adapter_rejects_unobserved_acceptance_claims() -> None:


### PR DESCRIPTION
## Summary

- finalize builtin LAMMPS progress from JARVIS-owned process exit status
- emit completed only after a zero exit and an observed final thermo timestep
- emit failed on nonzero exit without advancing the last truthful timestep
- make terminal finalization idempotent and resettable

## Root cause

The LAMMPS provider parsed thermo rows but implemented only the generic EOF finalizer. JARVIS therefore had no package-owned terminal observation tied to the authoritative process return code, leaving successful runs at a running progress state and making failures less explicit.

## Validation

- `uv run --frozen pytest -q test/unit/core/test_lammps_progress.py test/unit/core/test_progress_spi.py` (37 passed)
- `uv run --frozen pytest -q test/unit/core/test_lammps_package_runtime.py` (16 passed)
- touched-file Ruff check and format check
- Pyright on `builtin/builtin/lammps/progress.py`
- `git diff --check`