### PR TITLE
feat: materialize declared package inputs

### DIFF
--- a/builtin/builtin/lammps/pkg.py
+++ b/builtin/builtin/lammps/pkg.py
@@ -14,6 +14,7 @@ from typing import Any
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.deployment import (
     ConfigurationCondition,
+    ConfigurationInputBinding,
     ConfigurationRule,
     ExecutionProfile,
     PackageDeploymentContract,
@@ -56,11 +57,21 @@ class Lammps(Application):
             {
                 "name": "script",
                 "msg": (
-                    "Optional LAMMPS input script. Empty selects the package-owned "
-                    "bounded Lennard-Jones workload."
+                    "Optional native LAMMPS input script. In reduced Lennard-Jones "
+                    "units, `lattice fcc <density>` sets the FCC number density and "
+                    "`region ... units lattice` expresses unit-cell counts; no "
+                    "separate box rescaling is required. Every created atom type "
+                    "must receive a positive mass before velocity or integration "
+                    "commands; for the standard reduced Lennard-Jones single-type "
+                    "case, use `mass 1 1.0`. Empty selects the package-owned bounded "
+                    "Lennard-Jones workload."
                 ),
                 "type": str,
                 "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file",
+                    structure="regular_file",
+                ).to_dict(),
             },
             {
                 "name": "cuda_arch",
@@ -161,6 +172,10 @@ class Lammps(Application):
                     when=(ConfigurationCondition("script", "is_empty"),),
                     runtime_requirements=("lammps",),
                     readiness=completed,
+                    description=(
+                        "Built-in bounded Lennard-Jones smoke workload with a "
+                        "package-generated input script and trajectory output."
+                    ),
                 ),
                 ExecutionProfile(
                     name="input_script",
@@ -168,6 +183,15 @@ class Lammps(Application):
                     when=(ConfigurationCondition("script", "is_not_empty"),),
                     runtime_requirements=("lammps",),
                     readiness=completed,
+                    description=(
+                        "Caller-authored native LAMMPS input. For reduced-unit FCC "
+                        "systems, express target number density directly with "
+                        "`lattice fcc <density>` and cell counts with "
+                        "`region ... units lattice`. Assign every created atom type "
+                        "a positive mass before velocity or integration commands; "
+                        "for the standard reduced Lennard-Jones single-type case, "
+                        "use `mass 1 1.0`."
+                    ),
                 ),
             ),
             runtime_requirements=(runtime,),

--- a/builtin/builtin/lammps/progress.py
+++ b/builtin/builtin/lammps/progress.py
@@ -102,9 +102,35 @@ class LammpsThermoProgressAdapter:
         latest = self._last_observation
         if return_code == 0:
             total_steps = self.total_steps
+            if total_steps is None:
+                current = latest.current if latest is not None else None
+                metadata = (
+                    dict(latest.metadata)
+                    if latest is not None
+                    else self._base_progress_metadata()
+                )
+                metadata.update(
+                    {
+                        "completion_signal": "process_exit_zero_with_unknown_total",
+                        "return_code": return_code,
+                    }
+                )
+                observed_step = (
+                    f" after observed step {int(current)}"
+                    if current is not None
+                    else ""
+                )
+                return ProgressObservation(
+                    label=latest.label if latest is not None else "timestep",
+                    state=ProgressState.COMPLETED,
+                    current=current,
+                    total=None,
+                    unit=latest.unit if latest is not None else "step",
+                    message=f"LAMMPS completed successfully{observed_step}",
+                    metadata=metadata,
+                )
             if (
                 latest is None
-                or total_steps is None
                 or latest.current != total_steps
                 or latest.total != total_steps
             ):
@@ -508,6 +534,10 @@ def adapter_from_package(
     )
     if deploy_mode == "container" or not shared_log:
         output_dir = None
