### PR TITLE
feat: activate builtin resource graph profiles

### DIFF
--- a/docs/resource_graph.md
+++ b/docs/resource_graph.md
@@ -180,6 +180,16 @@ jarvis rg path
 # Load resource graph from custom file
 jarvis rg load /path/to/custom_resource_graph.yaml
 
+# List profiles shipped by the active JARVIS builtin repository
+jarvis rg builtins
+
+# Activate an exact shipped profile through JARVIS-owned resolution
+jarvis rg load-builtin ares
+
+# Emit one bounded JSON result for orchestration clients. An unavailable exact
+# profile is an expected result; corrupt/unreadable profiles remain hard errors.
+jarvis rg load-builtin ares +json
+
 # Show path to current resource graph file (prints only the path)
 jarvis rg path
 

--- a/jarvis_cd/core/cli.py
+++ b/jarvis_cd/core/cli.py
@@ -1,9 +1,10 @@
 import json
 import sys
 import os
+from contextlib import redirect_stdout
 from pathlib import Path
 from jarvis_cd.util.argparse import ArgParse
-from jarvis_cd.core.config import Jarvis
+from jarvis_cd.core.config import BuiltinResourceGraphUnavailable, Jarvis
 from jarvis_cd.core.execution import ExecutionHandle
 from jarvis_cd.core.pipeline import Pipeline
 from jarvis_cd.core.pipeline_test import load_yaml_auto
@@ -12,6 +13,10 @@ from jarvis_cd.core.repository import RepositoryManager
 from jarvis_cd.core.pkg import Pkg
 from jarvis_cd.core.environment import EnvironmentManager
 from jarvis_cd.core.resource_graph import ResourceGraphManager
+
+
+BUILTIN_RESOURCE_GRAPH_RESULT_SCHEMA = "jarvis.resource-graph-builtin.v1"
+MAX_BUILTIN_RESOURCE_GRAPH_RESULT_BYTES = 64 * 1024
 
 
 class JarvisCLI(ArgParse):
@@ -1063,6 +1068,29 @@ class JarvisCLI(ArgParse):
                     "type": str,
                     "required": True,
                     "pos": True,
+                }
+            ]
+        )
+
+        self.add_cmd("rg builtins", msg="List builtin resource graph profiles")
+        self.add_args([])
+
+        self.add_cmd("rg load-builtin", msg="Load a builtin resource graph profile")
+        self.add_args(
+            [
+                {
+                    "name": "profile",
+                    "msg": "Exact builtin resource graph profile name",
+                    "type": str,
+                    "required": True,
+                    "pos": True,
+                },
+                {
+                    "name": "json",
+                    "msg": "Emit one bounded machine-readable activation result",
+                    "type": bool,
+                    "default": False,
+                    "prefix": "+",
                 }
             ]
         )
@@ -2597,6 +2625,76 @@ class JarvisCLI(ArgParse):
         self._ensure_initialized()
         file_path = Path(self.kwargs["file_path"])
         self.rg_manager.load(file_path)
