### PR TITLE
fix: harden builtin graph activation release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,7 @@ jobs:
             test/unit/core/test_execution.py \
             test/unit/core/test_execution_cli.py \
             test/unit/core/test_service_runtime.py \
+            test/unit/core/test_resource_graph_activation.py \
             test/unit/core/test_gray_scott_artifacts.py \
             test/unit/core/test_gray_scott_progress.py \
             test/unit/core/test_adios2_gray_scott_artifacts.py \
@@ -324,6 +325,33 @@ jobs:
           PY
           )
           .release-smoke/bin/jarvis --help >/dev/null
+          (
+          cd .release-smoke
+          export JARVIS_ROOT="$PWD/jarvis-root"
+          bin/jarvis init "$PWD/config" "$PWD/private" "$PWD/shared" >/dev/null
+          bin/jarvis rg builtins | grep -Fx ares >/dev/null
+          BUILTIN_RESULT="$(bin/jarvis rg load-builtin ares +json)" \
+            bin/python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          result = json.loads(os.environ['BUILTIN_RESULT'])
+          if result.get('schema_version') != 'jarvis.resource-graph-builtin.v1':
+              raise SystemExit('installed builtin graph schema is not functional')
+          if result.get('profile') != 'ares' or result.get('action') != 'loaded':
+              raise SystemExit(f'installed builtin graph activation failed: {result}')
+          if result.get('available') is not True or 'ares' not in result.get('catalog', []):
+              raise SystemExit(f'installed builtin graph catalog failed: {result}')
+          source = Path(result['source'])
+          if hashlib.sha256(source.read_bytes()).hexdigest() != result['source_sha256']:
+              raise SystemExit('installed builtin graph source digest is incorrect')
+          active = Path(os.environ['JARVIS_ROOT']) / 'resource_graph.yaml'
+          if not active.is_file() or '/mnt/ssd' not in active.read_text(encoding='utf-8'):
+              raise SystemExit('installed builtin graph was not durably activated')
+          PY
+          )
 
       - name: Create release manifest
         env:

--- a/jarvis_cd/core/config.py
+++ b/jarvis_cd/core/config.py
@@ -17,6 +17,21 @@ class BuiltinResourceGraphUnavailable(FileNotFoundError):
     """Raised only when an exact profile is absent from the builtin catalog."""
 
 
+def _validate_builtin_resource_graph_profile(profile: str) -> str:
+    """Return one safe exact builtin profile name or fail closed."""
+    if (
+        not profile
+        or profile != profile.strip()
+        or len(profile) > 256
+        or profile in {".", ".."}
+        or "/" in profile
+        or "\\" in profile
+        or any(ord(character) < 32 or ord(character) == 127 for character in profile)
+    ):
+        raise ValueError("builtin resource graph profile must be one safe exact name")
+    return profile
+
+
 def _fsync_directory(path: Path) -> None:
     """Durably publish a completed state-file replacement on POSIX."""
     if os.name == "nt":
@@ -666,29 +681,19 @@ class Jarvis:
                 ".yml",
             }:
                 continue
-            profile = candidate.stem
+            profile = _validate_builtin_resource_graph_profile(candidate.stem)
             if profile in profiles:
                 raise ValueError(f"duplicate builtin resource graph profile: {profile}")
             if len(profiles) >= MAX_BUILTIN_RESOURCE_GRAPH_PROFILES:
-                raise ValueError("builtin resource graph catalog exceeds its profile limit")
+                raise ValueError(
+                    "builtin resource graph catalog exceeds its profile limit"
+                )
             profiles[profile] = candidate
         return profiles
 
     def get_builtin_resource_graph_path(self, profile: str) -> Path:
         """Resolve one exact builtin graph profile or report the owned catalog."""
-        if (
-            not profile
-            or profile != profile.strip()
-            or len(profile) > 256
-            or profile in {".", ".."}
-            or "/" in profile
-            or "\\" in profile
-            or any(
-                ord(character) < 32 or ord(character) == 127
-                for character in profile
-            )
-        ):
-            raise ValueError("builtin resource graph profile must be one safe exact name")
+        _validate_builtin_resource_graph_profile(profile)
         profiles = self.list_builtin_resource_graphs()
         selected = profiles.get(profile)
         if selected is None:

