### PR TITLE
fix: support verified hardlinked graph payloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,14 +330,19 @@ jobs:
           export JARVIS_ROOT="$PWD/jarvis-root"
           bin/jarvis init "$PWD/config" "$PWD/private" "$PWD/shared" >/dev/null
           bin/jarvis rg builtins | grep -Fx ares >/dev/null
-          BUILTIN_RESULT="$(bin/jarvis rg load-builtin ares +json)" \
-            bin/python - <<'PY'
+          bin/jarvis rg load-builtin ares +json > builtin-graph-result.json
+          test -s builtin-graph-result.json
+          BUILTIN_RESULT_PATH="$PWD/builtin-graph-result.json" bin/python - <<'PY'
           import hashlib
           import json
           import os
           from pathlib import Path
 
-          result = json.loads(os.environ['BUILTIN_RESULT'])
+          result_path = Path(os.environ['BUILTIN_RESULT_PATH'])
+          payload = result_path.read_bytes()
+          if not payload or len(payload) > 64 * 1024:
+              raise SystemExit('installed builtin graph result is not bounded JSON')
+          result = json.loads(payload)
           if result.get('schema_version') != 'jarvis.resource-graph-builtin.v1':
               raise SystemExit('installed builtin graph schema is not functional')
           if result.get('profile') != 'ares' or result.get('action') != 'loaded':

--- a/jarvis_cd/core/resource_graph.py
+++ b/jarvis_cd/core/resource_graph.py
@@ -5,11 +5,12 @@ Coordinates resource collection across nodes and provides analysis capabilities.
 
 import hashlib
 import json
+import os
 import stat
 import sys
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, cast
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from jarvis_cd.core.config import Jarvis
@@ -22,32 +23,71 @@ MAX_BUILTIN_RESOURCE_GRAPH_BYTES = 64 * 1024 * 1024
 
 
 def _read_regular_file(path: Path) -> tuple[bytes, str]:
-    """Read one bounded regular graph file while proving stable identity."""
-    before = path.lstat()
-    if (
-        not stat.S_ISREG(before.st_mode)
-        or before.st_nlink != 1
-        or before.st_size <= 0
-        or before.st_size > MAX_BUILTIN_RESOURCE_GRAPH_BYTES
-    ):
-        raise ValueError(
-            "builtin resource graph source must be one bounded regular file"
+    """Read one bounded graph while binding the opened file to its path."""
+
+    def identity(details: os.stat_result) -> tuple[int, int, int, int, int, int, int]:
+        # Windows can advance ctime merely by opening the file, so descriptor
+        # binding there relies on the stable volume/file identity plus the
+        # reparse-point rejection. POSIX ctime is included because an
+        # unprivileged alternate hardlink writer cannot restore it.
+        stable_ctime_ns = 0 if os.name == "nt" else details.st_ctime_ns
+        return (
+            details.st_mode,
+            details.st_dev,
+            details.st_ino,
+            details.st_nlink,
+            details.st_size,
+            details.st_mtime_ns,
+            stable_ctime_ns,
         )
-    with path.open("rb") as stream:
-        payload = stream.read(MAX_BUILTIN_RESOURCE_GRAPH_BYTES + 1)
-    if len(payload) != before.st_size:
-        raise ValueError("builtin resource graph source changed during activation")
-    after = path.lstat()
+
+    def is_reparse_point(details: os.stat_result) -> bool:
+        attributes = cast(int, getattr(details, "st_file_attributes", 0))
+        reparse_flag = cast(int, getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400))
+        return bool(attributes & reparse_flag)
+
+    linked_before = path.lstat()
     if (
-        before.st_dev,
-        before.st_ino,
-        before.st_size,
-        before.st_mtime_ns,
-    ) != (
-        after.st_dev,
-        after.st_ino,
-        after.st_size,
-        after.st_mtime_ns,
+        not stat.S_ISREG(linked_before.st_mode)
+        or is_reparse_point(linked_before)
+        or linked_before.st_nlink < 1
+        or linked_before.st_size <= 0
+        or linked_before.st_size > MAX_BUILTIN_RESOURCE_GRAPH_BYTES
+    ):
+        raise ValueError("builtin resource graph source must be one bounded regular file")
+    flags = (
+        os.O_RDONLY
+        | cast(int, getattr(os, "O_BINARY", 0))
+        | cast(int, getattr(os, "O_CLOEXEC", 0))
+        | cast(int, getattr(os, "O_NOFOLLOW", 0))
+    )
+    descriptor = os.open(path, flags)
+    try:
+        opened_before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened_before.st_mode)
+            or is_reparse_point(opened_before)
+            or identity(opened_before) != identity(linked_before)
+        ):
+            raise ValueError("builtin resource graph source changed before activation")
+        chunks: list[bytes] = []
+        remaining = MAX_BUILTIN_RESOURCE_GRAPH_BYTES + 1
+        while remaining:
+            chunk = os.read(descriptor, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        payload = b"".join(chunks)
+        opened_after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    linked_after = path.lstat()
+    if (
+        len(payload) != opened_before.st_size
+        or is_reparse_point(linked_after)
+        or identity(opened_after) != identity(opened_before)
+        or identity(linked_after) != identity(opened_after)
     ):
         raise ValueError("builtin resource graph source changed during activation")
     return payload, hashlib.sha256(payload).hexdigest()

--- a/test/unit/core/test_resource_graph_activation.py
+++ b/test/unit/core/test_resource_graph_activation.py
@@ -15,7 +15,7 @@ import yaml
 
 from jarvis_cd.core.cli import JarvisCLI
 from jarvis_cd.core.config import Jarvis
-from jarvis_cd.core.resource_graph import ResourceGraphManager
+from jarvis_cd.core.resource_graph import ResourceGraphManager, _read_regular_file
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -232,6 +232,69 @@ def test_load_builtin_activates_packaged_graph_for_a_new_process(
     observed = _run_jarvis("rg", "show", jarvis_root=jarvis_root)
     assert "/mnt/ssd" in observed.stdout
     assert "dev_type: ssd" in observed.stdout
+
+
+def test_load_builtin_accepts_stable_hardlinked_wheel_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """uv's hardlink install mode must remain a valid packaged source."""
+    jarvis_root = tmp_path / "custom-jarvis-root"
+    monkeypatch.setenv("JARVIS_ROOT", str(jarvis_root))
+    Jarvis._instance = None
+    try:
+        jarvis = Jarvis.get_instance()
+        jarvis.initialize(
+            str(tmp_path / "config"),
+            str(tmp_path / "private"),
+            str(tmp_path / "shared"),
+        )
+        cache_source = tmp_path / "wheel-cache-ares.yaml"
+        cache_source.write_text(
+            "fs:\n- mount: /hardlinked\n  dev_type: ssd\n  shared: true\n",
+            encoding="utf-8",
+        )
+        installed_source = tmp_path / "installed-ares.yaml"
+        os.link(cache_source, installed_source)
+        assert installed_source.stat().st_nlink >= 2
+        monkeypatch.setattr(
+            jarvis,
+            "get_builtin_resource_graph_path",
+            lambda _profile: installed_source,
+        )
+
+        source, source_sha256 = ResourceGraphManager().load_builtin("ares")
+
+        assert source == installed_source
+        assert source_sha256 == hashlib.sha256(installed_source.read_bytes()).hexdigest()
+        assert "/hardlinked" in jarvis.resource_graph_file.read_text(encoding="utf-8")
+    finally:
+        Jarvis._instance = None
+
+
+def test_builtin_reader_rejects_path_swap_between_lstat_and_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The opened descriptor must be the exact file inspected by path."""
+    source = tmp_path / "ares.yaml"
+    source.write_text("fs:\n- mount: /expected\n", encoding="utf-8")
+    replacement = tmp_path / "replacement.yaml"
+    replacement.write_text("fs:\n- mount: /substituted\n", encoding="utf-8")
+    original_open = os.open
+    swapped = False
+
+    def swap_before_open(path: os.PathLike[str] | str, flags: int) -> int:
+        nonlocal swapped
+        if not swapped and Path(path) == source:
+            swapped = True
+            os.replace(replacement, source)
+        return original_open(path, flags)
+
+    monkeypatch.setattr("jarvis_cd.core.resource_graph.os.open", swap_before_open)
+
+    with pytest.raises(ValueError, match="changed before activation"):
+        _read_regular_file(source)
 
 
 @pytest.mark.parametrize("profile", ["missing-cluster", "../ares", "ares/path"])

--- a/test/unit/test_release_workflow.py
+++ b/test/unit/test_release_workflow.py
@@ -363,6 +363,10 @@ def test_exact_release_request_gates_artifact_build() -> None:
     assert "sys.path.insert(0, str(distribution_root / 'builtin'))" in WORKFLOW
     assert "bin/jarvis rg builtins | grep -Fx ares" in WORKFLOW
     assert "bin/jarvis rg load-builtin ares +json" in WORKFLOW
+    assert "> builtin-graph-result.json" in WORKFLOW
+    assert "BUILTIN_RESULT_PATH" in WORKFLOW
+    assert "os.environ['BUILTIN_RESULT']" not in WORKFLOW
+    assert 'BUILTIN_RESULT="$(bin/jarvis rg load-builtin' not in WORKFLOW
     assert "jarvis.resource-graph-builtin.v1" in WORKFLOW
     build_block = WORKFLOW[build_index : WORKFLOW.index("  release:")]
     assert "    needs: release-preflight" in build_block


### PR DESCRIPTION
## Summary

- accept stable hardlinked builtin graph files produced by uv wheel installation
- bind the opened descriptor to the inspected path across mode, file identity, link count, size, timestamps, and reparse status
- make the installed-wheel release smoke preserve the JARVIS exit status through a bounded result file

## Root cause

The v1.4.7 installed-wheel smoke used uv's hardlink install mode, while JARVIS required the packaged graph file to have exactly one link. The builtin activation therefore failed. Bash then masked that failure because the command substitution was an environment assignment attached to the Python verifier; the verifier ran with an empty value and became the command whose exit status was observed.

## Validation

- `uv run pytest -q test/unit/core/test_resource_graph_activation.py test/unit/test_release_workflow.py` (21 passed)
- focused Ruff checks passed
- POSIX hardlink reader probe passed under WSL
