### PR TITLE
fix: keep graph cache coherent after publication

### DIFF
--- a/jarvis_cd/core/config.py
+++ b/jarvis_cd/core/config.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import tempfile
 import yaml
@@ -9,6 +10,17 @@ from jarvis_cd.util.hostfile import Hostfile
 
 _JARVIS_ROOT_ENVIRONMENT = "JARVIS_ROOT"
 _STATE_ROOT_FIELDS = ("config_dir", "private_dir", "shared_dir")
+
+
+def _fsync_directory(path: Path) -> None:
+    """Durably publish a completed state-file replacement on POSIX."""
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def _canonicalize_state_roots(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -328,6 +340,7 @@ class Jarvis:
     def save_resource_graph(self, resource_graph: Dict[str, Any]):
         """Atomically save the active graph under the configured JARVIS root."""
         self.jarvis_root.mkdir(parents=True, exist_ok=True)
+        persisted_graph = copy.deepcopy(resource_graph)
         descriptor, temporary_name = tempfile.mkstemp(
             dir=self.jarvis_root,
             prefix=".resource_graph.",
@@ -339,19 +352,14 @@ class Jarvis:
             if os.name != "nt":
                 os.fchmod(descriptor, 0o600)
             with os.fdopen(descriptor, "w") as stream:
-                yaml.dump(resource_graph, stream, default_flow_style=False)
+                yaml.dump(persisted_graph, stream, default_flow_style=False)
                 stream.flush()
                 os.fsync(stream.fileno())
             os.replace(temporary_path, self.resource_graph_file)
-            if os.name != "nt":
-                directory_descriptor = os.open(self.jarvis_root, os.O_RDONLY)
-                try:
-                    os.fsync(directory_descriptor)
-                finally:
-                    os.close(directory_descriptor)
+            self._resource_graph = persisted_graph
+            _fsync_directory(self.jarvis_root)
         finally:
             temporary_path.unlink(missing_ok=True)
-        self._resource_graph = resource_graph
 
     def add_repo(self, repo_path: str, force: bool = False):
         """Add a repository to the repos configuration"""

--- a/test/unit/core/test_resource_graph_activation.py
+++ b/test/unit/core/test_resource_graph_activation.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 from jarvis_cd.core.config import Jarvis
 from jarvis_cd.core.resource_graph import ResourceGraphManager
@@ -111,6 +112,44 @@ def test_rg_load_failed_activation_preserves_file_and_in_memory_graph(
             for device in manager.resource_graph.get_node_storage(node)
         }
         assert mounts == {"/old"}
+        assert not list(jarvis_root.glob(".resource_graph.*.tmp"))
+    finally:
+        Jarvis._instance = None
+
+
+def test_post_replace_fsync_failure_keeps_file_and_cache_coherent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A durability error after replace must expose the same new graph in both views."""
+    jarvis_root = tmp_path / "custom-jarvis-root"
+    monkeypatch.setenv("JARVIS_ROOT", str(jarvis_root))
+    Jarvis._instance = None
+    try:
+        jarvis = Jarvis.get_instance()
+        jarvis.initialize(
+            str(tmp_path / "config"),
+            str(tmp_path / "private"),
+            str(tmp_path / "shared"),
+        )
+        replacement = {"fs": [{"mount": "/new", "dev_type": "ssd", "shared": True}]}
+
+        def fail_directory_fsync(_path: Path) -> None:
+            raise OSError("simulated directory fsync failure")
+
+        monkeypatch.setattr(
+            "jarvis_cd.core.config._fsync_directory", fail_directory_fsync
+        )
+        with pytest.raises(OSError, match="simulated directory fsync failure"):
+            jarvis.save_resource_graph(replacement)
+
+        persisted = yaml.safe_load(
+            jarvis.resource_graph_file.read_text(encoding="utf-8")
+        )
+        assert persisted == replacement
+        assert jarvis.resource_graph == replacement
+        replacement["fs"][0]["mount"] = "/caller-mutated"
+        assert jarvis.resource_graph == persisted
         assert not list(jarvis_root.glob(".resource_graph.*.tmp"))
     finally:
         Jarvis._instance = None


### PR DESCRIPTION
## What changed

- snapshots caller-owned graph data before serializing it
- updates the in-memory cache immediately after successful atomic publication
- isolates parent-directory fsync behind the durability boundary
- keeps disk and cache coherent if the post-replace directory fsync reports an error

## Why

The first persistence fix had one ambiguous post-publication edge: directory fsync could fail after `os.replace`, leaving the new file on disk while the cache still referenced the old graph. It also retained a mutable caller alias after a successful save.

## Validation

- `93 passed`: focused resource-graph manager, utility, CLI, cross-process, replace-failure, and post-replace-fsync tests
- focused Ruff correctness checks pass
- Pyright: 0 errors on the changed persistence boundary and acceptance tests