--- a/jarvis_cd/core/resource_graph.py
+++ b/jarvis_cd/core/resource_graph.py
@@ -2,12 +2,12 @@
 Resource graph management for Jarvis.
 Coordinates resource collection across nodes and provides analysis capabilities.
 """
+
 import hashlib
 import json
 import stat
 import sys
 import tempfile
-import threading
 from pathlib import Path
 from typing import Dict, List, Any, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -15,7 +15,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from jarvis_cd.core.config import Jarvis
 from jarvis_cd.util.resource_graph import ResourceGraph
 from jarvis_cd.util.logger import logger
-from jarvis_cd.shell import ResourceGraphExec, PsshExecInfo, LocalExec, LocalExecInfo
+from jarvis_cd.shell import PsshExecInfo, LocalExec, LocalExecInfo
 
 
 MAX_BUILTIN_RESOURCE_GRAPH_BYTES = 64 * 1024 * 1024
@@ -30,7 +30,9 @@ def _read_regular_file(path: Path) -> tuple[bytes, str]:
         or before.st_size <= 0
         or before.st_size > MAX_BUILTIN_RESOURCE_GRAPH_BYTES
     ):
-        raise ValueError("builtin resource graph source must be one bounded regular file")
+        raise ValueError(
+            "builtin resource graph source must be one bounded regular file"
+        )
     with path.open("rb") as stream:
         payload = stream.read(MAX_BUILTIN_RESOURCE_GRAPH_BYTES + 1)
     if len(payload) != before.st_size:
@@ -55,7 +57,7 @@ class ResourceGraphManager:
     """
     Manages resource graph collection and analysis across the Jarvis cluster.
     """
-    
+
     def __init__(self):
         """
         Initialize resource graph manager.
@@ -72,7 +74,7 @@ class ResourceGraphManager:
             except Exception:
                 # Silently continue if load fails
                 pass
-        
+
     def build(self, benchmark: bool = True, duration: int = 25):
         """
         Build resource graph by collecting information from all nodes in hostfile.
@@ -84,122 +86,126 @@ class ResourceGraphManager:
         jarvis = Jarvis.get_instance()
         if not jarvis.hostfile:
             raise ValueError("No hostfile set. Use 'jarvis hostfile set <path>' first.")
-            
+
         hostfile = jarvis.hostfile
         nodes = hostfile.hosts
-        
+
         if not nodes:
             raise ValueError("Hostfile contains no hosts")
-            
+
         logger.pipeline(f"Building resource graph for {len(nodes)} nodes...")
-        
+
         # Clear existing resource graph
         self.resource_graph = ResourceGraph()
-        
+
         # Collect resources from all nodes in parallel
         self._collect_from_nodes(nodes, benchmark, duration)
-        
+
         # Save resource graph
         self._save()
-        
+
         # Display summary
         self.resource_graph.print_summary()
         self.resource_graph.print_common_storage()
-        
+
     def _collect_from_nodes(self, nodes: List[str], benchmark: bool, duration: int):
         """
         Collect resource information from multiple nodes in parallel.
