### PR TITLE
feat: add package deployment readiness contracts

### DIFF
--- a/builtin/builtin/lammps/pkg.py
+++ b/builtin/builtin/lammps/pkg.py
@@ -12,6 +12,17 @@ from pathlib import Path
 from typing import Any
 
 from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
 from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
 
@@ -44,15 +55,12 @@ class Lammps(Application):
             },
             {
                 "name": "script",
-                "msg": "Path to LAMMPS input script (e.g., in.lj)",
+                "msg": (
+                    "Optional LAMMPS input script. Empty selects the package-owned "
+                    "bounded Lennard-Jones workload."
+                ),
                 "type": str,
-                "default": None,
-            },
-            {
-                "name": "lmp_bin",
-                "msg": "Path to LAMMPS binary (default: lmp in PATH)",
-                "type": str,
-                "default": "lmp",
+                "default": "",
             },
             {
                 "name": "cuda_arch",
@@ -91,11 +99,11 @@ class Lammps(Application):
             {
                 "name": "io_dump_interval",
                 "msg": (
-                    "If >0, use the package-owned Lennard-Jones workload and dump "
-                    "every N steps in system/Spack or container mode"
+                    "Trajectory interval for the package-owned Lennard-Jones "
+                    "workload selected when script is empty"
                 ),
                 "type": int,
-                "default": 0,
+                "default": 100,
             },
             {
                 "name": "io_lattice_size",
@@ -110,6 +118,74 @@ class Lammps(Application):
                 "default": 5000,
             },
         ]
+
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe portable LAMMPS deployment and completion semantics."""
+        if self.config.get("deploy_mode") == "container":
+            status = RuntimeStatus("unknown", "container_runtime_not_probed")
+            capabilities: tuple[str, ...] = ()
+        else:
+            probe = probe_program(
+                "lmp",
+                environment=self._deployment_environment(),
+                arguments=("-help",),
+            )
+            status = probe.status
+            capabilities = (
+                ("mpi_execution", "molecular_dynamics") if status.usable is True else ()
+            )
+        runtime = RuntimeRequirement(
+            requirement_id="lammps",
+            description="LAMMPS runtime able to execute molecular dynamics under MPI",
+            required_capabilities=("mpi_execution", "molecular_dynamics"),
+            available_capabilities=capabilities,
+            status=status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="spack",
+                    query_kind="spec",
+                    query_value="lammps",
+                ),
+            ),
+        )
+        completed = ReadinessContract(
+            mechanism="process_exit",
+            condition="successful_exit",
+        )
+        return PackageDeploymentContract(
+            package="builtin.lammps",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="generated_workload",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("script", "is_empty"),),
+                    runtime_requirements=("lammps",),
+                    readiness=completed,
+                ),
+                ExecutionProfile(
+                    name="input_script",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("script", "is_not_empty"),),
+                    runtime_requirements=("lammps",),
+                    readiness=completed,
+                ),
+            ),
+            runtime_requirements=(runtime,),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("script", "is_empty"),),
+                    requires=(
+                        ConfigurationCondition("io_dump_interval", "greater_than", 0),
+                        ConfigurationCondition("io_lattice_size", "greater_than", 0),
+                        ConfigurationCondition("io_run_steps", "greater_than", 0),
+                    ),
+                    description=(
+                        "The generated workload requires positive bounded size, "
+                        "duration, and trajectory interval values."
+                    ),
+                ),
+            ),
+        )
 
     # ------------------------------------------------------------------
     # Container Dockerfile generators
@@ -172,8 +248,37 @@ class Lammps(Application):
         """
         super()._configure(**kwargs)
 
+        self._validate_legacy_runtime_configuration()
+        self._validate_workload_configuration()
+
         if self.config.get("deploy_mode") == "default":
             self._ensure_output_dir()
+
+    def _validate_legacy_runtime_configuration(self) -> None:
+        """Reject concrete launcher overrides while accepting the old default."""
+        configured = self.config.get("lmp_bin")
+        if configured in (None, "", "lmp"):
+            return
+        raise ValueError(
+            "LAMMPS lmp_bin is no longer configurable; make LAMMPS available "
+            "through the JARVIS pipeline execution environment PATH"
+        )
+
+    def _validate_workload_configuration(self) -> None:
+        """Ensure every launch selects a real user or generated input."""
+        script = self.config.get("script")
+        if script not in (None, ""):
+            if not isinstance(script, str):
+                raise TypeError("script must be a path string")
+            return
+        raw_values: dict[str, object] = {
+            "io_dump_interval": self.config.get("io_dump_interval", 100),
+            "io_lattice_size": self.config.get("io_lattice_size", 80),
+            "io_run_steps": self.config.get("io_run_steps", 5000),
+        }
+        for name, value in raw_values.items():
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -238,15 +343,13 @@ class Lammps(Application):
         lives in the pipeline shared directory so every allocated node sees
         the same immutable launch input.
         """
-        interval: object = self.config.get("io_dump_interval", 0)
-        if interval == 0:
-            script: object = self.config.get("script")
-            if script is None or script == "":
-                return None
-            if not isinstance(script, str):
-                raise TypeError("script must be a path string")
+        self._validate_workload_configuration()
+        script: object = self.config.get("script")
+        if script not in (None, ""):
+            assert isinstance(script, str)
             return os.path.expanduser(os.path.expandvars(script))
 
+        interval: object = self.config.get("io_dump_interval", 100)
         raw_values: dict[str, object] = {
             "io_dump_interval": interval,
             "io_lattice_size": self.config.get("io_lattice_size", 80),
@@ -323,6 +426,7 @@ class Lammps(Application):
         Branches on deploy_mode: uses MpiExecInfo with container engine for
         container mode, MpiExecInfo with hostfile for default mode.
         """
+        self._validate_legacy_runtime_configuration()
         script_path = self._generated_input_script()
         self._ensure_output_dir()
         self._remove_stale_log()
@@ -358,7 +462,7 @@ class Lammps(Application):
             ).run()
         else:
             cmd = [
-                self.config["lmp_bin"],
+                "lmp",
                 f"-log {shlex.quote(self._log_path())}",
             ]
             if script_path:

--- a/builtin/builtin/paraview/pkg.py
+++ b/builtin/builtin/paraview/pkg.py
@@ -1,6 +1,7 @@
 """Launch generic ParaView servers, services, or user-supplied batch scripts."""
 
 import os
+import re
 import secrets
 import shlex
 import sys