+    script = package.get("script")
+    generated_workload = script is None or (
+        isinstance(script, str) and not script.strip()
+    )
     return LammpsThermoProgressAdapter(
         package_name=str(package_type),
         package_id=str(package.get("pkg_id") or "lammps"),
@@ -518,7 +548,8 @@ def adapter_from_package(
             or package.get("steps")
             or (
                 package.get("io_run_steps")
-                if _optional_float(package.get("io_dump_interval"))
+                if generated_workload
+                and _optional_float(package.get("io_dump_interval"))
                 else None
             )
             or _nested_progress_total(progress)

--- a/docs/package-deployment.md
+++ b/docs/package-deployment.md
@@ -21,6 +21,7 @@ The current schema is `jarvis.package-deployment.v1`:
   "execution_profiles": [
     {
       "name": "generated_workload",
+      "description": "Package-generated bounded smoke workload.",
       "execution_kind": "batch",
       "when": [
         {"parameter": "script", "operator": "is_empty"}
@@ -80,7 +81,9 @@ Execution profiles use only two portable kinds:
 
 Configuration conditions support `equals`, `greater_than`, `is_empty`, and
 `is_not_empty`. Every profile and rule is explicit; clients do not need to
-interpret help prose to discover requirements.
+interpret help prose to discover requirements. A profile may also include a
+short package-owned `description` that explains the scientific meaning of that
+mode without exposing site paths or launcher details.
 
 ## Package implementation
 
@@ -101,14 +104,50 @@ Generic implementation and administrative menu settings are marked
 but an agent-facing describer should omit them. Package semantic inputs remain
 visible and are governed by `configuration_rules`.
 
+### Declared local configuration inputs
+
+A package can opt one configuration setting into caller-local file staging by
+attaching the following closed descriptor to that setting in its configuration
+menu:
+
+```json
+{
+  "input_binding": {
+    "schema_version": "jarvis.configuration-input-binding.v1",
+    "kind": "local_file",
+    "structure": "regular_file"
+  }
+}
+```
+
+This authority is explicit and per setting. Clients must not infer file
+semantics from a setting name, its value, or help prose. Version 1 accepts only
+one bounded regular file; directories, links, reparse points, special files,
+and files larger than 16 MiB are rejected.
+
+During package configuration, JARVIS copies each non-empty declared input into
+package-owned shared storage at
+`configuration-inputs/<parameter>/<sha256><safe-suffix>` and persists that
+absolute content-addressed path. The resulting pipeline no longer depends on a
+transport-owned staging pathname, so the transport may remove its copy after
+the configuration transaction succeeds. Reconfiguration is idempotent when
+the persisted content-addressed file is supplied again.
+
+Transport adapters that verify the durable transaction can call
+`Pkg.configuration_input_materialization_matches()`. It returns true only when
+the requested source and persisted target have identical bytes and the target
+is the exact content-addressed file under the declaring package's shared root.
+It does not authorize undeclared settings or arbitrary path rewrites.
+
 ## Built-in packages
 
 `builtin.lammps` exposes two batch profiles. An empty `script` selects its
 bounded generated Lennard-Jones workload; a non-empty `script` selects a user
-input. The default trajectory interval is 100, so default configuration always
-launches a real finite workload. Host execution resolves LAMMPS from the
-activated environment, and the contract offers the Spack spec `lammps` when
-that runtime is not yet usable.
+input. `script` declares the versioned regular-file input binding, while all
+materialization remains generic JARVIS core behavior. The default trajectory
+interval is 100, so default configuration always launches a real finite
+workload. Host execution resolves LAMMPS from the activated environment, and
+the contract offers the Spack spec `lammps` when that runtime is not yet usable.
 
 `builtin.paraview` exposes batch-script, client-server, and health-checked live
 dataset service profiles. The package resolves and capability-checks ParaView

--- a/jarvis_cd/configuration_input.py
+++ b/jarvis_cd/configuration_input.py
@@ -1,0 +1,348 @@
+"""Durable materialization for package-declared local configuration inputs."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import stat
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping, Sequence, cast
+
+from jarvis_cd.deployment import ConfigurationInputBinding
+from jarvis_cd.util.private_path import reject_private_path_redirection
+
+MAX_CONFIGURATION_INPUT_BYTES = 16 * 1024 * 1024
+_PARAMETER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SAFE_SUFFIX_PATTERN = re.compile(r"^\.[A-Za-z0-9][A-Za-z0-9._-]{0,31}$")
+
+
+def materialize_configuration_inputs(
+    *,
+    menu: Sequence[Mapping[str, Any]],
+    config: Mapping[str, Any],
+    shared_dir: str | os.PathLike[str],
+) -> dict[str, Any]:
+    """Copy declared caller-local files into package-owned shared storage.
+
+    The returned configuration replaces each nonempty declared input with an
+    absolute content-addressed path. No setting is treated as a file unless its
+    package menu carries the exact versioned ``input_binding`` descriptor.
+    """
+    shared_root = Path(shared_dir).expanduser()
+    if not shared_root.is_absolute():
+        raise ValueError("configuration input shared directory must be absolute")
+    shared_root = Path(os.path.abspath(shared_root))
+    reject_private_path_redirection(shared_root)
+    shared_root.mkdir(parents=True, exist_ok=True)
+    reject_private_path_redirection(shared_root)
+
+    materialized = dict(config)
+    seen_parameters: set[str] = set()
+    for item in menu:
+        raw_binding = item.get("input_binding")
+        if raw_binding is None:
+            continue
+        parameter = item.get("name")
+        if (
+            not isinstance(parameter, str)
+            or _PARAMETER_PATTERN.fullmatch(parameter) is None
+        ):
+            raise ValueError("configuration input binding requires a valid parameter")
+        if parameter in seen_parameters:
+            raise ValueError(
+                f"configuration input binding is duplicated for {parameter!r}"
+            )
+        seen_parameters.add(parameter)
+        if not isinstance(raw_binding, Mapping):
+            raise ValueError(
+                f"configuration input binding for {parameter!r} must be an object"
+            )
+        binding = ConfigurationInputBinding.from_dict(
+            cast(Mapping[str, object], raw_binding)
+        )
+        if binding.kind != "local_file" or binding.structure != "regular_file":
+            raise ValueError(
+                f"unsupported configuration input binding for {parameter!r}"
+            )
+        value = materialized.get(parameter)
+        if value is None or value == "":
+            continue
+        if not isinstance(value, (str, os.PathLike)):
+            raise TypeError(
+                f"declared configuration input {parameter!r} must be a path string"
+            )
+        source = _configuration_input_source(value, parameter=parameter)
+        payload, digest = _read_bounded_regular_file(source, parameter=parameter)
+        target = _materialized_target(
+            shared_root,
+            parameter=parameter,
+            source=source,
+            payload=payload,
+            digest=digest,
+        )
+        materialized[parameter] = str(target)
+    return materialized
+
+
+def configuration_input_materialization_matches(
+    *,
+    menu: Sequence[Mapping[str, Any]],
+    parameter: str,
+    requested: object,
+    materialized: object,
+    shared_dir: str | os.PathLike[str],
+) -> bool:
+    """Verify one declared rewrite against its source bytes and owned root."""
+    if not isinstance(requested, (str, os.PathLike)) or not isinstance(
+        materialized, (str, os.PathLike)
+    ):
+        return False
+    declaration = next(
+        (
+            item
+            for item in menu
+            if item.get("name") == parameter and item.get("input_binding") is not None
+        ),
+        None,
+    )
+    if declaration is None:
+        return False
+    raw_binding = declaration.get("input_binding")
+    if not isinstance(raw_binding, Mapping):
+        return False
+    try:
+        ConfigurationInputBinding.from_dict(cast(Mapping[str, object], raw_binding))
+        source = _configuration_input_source(requested, parameter=parameter)
+        source_payload, source_digest = _read_bounded_regular_file(
+            source,
+            parameter=parameter,
+        )
+        shared_root = Path(os.path.abspath(Path(shared_dir).expanduser()))
+        expected_root = shared_root / "configuration-inputs" / parameter
+        target = Path(os.path.abspath(os.fspath(materialized)))
+        reject_private_path_redirection(target)
+        if target.parent != expected_root or target.name != _materialized_name(
+            source, source_digest
+        ):
+            return False
+        target_payload, target_digest = _read_bounded_regular_file(
+            target,
+            parameter=parameter,
+            require_single_link=True,
+        )
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return False
+    return source_digest == target_digest and source_payload == target_payload
+
+
+def _configuration_input_source(
+    value: str | os.PathLike[str],
+    *,
+    parameter: str,
+) -> Path:
+    raw = os.path.expanduser(os.path.expandvars(os.fspath(value)))
+    if not raw or any(ord(character) < 32 for character in raw):
+        raise ValueError(
+            f"declared configuration input {parameter!r} must be a printable path"
+        )
+    source = Path(os.path.abspath(raw))
+    try:
+        reject_private_path_redirection(source)
+    except RuntimeError as exc:
+        raise ValueError(
+            f"declared configuration input {parameter!r} cannot traverse links"
+        ) from exc
+    return source
+
+
+def _read_bounded_regular_file(
+    path: Path,
+    *,
+    parameter: str,
+    require_single_link: bool = False,
+) -> tuple[bytes, str]:
+    """Read one stable regular file through a no-follow descriptor."""
+    try:
+        linked_before = path.lstat()
+    except OSError as exc:
+        raise ValueError(
+            f"declared configuration input {parameter!r} is not readable"
+        ) from exc
+    if (
+        not stat.S_ISREG(linked_before.st_mode)
+        or _is_path_redirection(linked_before)
+        or linked_before.st_nlink < 1
+        or (require_single_link and linked_before.st_nlink != 1)
+        or linked_before.st_size > MAX_CONFIGURATION_INPUT_BYTES
+    ):
+        raise ValueError(
+            f"declared configuration input {parameter!r} must be one bounded "
+            "regular file"
+        )
+    flags = (
+        os.O_RDONLY
+        | cast(int, getattr(os, "O_BINARY", 0))
+        | cast(int, getattr(os, "O_CLOEXEC", 0))
+        | cast(int, getattr(os, "O_NOFOLLOW", 0))
+    )
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise ValueError(
+            f"declared configuration input {parameter!r} could not be opened safely"
+        ) from exc
+    try:
+        opened_before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened_before.st_mode)
+            or _is_path_redirection(opened_before)
+            or _file_identity(opened_before) != _file_identity(linked_before)
+            or (require_single_link and opened_before.st_nlink != 1)
+        ):
+            raise ValueError(
+                f"declared configuration input {parameter!r} changed before reading"
+            )
+        chunks: list[bytes] = []
+        remaining = MAX_CONFIGURATION_INPUT_BYTES + 1
+        while remaining:
+            chunk = os.read(descriptor, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        payload = b"".join(chunks)
+        opened_after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    try:
+        linked_after = path.lstat()
+    except OSError as exc:
+        raise ValueError(
+            f"declared configuration input {parameter!r} changed while reading"
+        ) from exc
+    if (
+        len(payload) > MAX_CONFIGURATION_INPUT_BYTES
+        or len(payload) != opened_before.st_size
+        or _is_path_redirection(linked_after)
+        or (require_single_link and linked_after.st_nlink != 1)
+        or _file_identity(opened_after) != _file_identity(opened_before)
+        or _file_identity(linked_after) != _file_identity(opened_after)
+    ):
+        raise ValueError(
+            f"declared configuration input {parameter!r} changed while reading"
+        )
+    return payload, hashlib.sha256(payload).hexdigest()
+
+
+def _materialized_target(
+    shared_root: Path,
+    *,
+    parameter: str,
+    source: Path,
+    payload: bytes,
+    digest: str,
+) -> Path:
+    bindings_root = shared_root / "configuration-inputs"
+    parameter_root = bindings_root / parameter
+    for directory in (bindings_root, parameter_root):
+        reject_private_path_redirection(directory)
+        directory.mkdir(mode=0o700, exist_ok=True)
+        reject_private_path_redirection(directory)
+        if os.name != "nt":
+            directory.chmod(0o700)
+
+    target = parameter_root / _materialized_name(source, digest)
+    if target == source:
+        return target
+    if target.exists():
+        existing, existing_digest = _read_bounded_regular_file(
+            target,
+            parameter=parameter,
+            require_single_link=True,
+        )
+        if existing_digest == digest and existing == payload:
+            return target
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{digest}.",
+        suffix=".tmp",
+        dir=parameter_root,
+    )
+    temporary = Path(temporary_name)
+    descriptor_open = True
+    try:
+        offset = 0
+        while offset < len(payload):
+            written = os.write(descriptor, payload[offset:])
+            if written <= 0:
+                raise OSError("short write while materializing configuration input")
+            offset += written
+        os.fsync(descriptor)
+        if os.name != "nt":
+            descriptor_chmod = cast(Any, getattr(os, "fchmod"))
+            descriptor_chmod(descriptor, 0o400)
+        os.close(descriptor)
+        descriptor_open = False
+        os.replace(temporary, target)
+        if os.name != "nt":
+            target.chmod(0o400)
+            _fsync_directory(parameter_root)
+    finally:
+        if descriptor_open:
+            os.close(descriptor)
+        if temporary.exists():
+            temporary.unlink()
+    persisted, persisted_digest = _read_bounded_regular_file(
+        target,
+        parameter=parameter,
+        require_single_link=True,
+    )
+    if persisted_digest != digest or persisted != payload:
+        raise RuntimeError(
+            f"materialized configuration input {parameter!r} failed verification"
+        )
+    return target
+
+
+def _materialized_name(source: Path, digest: str) -> str:
+    """Return the deterministic safe filename for one input snapshot."""
+    suffix = source.suffix
+    if _SAFE_SUFFIX_PATTERN.fullmatch(suffix) is None:
+        suffix = ""
+    return f"{digest}{suffix}"
+
+
+def _file_identity(value: os.stat_result) -> tuple[int, int, int, int, int, int, int]:
+    stable_ctime_ns = 0 if os.name == "nt" else value.st_ctime_ns
+    return (
+        value.st_mode,
+        value.st_dev,
+        value.st_ino,
+        value.st_nlink,
+        value.st_size,
+        value.st_mtime_ns,
+        stable_ctime_ns,
+    )
+
+
+def _is_path_redirection(value: os.stat_result) -> bool:
+    attributes = cast(int, getattr(value, "st_file_attributes", 0))
+    reparse_flag = cast(int, getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400))
+    return stat.S_ISLNK(value.st_mode) or bool(attributes & reparse_flag)
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+__all__ = [
+    "MAX_CONFIGURATION_INPUT_BYTES",
+    "configuration_input_materialization_matches",
+    "materialize_configuration_inputs",
+]

--- a/jarvis_cd/core/pkg.py
+++ b/jarvis_cd/core/pkg.py
@@ -882,6 +882,27 @@ class Pkg:
         # Combine package-specific and common menus
         return package_menu + common_menu
 
+    def configuration_input_materialization_matches(
+        self,
+        parameter: str,
+        requested: object,
+        materialized: object,
+    ) -> bool:
+        """Verify one package-declared durable configuration-input rewrite."""
+        from jarvis_cd.configuration_input import (
+            configuration_input_materialization_matches,
+        )
+
+        if self.shared_dir is None:
+            return False
+        return configuration_input_materialization_matches(
+            menu=self.configure_menu(),
+            parameter=parameter,
+            requested=requested,
+            materialized=materialized,
+            shared_dir=self.shared_dir,
+        )
+
     def get_argparse(self):
         """
         Get PkgArgParse instance for this package.
@@ -919,6 +940,19 @@ class Pkg:
 
         # Call the internal configuration method
         self._configure(**kwargs)
+
+        # Snapshot only inputs explicitly declared by the package. This runs
+        # after package validation/configuration so persisted pipeline state no
+        # longer depends on a caller- or transport-owned staging pathname.
+        from jarvis_cd.configuration_input import materialize_configuration_inputs
+
+        if self.shared_dir is None:
+            raise RuntimeError("package configuration requires a shared directory")
+        self.config = materialize_configuration_inputs(
+            menu=self.configure_menu(),
+            config=self.config,
+            shared_dir=self.shared_dir,
+        )
 
         return self.config.copy()
 

--- a/jarvis_cd/deployment.py
+++ b/jarvis_cd/deployment.py
@@ -12,9 +12,10 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import PurePosixPath, PureWindowsPath
 from shutil import which
-from typing import Any, Literal, Mapping, Sequence
+from typing import Any, Literal, Mapping, Sequence, cast
 
 PACKAGE_DEPLOYMENT_SCHEMA_VERSION = "jarvis.package-deployment.v1"
+CONFIGURATION_INPUT_BINDING_SCHEMA_VERSION = "jarvis.configuration-input-binding.v1"
 
 ExecutionKind = Literal["batch", "service"]
 ReadinessMechanism = Literal[
@@ -30,6 +31,8 @@ ConditionOperator = Literal[
     "is_not_empty",
 ]
 JsonScalar = str | int | float | bool | None
+InputBindingKind = Literal["local_file"]
+InputBindingStructure = Literal["regular_file"]
 
 _TOKEN_PATTERN = re.compile(r"^[a-z][a-z0-9_.-]*$")
 _PARAMETER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -126,6 +129,62 @@ class ConfigurationRule:
             "requires": [condition.to_dict() for condition in self.requires],
             "description": self.description,
         }
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigurationInputBinding:
+    """Machine-readable staging semantics for one configuration setting.
+
+    Package menus attach this descriptor to a setting under ``input_binding``.
+    Clients can then stage declared inputs without inferring filesystem
+    semantics from a parameter name or its prose description.
+    """
+
+    kind: InputBindingKind
+    structure: InputBindingStructure
+    schema_version: str = CONFIGURATION_INPUT_BINDING_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        """Reject unsupported input sources and filesystem structures."""
+        if self.schema_version != CONFIGURATION_INPUT_BINDING_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported configuration input binding schema: "
+                f"{self.schema_version!r}"
+            )
+        if self.kind != "local_file":
+            raise ValueError(f"unsupported configuration input kind: {self.kind!r}")
+        if self.structure != "regular_file":
+            raise ValueError(
+                f"unsupported configuration input structure: {self.structure!r}"
+            )
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialize the closed descriptor consumed by staging clients."""
+        return {
+            "schema_version": self.schema_version,
+            "kind": self.kind,
+            "structure": self.structure,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> "ConfigurationInputBinding":
+        """Parse one closed package-menu descriptor without accepting extensions."""
+        expected = {"schema_version", "kind", "structure"}
+        if set(value) != expected:
+            raise ValueError(
+                "configuration input binding fields must be exactly: "
+                + ", ".join(sorted(expected))
+            )
+        schema_version = value["schema_version"]
+        kind = value["kind"]
+        structure = value["structure"]
+        if not all(isinstance(item, str) for item in (schema_version, kind, structure)):
+            raise ValueError("configuration input binding fields must be strings")
+        return cls(
+            schema_version=cast(str, schema_version),
+            kind=cast(InputBindingKind, kind),
+            structure=cast(InputBindingStructure, structure),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -336,6 +395,7 @@ class ExecutionProfile:
     when: tuple[ConfigurationCondition, ...]
     runtime_requirements: tuple[str, ...]
     readiness: ReadinessContract
+    description: str | None = None
 
     def __post_init__(self) -> None:
         """Validate a complete execution profile."""
@@ -350,16 +410,21 @@ class ExecutionProfile:
             self.runtime_requirements,
             "execution profile runtime requirements",
         )
+        if self.description is not None:
+            _validate_text(self.description, "execution profile description")
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize one agent-selectable execution profile."""
-        return {
+        value: dict[str, Any] = {
             "name": self.name,
             "execution_kind": self.execution_kind,
             "when": [condition.to_dict() for condition in self.when],
             "runtime_requirements": list(self.runtime_requirements),
             "readiness": self.readiness.to_dict(),
         }
+        if self.description is not None:
+            value["description"] = self.description
+        return value
 
 
 @dataclass(frozen=True, slots=True)
@@ -418,8 +483,10 @@ class PackageDeploymentContract:
 
 
 __all__ = [
+    "CONFIGURATION_INPUT_BINDING_SCHEMA_VERSION",
     "PACKAGE_DEPLOYMENT_SCHEMA_VERSION",
     "ConfigurationCondition",
+    "ConfigurationInputBinding",
     "ConfigurationRule",
     "ExecutionProfile",
     "PackageDeploymentContract",

--- a/test/unit/core/test_configuration_input_materialization.py
+++ b/test/unit/core/test_configuration_input_materialization.py
@@ -1,0 +1,259 @@
+"""Tests for generic package configuration-input materialization."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from jarvis_cd.configuration_input import (
+    configuration_input_materialization_matches,
+    materialize_configuration_inputs,
+)
+from jarvis_cd.core.config import Jarvis
+from jarvis_cd.core.pipeline import Pipeline
+
+
+_INPUT_BINDING = {
+    "schema_version": "jarvis.configuration-input-binding.v1",
+    "kind": "local_file",
+    "structure": "regular_file",
+}
+
+
+class _SuccessfulOperation:
+    """Capture a package operation without invoking LAMMPS or a shell."""
+
+    commands: list[str] = []
+
+    def __init__(self, command: str, _exec_info: Any) -> None:
+        self.command = command
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> "_SuccessfulOperation":
+        """Record the operation and report success."""
+        self.commands.append(self.command)
+        return self
+
+
+def test_materialization_is_content_addressed_and_source_independent(
+    tmp_path: Path,
+) -> None:
+    """A configured input remains stable after its caller-owned source changes."""
+    source = tmp_path / "caller" / "in.research"
+    source.parent.mkdir()
+    original = b"units lj\nrun 250\n"
+    source.write_bytes(original)
+    shared_dir = (tmp_path / "pipeline-shared" / "simulation").resolve()
+    shared_dir.mkdir(parents=True)
+    menu = [
+        {
+            "name": "script",
+            "type": str,
+            "default": "",
+            "input_binding": dict(_INPUT_BINDING),
+        }
+    ]
+
+    configured = materialize_configuration_inputs(
+        menu=menu,
+        config={"script": str(source)},
+        shared_dir=shared_dir,
+    )
+
+    target = Path(configured["script"])
+    assert target.is_relative_to(shared_dir / "configuration-inputs" / "script")
+    assert target.read_bytes() == original
+    assert target.name.endswith(".research")
+
+    source.write_text("units metal\nrun 999\n", encoding="utf-8")
+    source.unlink()
+
+    replayed = materialize_configuration_inputs(
+        menu=menu,
+        config=configured,
+        shared_dir=shared_dir,
+    )
+    assert replayed == configured
+    assert target.read_bytes() == original
+
+
+def test_undeclared_path_setting_is_not_materialized(tmp_path: Path) -> None:
+    """JARVIS never infers local-file authority from a setting name or value."""
+    source = tmp_path / "script.py"
+    source.write_text("print('not declared')\n", encoding="utf-8")
+    shared_dir = (tmp_path / "shared").resolve()
+    shared_dir.mkdir()
+
+    configured = materialize_configuration_inputs(
+        menu=[{"name": "script", "type": str, "default": ""}],
+        config={"script": str(source)},
+        shared_dir=shared_dir,
+    )
+
+    assert configured == {"script": str(source)}
+    assert not (shared_dir / "configuration-inputs").exists()
+
+
+def test_materialization_match_requires_the_exact_owned_content_address(
+    tmp_path: Path,
+) -> None:
+    """Transport adapters can distinguish a valid rewrite from path substitution."""
+    source = tmp_path / "relay-staging" / "in.research"
+    source.parent.mkdir()
+    source.write_text("units lj\nrun 25\n", encoding="utf-8")
+    shared_dir = (tmp_path / "shared").resolve()
+    shared_dir.mkdir()
+    menu = [
+        {
+            "name": "script",
+            "type": str,
+            "default": "",
+            "input_binding": dict(_INPUT_BINDING),
+        }
+    ]
+
+    configured = materialize_configuration_inputs(
+        menu=menu,
+        config={"script": str(source)},
+        shared_dir=shared_dir,
+    )
+    target = Path(configured["script"])
+
+    assert configuration_input_materialization_matches(
+        menu=menu,
+        parameter="script",
+        requested=source,
+        materialized=target,
+        shared_dir=shared_dir,
+    )
+
+    substituted = target.with_name(f"substituted{target.suffix}")
+    substituted.write_bytes(target.read_bytes())
+    assert not configuration_input_materialization_matches(
+        menu=menu,
+        parameter="script",
+        requested=source,
+        materialized=substituted,
+        shared_dir=shared_dir,
+    )
+
+
+def test_materialized_input_rejects_external_hardlink_alias(tmp_path: Path) -> None:
+    """Package-owned bytes cannot remain mutable through another hardlink."""
+    source = tmp_path / "relay-staging" / "in.research"
+    source.parent.mkdir()
+    source.write_text("units lj\nrun 25\n", encoding="utf-8")
+    shared_dir = (tmp_path / "shared").resolve()
+    shared_dir.mkdir()
+    menu = [
+        {
+            "name": "script",
+            "type": str,
+            "default": "",
+            "input_binding": dict(_INPUT_BINDING),
+        }
+    ]
+
+    configured = materialize_configuration_inputs(
+        menu=menu,
+        config={"script": str(source)},
+        shared_dir=shared_dir,
+    )
+    target = Path(configured["script"])
+    alias = tmp_path / "external-alias"
+    os.link(target, alias)
+
+    assert not configuration_input_materialization_matches(
+        menu=menu,
+        parameter="script",
+        requested=source,
+        materialized=target,
+        shared_dir=shared_dir,
+    )
+
+
+def test_malformed_declared_input_binding_fails_closed(tmp_path: Path) -> None:
+    """A near-match descriptor cannot silently acquire local-file authority."""
+    source = tmp_path / "in.research"
+    source.write_text("run 1\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="fields must be exactly"):
+        materialize_configuration_inputs(
+            menu=[
+                {
+                    "name": "script",
+                    "input_binding": {
+                        **_INPUT_BINDING,
+                        "unreviewed_extension": True,
+                    },
+                }
+            ],
+            config={"script": str(source)},
+            shared_dir=(tmp_path / "shared").resolve(),
+        )
+
+
+def test_lammps_pipeline_runs_from_materialized_input_after_source_deletion(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A later package launch uses pipeline-owned bytes, not relay staging."""
+    previous = Jarvis._instance
+    Jarvis._instance = None
+    try:
+        jarvis = Jarvis(jarvis_root=str(tmp_path / "jarvis"))
+        jarvis.initialize(
+            config_dir=str(tmp_path / "config"),
+            private_dir=str(tmp_path / "private"),
+            shared_dir=str(tmp_path / "shared"),
+        )
+        pipeline = Pipeline()
+        pipeline.create("materialized-lammps-input")
+        source = tmp_path / "relay-staging" / "in.research"
+        source.parent.mkdir()
+        original = "units lj\natom_style atomic\nrun 25\n"
+        source.write_text(original, encoding="utf-8")
+        pipeline.append(
+            "builtin.lammps",
+            package_alias="simulation",
+            config_args=[f"script={source}", "out=."],
+        )
+        pipeline.configure_package(
+            "simulation",
+            [f"script={source}", "out=."],
+        )
+
+        persisted = Pipeline("materialized-lammps-input")
+        definition = persisted.packages[0]
+        target = Path(definition["config"]["script"])
+        assert target != source
+        assert target.read_text(encoding="utf-8") == original
+
+        source.write_text("clear\n", encoding="utf-8")
+        source.unlink()
+        reloaded = Pipeline("materialized-lammps-input")
+        definition = reloaded.packages[0]
+        package = reloaded._load_package_instance(definition, reloaded.env)
+        lammps_module = sys.modules[type(package).__module__]
+        assert Path(package.config["script"]) == target
+        assert target.read_text(encoding="utf-8") == original
+
+        _SuccessfulOperation.commands = []
+        monkeypatch.setattr(lammps_module, "Exec", _SuccessfulOperation)
+        monkeypatch.setattr(lammps_module, "Mkdir", _SuccessfulOperation)
+        package.start()
+
+        launch = next(
+            command
+            for command in _SuccessfulOperation.commands
+            if command.startswith("lmp ")
+        )
+        assert f"-in {shlex.quote(str(target))}" in launch
+        assert str(source) not in launch
+    finally:
+        Jarvis._instance = previous

--- a/test/unit/core/test_lammps_progress.py
+++ b/test/unit/core/test_lammps_progress.py
@@ -100,6 +100,64 @@ def test_default_output_progress_uses_execution_package_shared_log(
     assert adapter.total_steps == 5000
 
 
+def test_caller_script_does_not_inherit_generated_workload_total(
+    tmp_path: Path,
+) -> None:
+    """An arbitrary input script cannot inherit the built-in smoke-test size."""
+    shared_dir = (tmp_path / "execution" / "shared" / "lammps").resolve()
+
+    adapter = adapter_from_package(
+        {
+            "pkg_type": "builtin.lammps",
+            "out": ".",
+            "shared_dir": str(shared_dir),
+            "script": str(tmp_path / "staged" / "in.research"),
+            "io_dump_interval": 100,
+            "io_run_steps": 5000,
+        }
+    )
+
+    assert isinstance(adapter, LammpsThermoProgressAdapter)
+    assert adapter.progress_log_paths() == [shared_dir / "log.lammps"]
+    assert adapter.total_steps is None
+
+
+def test_caller_script_success_completes_indeterminate_progress() -> None:
+    """Process exit completes custom work without inventing a timestep total."""
+    provider = LammpsThermoProgressAdapter(total_steps=None)
+    observed = provider.observe_progress(
+        "run 250\nStep Temp CPU\n0 1.0 0.0\n125 1.1 1.0\n250 1.2 2.0\n"
+    )
+
+    terminal = provider.finalize_progress_for_exit(0)
+
+    assert [item.current for item in observed] == [0.0, 125.0, 250.0]
+    assert all(item.total is None for item in observed)
+    assert len(terminal) == 1
+    assert terminal[0].state is ProgressState.COMPLETED
+    assert terminal[0].current == 250.0
+    assert terminal[0].total is None
+    assert terminal[0].metadata["completion_signal"] == (
+        "process_exit_zero_with_unknown_total"
+    )
+    assert terminal[0].metadata["return_code"] == 0
+    assert provider.finalize_progress_for_exit(0) == []
+
+
+def test_caller_script_success_without_thermo_is_still_terminal() -> None:
+    """A quiet custom script retains authoritative process completion state."""
+    provider = LammpsThermoProgressAdapter(total_steps=None)
+
+    terminal = provider.finalize_progress_for_exit(0)
+
+    assert len(terminal) == 1
+    assert terminal[0].state is ProgressState.COMPLETED
+    assert terminal[0].current is None
+    assert terminal[0].total is None
+    assert terminal[0].message == "LAMMPS completed successfully"
+    assert terminal[0].metadata["progress_source"] == "process_exit"
+
+
 def test_adapter_observes_only_lammps_jarvis_scope() -> None:
     """Unscoped or unrelated stdout must not create trusted progress."""
     adapter = LammpsThermoProgressAdapter(total_steps=100, run_id="job_1")

--- a/test/unit/core/test_package_deployment_contract.py
+++ b/test/unit/core/test_package_deployment_contract.py
@@ -13,6 +13,7 @@ import pytest
 from jarvis_cd.core.pkg import Pkg
 from jarvis_cd.deployment import (
     ConfigurationCondition,
+    ConfigurationInputBinding,
     ExecutionProfile,
     PackageDeploymentContract,
     ProgramProbeResult,
@@ -114,6 +115,29 @@ def test_schema_rejects_path_provider_queries_and_dangling_runtimes() -> None:
         )
 
 
+def test_configuration_input_binding_is_closed_and_machine_readable() -> None:
+    """Clients receive explicit file semantics instead of guessing from prose."""
+    binding = ConfigurationInputBinding(
+        kind="local_file",
+        structure="regular_file",
+    )
+
+    assert binding.to_dict() == {
+        "schema_version": "jarvis.configuration-input-binding.v1",
+        "kind": "local_file",
+        "structure": "regular_file",
+    }
+    with pytest.raises(
+        ValueError,
+        match="unsupported configuration input binding schema",
+    ):
+        ConfigurationInputBinding(
+            kind="local_file",
+            structure="regular_file",
+            schema_version="jarvis.configuration-input-binding.v2",
+        )
+
+
 def test_lammps_contract_defaults_to_generated_batch_and_spack_resolution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -132,6 +156,17 @@ def test_lammps_contract_defaults_to_generated_batch_and_spack_resolution(
     document = package.describe_deployment()
 
     assert menu["script"]["default"] == ""
+    assert menu["script"]["input_binding"] == {
+        "schema_version": "jarvis.configuration-input-binding.v1",
+        "kind": "local_file",
+        "structure": "regular_file",
+    }
+    assert "`lattice fcc <density>`" in menu["script"]["msg"]
+    assert "`region ... units lattice`" in menu["script"]["msg"]
+    assert (
+        "Every created atom type must receive a positive mass" in menu["script"]["msg"]
+    )
+    assert "`mass 1 1.0`" in menu["script"]["msg"]
     assert menu["io_dump_interval"]["default"] == 100
     assert "lmp_bin" not in menu
     assert document is not None
@@ -141,6 +176,17 @@ def test_lammps_contract_defaults_to_generated_batch_and_spack_resolution(
         (profile["name"], profile["execution_kind"])
         for profile in document["execution_profiles"]
     } == {("generated_workload", "batch"), ("input_script", "batch")}
+    profiles = {profile["name"]: profile for profile in document["execution_profiles"]}
+    assert profiles["generated_workload"]["description"] == (
+        "Built-in bounded Lennard-Jones smoke workload with a package-generated "
+        "input script and trajectory output."
+    )
+    assert "`lattice fcc <density>`" in profiles["input_script"]["description"]
+    assert (
+        "Assign every created atom type a positive mass"
+        in profiles["input_script"]["description"]
+    )
+    assert "`mass 1 1.0`" in profiles["input_script"]["description"]
     runtime = document["runtime_requirements"][0]
     assert runtime["status"] == {
         "state": "ready",


### PR DESCRIPTION
## Summary

- add a closed, machine-readable configuration input binding contract
- materialize declared local files into package-owned content-addressed storage and expose verification semantics to transports
- declare LAMMPS script input semantics and keep custom-workload progress indeterminate until process completion
- reject redirected, oversized, unstable, or multiply-linked durable targets

## Verification

- `uv run pytest -q test/unit/core/test_configuration_input_materialization.py test/unit/core/test_package_deployment_contract.py test/unit/core/test_lammps_progress.py test/unit/core/test_lammps_package_runtime.py` (53 passed)
- Ruff check and format clean
- Pyright: 0 errors