-        
+
         :param nodes: List of node hostnames/IPs
         :param benchmark: Whether to run benchmarks
         :param duration: Benchmark duration
         """
+
         def collect_from_node(hostname: str) -> Dict[str, Any]:
             """Collect from a single node."""
             try:
                 logger.package(f"Collecting resources from {hostname}...")
-                
-                # Get jarvis singleton  
-                jarvis = Jarvis.get_instance()
-                
+
                 # Get current hostname using LocalExec to compare
-                exec_info_hostname = LocalExecInfo(collect_output=True, hide_output=True)
-                hostname_result = LocalExec('hostname', exec_info_hostname)
-                current_hostname = hostname_result.stdout.get('localhost', '').strip()
-                
+                exec_info_hostname = LocalExecInfo(
+                    collect_output=True, hide_output=True
+                )
+                hostname_result = LocalExec("hostname", exec_info_hostname)
+                current_hostname = hostname_result.stdout.get("localhost", "").strip()
+
                 # Use local execution for localhost, otherwise use SSH
-                if hostname in ['localhost', '127.0.0.1'] or hostname == current_hostname:
-                    exec_info = LocalExecInfo(
-                        collect_output=True,
-                        hide_output=True
-                    )
+                if (
+                    hostname in ["localhost", "127.0.0.1"]
+                    or hostname == current_hostname
+                ):
+                    exec_info = LocalExecInfo(collect_output=True, hide_output=True)
                 else:
                     # Create a temporary hostfile for this specific node
                     from jarvis_cd.util.hostfile import Hostfile
+
                     single_host_hostfile = Hostfile([hostname])
-                    
+
                     # Create execution info for this node
                     exec_info = PsshExecInfo(
                         hostfile=single_host_hostfile,
                         collect_output=True,
-                        hide_output=True
+                        hide_output=True,
                     )
-                
+
                 # Build command string
-                cmd_parts = ['jarvis_resource_graph']
+                cmd_parts = ["jarvis_resource_graph"]
                 if not benchmark:
-                    cmd_parts.append('--no-benchmark')
+                    cmd_parts.append("--no-benchmark")
                 if duration != 25:
-                    cmd_parts.extend(['--duration', str(duration)])
-                cmd = ' '.join(cmd_parts)
-                
+                    cmd_parts.extend(["--duration", str(duration)])
+                cmd = " ".join(cmd_parts)
+
                 logger.debug(f"Command to execute: {cmd}")
-                
+
                 # Execute resource collection based on execution type
-                if exec_info.exec_type.name == 'LOCAL':
+                if exec_info.exec_type.name == "LOCAL":
                     executor = LocalExec(cmd, exec_info)
                 else:
                     from jarvis_cd.shell import Exec
+
                     executor = Exec(cmd, exec_info)
-                
+
                 # Get results
                 exit_codes = executor.exit_code
-                
+
                 logger.debug(f"Exit codes: {exit_codes}")
                 logger.debug(f"Stdout: {executor.stdout}")
                 logger.debug(f"Stderr: {executor.stderr}")
-                
+
                 # Check for errors
                 if exit_codes.get(hostname, 1) != 0:
                     error_msg = executor.stderr.get(hostname, "Unknown error")
                     logger.error(f"Failed to collect from {hostname}: {error_msg}")
                     return None
-                    
+
                 # Parse JSON output
                 json_output = executor.stdout.get(hostname, "")
                 if not json_output.strip():
                     logger.error(f"No output from {hostname}")
                     return None
-                    
+
                 resource_data = json.loads(json_output)
-                logger.package(f"Collected {len(resource_data.get('fs', []))} storage devices from {hostname}")
-                
+                logger.package(
+                    f"Collected {len(resource_data.get('fs', []))} storage devices from {hostname}"
+                )
+
                 return resource_data
-                
+
             except Exception as e:
                 logger.error(f"Error collecting from {hostname}: {e}")
                 return None
-                
+
         # Use ThreadPoolExecutor for parallel collection
         max_workers = min(len(nodes), 10)  # Limit concurrent connections
-        
+
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             # Submit all collection tasks
             future_to_hostname = {
-                executor.submit(collect_from_node, hostname): hostname 
+                executor.submit(collect_from_node, hostname): hostname
                 for hostname in nodes
             }
-            
+
             # Process results as they complete
             for future in as_completed(future_to_hostname):
                 hostname = future_to_hostname[future]
@@ -211,14 +217,41 @@ class ResourceGraphManager:
                         logger.success(f"Added resources from {hostname} to graph")
                     else:
                         logger.warning(f"No resource data collected from {hostname}")
-                        
+
                 except Exception as e:
                     logger.error(f"Exception processing {hostname}: {e}")
-                    
+
     def _save(self):
         """Save resource graph through the configured JARVIS state boundary."""
         self.jarvis.save_resource_graph(self.resource_graph.to_dict())
-        
+
+    def _activate(self, loaded_graph: ResourceGraph) -> None:
+        """Publish a graph while keeping every live view coherent on failure."""
+        try:
+            self.jarvis.save_resource_graph(loaded_graph.to_dict())
+        except Exception:
+            # The Jarvis cache changes immediately after the atomic replace. A
+            # later directory-fsync error therefore means the file and cache are
+            # new even though activation reports an error. Reload the active file
+            # so this manager cannot remain a third, stale live view.
+            active_graph = ResourceGraph()
+            try:
+                active_graph.load_from_file(self.jarvis.resource_graph_file)
+            except Exception as recovery_error:
+                # A failure before replace leaves this manager's previous view
+                # correct. Preserve the publication error, adding recovery
+                # evidence without masking the primary failure.
+                publication_error = sys.exception()
+                if publication_error is not None:
+                    publication_error.add_note(
+                        "Could not reload the active resource graph after failed "
+                        f"activation: {recovery_error}"
+                    )
+            else:
+                self.resource_graph = active_graph
+            raise
+        self.resource_graph = loaded_graph
+
     def load(self, file_path: Optional[Path] = None):
         """
         Load resource graph from file.
