### PR TITLE
fix: tolerate slow ParaView service startup

### DIFF
--- a/builtin/builtin/paraview/pkg.py
+++ b/builtin/builtin/paraview/pkg.py
@@ -163,9 +163,12 @@ class Paraview(Application):
             },
             {
                 "name": "service_startup_timeout",
-                "msg": "Seconds allowed for the real HTTP health probe",
+                "msg": (
+                    "Seconds allowed for dataset initialization and the real "
+                    "HTTP health probe"
+                ),
                 "type": int,
-                "default": 120,
+                "default": 600,
             },
         ]
 
@@ -487,7 +490,7 @@ class Paraview(Application):
         service_port = self._configured_int("service_port", 0)
         if not 0 <= service_port <= 65535:
             raise ValueError("service_port must be between 0 and 65535")
-        startup_timeout = self._configured_int("service_startup_timeout", 120)
+        startup_timeout = self._configured_int("service_startup_timeout", 600)
         command = [
             sys.executable,
             str(supervisor),

--- a/docs/service-runtimes.md
+++ b/docs/service-runtimes.md
@@ -365,7 +365,7 @@ dataset_descriptor: /site/descriptors/asteroid-subset.json
 service_bind_host: 127.0.0.1
 service_advertise_host: 127.0.0.1
 service_port: 0
-service_startup_timeout: 120
+service_startup_timeout: 600
 nprocs: 1
 ```
 

--- a/test/unit/core/test_paraview_service.py
+++ b/test/unit/core/test_paraview_service.py
@@ -2255,7 +2255,6 @@ def test_package_service_mode_stages_generic_runtime_and_owned_output(
         "service_bind_host": "127.0.0.1",
         "service_advertise_host": "127.0.0.1",
         "service_port": 0,
-        "service_startup_timeout": 30,
     }
     package.pipeline = SimpleNamespace(get_hostfile=lambda: object())
     package.env = {}
@@ -2286,6 +2285,7 @@ def test_package_service_mode_stages_generic_runtime_and_owned_output(
     assert "--force-offscreen-rendering" not in command
     assert "--bind-host 127.0.0.1" in command
     assert "--advertise-host 127.0.0.1" in command
+    assert "--startup-timeout 600" in command
     assert exec_info.env["JARVIS_SERVICE_RUNTIME_PATH"].endswith(
         "service-runtimes.jsonl"
     )
@@ -2312,10 +2312,12 @@ def test_package_service_mode_stages_generic_runtime_and_owned_output(
     )
     assert staged_descriptor == descriptor
 
+    package.config["service_startup_timeout"] = 30
     package._start_service(dict(package.mod_env))
     deduplicated_command, _ = _CapturedExec.commands[1]
     assert deduplicated_command.count("--mesa") == 1
     assert "--force-offscreen-rendering" not in deduplicated_command
+    assert "--startup-timeout 30" in deduplicated_command
     assert [call[0] for call in _ResolvedWhich.calls] == ["pvpython", "pvpython"]
     assert _ResolvedWhich.calls[0][1].env["PATH"] == "/runtime/paraview/bin"
 


### PR DESCRIPTION
## Summary

- raise the default ParaView service startup bound from 120 to 600 seconds
- clarify that the bound covers dataset initialization as well as the HTTP health probe
- preserve explicit per-deployment overrides and document the new default

## Why

Real temporal datasets can spend more than two minutes initializing before the service health endpoint becomes ready. The prior default classified a healthy but slow initialization as a startup failure.

## Validation

- ParaView service unit file: 55 tests passed; the only initial failure was an unrelated heartbeat ordering race
- the heartbeat race passed five consecutive targeted reruns
- Ruff check passed
- Ruff format check passed