+
+    def rg_builtins(self):
+        """List exact builtin resource graph profiles."""
+        self._ensure_initialized()
+        for profile in self.rg_manager.list_builtins():
+            print(profile)
+
+    def rg_load_builtin(self):
+        """Activate one exact builtin resource graph profile."""
+        self._ensure_initialized()
+        profile = self.kwargs["profile"]
+        json_output = bool(self.kwargs.get("json", False))
+        catalog = self.rg_manager.list_builtins()
+        try:
+            if json_output:
+                with redirect_stdout(sys.stderr):
+                    source, source_sha256 = self.rg_manager.load_builtin(profile)
+            else:
+                source, source_sha256 = self.rg_manager.load_builtin(profile)
+        except BuiltinResourceGraphUnavailable:
+            if not json_output:
+                raise
+            self._emit_builtin_resource_graph_result(
+                profile=profile,
+                action="unavailable",
+                available=False,
+                source=None,
+                source_sha256=None,
+                catalog=catalog,
+            )
+            return
+        if json_output:
+            self._emit_builtin_resource_graph_result(
+                profile=profile,
+                action="loaded",
+                available=True,
+                source=source,
+                source_sha256=source_sha256,
+                catalog=catalog,
+            )
+            return
+        print(f"Activated builtin resource graph profile {profile} from {source}")
+
+    @staticmethod
+    def _emit_builtin_resource_graph_result(
+        *,
+        profile: str,
+        action: str,
+        available: bool,
+        source: Path | None,
+        source_sha256: str | None,
+        catalog: list[str],
+    ) -> None:
+        """Emit one bounded result consumed by bootstrap clients."""
+        result = json.dumps(
+            {
+                "schema_version": BUILTIN_RESOURCE_GRAPH_RESULT_SCHEMA,
+                "profile": profile,
+                "action": action,
+                "available": available,
+                "source": str(source) if source is not None else None,
+                "source_sha256": source_sha256,
+                "catalog": catalog,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if len(result.encode("utf-8")) > MAX_BUILTIN_RESOURCE_GRAPH_RESULT_BYTES:
+            raise ValueError("builtin resource graph result exceeds its byte limit")
+        print(result)
 
     def rg_path(self):
         """Show path to current resource graph file"""

--- a/jarvis_cd/core/config.py
+++ b/jarvis_cd/core/config.py
@@ -10,6 +10,11 @@ from jarvis_cd.util.hostfile import Hostfile
 
 _JARVIS_ROOT_ENVIRONMENT = "JARVIS_ROOT"
 _STATE_ROOT_FIELDS = ("config_dir", "private_dir", "shared_dir")
+MAX_BUILTIN_RESOURCE_GRAPH_PROFILES = 128
+
+
+class BuiltinResourceGraphUnavailable(FileNotFoundError):
+    """Raised only when an exact profile is absent from the builtin catalog."""
 
 
 def _fsync_directory(path: Path) -> None:
@@ -647,6 +652,52 @@ class Jarvis:
 
         # Default fallback
         return user_builtin
+
+    def list_builtin_resource_graphs(self) -> Dict[str, Path]:
+        """Return the exact resource-graph profiles owned by the active builtin repo."""
+        graph_root = self.get_builtin_repo_path() / "resource_graph"
+        if not graph_root.is_dir():
+            return {}
+        profiles: Dict[str, Path] = {}
+        for candidate in sorted(graph_root.iterdir()):
+            if not candidate.is_file() or candidate.suffix not in {
+                ".json",
+                ".yaml",
+                ".yml",
+            }:
+                continue
+            profile = candidate.stem
+            if profile in profiles:
+                raise ValueError(f"duplicate builtin resource graph profile: {profile}")
+            if len(profiles) >= MAX_BUILTIN_RESOURCE_GRAPH_PROFILES:
+                raise ValueError("builtin resource graph catalog exceeds its profile limit")
+            profiles[profile] = candidate
+        return profiles
+
+    def get_builtin_resource_graph_path(self, profile: str) -> Path:
+        """Resolve one exact builtin graph profile or report the owned catalog."""
+        if (
+            not profile
+            or profile != profile.strip()
+            or len(profile) > 256
+            or profile in {".", ".."}
+            or "/" in profile
+            or "\\" in profile
+            or any(
+                ord(character) < 32 or ord(character) == 127
+                for character in profile
+            )
+        ):
+            raise ValueError("builtin resource graph profile must be one safe exact name")
+        profiles = self.list_builtin_resource_graphs()
+        selected = profiles.get(profile)
+        if selected is None:
+            available = ", ".join(profiles) if profiles else "none"
+            raise BuiltinResourceGraphUnavailable(
+                f"builtin resource graph profile {profile!r} is unavailable; "
+                f"available profiles: {available}"
+            )
+        return selected
 
     def _bind_distribution_builtin_repository(
         self,

--- a/jarvis_cd/core/resource_graph.py
+++ b/jarvis_cd/core/resource_graph.py
@@ -2,8 +2,11 @@
 Resource graph management for Jarvis.
 Coordinates resource collection across nodes and provides analysis capabilities.
 """
+import hashlib
 import json
+import stat
 import sys
+import tempfile
 import threading
 from pathlib import Path
 from typing import Dict, List, Any, Optional
@@ -13,6 +16,39 @@ from jarvis_cd.core.config import Jarvis
 from jarvis_cd.util.resource_graph import ResourceGraph
 from jarvis_cd.util.logger import logger
 from jarvis_cd.shell import ResourceGraphExec, PsshExecInfo, LocalExec, LocalExecInfo
+
+
+MAX_BUILTIN_RESOURCE_GRAPH_BYTES = 64 * 1024 * 1024
+
+
+def _read_regular_file(path: Path) -> tuple[bytes, str]:
+    """Read one bounded regular graph file while proving stable identity."""
+    before = path.lstat()
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or before.st_nlink != 1
+        or before.st_size <= 0
+        or before.st_size > MAX_BUILTIN_RESOURCE_GRAPH_BYTES
+    ):
+        raise ValueError("builtin resource graph source must be one bounded regular file")
+    with path.open("rb") as stream:
+        payload = stream.read(MAX_BUILTIN_RESOURCE_GRAPH_BYTES + 1)
+    if len(payload) != before.st_size:
+        raise ValueError("builtin resource graph source changed during activation")
+    after = path.lstat()
+    if (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+    ) != (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+        after.st_mtime_ns,
+    ):
+        raise ValueError("builtin resource graph source changed during activation")
+    return payload, hashlib.sha256(payload).hexdigest()
 
 
 class ResourceGraphManager:
@@ -203,6 +239,27 @@ class ResourceGraphManager:
             f"Loaded resource graph from {file_path} and activated it at "
             f"{self.jarvis.resource_graph_file}"
         )
+
+    def list_builtins(self) -> List[str]:
+        """Return the exact packaged resource-graph profile catalog."""
+        return list(self.jarvis.list_builtin_resource_graphs())
+
+    def load_builtin(self, profile: str) -> tuple[Path, str]:
+        """Activate one exact packaged resource-graph profile."""
+        source = self.jarvis.get_builtin_resource_graph_path(profile)
+        payload, source_sha256 = _read_regular_file(source)
+        with tempfile.TemporaryDirectory(prefix="jarvis-builtin-graph-") as directory:
+            snapshot = Path(directory) / source.name
+            snapshot.write_bytes(payload)
+            loaded_graph = ResourceGraph()
+            loaded_graph.load_from_file(snapshot)
+        self.jarvis.save_resource_graph(loaded_graph.to_dict())
+        self.resource_graph = loaded_graph
+        logger.success(
+            f"Loaded builtin resource graph from {source} and activated it at "
+            f"{self.jarvis.resource_graph_file}"
+        )
+        return source, source_sha256
         
     def show(self):
         """Display the current resource graph YAML file."""

--- a/test/unit/core/test_resource_graph_activation.py
+++ b/test/unit/core/test_resource_graph_activation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import hashlib
 import os
 import stat
 import subprocess
@@ -11,6 +13,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from jarvis_cd.core.cli import JarvisCLI
 from jarvis_cd.core.config import Jarvis
 from jarvis_cd.core.resource_graph import ResourceGraphManager
 
@@ -18,7 +21,11 @@ from jarvis_cd.core.resource_graph import ResourceGraphManager
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 
-def _run_jarvis(*arguments: str, jarvis_root: Path) -> subprocess.CompletedProcess[str]:
+def _run_jarvis(
+    *arguments: str,
+    jarvis_root: Path,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
     """Run the real JARVIS CLI in a fresh, bounded interpreter."""
     environment = os.environ.copy()
     environment["JARVIS_ROOT"] = str(jarvis_root)
@@ -26,7 +33,7 @@ def _run_jarvis(*arguments: str, jarvis_root: Path) -> subprocess.CompletedProce
         [sys.executable, "-m", "jarvis_cd.core.cli", *arguments],
         cwd=PROJECT_ROOT,
         env=environment,
-        check=True,
+        check=check,
         capture_output=True,
         text=True,
         timeout=15,
@@ -153,3 +160,139 @@ def test_post_replace_fsync_failure_keeps_file_and_cache_coherent(
         assert not list(jarvis_root.glob(".resource_graph.*.tmp"))
     finally:
         Jarvis._instance = None
+
+
+def test_load_builtin_activates_packaged_graph_for_a_new_process(
+    tmp_path: Path,
+) -> None:
+    """JARVIS must own catalog resolution and durable builtin activation."""
+    jarvis_root = tmp_path / "custom-jarvis-root"
+    _run_jarvis(
+        "init",
+        str(tmp_path / "config"),
+        str(tmp_path / "private"),
+        str(tmp_path / "shared"),
+        jarvis_root=jarvis_root,
+    )
+
+    catalog = _run_jarvis("rg", "builtins", jarvis_root=jarvis_root)
+    assert "ares" in catalog.stdout.splitlines()
+    loaded = _run_jarvis("rg", "load-builtin", "ares", "+json", jarvis_root=jarvis_root)
+    result = json.loads(loaded.stdout)
+    assert result == {
+        "action": "loaded",
+        "available": True,
+        "catalog": ["ares", "deception", "delta", "g2-standard-4", "polaris"],
+        "profile": "ares",
+        "schema_version": "jarvis.resource-graph-builtin.v1",
+        "source": result["source"],
+        "source_sha256": result["source_sha256"],
+    }
+    assert result["source"].endswith("/builtin/resource_graph/ares.yaml") or result[
+        "source"
+    ].endswith("\\builtin\\resource_graph\\ares.yaml")
+    assert (
+        result["source_sha256"]
+        == hashlib.sha256(Path(result["source"]).read_bytes()).hexdigest()
+    )
+
+    observed = _run_jarvis("rg", "show", jarvis_root=jarvis_root)
+    assert "/mnt/ssd" in observed.stdout
+    assert "dev_type: ssd" in observed.stdout
+
+
+@pytest.mark.parametrize("profile", ["missing-cluster", "../ares", "ares/path"])
+def test_load_builtin_reports_exact_availability_boundary(
+    tmp_path: Path,
+    profile: str,
+) -> None:
+    """Unknown and unsafe names must fail without relay-owned path guessing."""
+    jarvis_root = tmp_path / "custom-jarvis-root"
+    _run_jarvis(
+        "init",
+        str(tmp_path / "config"),
+        str(tmp_path / "private"),
+        str(tmp_path / "shared"),
+        jarvis_root=jarvis_root,
+    )
+
+    result = _run_jarvis(
+        "rg",
+        "load-builtin",
+        profile,
+        "+json",
+        jarvis_root=jarvis_root,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+    if profile == "missing-cluster":
+        assert result.returncode == 0
+        document = json.loads(result.stdout)
+        assert document["schema_version"] == "jarvis.resource-graph-builtin.v1"
+        assert document["profile"] == profile
+        assert document["action"] == "unavailable"
+        assert document["available"] is False
+        assert document["source"] is None
+        assert document["source_sha256"] is None
+        assert "ares" in document["catalog"]
+    else:
+        assert result.returncode != 0
+        assert "jarvis.resource-graph-builtin.v1" not in result.stdout
+        assert "must be one safe exact name" in output
+
+
+def test_load_builtin_json_keeps_corrupt_profile_as_a_hard_error(
+    tmp_path: Path,
+) -> None:
+    """Only a clean catalog miss is structured as unavailable."""
+    jarvis_root = tmp_path / "custom-jarvis-root"
+    _run_jarvis(
+        "init",
+        str(tmp_path / "config"),
+        str(tmp_path / "private"),
+        str(tmp_path / "shared"),
+        jarvis_root=jarvis_root,
+    )
+    operator_builtin = tmp_path / "operator" / "builtin"
+    graph_root = operator_builtin / "resource_graph"
+    graph_root.mkdir(parents=True)
+    (graph_root / "corrupt.yaml").write_text("fs: [", encoding="utf-8")
+    (jarvis_root / "repos.yaml").write_text(
+        yaml.safe_dump({"repos": [str(operator_builtin)]}),
+        encoding="utf-8",
+    )
+
+    result = _run_jarvis(
+        "rg",
+        "load-builtin",
+        "corrupt",
+        "+json",
+        jarvis_root=jarvis_root,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "jarvis.resource-graph-builtin.v1" not in result.stdout
+    assert "Error:" in result.stdout + result.stderr
+
+
+def test_load_builtin_json_does_not_relabel_selected_source_disappearance(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A catalog hit that vanishes during I/O is a hard error, not unavailable."""
+
+    class VanishingSourceManager:
+        def list_builtins(self) -> list[str]:
+            return ["ares"]
+
+        def load_builtin(self, _profile: str) -> tuple[Path, str]:
+            raise FileNotFoundError("selected builtin source vanished")
+
+    cli = JarvisCLI()
+    cli.kwargs = {"profile": "ares", "json": True}
+    monkeypatch.setattr(cli, "rg_manager", VanishingSourceManager())
+    monkeypatch.setattr(cli, "_ensure_initialized", lambda: None)
+
+    with pytest.raises(FileNotFoundError, match="selected builtin source vanished"):
+        cli.rg_load_builtin()
+    assert "jarvis.resource-graph-builtin.v1" not in capsys.readouterr().out


### PR DESCRIPTION
## What changed

- adds `jarvis rg builtins` as the JARVIS-owned packaged graph catalog
- adds `jarvis rg load-builtin <profile>` for exact durable activation
- adds `+json` with a bounded `jarvis.resource-graph-builtin.v1` result
- represents an exact catalog miss as structured `unavailable`
- keeps unsafe names, corruption, permission/I/O failures, and selected-source races as hard errors
- binds successful activation to the SHA-256 of the exact bytes parsed from a stable private snapshot

## Why

Relay needs to request a registered cluster key without deriving wheel paths or interpreting JARVIS package layout. Adding a graph for another cluster now changes only JARVIS's builtin catalog; relay can fall back to discovery solely on the explicit structured unavailable result.

## Validation

- `105 passed`: resource-graph utility, manager, CLI, configured-root, cross-process, failure, and catalog tests
- focused Ruff correctness checks pass
- Pyright: 0 errors on the catalog/persistence boundary and acceptance tests