@@ -227,14 +260,13 @@ class ResourceGraphManager:
         """
         if file_path is None:
             file_path = self.jarvis.resource_graph_file
-            
+
         if not file_path.exists():
             raise FileNotFoundError(f"Resource graph file not found: {file_path}")
-            
+
         loaded_graph = ResourceGraph()
         loaded_graph.load_from_file(file_path)
-        self.jarvis.save_resource_graph(loaded_graph.to_dict())
-        self.resource_graph = loaded_graph
+        self._activate(loaded_graph)
         logger.success(
             f"Loaded resource graph from {file_path} and activated it at "
             f"{self.jarvis.resource_graph_file}"
@@ -253,14 +285,13 @@ class ResourceGraphManager:
             snapshot.write_bytes(payload)
             loaded_graph = ResourceGraph()
             loaded_graph.load_from_file(snapshot)
-        self.jarvis.save_resource_graph(loaded_graph.to_dict())
-        self.resource_graph = loaded_graph
+        self._activate(loaded_graph)
         logger.success(
             f"Loaded builtin resource graph from {source} and activated it at "
             f"{self.jarvis.resource_graph_file}"
         )
         return source, source_sha256
-        
+
     def show(self):
         """Display the current resource graph YAML file."""
         default_path = self.jarvis.resource_graph_file
@@ -270,13 +301,13 @@ class ResourceGraphManager:
             return
 
         # Read and print raw YAML file contents
-        with open(default_path, 'r') as f:
+        with open(default_path, "r") as f:
             print(f.read())
-        
+
     def show_node_details(self, hostname: str):
         """
         Show detailed storage information for a specific node.
-        
+
         :param hostname: Hostname to show details for
         """
         if not self.resource_graph.get_all_nodes():
@@ -286,9 +317,9 @@ class ResourceGraphManager:
             except FileNotFoundError:
                 logger.warning("No resource graph loaded. Run 'jarvis rg build' first.")
                 return
-            
+
         self.resource_graph.print_node_details(hostname)
-        
+
     def list_nodes(self):
         """List all nodes in the resource graph."""
         if not self.resource_graph.get_all_nodes():
@@ -296,49 +327,56 @@ class ResourceGraphManager:
             try:
                 self.load()
             except FileNotFoundError:
-                logger.warning("No nodes in resource graph. Run 'jarvis rg build' first.")
+                logger.warning(
+                    "No nodes in resource graph. Run 'jarvis rg build' first."
+                )
                 return
-        
+
         nodes = self.resource_graph.get_all_nodes()
-            
+
         logger.info(f"Nodes in resource graph ({len(nodes)}):")
         for node in sorted(nodes):
             storage_count = len(self.resource_graph.get_node_storage(node))
             logger.info(f"  {node}: {storage_count} storage devices")
-            
+
     def filter_by_type(self, dev_type: str):
         """
         Show storage devices filtered by type.