@@ -11,6 +12,16 @@ from pathlib import Path
 from typing import Any, cast
 
 from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+)
 from jarvis_cd.shell import Exec, ExecInfo, LocalExecInfo, MpiExecInfo, Which
 
 _EXEC_FAILURE_STDERR_LIMIT = 4096
@@ -20,6 +31,7 @@ _MODE_EXECUTABLES = {
     "service": "pvpython",
 }
 _HEADLESS_ARGUMENTS = ("--mesa", "--force-offscreen-rendering")
+_VERSION_COMPONENT = re.compile(r"\d+")
 
 
 @dataclass(frozen=True)
@@ -156,6 +168,134 @@ class Paraview(Application):
                 "default": 120,
             },
         ]
+
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe every generic ParaView execution and readiness mode."""
+        environment = self._deployment_environment()
+        requirements = tuple(
+            self._deployment_runtime_requirement(mode, environment)
+            for mode in ("batch", "server", "service")
+        )
+        return PackageDeploymentContract(
+            package="builtin.paraview",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="batch_script",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("mode", "equals", "batch"),),
+                    runtime_requirements=("paraview.batch",),
+                    readiness=ReadinessContract(
+                        mechanism="process_exit",
+                        condition="successful_exit",
+                    ),
+                ),
+                ExecutionProfile(
+                    name="client_server",
+                    execution_kind="service",
+                    when=(ConfigurationCondition("mode", "equals", "server"),),
+                    runtime_requirements=("paraview.server",),
+                    readiness=ReadinessContract(
+                        mechanism="progress_event",
+                        condition="application_ready",
+                    ),
+                ),
+                ExecutionProfile(
+                    name="live_dataset_service",
+                    execution_kind="service",
+                    when=(ConfigurationCondition("mode", "equals", "service"),),
+                    runtime_requirements=("paraview.service",),
+                    readiness=ReadinessContract(
+                        mechanism="service_runtime",
+                        condition="health_check_succeeded",
+                        capability="interactive_visualization",
+                    ),
+                ),
+            ),
+            runtime_requirements=requirements,
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("mode", "equals", "batch"),),
+                    requires=(
+                        ConfigurationCondition("script", "is_not_empty"),
+                        ConfigurationCondition("dataset_descriptor", "is_empty"),
+                    ),
+                    description=(
+                        "Batch execution requires a user script and does not "
+                        "create a live dataset service."
+                    ),
+                ),
+                ConfigurationRule(
+                    when=(ConfigurationCondition("mode", "equals", "server"),),
+                    requires=(
+                        ConfigurationCondition("dataset_descriptor", "is_empty"),
+                    ),
+                    description=(
+                        "Plain client-server execution does not consume a live-view "
+                        "dataset descriptor."
+                    ),
+                ),
+                ConfigurationRule(
+                    when=(ConfigurationCondition("mode", "equals", "service"),),
+                    requires=(
+                        ConfigurationCondition("dataset_descriptor", "is_not_empty"),
+                        ConfigurationCondition("nprocs", "equals", 1),
+                    ),
+                    description=(
+                        "The health-checked live dataset service requires one process "
+                        "and a dataset descriptor."
+                    ),
+                ),
+            ),
+        )
+
+    def _deployment_runtime_requirement(
+        self,
+        mode: str,
+        environment: dict[str, str],
+    ) -> RuntimeRequirement:
+        """Probe one mode without returning its selected launcher location."""
+        required_by_mode = {
+            "batch": ("batch_execution",),
+            "server": ("client_server",),
+            "service": ("headless_rendering", "python_automation"),
+        }
+        required = required_by_mode[mode]
+        try:
+            runtime = self._resolve_runtime(mode, environment)
+        except (OSError, RuntimeError, ValueError):
+            status = RuntimeStatus("unavailable", "software_not_usable")
+            available: tuple[str, ...] = ()
+        else:
+            baseline = {
+                "batch": "batch_execution",
+                "server": "client_server",
+                "service": "python_automation",
+            }[mode]
+            capabilities = {baseline}
+            if runtime.capabilities:
+                capabilities.add("headless_rendering")
+            available = tuple(sorted(capabilities))
+            if set(required).issubset(capabilities):
+                status = RuntimeStatus("ready", "runtime_probe_succeeded")
+            else:
+                status = RuntimeStatus(
+                    "unavailable",
+                    "required_capability_unavailable",
+                )
+        return RuntimeRequirement(
+            requirement_id=f"paraview.{mode}",
+            description=f"ParaView runtime for the {mode} execution profile",
+            required_capabilities=required,
+            available_capabilities=available,
+            status=status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="spack",
+                    query_kind="spec",
+                    query_value="paraview",
+                ),
+            ),
+        )
 
     def _configure(self, **kwargs: Any) -> None:
         """
@@ -418,50 +558,127 @@ class Paraview(Application):
         mode: str,
         environment: dict[str, str],
     ) -> _ParaViewRuntime:
-        """Resolve and probe the mode-specific launcher from ``self.mod_env``."""
+        """Discover and capability-rank one mode-specific ParaView launcher.
+
+        Discovery is owned by the package: the active PATH is considered along
+        with ``PARAVIEW_HOME`` and versioned user installations.  Concrete
+        locations remain internal and are never serialized by the deployment
+        contract.
+        """
         executable_name = _MODE_EXECUTABLES.get(mode)
         if executable_name is None:
             raise ValueError(f"Unsupported ParaView mode: {mode!r}")
         exec_info = self._runtime_probe_info(environment)
-        resolver = Which(executable_name, exec_info)
-        resolver.run()
-        failures = self._failed_exit_codes(resolver)
-        resolved = self._first_output_line(resolver.stdout)
-        if failures or not resolved:
+        candidates = self._runtime_candidates(
+            executable_name,
+            environment,
+            exec_info,
+        )
+        if not candidates:
             path = environment.get("PATH")
             path_context = "the configured PATH" if path else "PATH"
             raise RuntimeError(
                 f"builtin.paraview mode={mode!r} requires {executable_name!r} "
-                f"in the JARVIS execution environment {path_context}; install "
-                "ParaView or select a pipeline environment that provides it"
+                f"in the JARVIS execution environment {path_context} or a "
+                "package-discoverable ParaView installation"
             )
 