-        
+
         :param dev_type: Device type to filter by (ssd, hdd, etc.)
         """
         if not self.resource_graph.get_all_nodes():
             logger.warning("No resource graph loaded. Run 'jarvis rg build' first.")
             return
-            
+
         filtered = self.resource_graph.filter_by_type(dev_type)
-        
+
         if not filtered:
             logger.warning(f"No {dev_type} devices found")
             return
-            
+
         logger.info(f"=== {dev_type.upper()} Storage Devices ===")
         for hostname, devices in filtered.items():
             logger.info(f"\n{hostname}:")
             for device in devices:
                 perf_info = ""
-                if device.randwrite_4k_bw != 'unknown' and device.seqwrite_1m_bw != 'unknown':
-                    perf_info = f" [4K: {device.randwrite_4k_bw}, 1M: {device.seqwrite_1m_bw}]"
+                if (
+                    device.randwrite_4k_bw != "unknown"
+                    and device.seqwrite_1m_bw != "unknown"
+                ):
+                    perf_info = (
+                        f" [4K: {device.randwrite_4k_bw}, 1M: {device.seqwrite_1m_bw}]"
+                    )
                 logger.info(f"  {device.mount}: {device.avail}{perf_info}")
-                
+
     def get_common_mounts(self) -> List[str]:
         """Get list of common mount points."""
         return list(self.resource_graph.get_common_storage().keys())
-        
+
     def show_path(self):
         """Show the path to the current resource graph file."""
         default_path = self.jarvis.resource_graph_file
-        
+
         if default_path.exists():
             # Print only the path for shell command substitution
             print(default_path)

--- a/test/unit/core/test_resource_graph_activation.py
+++ b/test/unit/core/test_resource_graph_activation.py
@@ -79,11 +79,13 @@ def test_rg_load_atomically_activates_graph_for_a_new_process(tmp_path: Path) ->
     assert "dev_type: ssd" in observed.stdout
 
 
-def test_rg_load_failed_activation_preserves_file_and_in_memory_graph(
+@pytest.mark.parametrize("activation", ["load", "load_builtin"])
+def test_failed_replace_preserves_file_cache_and_manager_graph(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    activation: str,
 ) -> None:
-    """A failed atomic replace must leave both active views unchanged."""
+    """A failed atomic replace must leave all active views unchanged."""
     jarvis_root = tmp_path / "custom-jarvis-root"
     monkeypatch.setenv("JARVIS_ROOT", str(jarvis_root))
     Jarvis._instance = None
@@ -110,9 +112,18 @@ def test_rg_load_failed_activation_preserves_file_and_in_memory_graph(
 
         monkeypatch.setattr("jarvis_cd.core.config.os.replace", fail_replace)
         with pytest.raises(OSError, match="simulated atomic replacement failure"):
-            manager.load(source)
+            if activation == "load":
+                manager.load(source)
+            else:
+                monkeypatch.setattr(
+                    jarvis,
+                    "get_builtin_resource_graph_path",
+                    lambda _profile: source,
+                )
+                manager.load_builtin("fixture")
 
         assert jarvis.resource_graph_file.read_bytes() == active_before
+        assert jarvis.resource_graph["fs"][0]["mount"] == "/old"
         mounts = {
             device["mount"]
             for node in manager.resource_graph.get_all_nodes()
@@ -124,11 +135,13 @@ def test_rg_load_failed_activation_preserves_file_and_in_memory_graph(
         Jarvis._instance = None
 
 
-def test_post_replace_fsync_failure_keeps_file_and_cache_coherent(
+@pytest.mark.parametrize("activation", ["load", "load_builtin"])
+def test_post_replace_fsync_failure_keeps_every_live_graph_coherent(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    activation: str,
 ) -> None:
-    """A durability error after replace must expose the same new graph in both views."""
+    """A post-replace error must expose the new graph in all three live views."""
     jarvis_root = tmp_path / "custom-jarvis-root"
     monkeypatch.setenv("JARVIS_ROOT", str(jarvis_root))
     Jarvis._instance = None
@@ -139,7 +152,15 @@ def test_post_replace_fsync_failure_keeps_file_and_cache_coherent(
             str(tmp_path / "private"),
             str(tmp_path / "shared"),
         )
-        replacement = {"fs": [{"mount": "/new", "dev_type": "ssd", "shared": True}]}
+        jarvis.save_resource_graph(
+            {"fs": [{"mount": "/old", "dev_type": "hdd", "shared": True}]}
+        )
+        manager = ResourceGraphManager()
+        source = tmp_path / "replacement.yaml"
+        source.write_text(
+            "fs:\n- mount: /new\n  dev_type: ssd\n  shared: true\n",
+            encoding="utf-8",
+        )
 
         def fail_directory_fsync(_path: Path) -> None:
             raise OSError("simulated directory fsync failure")
@@ -148,15 +169,27 @@ def test_post_replace_fsync_failure_keeps_file_and_cache_coherent(
             "jarvis_cd.core.config._fsync_directory", fail_directory_fsync
         )
         with pytest.raises(OSError, match="simulated directory fsync failure"):
-            jarvis.save_resource_graph(replacement)
+            if activation == "load":
+                manager.load(source)
+            else:
+                monkeypatch.setattr(
+                    jarvis,
+                    "get_builtin_resource_graph_path",
+                    lambda _profile: source,
+                )
+                manager.load_builtin("fixture")
 
         persisted = yaml.safe_load(
             jarvis.resource_graph_file.read_text(encoding="utf-8")
         )
-        assert persisted == replacement
-        assert jarvis.resource_graph == replacement
-        replacement["fs"][0]["mount"] = "/caller-mutated"
+        assert persisted["fs"][0]["mount"] == "/new"
         assert jarvis.resource_graph == persisted
+        mounts = {
+            device["mount"]
+            for node in manager.resource_graph.get_all_nodes()
+            for device in manager.resource_graph.get_node_storage(node)
+        }
+        assert mounts == {"/new"}
         assert not list(jarvis_root.glob(".resource_graph.*.tmp"))
     finally:
         Jarvis._instance = None
@@ -273,6 +306,42 @@ def test_load_builtin_json_keeps_corrupt_profile_as_a_hard_error(
     assert result.returncode != 0
     assert "jarvis.resource-graph-builtin.v1" not in result.stdout
     assert "Error:" in result.stdout + result.stderr
+
+
+def test_builtin_catalog_rejects_unsafe_discovered_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unsafe on-disk names must fail before entering human or JSON output."""
+    jarvis_root = tmp_path / "custom-jarvis-root"
+    monkeypatch.setenv("JARVIS_ROOT", str(jarvis_root))
+    Jarvis._instance = None
+    try:
+        jarvis = Jarvis.get_instance()
+        graph_root = tmp_path / "operator" / "builtin" / "resource_graph"
+        graph_root.mkdir(parents=True)
+        unsafe = graph_root / "unsafe\nprofile.yaml"
+        original_iterdir = Path.iterdir
+        original_is_file = Path.is_file
+
+        def fake_iterdir(path: Path):
+            if path == graph_root:
+                return iter([unsafe])
+            return original_iterdir(path)
+
+        def fake_is_file(path: Path) -> bool:
+            if path == unsafe:
+                return True
+            return original_is_file(path)
+
+        monkeypatch.setattr(jarvis, "get_builtin_repo_path", lambda: graph_root.parent)
+        monkeypatch.setattr(Path, "iterdir", fake_iterdir)
+        monkeypatch.setattr(Path, "is_file", fake_is_file)
+
+        with pytest.raises(ValueError, match="must be one safe exact name"):
+            jarvis.list_builtin_resource_graphs()
+    finally:
+        Jarvis._instance = None
 
 
 def test_load_builtin_json_does_not_relabel_selected_source_disappearance(

--- a/test/unit/test_release_workflow.py
+++ b/test/unit/test_release_workflow.py
@@ -346,6 +346,7 @@ def test_exact_release_request_gates_artifact_build() -> None:
     for release_contract_test in (
         "test/unit/core/test_execution_cli.py",
         "test/unit/core/test_service_runtime.py",
+        "test/unit/core/test_resource_graph_activation.py",
         "test/unit/core/test_paraview_scene_v2.py",
         "test/unit/core/test_paraview_service.py",
     ):
@@ -360,6 +361,9 @@ def test_exact_release_request_gates_artifact_build() -> None:
     assert "resolve-service-runtime-authority" in WORKFLOW
     assert "MAX_HTTP_CONNECTIONS" in WORKFLOW
     assert "sys.path.insert(0, str(distribution_root / 'builtin'))" in WORKFLOW
+    assert "bin/jarvis rg builtins | grep -Fx ares" in WORKFLOW
+    assert "bin/jarvis rg load-builtin ares +json" in WORKFLOW
+    assert "jarvis.resource-graph-builtin.v1" in WORKFLOW
     build_block = WORKFLOW[build_index : WORKFLOW.index("  release:")]
     assert "    needs: release-preflight" in build_block
     assert "release_request" in build_block


### PR DESCRIPTION
## Summary

- keep `ResourceGraphManager` synchronized with the active graph when atomic publication fails before or after replacement
- reject unsafe profile names discovered in the builtin graph catalog
- exercise builtin graph activation in the explicit release-contract test set and from the installed wheel

## Root cause

`Jarvis.save_resource_graph()` updates the active file and cache before the final directory fsync, while `ResourceGraphManager.load()` and `load_builtin()` previously updated their own view only after the save returned. A post-replace fsync error could therefore leave the manager stale even though the published file and JARVIS cache were new. The release workflow also did not execute the activation tests or call the builtin graph CLI from the installed wheel.

## Validation

- `uv run pytest -q test/unit/core/test_resource_graph_activation.py test/unit/test_release_workflow.py` (19 passed)
- `uv run ruff check jarvis_cd/core/config.py jarvis_cd/core/resource_graph.py test/unit/core/test_resource_graph_activation.py test/unit/test_release_workflow.py`
- `git diff --check`