-        help_result = Exec(
-            f"{shlex.quote(resolved)} --help",
-            exec_info,
-        ).run()
-        help_failures = self._failed_exit_codes(help_result)
-        if help_failures:
-            details = ", ".join(f"{host}={code!r}" for host, code in help_failures)
-            diagnostic = self._bounded_stderr(help_result, help_failures)
-            raise RuntimeError(
-                f"ParaView capability probe failed for {resolved!r}: {details}"
-                f"{diagnostic}"
+        require_headless = mode == "service" or bool(
+            self.config.get("force_offscreen_rendering", False)
+        )
+        usable: list[tuple[int, _ParaViewRuntime]] = []
+        for position, resolved in enumerate(candidates):
+            help_result = Exec(
+                f"{shlex.quote(resolved)} --help",
+                exec_info,
+            ).run()
+            if self._failed_exit_codes(help_result):
+                continue
+            help_text = "\n".join(
+                value
+                for output in (help_result.stdout, help_result.stderr)
+                if isinstance(output, dict)
+                for value in output.values()
+                if isinstance(value, str)
             )
-        help_text = "\n".join(
-            value
-            for output in (help_result.stdout, help_result.stderr)
-            if isinstance(output, dict)
-            for value in output.values()
-            if isinstance(value, str)
+            capabilities = frozenset(
+                argument for argument in _HEADLESS_ARGUMENTS if argument in help_text
+            )
+            if require_headless and not capabilities:
+                continue
+            usable.append(
+                (
+                    position,
+                    _ParaViewRuntime(
+                        executable=resolved,
+                        capabilities=capabilities,
+                    ),
+                )
+            )
+        if not usable:
+            requirement = " with headless rendering" if require_headless else ""
+            raise RuntimeError(
+                f"No discovered ParaView runtime for mode={mode!r}{requirement} "
+                "passed the package capability probe"
+            )
+
+        # Prefer the richest capability set, then the stable discovery order.
+        # This is deterministic even when multiple versioned installations exist.
+        usable.sort(
+            key=lambda item: (len(item[1].capabilities), -item[0]),
+            reverse=True,
         )
-        capabilities = frozenset(
-            argument for argument in _HEADLESS_ARGUMENTS if argument in help_text
+        return usable[0][1]
+
+    def _runtime_candidates(
+        self,
+        executable_name: str,
+        environment: dict[str, str],
+        exec_info: LocalExecInfo,
+    ) -> tuple[str, ...]:
+        """Return deduplicated PATH, explicit-home, and user-root candidates."""
+        candidates: list[str] = []
+        resolver = Which(executable_name, exec_info)
+        resolver.run()
+        if not self._failed_exit_codes(resolver):
+            resolved = self._first_output_line(resolver.stdout)
+            if resolved:
+                candidates.append(resolved)
+
+        explicit_home = environment.get("PARAVIEW_HOME")
+        if explicit_home:
+            root = Path(explicit_home).expanduser()
+            for candidate in (root / "bin" / executable_name, root / executable_name):
+                if candidate.is_file():
+                    candidates.append(str(candidate.resolve()))
+
+        home_value = environment.get("HOME")
+        home = Path(home_value).expanduser() if home_value else Path.home()
+        versioned = list((home / "opt").glob("ParaView-*/bin"))
+        versioned.sort(key=self._versioned_runtime_key, reverse=True)
+        for bin_dir in versioned:
+            candidate = bin_dir / executable_name
+            if candidate.is_file():
+                candidates.append(str(candidate.resolve()))
+
+        unique: list[str] = []
+        seen: set[str] = set()
+        for candidate in candidates:
+            key = os.path.normcase(os.path.normpath(candidate))
+            if key in seen:
+                continue
+            seen.add(key)
+            unique.append(candidate)
+        return tuple(unique)
+
+    @staticmethod
+    def _versioned_runtime_key(bin_dir: Path) -> tuple[tuple[int, ...], str]:
+        """Sort versioned ParaView roots numerically with a stable text tie-break."""
+        install_name = bin_dir.parent.name
+        version = tuple(
+            int(component) for component in _VERSION_COMPONENT.findall(install_name)
         )
-        return _ParaViewRuntime(
-            executable=resolved,
-            capabilities=capabilities,
-        )
+        return version, install_name.casefold()
 
     def _runtime_probe_info(self, environment: dict[str, str]) -> LocalExecInfo:
         """Use the same host, container, environment, and cwd as package launch."""

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Jarvis-CD is a unified platform for deploying scientific applications, storage s
 
 ## Reference
 
+- [Package Deployment Contracts](package-deployment.md) - Versioned execution, runtime resolution, configuration, and readiness metadata
 - [Pipeline Configuration](pipelines.md) — Full YAML format, install managers (container/spack), environment management, multi-node, devcontainers
 - [Package Development Guide](package_dev_guide.md) — Create new packages, Dockerfile templates, container and spack support
 - [Pipeline Tests](pipeline_tests.md) — Automated testing with grid search and parameter sweeps

--- a/docs/package-deployment.md
+++ b/docs/package-deployment.md
@@ -1,0 +1,119 @@
+# Package deployment and readiness contracts
+
+JARVIS packages can publish a versioned, machine-readable deployment contract
+through `Pkg.describe_deployment()`. Generic clients can use this document to
+select a batch or service workflow, resolve missing software, validate
+conditional configuration, and choose the correct readiness observation. They
+do not need application-specific instructions in their system prompt.
+
+Packages that have not adopted this interface return `None`. Callers must not
+infer deployment behavior from a package class name, source directory, README,
+or configuration parameter names.
+
+## Version 1 document
+
+The current schema is `jarvis.package-deployment.v1`:
+
+```json
+{
+  "schema_version": "jarvis.package-deployment.v1",
+  "package": "example.simulator",
+  "execution_profiles": [
+    {
+      "name": "generated_workload",
+      "execution_kind": "batch",
+      "when": [
+        {"parameter": "script", "operator": "is_empty"}
+      ],
+      "runtime_requirements": ["simulator"],
+      "readiness": {
+        "mechanism": "process_exit",
+        "condition": "successful_exit"
+      }
+    }
+  ],
+  "runtime_requirements": [
+    {
+      "id": "simulator",
+      "description": "Runtime able to execute the simulation",
+      "required_capabilities": ["parallel_execution"],
+      "available_capabilities": [],
+      "status": {
+        "state": "unavailable",
+        "usable": false,
+        "reason_code": "software_not_found"
+      },
+      "provider_resolutions": [
+        {
+          "provider": "spack",
+          "query": {"kind": "spec", "value": "simulator"}
+        }
+      ]
+    }
+  ],
+  "configuration_rules": [
+    {
+      "when": [
+        {"parameter": "script", "operator": "is_empty"}
+      ],
+      "requires": [
+        {"parameter": "steps", "operator": "greater_than", "value": 0}
+      ],
+      "description": "The generated workload requires a positive duration."
+    }
+  ]
+}
+```
+
+`status` is a snapshot of the package's bounded readiness probe in the effective
+JARVIS execution environment. `usable` is `true`, `false`, or `null` when the
+package cannot determine current usability. A provider resolution is an
+optional semantic lookup hint. For example, a Spack `spec` tells a client how
+to find and activate an existing installation; it is not an instruction to
+build or install software.
+
+Execution profiles use only two portable kinds:
+
+- `batch` completes and normally uses `process_exit` readiness.
+- `service` remains live and uses either a package progress event or a durable
+  `service_runtime` health observation.
+
+Configuration conditions support `equals`, `greater_than`, `is_empty`, and
+`is_not_empty`. Every profile and rule is explicit; clients do not need to
+interpret help prose to discover requirements.
+
+## Package implementation
+
+Override `_deployment_contract()` and return a
+`jarvis_cd.deployment.PackageDeploymentContract`. The base implementation
+returns `None`. `Pkg.describe_deployment()` validates the return type and emits
+the stable dictionary form.
+
+Runtime facts remain package-owned. A package decides what software and
+capabilities it requires, which non-mutating probe establishes usability, what
+provider query can resolve it, and which lifecycle signal constitutes
+readiness. Contract output must never contain a resolved executable path,
+install prefix, or package source path. Provider selectors are semantic values
+such as a Spack spec.
+
+Generic implementation and administrative menu settings are marked
+`agent_visible: false`. They remain available to the CLI and persisted config,
+but an agent-facing describer should omit them. Package semantic inputs remain
+visible and are governed by `configuration_rules`.
+
+## Built-in packages
+
+`builtin.lammps` exposes two batch profiles. An empty `script` selects its
+bounded generated Lennard-Jones workload; a non-empty `script` selects a user
+input. The default trajectory interval is 100, so default configuration always
+launches a real finite workload. Host execution resolves LAMMPS from the
+activated environment, and the contract offers the Spack spec `lammps` when
+that runtime is not yet usable.
+
+`builtin.paraview` exposes batch-script, client-server, and health-checked live
+dataset service profiles. The package resolves and capability-checks ParaView
+from the active environment, an explicit `PARAVIEW_HOME`, or deterministic
+versioned user installations. The selected location is used internally for
+launch but is absent from the deployment document. Service mode requires a
+headless-capable Python runtime and reports readiness through the durable
+service-runtime record.

--- a/jarvis_cd/core/pkg.py
+++ b/jarvis_cd/core/pkg.py
@@ -9,11 +9,12 @@ import time
 import inspect
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Any, Callable, List, Optional, cast
+from typing import TYPE_CHECKING, Dict, Any, Callable, List, Mapping, Optional, cast
 from jarvis_cd.core.config import Jarvis
 from jarvis_cd.util.hostfile import Hostfile
 
 if TYPE_CHECKING:
+    from jarvis_cd.deployment import PackageDeploymentContract
     from jarvis_cd.artifacts import (
         ArtifactObservation,
         ArtifactReporter,
@@ -717,6 +718,55 @@ class Pkg:
         """
         return []
 
+    def _deployment_environment(self) -> dict[str, str]:
+        """Return the effective environment used by package readiness probes.
+
+        The mapping is never included in the public deployment document.  It
+        merely lets a package test the same activated PATH and provider state
+        that its launch will inherit.
+        """
+        environment = dict(os.environ)
+        for values in (self.env, self.mod_env):
+            if not isinstance(values, Mapping):
+                continue
+            environment.update(
+                {
+                    key: value
+                    for key, value in values.items()
+                    if isinstance(key, str) and isinstance(value, str)
+                }
+            )
+        return environment
+
+    def _deployment_contract(self) -> Optional["PackageDeploymentContract"]:
+        """Return package-owned deployment metadata when implemented.
+
+        Legacy packages deliberately return ``None``.  This keeps deployment
+        semantics opt-in instead of inferring them from class names, source
+        paths, or application-specific prompts.
+        """
+        return None
+
+    def deployment_contract(self) -> Optional["PackageDeploymentContract"]:
+        """Return and type-check this package's versioned deployment contract."""
+        from jarvis_cd.deployment import PackageDeploymentContract
+
+        contract = self._deployment_contract()
+        if contract is not None and not isinstance(contract, PackageDeploymentContract):
+            raise TypeError(
+                "package deployment contract must be a PackageDeploymentContract"
+            )
+        return contract
+
+    def describe_deployment(self) -> Optional[Dict[str, Any]]:
+        """Serialize package deployment/readiness metadata for generic clients.
+
+        :return: A ``jarvis.package-deployment.v1`` document, or ``None`` for a
+            package that has not declared the contract.
+        """
+        contract = self.deployment_contract()
+        return None if contract is None else contract.to_dict()
+
     def _configure(self, **kwargs):
         """
         Override this method to handle package configuration.
@@ -822,6 +872,12 @@ class Pkg:
                 "default": "",
             },
         ]
+
+        # These controls remain part of the CLI and persisted package config,
+        # but generic agents should reason from the package-owned deployment
+        # contract instead of choosing installers, paths, or debug machinery.
+        for parameter in common_menu:
+            parameter["agent_visible"] = False
 
         # Combine package-specific and common menus
         return package_menu + common_menu

--- a/jarvis_cd/deployment.py
+++ b/jarvis_cd/deployment.py
@@ -1,0 +1,432 @@
+"""Versioned, path-free package deployment and readiness contracts.
+
+Packages own the semantic facts in these contracts.  JARVIS supplies only the
+strict schema and serialization boundary so callers such as ``jarvis_describe``
+do not need application-specific prompt instructions.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import PurePosixPath, PureWindowsPath
+from shutil import which
+from typing import Any, Literal, Mapping, Sequence
+
+PACKAGE_DEPLOYMENT_SCHEMA_VERSION = "jarvis.package-deployment.v1"
+
+ExecutionKind = Literal["batch", "service"]
+ReadinessMechanism = Literal[
+    "process_exit",
+    "progress_event",
+    "service_runtime",
+]
+RuntimeState = Literal["ready", "unavailable", "unknown"]
+ConditionOperator = Literal[
+    "equals",
+    "greater_than",
+    "is_empty",
+    "is_not_empty",
+]
+JsonScalar = str | int | float | bool | None
+
+_TOKEN_PATTERN = re.compile(r"^[a-z][a-z0-9_.-]*$")
+_PARAMETER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_token(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or _TOKEN_PATTERN.fullmatch(value) is None:
+        raise ValueError(
+            f"{field_name} must be a lowercase semantic token, got {value!r}"
+        )
+
+
+def _validate_text(value: str, field_name: str) -> None:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or any(ord(character) < 32 for character in value)
+    ):
+        raise ValueError(f"{field_name} must be non-empty printable text")
+
+
+def _validate_unique_tokens(values: tuple[str, ...], field_name: str) -> None:
+    if len(set(values)) != len(values):
+        raise ValueError(f"{field_name} cannot contain duplicates")
+    for value in values:
+        _validate_token(value, field_name)
+
+
+def _looks_absolute(value: str) -> bool:
+    """Recognize both POSIX and Windows absolute paths on every host OS."""
+    return PurePosixPath(value).is_absolute() or PureWindowsPath(value).is_absolute()
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigurationCondition:
+    """One machine-readable predicate over a package configuration parameter."""
+
+    parameter: str
+    operator: ConditionOperator
+    value: JsonScalar = None
+
+    def __post_init__(self) -> None:
+        """Reject ambiguous conditions at the package boundary."""
+        if (
+            not isinstance(self.parameter, str)
+            or _PARAMETER_PATTERN.fullmatch(self.parameter) is None
+        ):
+            raise ValueError(f"invalid configuration parameter: {self.parameter!r}")
+        if self.operator not in {
+            "equals",
+            "greater_than",
+            "is_empty",
+            "is_not_empty",
+        }:
+            raise ValueError(f"unsupported condition operator: {self.operator!r}")
+        if self.operator in {"is_empty", "is_not_empty"} and self.value is not None:
+            raise ValueError(f"{self.operator} conditions cannot include a value")
+        if self.operator == "greater_than" and (
+            isinstance(self.value, bool) or not isinstance(self.value, (int, float))
+        ):
+            raise ValueError("greater_than conditions require a numeric value")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the condition without implementation-only fields."""
+        value: dict[str, Any] = {
+            "parameter": self.parameter,
+            "operator": self.operator,
+        }
+        if self.operator not in {"is_empty", "is_not_empty"}:
+            value["value"] = self.value
+        return value
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigurationRule:
+    """Configuration requirements activated when every ``when`` predicate holds."""
+
+    when: tuple[ConfigurationCondition, ...]
+    requires: tuple[ConfigurationCondition, ...]
+    description: str
+
+    def __post_init__(self) -> None:
+        """Require every rule to carry actionable semantics."""
+        if not self.when:
+            raise ValueError("configuration rules require at least one condition")
+        if not self.requires:
+            raise ValueError("configuration rules require at least one requirement")
+        _validate_text(self.description, "configuration rule description")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize one conditional configuration rule."""
+        return {
+            "when": [condition.to_dict() for condition in self.when],
+            "requires": [condition.to_dict() for condition in self.requires],
+            "description": self.description,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderResolution:
+    """A provider-native query that may satisfy a runtime requirement.
+
+    The query is a semantic selector such as a Spack spec, never an install
+    prefix, executable path, or source directory.
+    """
+
+    provider: str
+    query_kind: str
+    query_value: str
+
+    def __post_init__(self) -> None:
+        """Validate provider identity and keep resolution hints path-free."""
+        _validate_token(self.provider, "runtime provider")
+        _validate_token(self.query_kind, "provider query kind")
+        _validate_text(self.query_value, "provider query value")
+        if _looks_absolute(self.query_value):
+            raise ValueError("provider queries cannot expose an absolute path")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the provider-neutral resolution envelope."""
+        return {
+            "provider": self.provider,
+            "query": {
+                "kind": self.query_kind,
+                "value": self.query_value,
+            },
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeStatus:
+    """Current usability result for one package-owned runtime probe."""
+
+    state: RuntimeState
+    reason_code: str
+
+    def __post_init__(self) -> None:
+        """Keep usability and diagnostics finite and machine-readable."""
+        if self.state not in {"ready", "unavailable", "unknown"}:
+            raise ValueError(f"unsupported runtime state: {self.state!r}")
+        _validate_token(self.reason_code, "runtime status reason code")
+
+    @property
+    def usable(self) -> bool | None:
+        """Return the tri-state usability projection required by agent callers."""
+        if self.state == "ready":
+            return True
+        if self.state == "unavailable":
+            return False
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize status without leaking probe commands or resolved paths."""
+        return {
+            "state": self.state,
+            "usable": self.usable,
+            "reason_code": self.reason_code,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProgramProbeResult:
+    """Internal result of a bounded program usability probe."""
+
+    status: RuntimeStatus
+    output: str = ""
+
+
+def probe_program(
+    program: str,
+    *,
+    environment: Mapping[str, str],
+    arguments: Sequence[str] = ("--help",),
+    timeout_seconds: float = 15,
+) -> ProgramProbeResult:
+    """Probe a program through ``PATH`` without exposing its resolved location.
+
+    Packages choose the semantic program and interpret any advertised
+    capabilities.  This helper only performs bounded, side-effect-free process
+    discovery and execution.
+    """
+    _validate_text(program, "runtime program")
+    if _looks_absolute(program):
+        raise ValueError("runtime probes must use a semantic program name")
+    if timeout_seconds <= 0:
+        raise ValueError("runtime probe timeout must be positive")
+    resolved = which(program, path=environment.get("PATH"))
+    if resolved is None:
+        return ProgramProbeResult(RuntimeStatus("unavailable", "software_not_found"))
+    try:
+        completed = subprocess.run(
+            [resolved, *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=dict(environment),
+            timeout=timeout_seconds,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ProgramProbeResult(RuntimeStatus("unavailable", "runtime_probe_failed"))
+    if completed.returncode != 0:
+        return ProgramProbeResult(RuntimeStatus("unavailable", "runtime_probe_failed"))
+    return ProgramProbeResult(
+        RuntimeStatus("ready", "runtime_probe_succeeded"),
+        output=f"{completed.stdout}\n{completed.stderr}",
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeRequirement:
+    """One semantic software dependency and its current capability state."""
+
+    requirement_id: str
+    description: str
+    required_capabilities: tuple[str, ...]
+    available_capabilities: tuple[str, ...]
+    status: RuntimeStatus
+    provider_resolutions: tuple[ProviderResolution, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Validate capability claims and provider alternatives."""
+        _validate_token(self.requirement_id, "runtime requirement ID")
+        _validate_text(self.description, "runtime requirement description")
+        if not self.required_capabilities:
+            raise ValueError("runtime requirements need at least one capability")
+        _validate_unique_tokens(
+            self.required_capabilities,
+            "required runtime capabilities",
+        )
+        _validate_unique_tokens(
+            self.available_capabilities,
+            "available runtime capabilities",
+        )
+        if self.status.usable is True and not set(self.required_capabilities).issubset(
+            self.available_capabilities
+        ):
+            raise ValueError("a ready runtime must advertise every required capability")
+        provider_keys = {
+            (resolution.provider, resolution.query_kind, resolution.query_value)
+            for resolution in self.provider_resolutions
+        }
+        if len(provider_keys) != len(self.provider_resolutions):
+            raise ValueError("runtime provider resolutions cannot contain duplicates")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize one path-free runtime requirement."""
+        return {
+            "id": self.requirement_id,
+            "description": self.description,
+            "required_capabilities": list(self.required_capabilities),
+            "available_capabilities": list(self.available_capabilities),
+            "status": self.status.to_dict(),
+            "provider_resolutions": [
+                resolution.to_dict() for resolution in self.provider_resolutions
+            ],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReadinessContract:
+    """How a caller observes that an execution became useful or completed."""
+
+    mechanism: ReadinessMechanism
+    condition: str
+    capability: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate generic readiness semantics."""
+        if self.mechanism not in {
+            "process_exit",
+            "progress_event",
+            "service_runtime",
+        }:
+            raise ValueError(f"unsupported readiness mechanism: {self.mechanism!r}")
+        _validate_token(self.condition, "readiness condition")
+        if self.capability is not None:
+            _validate_token(self.capability, "readiness capability")
+        if self.mechanism == "service_runtime" and self.capability is None:
+            raise ValueError("service runtime readiness requires a capability")
+        if self.mechanism != "service_runtime" and self.capability is not None:
+            raise ValueError(
+                "only service runtime readiness can name a service capability"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize readiness without scheduler- or site-specific details."""
+        value: dict[str, Any] = {
+            "mechanism": self.mechanism,
+            "condition": self.condition,
+        }
+        if self.capability is not None:
+            value["capability"] = self.capability
+        return value
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionProfile:
+    """One selectable package execution mode."""
+
+    name: str
+    execution_kind: ExecutionKind
+    when: tuple[ConfigurationCondition, ...]
+    runtime_requirements: tuple[str, ...]
+    readiness: ReadinessContract
+
+    def __post_init__(self) -> None:
+        """Validate a complete execution profile."""
+        _validate_token(self.name, "execution profile name")
+        if self.execution_kind not in {"batch", "service"}:
+            raise ValueError(f"unsupported execution kind: {self.execution_kind!r}")
+        if not self.when:
+            raise ValueError("execution profiles require selection conditions")
+        if not self.runtime_requirements:
+            raise ValueError("execution profiles require a runtime")
+        _validate_unique_tokens(
+            self.runtime_requirements,
+            "execution profile runtime requirements",
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize one agent-selectable execution profile."""
+        return {
+            "name": self.name,
+            "execution_kind": self.execution_kind,
+            "when": [condition.to_dict() for condition in self.when],
+            "runtime_requirements": list(self.runtime_requirements),
+            "readiness": self.readiness.to_dict(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PackageDeploymentContract:
+    """Complete package-owned deployment metadata exposed to generic clients."""
+
+    package: str
+    execution_profiles: tuple[ExecutionProfile, ...]
+    runtime_requirements: tuple[RuntimeRequirement, ...]
+    configuration_rules: tuple[ConfigurationRule, ...] = ()
+    schema_version: str = PACKAGE_DEPLOYMENT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        """Validate references and the exact supported contract version."""
+        if self.schema_version != PACKAGE_DEPLOYMENT_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported package deployment schema: {self.schema_version!r}"
+            )
+        _validate_token(self.package, "package identity")
+        if not self.execution_profiles:
+            raise ValueError("deployment contracts require an execution profile")
+        if not self.runtime_requirements:
+            raise ValueError("deployment contracts require a runtime requirement")
+
+        profile_names = [profile.name for profile in self.execution_profiles]
+        if len(set(profile_names)) != len(profile_names):
+            raise ValueError("execution profile names must be unique")
+        requirements = {
+            requirement.requirement_id for requirement in self.runtime_requirements
+        }
+        if len(requirements) != len(self.runtime_requirements):
+            raise ValueError("runtime requirement IDs must be unique")
+        for profile in self.execution_profiles:
+            missing = set(profile.runtime_requirements) - requirements
+            if missing:
+                raise ValueError(
+                    f"execution profile {profile.name!r} references unknown runtime "
+                    f"requirements: {sorted(missing)}"
+                )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the stable contract consumed by package describers."""
+        return {
+            "schema_version": self.schema_version,
+            "package": self.package,
+            "execution_profiles": [
+                profile.to_dict() for profile in self.execution_profiles
+            ],
+            "runtime_requirements": [
+                requirement.to_dict() for requirement in self.runtime_requirements
+            ],
+            "configuration_rules": [
+                rule.to_dict() for rule in self.configuration_rules
+            ],
+        }
+
+
+__all__ = [
+    "PACKAGE_DEPLOYMENT_SCHEMA_VERSION",
+    "ConfigurationCondition",
+    "ConfigurationRule",
+    "ExecutionProfile",
+    "PackageDeploymentContract",
+    "ProgramProbeResult",
+    "ProviderResolution",
+    "ReadinessContract",
+    "RuntimeRequirement",
+    "RuntimeStatus",
+    "probe_program",
+]

--- a/test/unit/core/test_lammps_package_runtime.py
+++ b/test/unit/core/test_lammps_package_runtime.py
@@ -213,7 +213,7 @@ def test_default_launch_owns_deterministic_lammps_log(
     package = object.__new__(lammps_package.Lammps)
     package.config = {
         "kokkos_gpu": False,
-        "lmp_bin": "/opt/spack/bin/lmp",
+        "lmp_bin": "lmp",
         "nprocs": 2,
         "out": str(output_dir),
         "ppn": 2,
@@ -231,6 +231,7 @@ def test_default_launch_owns_deterministic_lammps_log(
     expected_log = output_dir.resolve() / "log.lammps"
     assert _CapturedExec.commands[0] == f"rm -f {shlex.quote(str(expected_log))}"
     command = _CapturedExec.commands[1]
+    assert shlex.split(command)[0] == "lmp"
     assert f"-log {shlex.quote(str(expected_log))}" in command
     assert f"-in {shlex.quote(str(script))}" in command
 
@@ -248,7 +249,7 @@ def test_default_launch_generates_package_owned_lennard_jones_input(
         "io_lattice_size": 6,
         "io_run_steps": 100,
         "kokkos_gpu": False,
-        "lmp_bin": "/opt/spack/bin/lmp",
+        "lmp_bin": "lmp",
         "nprocs": 2,
         "out": str(output_dir),
         "ppn": 2,
@@ -348,7 +349,7 @@ def test_container_launch_creates_log_directory_before_lammps(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Container LAMMPS must be able to open its explicit log at startup."""
+    """Container LAMMPS gets its log directory and a real default input."""
     output_dir = tmp_path / "container output"
     package = object.__new__(lammps_package.Lammps)
     package.config = {
@@ -380,10 +381,12 @@ def test_container_launch_creates_log_directory_before_lammps(
     assert _CapturedExec.commands[0] == f"rm -f {shlex.quote(str(expected_log))}"
     argv = shlex.split(_CapturedExec.commands[1])
     assert argv[:2] == ["bash", "-c"]
-    assert argv[2] == (
+    expected_prefix = (
         f"mkdir -p {shlex.quote(str(output_dir.resolve()))} "
         f"&& exec /usr/local/bin/lmp -log {shlex.quote(str(expected_log))}"
     )
+    assert argv[2].startswith(expected_prefix + " -in ")
+    assert "generated_io_input-" in argv[2]
 
 
 def test_container_launch_keeps_package_owned_generated_input(
@@ -438,7 +441,7 @@ def test_launch_fails_closed_when_stale_log_cannot_be_removed(
     package = object.__new__(lammps_package.Lammps)
     package.config = {
         "kokkos_gpu": False,
-        "lmp_bin": "/opt/spack/bin/lmp",
+        "lmp_bin": "lmp",
         "nprocs": 1,
         "out": str(tmp_path),
         "ppn": 1,
@@ -447,6 +450,7 @@ def test_launch_fails_closed_when_stale_log_cannot_be_removed(
     package.pipeline = SimpleNamespace(get_hostfile=lambda: None)
     package.env = {}
     package.mod_env = {}
+    package.shared_dir = tmp_path
     _FailedCleanupExec.commands = []
     monkeypatch.setattr(lammps_package, "Exec", _FailedCleanupExec)
 

--- a/test/unit/core/test_package_deployment_contract.py
+++ b/test/unit/core/test_package_deployment_contract.py
@@ -1,0 +1,288 @@
+"""Focused tests for generic package deployment/readiness metadata."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.core.pkg import Pkg
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProgramProbeResult,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+)
+
+_BUILTIN_REPOSITORY_ROOT = Path(__file__).resolve().parents[3] / "builtin"
+sys.path.insert(0, str(_BUILTIN_REPOSITORY_ROOT))
+
+from builtin.lammps import pkg as lammps_module  # noqa: E402
+from builtin.paraview import pkg as paraview_module  # noqa: E402
+from jarvis_cd.core.config import Jarvis  # noqa: E402
+
+
+def _ready_probe() -> ProgramProbeResult:
+    """Return a deterministic usable program probe."""
+    return ProgramProbeResult(RuntimeStatus("ready", "runtime_probe_succeeded"))
+
+
+def test_legacy_package_has_no_inferred_deployment_contract() -> None:
+    """Class names and source locations cannot fabricate deployment semantics."""
+    package = object.__new__(Pkg)
+
+    assert package.describe_deployment() is None
+
+
+def test_common_implementation_controls_are_not_agent_visible() -> None:
+    """Generic agents see semantic package inputs, not JARVIS admin controls."""
+    package = object.__new__(Pkg)
+
+    parameters = package.configure_menu()
+
+    assert parameters
+    assert all(parameter["agent_visible"] is False for parameter in parameters)
+    assert {parameter["name"] for parameter in parameters} >= {
+        "install_method",
+        "install_query",
+        "install",
+        "hostfile",
+        "timeout",
+    }
+
+
+def test_standalone_descriptor_preserves_canonical_package_identity(
+    tmp_path: Path,
+) -> None:
+    """Generic consumers can validate deployment identity against their lookup."""
+    previous = Jarvis._instance
+    Jarvis._instance = None
+    try:
+        jarvis = Jarvis(jarvis_root=str(tmp_path / ".ppi-jarvis"))
+        jarvis.initialize(
+            config_dir=str(tmp_path / "config"),
+            private_dir=str(tmp_path / "private"),
+            shared_dir=str(tmp_path / "shared"),
+        )
+
+        package = Pkg.load_standalone("builtin.lammps")
+        document = package.describe_deployment()
+
+        assert document is not None
+        assert document["package"] == "builtin.lammps"
+    finally:
+        Jarvis._instance = previous
+
+
+def test_schema_rejects_path_provider_queries_and_dangling_runtimes() -> None:
+    """Provider selectors stay path-free and profile references stay exact."""
+    with pytest.raises(ValueError, match="absolute path"):
+        ProviderResolution("spack", "spec", "/opt/software/paraview")
+
+    with pytest.raises(ValueError, match="unknown runtime requirements"):
+        PackageDeploymentContract(
+            package="site.demo",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="run",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("mode", "equals", "run"),),
+                    runtime_requirements=("missing",),
+                    readiness=ReadinessContract(
+                        "process_exit",
+                        "successful_exit",
+                    ),
+                ),
+            ),
+            runtime_requirements=(
+                RuntimeRequirement(
+                    requirement_id="present",
+                    description="One usable test runtime",
+                    required_capabilities=("compute",),
+                    available_capabilities=("compute",),
+                    status=RuntimeStatus("ready", "runtime_probe_succeeded"),
+                ),
+            ),
+        )
+
+
+def test_lammps_contract_defaults_to_generated_batch_and_spack_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A null script is a real bounded workload rather than an empty launch."""
+    monkeypatch.setattr(
+        lammps_module,
+        "probe_program",
+        lambda *_args, **_kwargs: _ready_probe(),
+    )
+    package = object.__new__(lammps_module.Lammps)
+    package.config = {}
+    package.env = {}
+    package.mod_env = {}
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    document = package.describe_deployment()
+
+    assert menu["script"]["default"] == ""
+    assert menu["io_dump_interval"]["default"] == 100
+    assert "lmp_bin" not in menu
+    assert document is not None
+    assert document["schema_version"] == "jarvis.package-deployment.v1"
+    assert document["package"] == "builtin.lammps"
+    assert {
+        (profile["name"], profile["execution_kind"])
+        for profile in document["execution_profiles"]
+    } == {("generated_workload", "batch"), ("input_script", "batch")}
+    runtime = document["runtime_requirements"][0]
+    assert runtime["status"] == {
+        "state": "ready",
+        "usable": True,
+        "reason_code": "runtime_probe_succeeded",
+    }
+    assert runtime["provider_resolutions"] == [
+        {
+            "provider": "spack",
+            "query": {"kind": "spec", "value": "lammps"},
+        }
+    ]
+
+
+def test_lammps_concrete_launcher_override_is_not_agent_configuration() -> None:
+    """Spack activation supplies PATH; callers cannot inject an executable path."""
+    package = object.__new__(lammps_module.Lammps)
+    package.config = {"lmp_bin": "/site/software/lmp"}
+
+    with pytest.raises(ValueError, match="execution environment PATH"):
+        package._validate_legacy_runtime_configuration()
+
+
+def test_paraview_contract_is_mode_complete_and_path_free(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All ParaView modes expose generic readiness without selected paths."""
+
+    def resolve(
+        _package: Any,
+        mode: str,
+        _environment: dict[str, str],
+    ) -> Any:
+        capabilities = frozenset({"--mesa"}) if mode == "service" else frozenset()
+        return paraview_module._ParaViewRuntime(
+            executable=f"/private/runtime/{mode}",
+            capabilities=capabilities,
+        )
+
+    monkeypatch.setattr(paraview_module.Paraview, "_resolve_runtime", resolve)
+    package = object.__new__(paraview_module.Paraview)
+    package.config = {}
+    package.env = {}
+    package.mod_env = {}
+
+    document = package.describe_deployment()
+
+    assert document is not None
+    profiles = {profile["name"]: profile for profile in document["execution_profiles"]}
+    assert profiles["batch_script"]["execution_kind"] == "batch"
+    assert profiles["client_server"]["readiness"]["mechanism"] == "progress_event"
+    assert profiles["live_dataset_service"]["readiness"] == {
+        "mechanism": "service_runtime",
+        "condition": "health_check_succeeded",
+        "capability": "interactive_visualization",
+    }
+    encoded = json.dumps(document, sort_keys=True)
+    assert "/private/runtime" not in encoded
+    assert "executable" not in encoded
+    assert "source_path" not in encoded
+
+
+class _MissingWhich:
+    """Represent a ParaView launcher absent from PATH."""
+
+    def __init__(self, _executable: str, _exec_info: Any) -> None:
+        self.exit_code = {"localhost": 1}
+        self.stdout = {"localhost": ""}
+        self.stderr = {"localhost": ""}
+
+    def run(self) -> "_MissingWhich":
+        """Return the completed deterministic lookup."""
+        return self
+
+
+class _RootProbeExec:
+    """Probe discovered user installations with version-specific capabilities."""
+
+    def __init__(self, command: str, _exec_info: Any) -> None:
+        self.exit_code = {"localhost": 0}
+        self.stdout = {"localhost": ""}
+        self.stderr = {"localhost": ""}
+        if "5.12" in command or "explicit" in command:
+            self.stdout["localhost"] = "--mesa\n"
+
+    def run(self) -> "_RootProbeExec":
+        """Return the completed deterministic capability probe."""
+        return self
+
+
+def _paraview_probe_package() -> Any:
+    """Build the minimum real package context required by runtime discovery."""
+    package = object.__new__(paraview_module.Paraview)
+    package.config = {"cwd": "", "force_offscreen_rendering": False}
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: object())
+    return package
+
+
+def test_paraview_discovers_explicit_home_without_path_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """PARAVIEW_HOME is a package-owned fallback, not an agent-supplied binary."""
+    executable = tmp_path / "explicit" / "bin" / "pvpython"
+    executable.parent.mkdir(parents=True)
+    executable.write_text("test launcher", encoding="utf-8")
+    monkeypatch.setattr(paraview_module, "Which", _MissingWhich)
+    monkeypatch.setattr(paraview_module, "Exec", _RootProbeExec)
+    package = _paraview_probe_package()
+
+    runtime = package._resolve_runtime(
+        "service",
+        {
+            "HOME": str(tmp_path / "home"),
+            "PARAVIEW_HOME": str(executable.parents[1]),
+            "PATH": "",
+        },
+    )
+
+    assert runtime.executable == str(executable.resolve())
+    assert runtime.arguments(force_offscreen=True) == ("--mesa",)
+
+
+def test_paraview_selects_capable_versioned_user_install_deterministically(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A newer but incapable runtime cannot displace a usable service runtime."""
+    home = tmp_path / "home"
+    older = home / "opt" / "ParaView-5.12.1" / "bin" / "pvpython"
+    newer = home / "opt" / "ParaView-5.13.0" / "bin" / "pvpython"
+    for executable in (older, newer):
+        executable.parent.mkdir(parents=True)
+        executable.write_text("test launcher", encoding="utf-8")
+    monkeypatch.setattr(paraview_module, "Which", _MissingWhich)
+    monkeypatch.setattr(paraview_module, "Exec", _RootProbeExec)
+    package = _paraview_probe_package()
+
+    runtime = package._resolve_runtime(
+        "service",
+        {"HOME": str(home), "PATH": ""},
+    )
+
+    assert runtime.executable == str(older.resolve())
+    assert runtime.capabilities == frozenset({"--mesa"})


### PR DESCRIPTION
﻿## What changed

- Adds the versioned, path-free `jarvis.package-deployment.v1` package contract.
- Makes built-in LAMMPS describe its generated and input-script profiles plus its Spack runtime requirement.
- Makes built-in ParaView describe batch/server/service profiles and discover usable runtimes through PATH, PARAVIEW_HOME, or versioned user installs.
- Keeps concrete paths and generic administrative settings out of agent-facing metadata.

## Why

Generic remote agents need package-owned software, configuration, execution, and readiness semantics. They should not require LAMMPS- or ParaView-specific prompt recipes, site profiles, or concrete executable paths.

## Validation

- 81 focused tests passed.
- 52 supplemental tests passed; one unrelated registry-locality test was excluded because the machine registry points at a different checkout.
- Ruff passed.
- Pyright passed for the deployment, LAMMPS, and ParaView implementations.
