### PR TITLE
feat: import and export reusable ParaView scenes

### DIFF
--- a/builtin/builtin/paraview/README.md
+++ b/builtin/builtin/paraview/README.md
@@ -14,6 +14,17 @@ and array facts, and a SHA-256 fingerprint. It cannot contain a camera,
 threshold, color transfer, or scene recipe. Those are explicit versioned
 commands sent to the running service.
 
+Service mode also accepts an optional `initial_scene` file using the
+`jarvis.paraview.scene-manifest.v1` declarative contract. JARVIS declares this
+setting as a regular local-file input, so relay can synchronize a Host-local
+manifest without agent-managed upload or repeated edits. The service preflights
+the descriptor fingerprint policy, topology, bounds, timesteps, fields,
+filters, actors, color ranges, scalar bars, camera, plugins, and resource
+limits before readiness. It rejects executable Python, `.pvsm` state, paths,
+unknown fields, and unsupported plugins with a structured
+`jarvis.paraview.scene-rejection.v1` record. Empty `initial_scene` preserves
+the generic root-only workflow.
+
 Service-state v2 is an explicit scene graph, not a set of global view aliases.
 It starts with a stable reader node and visible root actor. Commands create
 branching slice, clip, threshold, and point-scalar contour nodes; create or
@@ -89,3 +100,14 @@ intentionally not part of the package contract.
 
 See [`docs/service-runtimes.md`](../../../docs/service-runtimes.md) for the
 exact report, state, command, SSE, and artifact schemas.
+
+`export_scene` writes a canonical JSON scene artifact through the same durable,
+recoverable JARVIS artifact ledger as image export. The path-free manifest
+records its source descriptor fingerprint, exact or compatible fingerprint
+policy, package and ParaView versions, final service revision, portable filter
+and actor aliases, frozen effective transfer ranges with measurement-policy
+provenance, scalar-bar choices, timestep, and camera. It deliberately omits
+authorization, service ports, execution/scheduler identities, and dataset
+member locations. Import copies the accepted manifest into the new execution
+as a queryable `provenance` artifact; later live commands continue at normal
+service revisions.

--- a/builtin/builtin/paraview/USE.MD
+++ b/builtin/builtin/paraview/USE.MD
@@ -12,5 +12,28 @@ jarvis execution service-runtimes <execution-id> \
   --pipeline-id <pipeline> +json
 ```
 
+To start from a previously exported canonical scene, set
+`initial_scene=/path/to/scene.json` when appending or editing the service step.
+The setting is a declared local-file input and is materialized by JARVIS before
+launch. Omit it for the generic root-only scene. Export the current reusable
+scene with a revisioned service command:
+
+```json
+{
+  "schema_version": "jarvis.paraview.command.v2",
+  "command_id": "export-reusable-scene",
+  "operation": "export_scene",
+  "expected_revision": 12,
+  "arguments": {
+    "filename": "scenes/reusable-scene.json",
+    "fingerprint_constraint": "exact"
+  }
+}
+```
+
+Use `fingerprint_constraint:"compatible"` only when the target descriptor may
+differ but must retain the exported kind, format, topology, bounds, timestep
+count, and required fields.
+
 See [the service-runtime reference](../../../docs/service-runtimes.md) for
 configuration and command examples.

--- a/builtin/builtin/paraview/pkg.py
+++ b/builtin/builtin/paraview/pkg.py
@@ -14,6 +14,7 @@ from typing import Any, cast
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.deployment import (
     ConfigurationCondition,
+    ConfigurationInputBinding,
     ConfigurationRule,
     ExecutionProfile,
     PackageDeploymentContract,
@@ -32,6 +33,7 @@ _MODE_EXECUTABLES = {
 }
 _HEADLESS_ARGUMENTS = ("--mesa", "--force-offscreen-rendering")
 _VERSION_COMPONENT = re.compile(r"\d+")
+_MAX_INITIAL_SCENE_BYTES = 2 * 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -59,13 +61,13 @@ class Paraview(Application):
     This class provides methods to launch the Paraview application.
     """
 
-    def _init(self):
+    def _init(self) -> None:
         """
         Initialize paths
         """
         pass
 
-    def _configure_menu(self):
+    def _configure_menu(self) -> list[dict[str, Any]]:
         """
         Create a CLI menu for the configurator method.
         For thorough documentation of these parameters, view:
@@ -142,6 +144,19 @@ class Paraview(Application):
                 ),
                 "type": str,
                 "default": "",
+            },
+            {
+                "name": "initial_scene",
+                "msg": (
+                    "Optional canonical reusable scene-manifest JSON file; "
+                    "requires mode=service"
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file",
+                    structure="regular_file",
+                ).to_dict(),
             },
             {
                 "name": "service_bind_host",
@@ -221,6 +236,7 @@ class Paraview(Application):
                     requires=(
                         ConfigurationCondition("script", "is_not_empty"),
                         ConfigurationCondition("dataset_descriptor", "is_empty"),
+                        ConfigurationCondition("initial_scene", "is_empty"),
                     ),
                     description=(
                         "Batch execution requires a user script and does not "
@@ -231,6 +247,7 @@ class Paraview(Application):
                     when=(ConfigurationCondition("mode", "equals", "server"),),
                     requires=(
                         ConfigurationCondition("dataset_descriptor", "is_empty"),
+                        ConfigurationCondition("initial_scene", "is_empty"),
                     ),
                     description=(
                         "Plain client-server execution does not consume a live-view "
@@ -314,11 +331,17 @@ class Paraview(Application):
         if mode not in _MODE_EXECUTABLES:
             raise ValueError(f"Unsupported ParaView mode: {mode!r}")
         configured = self.config.get("dataset_descriptor")
+        initial_scene = self.config.get("initial_scene") or ""
         if mode != "service":
             if configured not in (None, ""):
                 raise ValueError(
                     "ParaView dataset_descriptor requires mode='service' for "
                     "live dataset viewing"
+                )
+            if initial_scene not in (None, ""):
+                raise ValueError(
+                    "ParaView initial_scene requires mode='service' for "
+                    "declarative scene import"
                 )
             return
 
@@ -329,8 +352,12 @@ class Paraview(Application):
                 "ParaView dataset_descriptor must be JSON text or a file path"
             )
         self._load_dataset_descriptor(configured, DatasetDescriptor)
+        if not isinstance(initial_scene, str):
+            raise ValueError("ParaView initial_scene must be a JSON file path")
+        if initial_scene:
+            self._read_initial_scene(initial_scene)
 
-    def start(self):
+    def start(self) -> None:
         """
         Launch an application. E.g., OrangeFS will launch the servers, clients,
         and metadata services on all necessary pkgs.
@@ -471,6 +498,10 @@ class Paraview(Application):
             package_root / "service_http.py",
             service_root / "service_http.py",
         )
+        self._stage_payload(
+            package_root / "scene_manifest.py",
+            service_root / "scene_manifest.py",
+        )
         supervisor = self._stage_payload(
             package_root / "service_supervisor.py",
             service_root / "service_supervisor.py",
@@ -516,6 +547,14 @@ class Paraview(Application):
             "--authorization-file",
             str(authorization_path),
         ]
+        initial_scene_value = cast(str, self.config.get("initial_scene") or "")
+        if initial_scene_value:
+            initial_scene_path = service_root / "initial-scene.json"
+            self._write_private_payload(
+                initial_scene_path,
+                self._read_initial_scene(initial_scene_value),
+            )
+            command.extend(["--initial-scene", str(initial_scene_path)])
         environment.update(
             {
                 "JARVIS_ARTIFACT_TRANSPORT": "sidecar",
@@ -774,6 +813,23 @@ class Paraview(Application):
                 raise ValueError("dataset_descriptor file is missing or too large")
             payload = path.read_text(encoding="utf-8")
         return descriptor_type.from_json(payload)
+
+    @staticmethod
+    def _read_initial_scene(configured: str) -> bytes:
+        """Read one bounded regular scene input before private service staging."""
+        rendered = os.path.expandvars(configured).strip()
+        if not rendered:
+            raise ValueError("initial_scene file path cannot be empty")
+        path = Path(rendered).expanduser()
+        if path.is_symlink() or not path.is_file():
+            raise ValueError("initial_scene must be a regular file")
+        size = path.stat().st_size
+        if not 2 <= size <= _MAX_INITIAL_SCENE_BYTES:
+            raise ValueError("initial_scene file is empty or too large")
+        payload = path.read_bytes()
+        if len(payload) != size:
+            raise ValueError("initial_scene changed while it was being read")
+        return payload
 
     def _stage_progress_reporter(self) -> Path:
         """Copy the standalone reporter into the package's mounted shared path."""

--- a/builtin/builtin/paraview/pkg.py
+++ b/builtin/builtin/paraview/pkg.py
@@ -47,9 +47,13 @@ class _ParaViewRuntime:
         """Return package-selected launcher arguments for semantic headless mode."""
         if not force_offscreen:
             return ()
-        for argument in _HEADLESS_ARGUMENTS:
-            if argument in self.capabilities:
-                return (argument,)
+        arguments = tuple(
+            argument
+            for argument in _HEADLESS_ARGUMENTS
+            if argument in self.capabilities
+        )
+        if arguments:
+            return arguments
         raise RuntimeError(
             f"ParaView launcher {self.executable!r} does not advertise a supported "
             "headless rendering capability (--mesa or --force-offscreen-rendering)"
@@ -643,9 +647,20 @@ class Paraview(Application):
                 for value in output.values()
                 if isinstance(value, str)
             )
-            capabilities = frozenset(
+            capabilities = {
                 argument for argument in _HEADLESS_ARGUMENTS if argument in help_text
-            )
+            }
+            # Some ParaView launchers accept the Mesa selector in their wrapper
+            # even though the delegated pvpython help omits that wrapper option.
+            # Probe the parser without rendering so known-safe companion flags
+            # are preserved instead of silently selecting an incomplete mode.
+            if "--mesa" not in capabilities:
+                mesa_result = Exec(
+                    f"{shlex.quote(resolved)} --mesa --help",
+                    exec_info,
+                ).run()
+                if not self._failed_exit_codes(mesa_result):
+                    capabilities.add("--mesa")
             if require_headless and not capabilities:
                 continue
             usable.append(
@@ -653,7 +668,7 @@ class Paraview(Application):
                     position,
                     _ParaViewRuntime(
                         executable=resolved,
-                        capabilities=capabilities,
+                        capabilities=frozenset(capabilities),
                     ),
                 )
             )

--- a/builtin/builtin/paraview/scene_manifest.py
+++ b/builtin/builtin/paraview/scene_manifest.py
@@ -1,0 +1,1401 @@
+"""Declarative import and export contract for reusable ParaView service scenes."""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+import os
+import re
+import stat
+from pathlib import Path
+from typing import Any, Mapping, Sequence, cast
+
+SCENE_MANIFEST_SCHEMA = "jarvis.paraview.scene-manifest.v1"
+SERVICE_STATE_SCHEMA = "jarvis.paraview.service-state.v2"
+SCENE_ARTIFACT_MEDIA_TYPE = "application/vnd.jarvis.paraview.scene+json"
+MAX_SCENE_MANIFEST_BYTES = 2 * 1024 * 1024
+MAX_SCENE_NODES = 32
+MAX_SCENE_ACTORS = 32
+MAX_SCENE_FIELDS = 256
+MAX_CONTOUR_VALUES = 64
+_SCENE_ID = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+_ARTIFACT_ID = re.compile(r"^art_[A-Za-z0-9_-]{22,86}$")
+_VERSION_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+:-]{0,127}$")
+
+
+class SceneManifestError(ValueError):
+    """A reusable scene was rejected with stable machine-readable evidence."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.details = dict(details or {})
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the bounded rejection envelope emitted before service readiness."""
+        return {
+            "schema_version": "jarvis.paraview.scene-rejection.v1",
+            "code": self.code,
+            "message": str(self),
+            "details": copy.deepcopy(self.details),
+        }
+
+
+def load_scene_manifest(path: Path) -> dict[str, Any]:
+    """Load one bounded private regular JSON scene manifest."""
+    if not path.is_absolute():
+        raise SceneManifestError(
+            "unsafe_scene_path",
+            "initial_scene must resolve to an absolute materialized file",
+        )
+    descriptor: int | None = None
+    try:
+        link_metadata = path.lstat()
+        if stat.S_ISLNK(link_metadata.st_mode):
+            raise SceneManifestError(
+                "unsafe_scene_path",
+                "initial_scene must be a nonempty bounded regular file",
+                details={"maximum_bytes": MAX_SCENE_MANIFEST_BYTES},
+            )
+        descriptor = os.open(
+            path,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        )
+        metadata = os.fstat(descriptor)
+    except SceneManifestError:
+        raise
+    except OSError as exc:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise SceneManifestError(
+            "unsafe_scene_path",
+            "initial_scene is missing or unreadable",
+        ) from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_size < 2
+        or metadata.st_size > MAX_SCENE_MANIFEST_BYTES
+    ):
+        if descriptor is not None:
+            os.close(descriptor)
+        raise SceneManifestError(
+            "unsafe_scene_path",
+            "initial_scene must be a nonempty bounded regular file",
+            details={"maximum_bytes": MAX_SCENE_MANIFEST_BYTES},
+        )
+    try:
+        chunks: list[bytes] = []
+        remaining = metadata.st_size
+        while remaining:
+            chunk = os.read(descriptor, min(remaining, 64 * 1024))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        payload = b"".join(chunks)
+    except OSError as exc:
+        raise SceneManifestError(
+            "unsafe_scene_path",
+            "initial_scene could not be read",
+        ) from exc
+    finally:
+        assert descriptor is not None
+        os.close(descriptor)
+    if len(payload) != metadata.st_size:
+        raise SceneManifestError(
+            "unsafe_scene_path",
+            "initial_scene changed while it was being read",
+        )
+    try:
+        value = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise SceneManifestError(
+            "invalid_manifest",
+            "initial_scene is not canonicalizable JSON",
+        ) from exc
+    if not isinstance(value, dict):
+        raise SceneManifestError(
+            "invalid_manifest",
+            "initial_scene must contain one JSON object",
+        )
+    canonical = canonical_scene_bytes(value)
+    if len(canonical) > MAX_SCENE_MANIFEST_BYTES:
+        raise SceneManifestError(
+            "resource_limit",
+            "canonical initial_scene exceeds the service size limit",
+            details={"maximum_bytes": MAX_SCENE_MANIFEST_BYTES},
+        )
+    return cast(dict[str, Any], value)
+
+
+def validate_scene_manifest(
+    value: Mapping[str, Any],
+    *,
+    descriptor: Mapping[str, Any],
+    discovery: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate a complete manifest against one opened dataset before mutation."""
+    _require_fields(
+        value,
+        {"schema_version", "dataset_binding", "compatibility", "source", "scene"},
+        code="invalid_manifest",
+        label="scene manifest",
+    )
+    if value.get("schema_version") != SCENE_MANIFEST_SCHEMA:
+        raise SceneManifestError(
+            "unsupported_scene_schema",
+            "initial_scene uses an unsupported schema version",
+            details={
+                "expected": SCENE_MANIFEST_SCHEMA,
+                "actual": value.get("schema_version"),
+            },
+        )
+    _validate_source(value.get("source"))
+    binding = _validate_dataset_binding(
+        value.get("dataset_binding"),
+        descriptor=descriptor,
+        discovery=discovery,
+    )
+    compatibility = _validate_compatibility(value.get("compatibility"))
+    scene = _mapping(value.get("scene"), "invalid_manifest", "scene must be an object")
+    _require_fields(
+        scene,
+        {"timestep_index", "filters", "actors", "camera"},
+        code="invalid_manifest",
+        label="scene",
+    )
+    filters = scene.get("filters")
+    actors = scene.get("actors")
+    if not isinstance(filters, list) or not isinstance(actors, list):
+        raise SceneManifestError(
+            "invalid_manifest",
+            "scene filters and actors must be lists",
+        )
+    requested_nodes = compatibility["resource_requirements"]["nodes"]
+    requested_actors = compatibility["resource_requirements"]["actors"]
+    if (
+        len(filters) + 1 != requested_nodes
+        or len(actors) != requested_actors
+        or requested_nodes > MAX_SCENE_NODES
+        or requested_actors > MAX_SCENE_ACTORS
+    ):
+        raise SceneManifestError(
+            "resource_limit",
+            "scene resource requirements disagree with bounded content",
+            details={
+                "maximum_nodes": MAX_SCENE_NODES,
+                "maximum_actors": MAX_SCENE_ACTORS,
+            },
+        )
+    timestep_index = _integer(
+        scene.get("timestep_index"),
+        "timestep_index",
+        minimum=0,
+    )
+    timestep_count = cast(int, binding["timestep_count"])
+    if (timestep_count == 0 and timestep_index != 0) or (
+        timestep_count > 0 and timestep_index >= timestep_count
+    ):
+        raise SceneManifestError(
+            "timestep_mismatch",
+            "scene timestep does not exist in the opened dataset",
+            details={
+                "timestep_index": timestep_index,
+                "timestep_count": timestep_count,
+            },
+        )
+    nodes = _validate_filters(filters, discovery=discovery)
+    _validate_actors(actors, nodes=nodes)
+    _validate_camera(scene.get("camera"))
+    canonical = canonical_scene_bytes(value)
+    if len(canonical) > MAX_SCENE_MANIFEST_BYTES:
+        raise SceneManifestError(
+            "resource_limit",
+            "canonical initial_scene exceeds the service size limit",
+            details={"maximum_bytes": MAX_SCENE_MANIFEST_BYTES},
+        )
+    return json.loads(canonical.decode("utf-8"))
+
+
+def build_scene_manifest(
+    *,
+    descriptor: Mapping[str, Any],
+    pipeline: Mapping[str, Any],
+    final_revision: int,
+    artifact_id: str,
+    jarvis_version: str,
+    paraview_version: str,
+    fingerprint_constraint: str,
+) -> dict[str, Any]:
+    """Project authoritative service state into a path-free canonical manifest."""
+    if fingerprint_constraint not in {"exact", "compatible"}:
+        raise ValueError("fingerprint_constraint must be exact or compatible")
+    if not _ARTIFACT_ID.fullmatch(artifact_id):
+        raise ValueError("scene artifact_id is invalid")
+    if isinstance(final_revision, bool) or not isinstance(final_revision, int):
+        raise ValueError("final_revision must be an integer")
+    if final_revision < 1:
+        raise ValueError("final_revision must be positive")
+    nodes_value = pipeline.get("nodes")
+    actors_value = pipeline.get("representations")
+    timestep_value = pipeline.get("timestep")
+    if (
+        not isinstance(nodes_value, list)
+        or not isinstance(actors_value, list)
+        or not isinstance(timestep_value, dict)
+        or not nodes_value
+        or not actors_value
+    ):
+        raise ValueError("authoritative ParaView scene is incomplete")
+    nodes = [cast(Mapping[str, Any], item) for item in nodes_value]
+    actors = [cast(Mapping[str, Any], item) for item in actors_value]
+    root = nodes[0]
+    aliases: dict[str, str] = {cast(str, root["node_id"]): "root"}
+    filters: list[dict[str, Any]] = []
+    for index, node in enumerate(nodes[1:], start=1):
+        node_id = cast(str, node["node_id"])
+        alias = f"filter-{index:02d}"
+        aliases[node_id] = alias
+        input_ids = cast(Sequence[str], node["input_node_ids"])
+        filter_record = cast(Mapping[str, Any], node["filter"])
+        filters.append(
+            {
+                "filter_id": alias,
+                "input": aliases[input_ids[0]],
+                "type": filter_record["type"],
+                "parameters": copy.deepcopy(filter_record["parameters"]),
+            }
+        )
+    rendered_actors: list[dict[str, Any]] = []
+    required_fields: dict[tuple[str, str], dict[str, Any]] = {}
+    node_by_id = {cast(str, item["node_id"]): item for item in nodes}
+    for index, actor in enumerate(actors):
+        actor_id = "actor-root" if index == 0 else f"actor-{index:02d}"
+        node_id = cast(str, actor["node_id"])
+        color, provenance = _portable_color(actor["color"])
+        field = color.get("field")
+        if isinstance(field, dict):
+            authoritative_node = node_by_id[node_id]
+            required = _find_field(
+                cast(Mapping[str, Any], authoritative_node["output"]),
+                cast(str, field["name"]),
+                cast(str, field["association"]),
+            )
+            required_fields[(required["association"], required["name"])] = {
+                "name": required["name"],
+                "association": required["association"],
+                "components": required["components"],
+                "units": required.get("units"),
+            }
+        rendered_actors.append(
+            {
+                "actor_id": actor_id,
+                "node": aliases[node_id],
+                "type": actor["type"],
+                "visible": actor["visible"],
+                "opacity": actor["opacity"],
+                "point_size_px": actor["point_size_px"],
+                "color": color,
+                "range_provenance": provenance,
+            }
+        )
+    for node in nodes[1:]:
+        record = cast(Mapping[str, Any], node["filter"])
+        parameters = cast(Mapping[str, Any], record["parameters"])
+        if record["type"] not in {"threshold", "contour"}:
+            continue
+        parent = node_by_id[cast(Sequence[str], node["input_node_ids"])[0]]
+        required = _find_field(
+            cast(Mapping[str, Any], parent["output"]),
+            cast(str, parameters["name"]),
+            cast(str, parameters["association"]),
+        )
+        required_fields[(required["association"], required["name"])] = {
+            "name": required["name"],
+            "association": required["association"],
+            "components": required["components"],
+            "units": required.get("units"),
+        }
+    descriptor_fingerprint = copy.deepcopy(descriptor["fingerprint"])
+    manifest = {
+        "schema_version": SCENE_MANIFEST_SCHEMA,
+        "dataset_binding": {
+            "descriptor_schema": descriptor["schema_version"],
+            "source_fingerprint": descriptor_fingerprint,
+            "fingerprint_constraint": fingerprint_constraint,
+            "kind": descriptor["kind"],
+            "format": descriptor["format"],
+            "topology": root["output"]["topology"],
+            "bounds": copy.deepcopy(root["output"]["bounds"]),
+            "timestep_count": timestep_value["count"],
+            "required_fields": sorted(
+                required_fields.values(),
+                key=lambda item: (item["association"], item["name"]),
+            ),
+        },
+        "compatibility": {
+            "service_state_schema": SERVICE_STATE_SCHEMA,
+            "required_plugins": [],
+            "resource_requirements": {
+                "nodes": len(nodes),
+                "actors": len(actors),
+            },
+        },
+        "source": {
+            "package": "builtin.paraview",
+            "jarvis_cd_version": _version(jarvis_version, "jarvis_cd_version"),
+            "paraview_version": _version(paraview_version, "paraview_version"),
+            "final_revision": final_revision,
+            "artifact_id": artifact_id,
+        },
+        "scene": {
+            "timestep_index": timestep_value["index"],
+            "filters": filters,
+            "actors": rendered_actors,
+            "camera": copy.deepcopy(pipeline["camera"]),
+        },
+    }
+    canonical = canonical_scene_bytes(manifest)
+    if len(canonical) > MAX_SCENE_MANIFEST_BYTES:
+        raise ValueError("canonical scene manifest exceeds the service size limit")
+    return json.loads(canonical.decode("utf-8"))
+
+
+def canonical_scene_bytes(value: Mapping[str, Any]) -> bytes:
+    """Encode one manifest deterministically without platform-specific details."""
+    try:
+        payload = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise SceneManifestError(
+            "invalid_manifest",
+            "scene manifest contains a non-JSON value",
+        ) from exc
+    return payload + b"\n"
+
+
+def _validate_source(value: object) -> None:
+    source = _mapping(value, "invalid_manifest", "source must be an object")
+    _require_fields(
+        source,
+        {
+            "package",
+            "jarvis_cd_version",
+            "paraview_version",
+            "final_revision",
+            "artifact_id",
+        },
+        code="invalid_manifest",
+        label="source",
+    )
+    if source.get("package") != "builtin.paraview":
+        raise SceneManifestError(
+            "incompatible_runtime",
+            "scene source package is not builtin.paraview",
+        )
+    _version(source.get("jarvis_cd_version"), "jarvis_cd_version")
+    _version(source.get("paraview_version"), "paraview_version")
+    _integer(source.get("final_revision"), "final_revision", minimum=1)
+    artifact_id = source.get("artifact_id")
+    if not isinstance(artifact_id, str) or not _ARTIFACT_ID.fullmatch(artifact_id):
+        raise SceneManifestError(
+            "invalid_manifest",
+            "source artifact_id is invalid",
+        )
+
+
+def _validate_dataset_binding(
+    value: object,
+    *,
+    descriptor: Mapping[str, Any],
+    discovery: Mapping[str, Any],
+) -> dict[str, Any]:
+    binding = _mapping(
+        value,
+        "invalid_manifest",
+        "dataset_binding must be an object",
+    )
+    _require_fields(
+        binding,
+        {
+            "descriptor_schema",
+            "source_fingerprint",
+            "fingerprint_constraint",
+            "kind",
+            "format",
+            "topology",
+            "bounds",
+            "timestep_count",
+            "required_fields",
+        },
+        code="invalid_manifest",
+        label="dataset_binding",
+    )
+    if binding.get("descriptor_schema") != "jarvis.dataset-descriptor.v1":
+        raise SceneManifestError(
+            "incompatible_descriptor",
+            "scene requires an unsupported dataset descriptor schema",
+        )
+    fingerprint = _mapping(
+        binding.get("source_fingerprint"),
+        "invalid_manifest",
+        "source_fingerprint must be an object",
+    )
+    if (
+        set(fingerprint) != {"algorithm", "digest"}
+        or fingerprint.get("algorithm") != "sha256"
+        or not isinstance(fingerprint.get("digest"), str)
+        or re.fullmatch(r"[0-9a-f]{64}", cast(str, fingerprint.get("digest"))) is None
+    ):
+        raise SceneManifestError(
+            "invalid_manifest",
+            "source_fingerprint is invalid",
+        )
+    constraint = binding.get("fingerprint_constraint")
+    if constraint not in {"exact", "compatible"}:
+        raise SceneManifestError(
+            "invalid_manifest",
+            "fingerprint_constraint must be exact or compatible",
+        )
+    current_fingerprint = descriptor.get("fingerprint")
+    if constraint == "exact" and fingerprint != current_fingerprint:
+        raise SceneManifestError(
+            "descriptor_fingerprint_mismatch",
+            "scene requires the exact source dataset descriptor",
+            details={
+                "required": fingerprint,
+                "actual": current_fingerprint,
+            },
+        )
+    for field in ("kind", "format"):
+        if binding.get(field) != descriptor.get(field):
+            raise SceneManifestError(
+                "incompatible_descriptor",
+                f"scene dataset {field} does not match the opened descriptor",
+                details={
+                    "field": field,
+                    "required": binding.get(field),
+                    "actual": descriptor.get(field),
+                },
+            )
+    topology = discovery.get("topology")
+    if binding.get("topology") != topology:
+        raise SceneManifestError(
+            "topology_mismatch",
+            "scene topology does not match the opened dataset",
+            details={"required": binding.get("topology"), "actual": topology},
+        )
+    bounds = binding.get("bounds")
+    if bounds is not None and not _finite_bounds(bounds):
+        raise SceneManifestError("invalid_manifest", "scene bounds are invalid")
+    if bounds != discovery.get("bounds"):
+        raise SceneManifestError(
+            "bounds_mismatch",
+            "scene bounds do not match the opened dataset",
+            details={"required": bounds, "actual": discovery.get("bounds")},
+        )
+    timestep_count = _integer(
+        binding.get("timestep_count"),
+        "timestep_count",
+        minimum=0,
+    )
+    if timestep_count != discovery.get("timestep_count"):
+        raise SceneManifestError(
+            "timestep_mismatch",
+            "scene timestep count does not match the opened dataset",
+            details={
+                "required": timestep_count,
+                "actual": discovery.get("timestep_count"),
+            },
+        )
+    fields = binding.get("required_fields")
+    if not isinstance(fields, list) or len(fields) > MAX_SCENE_FIELDS:
+        raise SceneManifestError(
+            "resource_limit",
+            "scene required_fields exceeds the bounded limit",
+            details={"maximum_fields": MAX_SCENE_FIELDS},
+        )
+    discovered_fields = discovery.get("arrays")
+    if not isinstance(discovered_fields, list):
+        raise SceneManifestError(
+            "incompatible_descriptor",
+            "opened dataset discovery has no field list",
+        )
+    identities: set[tuple[str, str]] = set()
+    for field in fields:
+        parsed = _field_identity(field)
+        identity = (parsed["association"], parsed["name"])
+        if identity in identities:
+            raise SceneManifestError(
+                "invalid_manifest",
+                "scene required_fields contains a duplicate",
+            )
+        identities.add(identity)
+        matches = [
+            candidate
+            for candidate in discovered_fields
+            if isinstance(candidate, dict)
+            and candidate.get("name") == parsed["name"]
+            and candidate.get("association") == parsed["association"]
+        ]
+        if (
+            len(matches) != 1
+            or matches[0].get("components") != parsed["components"]
+            or matches[0].get("units") != parsed["units"]
+        ):
+            raise SceneManifestError(
+                "stale_field",
+                "scene requires a field unavailable in the opened dataset",
+                details={"field": parsed},
+            )
+    return cast(dict[str, Any], binding)
+
+
+def _validate_compatibility(value: object) -> dict[str, Any]:
+    compatibility = _mapping(
+        value,
+        "invalid_manifest",
+        "compatibility must be an object",
+    )
+    _require_fields(
+        compatibility,
+        {"service_state_schema", "required_plugins", "resource_requirements"},
+        code="invalid_manifest",
+        label="compatibility",
+    )
+    if compatibility.get("service_state_schema") != SERVICE_STATE_SCHEMA:
+        raise SceneManifestError(
+            "incompatible_runtime",
+            "scene requires an unsupported service-state contract",
+        )
+    plugins = compatibility.get("required_plugins")
+    if not isinstance(plugins, list) or any(
+        not isinstance(item, str) or not item for item in plugins
+    ):
+        raise SceneManifestError(
+            "invalid_manifest",
+            "required_plugins must be a list of plugin names",
+        )
+    if plugins:
+        raise SceneManifestError(
+            "unsupported_plugin",
+            "declarative scene import does not activate ParaView plugins",
+            details={"required_plugins": plugins},
+        )
+    requirements = _mapping(
+        compatibility.get("resource_requirements"),
+        "invalid_manifest",
+        "resource_requirements must be an object",
+    )
+    _require_fields(
+        requirements,
+        {"nodes", "actors"},
+        code="invalid_manifest",
+        label="resource_requirements",
+    )
+    _integer(requirements.get("nodes"), "nodes", minimum=1)
+    _integer(requirements.get("actors"), "actors", minimum=1)
+    return cast(dict[str, Any], compatibility)
+
+
+def _validate_filters(
+    values: Sequence[object],
+    *,
+    discovery: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    if len(values) + 1 > MAX_SCENE_NODES:
+        raise SceneManifestError(
+            "resource_limit",
+            "scene contains too many filter nodes",
+            details={"maximum_nodes": MAX_SCENE_NODES},
+        )
+    root_arrays = discovery.get("arrays")
+    if not isinstance(root_arrays, list):
+        raise SceneManifestError(
+            "incompatible_descriptor",
+            "opened dataset discovery has no field list",
+        )
+    nodes: dict[str, dict[str, Any]] = {
+        "root": {
+            "topology": discovery.get("topology"),
+            "arrays": copy.deepcopy(root_arrays),
+        }
+    }
+    for raw in values:
+        value = _mapping(raw, "invalid_filter", "filter must be an object")
+        _require_fields(
+            value,
+            {"filter_id", "input", "type", "parameters"},
+            code="invalid_filter",
+            label="filter",
+        )
+        filter_id = _scene_id(value.get("filter_id"), "filter_id", "invalid_filter")
+        input_id = _scene_id(value.get("input"), "input", "invalid_filter")
+        if filter_id == "root" or filter_id in nodes:
+            raise SceneManifestError(
+                "invalid_filter",
+                "filter_id must be unique and cannot be root",
+            )
+        parent = nodes.get(input_id)
+        if parent is None:
+            raise SceneManifestError(
+                "invalid_filter",
+                "filter input must reference an earlier node",
+                details={"input": input_id},
+            )
+        filter_type = value.get("type")
+        parameters = _mapping(
+            value.get("parameters"),
+            "invalid_filter",
+            "filter parameters must be an object",
+        )
+        _validate_filter_parameters(filter_type, parameters, parent)
+        nodes[filter_id] = {
+            "topology": (
+                "surface" if filter_type in {"slice", "contour"} else parent["topology"]
+            ),
+            "arrays": copy.deepcopy(parent["arrays"]),
+        }
+    return nodes
+
+
+def _validate_filter_parameters(
+    filter_type: object,
+    parameters: Mapping[str, Any],
+    parent: Mapping[str, Any],
+) -> None:
+    if filter_type in {"slice", "clip"}:
+        _require_fields(
+            parameters,
+            {"origin", "normal"},
+            code="invalid_filter",
+            label=cast(str, filter_type),
+        )
+        _vector(parameters.get("origin"), "origin", length=3, code="invalid_filter")
+        normal = _vector(
+            parameters.get("normal"),
+            "normal",
+            length=3,
+            code="invalid_filter",
+        )
+        if math.sqrt(sum(item * item for item in normal)) <= 1e-12:
+            raise SceneManifestError(
+                "invalid_filter",
+                "filter normal cannot be a zero vector",
+            )
+        return
+    if filter_type == "threshold":
+        _require_fields(
+            parameters,
+            {"name", "association", "lower", "upper"},
+            code="invalid_filter",
+            label="threshold",
+        )
+        _require_node_field(parameters, parent, scalar=True)
+        lower = _number(parameters.get("lower"), "lower", "invalid_filter")
+        upper = _number(parameters.get("upper"), "upper", "invalid_filter")
+        if lower > upper:
+            raise SceneManifestError(
+                "invalid_filter",
+                "threshold lower cannot exceed upper",
+            )
+        return
+    if filter_type == "contour":
+        _require_fields(
+            parameters,
+            {"name", "association", "isovalues"},
+            code="invalid_filter",
+            label="contour",
+        )
+        if parameters.get("association") != "point":
+            raise SceneManifestError(
+                "invalid_filter",
+                "contour requires a point-centered scalar field",
+            )
+        _require_node_field(parameters, parent, scalar=True)
+        values = parameters.get("isovalues")
+        if not isinstance(values, list) or not 1 <= len(values) <= MAX_CONTOUR_VALUES:
+            raise SceneManifestError(
+                "invalid_filter",
+                "contour isovalues must be a nonempty bounded list",
+            )
+        parsed = [_number(item, "isovalues", "invalid_filter") for item in values]
+        if len(set(parsed)) != len(parsed):
+            raise SceneManifestError(
+                "invalid_filter",
+                "contour isovalues must be unique",
+            )
+        return
+    raise SceneManifestError(
+        "invalid_filter",
+        "filter type must be slice, clip, threshold, or contour",
+    )
+
+
+def _validate_actors(
+    values: Sequence[object],
+    *,
+    nodes: Mapping[str, Mapping[str, Any]],
+) -> None:
+    if not 1 <= len(values) <= MAX_SCENE_ACTORS:
+        raise SceneManifestError(
+            "resource_limit",
+            "scene must contain a bounded nonempty actor list",
+            details={"maximum_actors": MAX_SCENE_ACTORS},
+        )
+    identities: set[str] = set()
+    root_actors = 0
+    for raw in values:
+        actor = _mapping(
+            raw,
+            "invalid_representation",
+            "actor must be an object",
+        )
+        _require_fields(
+            actor,
+            {
+                "actor_id",
+                "node",
+                "type",
+                "visible",
+                "opacity",
+                "point_size_px",
+                "color",
+                "range_provenance",
+            },
+            code="invalid_representation",
+            label="actor",
+        )
+        actor_id = _scene_id(
+            actor.get("actor_id"),
+            "actor_id",
+            "invalid_representation",
+        )
+        if actor_id in identities:
+            raise SceneManifestError(
+                "invalid_representation",
+                "actor_id must be unique",
+            )
+        identities.add(actor_id)
+        node_id = _scene_id(actor.get("node"), "node", "invalid_representation")
+        node = nodes.get(node_id)
+        if node is None:
+            raise SceneManifestError(
+                "invalid_representation",
+                "actor references an unknown scene node",
+                details={"node": node_id},
+            )
+        if node_id == "root":
+            root_actors += 1
+        representation_type = actor.get("type")
+        if representation_type not in {"surface", "points"}:
+            raise SceneManifestError(
+                "invalid_representation",
+                "actor type must be surface or points",
+            )
+        if not isinstance(actor.get("visible"), bool):
+            raise SceneManifestError(
+                "invalid_representation",
+                "actor visible must be boolean",
+            )
+        opacity = _number(
+            actor.get("opacity"),
+            "opacity",
+            "invalid_representation",
+        )
+        if not 0 <= opacity <= 1:
+            raise SceneManifestError(
+                "invalid_representation",
+                "actor opacity must be between zero and one",
+            )
+        point_size = actor.get("point_size_px")
+        if representation_type == "surface" and point_size is not None:
+            raise SceneManifestError(
+                "invalid_representation",
+                "surface actor point_size_px must be null",
+            )
+        if representation_type == "points":
+            parsed_size = _number(
+                point_size,
+                "point_size_px",
+                "invalid_representation",
+            )
+            if not 1 <= parsed_size <= 64:
+                raise SceneManifestError(
+                    "invalid_representation",
+                    "point actor size must be between 1 and 64 pixels",
+                )
+        _validate_actor_color(
+            actor.get("color"),
+            actor.get("range_provenance"),
+            node=node,
+            visible=cast(bool, actor.get("visible")),
+        )
+    if root_actors < 1 or values[0].get("node") != "root":  # type: ignore[union-attr]
+        raise SceneManifestError(
+            "invalid_representation",
+            "the first actor must represent the root dataset node",
+        )
+
+
+def _validate_actor_color(
+    value: object,
+    provenance_value: object,
+    *,
+    node: Mapping[str, Any],
+    visible: bool,
+) -> None:
+    color = _mapping(
+        value,
+        "invalid_representation",
+        "actor color must be an object",
+    )
+    if color.get("mode") == "solid":
+        _require_fields(
+            color,
+            {"mode", "rgb"},
+            code="invalid_representation",
+            label="solid color",
+        )
+        rgb = _vector(
+            color.get("rgb"),
+            "rgb",
+            length=3,
+            code="invalid_representation",
+        )
+        if any(not 0 <= item <= 1 for item in rgb):
+            raise SceneManifestError(
+                "invalid_representation",
+                "solid color components must be between zero and one",
+            )
+        if provenance_value is not None:
+            raise SceneManifestError(
+                "invalid_representation",
+                "solid actors cannot carry range provenance",
+            )
+        return
+    _require_fields(
+        color,
+        {
+            "mode",
+            "field",
+            "preset",
+            "invert",
+            "scale",
+            "range_policy",
+            "scalar_bar_visible",
+        },
+        code="invalid_representation",
+        label="field color",
+    )
+    if color.get("mode") != "field":
+        raise SceneManifestError(
+            "invalid_representation",
+            "actor color mode must be solid or field",
+        )
+    selector = _mapping(
+        color.get("field"),
+        "invalid_representation",
+        "field selector must be an object",
+    )
+    _require_fields(
+        selector,
+        {"name", "association"},
+        code="invalid_representation",
+        label="field selector",
+    )
+    _require_node_field(selector, node, scalar=False)
+    preset = color.get("preset")
+    if preset is not None:
+        _text(preset, "preset", maximum=256, code="invalid_representation")
+    if not isinstance(color.get("invert"), bool):
+        raise SceneManifestError(
+            "invalid_representation",
+            "field color invert must be boolean",
+        )
+    scale = color.get("scale")
+    if scale not in ({"mode": "linear"}, {"mode": "log"}):
+        raise SceneManifestError(
+            "invalid_representation",
+            "field color scale must be linear or log",
+        )
+    scalar_bar_visible = color.get("scalar_bar_visible")
+    if not isinstance(scalar_bar_visible, bool) or (not visible and scalar_bar_visible):
+        raise SceneManifestError(
+            "invalid_representation",
+            "hidden actors cannot expose scalar bars",
+        )
+    policy = _mapping(
+        color.get("range_policy"),
+        "invalid_representation",
+        "range_policy must be an object",
+    )
+    if (
+        set(policy) != {"mode", "range", "timestep_behavior"}
+        or policy.get("mode") != "fixed"
+        or policy.get("timestep_behavior") != "freeze"
+        or not _finite_pair(policy.get("range"), increasing=True)
+    ):
+        raise SceneManifestError(
+            "invalid_representation",
+            "imported field colors require a frozen fixed transfer range",
+        )
+    if scale == {"mode": "log"} and not (cast(Sequence[float], policy["range"])[0] > 0):
+        raise SceneManifestError(
+            "invalid_representation",
+            "log color scale requires a positive transfer range",
+        )
+    provenance = _mapping(
+        provenance_value,
+        "invalid_representation",
+        "field color range_provenance must be an object",
+    )
+    _require_fields(
+        provenance,
+        {"observed_range", "transfer_range", "source_policy"},
+        code="invalid_representation",
+        label="range_provenance",
+    )
+    source_policy = provenance.get("source_policy")
+    if (
+        not _finite_pair(provenance.get("observed_range"), increasing=False)
+        or not _finite_pair(provenance.get("transfer_range"), increasing=False)
+        or provenance.get("transfer_range") != policy.get("range")
+        or not isinstance(source_policy, dict)
+    ):
+        raise SceneManifestError(
+            "invalid_representation",
+            "field color range provenance is inconsistent",
+        )
+    _validate_source_range_policy(source_policy)
+
+
+def _validate_source_range_policy(value: Mapping[str, Any]) -> None:
+    """Validate export-only range provenance without accepting path-like extensions."""
+    mode = value.get("mode")
+    if mode == "full":
+        if value != {"mode": "full", "timestep_behavior": "recompute"}:
+            raise SceneManifestError(
+                "invalid_representation",
+                "full source range policy is invalid",
+            )
+        return
+    if mode == "fixed":
+        if (
+            set(value) != {"mode", "range", "timestep_behavior"}
+            or value.get("timestep_behavior") != "freeze"
+            or not _finite_pair(value.get("range"), increasing=True)
+        ):
+            raise SceneManifestError(
+                "invalid_representation",
+                "fixed source range policy is invalid",
+            )
+        return
+    if mode == "measurement_percentile":
+        if (
+            set(value)
+            != {
+                "mode",
+                "measurement_id",
+                "lower_percentile",
+                "upper_percentile",
+                "timestep_behavior",
+            }
+            or not isinstance(value.get("measurement_id"), str)
+            or re.fullmatch(
+                r"mea_[A-Za-z0-9._:-]{1,252}",
+                cast(str, value.get("measurement_id")),
+            )
+            is None
+            or value.get("timestep_behavior") != "freeze"
+        ):
+            raise SceneManifestError(
+                "invalid_representation",
+                "measurement source range policy is invalid",
+            )
+        lower = _number(
+            value.get("lower_percentile"),
+            "lower_percentile",
+            "invalid_representation",
+        )
+        upper = _number(
+            value.get("upper_percentile"),
+            "upper_percentile",
+            "invalid_representation",
+        )
+        if not 0 <= lower < upper <= 100:
+            raise SceneManifestError(
+                "invalid_representation",
+                "measurement source percentiles are invalid",
+            )
+        return
+    raise SceneManifestError(
+        "invalid_representation",
+        "source range policy mode is invalid",
+    )
+
+
+def _validate_camera(value: object) -> None:
+    camera = _mapping(
+        value,
+        "invalid_camera",
+        "camera must be an object",
+    )
+    _require_fields(
+        camera,
+        {
+            "position",
+            "focal_point",
+            "view_up",
+            "parallel_scale",
+            "projection",
+            "view_angle",
+        },
+        code="invalid_camera",
+        label="camera",
+    )
+    position = _vector(
+        camera.get("position"),
+        "position",
+        length=3,
+        code="invalid_camera",
+    )
+    focal = _vector(
+        camera.get("focal_point"),
+        "focal_point",
+        length=3,
+        code="invalid_camera",
+    )
+    view_up = _vector(
+        camera.get("view_up"),
+        "view_up",
+        length=3,
+        code="invalid_camera",
+    )
+    direction = [focal[index] - position[index] for index in range(3)]
+    direction_length = math.sqrt(sum(item * item for item in direction))
+    view_up_length = math.sqrt(sum(item * item for item in view_up))
+    cross = [
+        direction[1] * view_up[2] - direction[2] * view_up[1],
+        direction[2] * view_up[0] - direction[0] * view_up[2],
+        direction[0] * view_up[1] - direction[1] * view_up[0],
+    ]
+    if (
+        direction_length <= 1e-12
+        or view_up_length <= 1e-12
+        or math.sqrt(sum(item * item for item in cross))
+        <= 1e-12 * direction_length * view_up_length
+    ):
+        raise SceneManifestError(
+            "invalid_camera",
+            "camera orientation is degenerate",
+        )
+    if (
+        _number(
+            camera.get("parallel_scale"),
+            "parallel_scale",
+            "invalid_camera",
+        )
+        <= 0
+    ):
+        raise SceneManifestError(
+            "invalid_camera",
+            "camera parallel_scale must be positive",
+        )
+    if camera.get("projection") not in {"parallel", "perspective"}:
+        raise SceneManifestError(
+            "invalid_camera",
+            "camera projection is invalid",
+        )
+    view_angle = _number(
+        camera.get("view_angle"),
+        "view_angle",
+        "invalid_camera",
+    )
+    if not 0 < view_angle < 180:
+        raise SceneManifestError(
+            "invalid_camera",
+            "camera view_angle must be between zero and 180 degrees",
+        )
+
+
+def _portable_color(value: object) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    color = cast(Mapping[str, Any], value)
+    if color["mode"] == "solid":
+        return copy.deepcopy(dict(color)), None
+    transfer_range = copy.deepcopy(color["transfer_range"])
+    request = {
+        "mode": "field",
+        "field": {
+            "name": color["field"]["name"],
+            "association": color["field"]["association"],
+        },
+        "preset": color["preset"],
+        "invert": color["invert"],
+        "scale": copy.deepcopy(color["scale"]),
+        "range_policy": {
+            "mode": "fixed",
+            "range": transfer_range,
+            "timestep_behavior": "freeze",
+        },
+        "scalar_bar_visible": color["scalar_bar"]["visible"],
+    }
+    provenance = {
+        "observed_range": copy.deepcopy(color["observation"]["observed_range"]),
+        "transfer_range": copy.deepcopy(transfer_range),
+        "source_policy": copy.deepcopy(color["range_policy"]),
+    }
+    return request, provenance
+
+
+def _require_node_field(
+    selector: Mapping[str, Any],
+    node: Mapping[str, Any],
+    *,
+    scalar: bool,
+) -> None:
+    name = _text(
+        selector.get("name"),
+        "field name",
+        maximum=512,
+        code="stale_field",
+    )
+    association = selector.get("association")
+    if association not in {"point", "cell"}:
+        raise SceneManifestError(
+            "stale_field",
+            "field association must be point or cell",
+        )
+    arrays = node.get("arrays")
+    if not isinstance(arrays, list):
+        raise SceneManifestError(
+            "stale_field",
+            "scene node has no discoverable field list",
+        )
+    matches = [
+        field
+        for field in arrays
+        if isinstance(field, dict)
+        and field.get("name") == name
+        and field.get("association") == association
+    ]
+    if len(matches) != 1:
+        raise SceneManifestError(
+            "stale_field",
+            "scene references a field unavailable on its input node",
+            details={"name": name, "association": association},
+        )
+    if scalar and matches[0].get("components") != 1:
+        raise SceneManifestError(
+            "stale_field",
+            "scene filter requires a scalar field",
+        )
+
+
+def _find_field(
+    output: Mapping[str, Any],
+    name: str,
+    association: str,
+) -> dict[str, Any]:
+    arrays = output.get("arrays")
+    if not isinstance(arrays, list):
+        raise ValueError("authoritative node output has no array list")
+    matches = [
+        item
+        for item in arrays
+        if isinstance(item, dict)
+        and item.get("name") == name
+        and item.get("association") == association
+    ]
+    if len(matches) != 1:
+        raise ValueError("authoritative scene field is unavailable")
+    return cast(dict[str, Any], matches[0])
+
+
+def _field_identity(value: object) -> dict[str, Any]:
+    field = _mapping(value, "invalid_manifest", "field identity must be an object")
+    _require_fields(
+        field,
+        {"name", "association", "components", "units"},
+        code="invalid_manifest",
+        label="field identity",
+    )
+    name = _text(
+        field.get("name"),
+        "field name",
+        maximum=512,
+        code="invalid_manifest",
+    )
+    association = field.get("association")
+    if association not in {"point", "cell"}:
+        raise SceneManifestError(
+            "invalid_manifest",
+            "field association must be point or cell",
+        )
+    components = _integer(field.get("components"), "components", minimum=1)
+    if components > 256:
+        raise SceneManifestError(
+            "invalid_manifest",
+            "field components exceeds the service limit",
+        )
+    units = field.get("units")
+    if units is not None:
+        _text(units, "units", maximum=256, code="invalid_manifest")
+    return {
+        "name": name,
+        "association": association,
+        "components": components,
+        "units": units,
+    }
+
+
+def _mapping(value: object, code: str, message: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict):
+        raise SceneManifestError(code, message)
+    return value
+
+
+def _require_fields(
+    value: Mapping[str, Any],
+    expected: set[str],
+    *,
+    code: str,
+    label: str,
+) -> None:
+    if set(value) != expected:
+        raise SceneManifestError(
+            code,
+            f"{label} fields do not match the versioned contract",
+            details={
+                "missing": sorted(expected - set(value)),
+                "unexpected": sorted(set(value) - expected),
+            },
+        )
+
+
+def _scene_id(value: object, label: str, code: str) -> str:
+    if not isinstance(value, str) or _SCENE_ID.fullmatch(value) is None:
+        raise SceneManifestError(code, f"{label} is invalid")
+    return value
+
+
+def _text(
+    value: object,
+    label: str,
+    *,
+    maximum: int,
+    code: str,
+) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(value.encode("utf-8")) > maximum
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise SceneManifestError(code, f"{label} must be bounded text")
+    return value
+
+
+def _version(value: object, label: str) -> str:
+    if not isinstance(value, str) or _VERSION_TEXT.fullmatch(value) is None:
+        raise SceneManifestError(
+            "invalid_manifest",
+            f"{label} must be a portable version identifier",
+        )
+    return value
+
+
+def _integer(value: object, label: str, *, minimum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise SceneManifestError(
+            "invalid_manifest",
+            f"{label} must be an integer at least {minimum}",
+        )
+    return value
+
+
+def _number(value: object, label: str, code: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+    ):
+        raise SceneManifestError(code, f"{label} must be finite")
+    return float(value)
+
+
+def _vector(
+    value: object,
+    label: str,
+    *,
+    length: int,
+    code: str,
+) -> list[float]:
+    if not isinstance(value, list) or len(value) != length:
+        raise SceneManifestError(code, f"{label} must contain {length} values")
+    return [_number(item, label, code) for item in value]
+
+
+def _finite_pair(value: object, *, increasing: bool) -> bool:
+    if not isinstance(value, list) or len(value) != 2:
+        return False
+    if any(
+        isinstance(item, bool)
+        or not isinstance(item, (int, float))
+        or not math.isfinite(float(item))
+        for item in value
+    ):
+        return False
+    return value[0] < value[1] if increasing else value[0] <= value[1]
+
+
+def _finite_bounds(value: object) -> bool:
+    return (
+        isinstance(value, list)
+        and len(value) == 6
+        and all(
+            not isinstance(item, bool)
+            and isinstance(item, (int, float))
+            and math.isfinite(float(item))
+            for item in value
+        )
+        and all(value[index] <= value[index + 1] for index in (0, 2, 4))
+    )
+
+
+def _reject_duplicate_keys(
+    pairs: Sequence[tuple[str, Any]],
+) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        value[key] = item
+    return value
+
+
+__all__ = [
+    "MAX_SCENE_MANIFEST_BYTES",
+    "SCENE_ARTIFACT_MEDIA_TYPE",
+    "SCENE_MANIFEST_SCHEMA",
+    "SceneManifestError",
+    "build_scene_manifest",
+    "canonical_scene_bytes",
+    "load_scene_manifest",
+    "validate_scene_manifest",
+]

--- a/builtin/builtin/paraview/service.py
+++ b/builtin/builtin/paraview/service.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import argparse
 import hashlib
 import importlib
+import importlib.metadata
 import json
 import math
 import os
 import re
 import signal
 import stat
+import sys
 import tempfile
 import threading
 import time
@@ -20,8 +22,24 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Iterator, List, Mapping, Optional, Sequence, Tuple, cast
 
 try:
+    from .scene_manifest import (
+        SCENE_ARTIFACT_MEDIA_TYPE,
+        SceneManifestError,
+        build_scene_manifest,
+        canonical_scene_bytes,
+        load_scene_manifest,
+        validate_scene_manifest,
+    )
     from .service_http import CommandError, ServiceStateController, create_server
 except ImportError:  # Staged pvpython scripts are executed outside a package.
+    from scene_manifest import (  # type: ignore[no-redef]
+        SCENE_ARTIFACT_MEDIA_TYPE,
+        SceneManifestError,
+        build_scene_manifest,
+        canonical_scene_bytes,
+        load_scene_manifest,
+        validate_scene_manifest,
+    )
     from service_http import CommandError, ServiceStateController, create_server
 
 MAX_NODES = 32
@@ -61,6 +79,7 @@ class ParaViewBackend:
         execution_id: str,
         package_name: str,
         package_id: str,
+        initial_scene: Optional[Mapping[str, Any]] = None,
     ) -> None:
         """Open one descriptor and create only the stable root scene objects."""
         try:
@@ -155,6 +174,13 @@ class ParaViewBackend:
         bounds = root_output["bounds"]
         self._dataset_bounds = None if bounds is None else tuple(bounds)
         self._dataset_timesteps = list(self._timesteps)
+        self._scene_import: Optional[Dict[str, Any]] = None
+        if initial_scene is not None:
+            imported = self._import_scene_manifest(initial_scene)
+            self._scene_import = self._publish_imported_scene(
+                initial_scene,
+                imported,
+            )
 
     def dataset_state(self) -> Dict[str, Any]:
         """Return immutable descriptor identity and root discovery facts."""
@@ -205,6 +231,7 @@ class ParaViewBackend:
             "set_camera": self._set_camera,
             "inspect_selection": self._inspect_selection,
             "export_artifact": self._export_artifact,
+            "export_scene": self._export_scene,
         }
         handler = handlers.get(operation)
         if handler is None:
@@ -1383,6 +1410,348 @@ class ParaViewBackend:
         }
         return {"selection": _json_copy(self._selection)}
 
+    def _import_scene_manifest(
+        self,
+        value: Mapping[str, Any],
+    ) -> Dict[str, Any]:
+        """Preflight and atomically reconstruct one declarative initial scene."""
+        root = self._nodes[ROOT_NODE_ID]
+        validated = validate_scene_manifest(
+            value,
+            descriptor=self.descriptor,
+            discovery={
+                "topology": root["output"]["topology"],
+                "bounds": _json_copy_optional(root["output"]["bounds"]),
+                "arrays": _json_copy_list(root["output"]["arrays"]),
+                "timestep_count": len(self._timesteps),
+            },
+        )
+        canonical = canonical_scene_bytes(validated)
+        manifest_digest = hashlib.sha256(canonical).hexdigest()
+        scene = cast(Mapping[str, Any], validated["scene"])
+        node_ids: Dict[str, str] = {"root": ROOT_NODE_ID}
+        checkpoint = self.begin_command()
+        operation = "set_timestep"
+        try:
+            if self._timesteps:
+                self._set_timestep(
+                    {"index": scene["timestep_index"]},
+                    f"scene-import-time-{manifest_digest[:16]}",
+                )
+            filters = cast(Sequence[Mapping[str, Any]], scene["filters"])
+            for index, filter_record in enumerate(filters, start=1):
+                operation = f"filter:{filter_record['filter_id']}"
+                created = self._create_filter(
+                    {
+                        "input_node_id": node_ids[cast(str, filter_record["input"])],
+                        "type": filter_record["type"],
+                        "parameters": filter_record["parameters"],
+                    },
+                    f"scene-import-filter-{index:02d}-{manifest_digest[:16]}",
+                )
+                node_ids[cast(str, filter_record["filter_id"])] = cast(
+                    str,
+                    created["node"]["node_id"],
+                )
+            actors = cast(Sequence[Mapping[str, Any]], scene["actors"])
+            for index, actor in enumerate(actors):
+                operation = f"actor:{actor['actor_id']}"
+                self._set_representation(
+                    {
+                        "representation_id": (
+                            ROOT_REPRESENTATION_ID if index == 0 else None
+                        ),
+                        "node_id": node_ids[cast(str, actor["node"])],
+                        "type": actor["type"],
+                        "visible": actor["visible"],
+                        "opacity": actor["opacity"],
+                        "point_size_px": actor["point_size_px"],
+                        "color": actor["color"],
+                    },
+                    f"scene-import-actor-{index:02d}-{manifest_digest[:16]}",
+                )
+            operation = "camera"
+            self._set_camera(
+                cast(Mapping[str, Any], scene["camera"]),
+                f"scene-import-camera-{manifest_digest[:16]}",
+            )
+            self.commit_command(checkpoint)
+        except Exception as exc:
+            if self._transaction_open:
+                self.rollback_command(checkpoint)
+            if isinstance(exc, SceneManifestError):
+                raise
+            if isinstance(exc, CommandError):
+                details = dict(exc.details)
+                details["operation"] = operation
+                raise SceneManifestError(
+                    exc.code,
+                    "initial_scene could not be applied to the opened dataset",
+                    details=details,
+                ) from exc
+            raise SceneManifestError(
+                "scene_import_failed",
+                "initial_scene could not be reconstructed",
+                details={"operation": operation},
+            ) from exc
+        source = cast(Mapping[str, Any], validated["source"])
+        return {
+            "schema_version": "jarvis.paraview.scene-import.v1",
+            "source_artifact_id": source["artifact_id"],
+            "source_final_revision": source["final_revision"],
+            "manifest_sha256": manifest_digest,
+            "descriptor_fingerprint": _json_copy(
+                cast(Mapping[str, Any], self.descriptor["fingerprint"])
+            ),
+        }
+
+    def _export_scene(
+        self,
+        arguments: Mapping[str, Any],
+        command_id: str,
+    ) -> Dict[str, Any]:
+        """Stage one canonical reusable scene through the durable artifact ledger."""
+        _require_fields(
+            arguments,
+            {"filename", "fingerprint_constraint", "_final_revision"},
+            "export_scene",
+        )
+        filename = _safe_relative_json(arguments.get("filename"))
+        fingerprint_constraint = arguments.get("fingerprint_constraint")
+        if fingerprint_constraint not in {"exact", "compatible"}:
+            raise CommandError(
+                "invalid_arguments",
+                "fingerprint_constraint must be exact or compatible",
+            )
+        final_revision = _bounded_int(
+            arguments.get("_final_revision"),
+            "_final_revision",
+            minimum=1,
+        )
+        if len(self._artifacts) >= MAX_ARTIFACTS:
+            raise CommandError(
+                "artifact_limit", "the service artifact limit was reached"
+            )
+        candidate_path = self.output_dir / filename
+        output_parent = candidate_path.parent.resolve()
+        if (
+            output_parent != self.output_dir
+            and self.output_dir not in output_parent.parents
+        ):
+            raise CommandError("invalid_arguments", "artifact path escapes output root")
+        output_path = output_parent / candidate_path.name
+        scene_digest = self._scene_digest()
+        artifact_id = _deterministic_id(
+            "art",
+            self.service_instance_id + "\x00" + command_id,
+        )
+        visible_ids = sorted(
+            representation_id
+            for representation_id, record in self._representations.items()
+            if record["visible"]
+        )
+        try:
+            jarvis_version = importlib.metadata.version("jarvis-cd")
+        except importlib.metadata.PackageNotFoundError:
+            jarvis_version = "unknown"
+        manifest = build_scene_manifest(
+            descriptor=self.descriptor,
+            pipeline=self.pipeline_state(),
+            final_revision=final_revision,
+            artifact_id=artifact_id,
+            jarvis_version=jarvis_version,
+            paraview_version=self._paraview_version(),
+            fingerprint_constraint=cast(str, fingerprint_constraint),
+        )
+        payload = canonical_scene_bytes(manifest)
+        replay = _find_artifact_event(artifact_id)
+        if replay is not None:
+            _validate_artifact_replay(
+                replay,
+                logical_name=filename.as_posix(),
+                output_path=output_path,
+                service_instance_id=self.service_instance_id,
+                command_id=command_id,
+                representation_ids=visible_ids,
+                scene_digest=scene_digest,
+                execution_id=self.execution_id,
+                package_name=self.package_name,
+                package_id=self.package_id,
+                kind="visualization_scene",
+                role="output",
+                media_type=SCENE_ARTIFACT_MEDIA_TYPE,
+                format_name="json",
+                message="ParaView service exported a reusable scene",
+                artifact_metadata={
+                    "descriptor_fingerprint": _json_copy(
+                        cast(Mapping[str, Any], self.descriptor["fingerprint"])
+                    ),
+                    "final_revision": final_revision,
+                },
+            )
+            if not any(
+                artifact["artifact_id"] == artifact_id for artifact in self._artifacts
+            ):
+                self._artifacts.append(replay)
+            return {
+                "artifact": _json_copy(replay),
+                "scene_manifest": _json_copy(manifest),
+            }
+        staged_path = _stage_payload(
+            payload,
+            output_dir=output_path.parent,
+            suffix=".json",
+        )
+        digest = hashlib.sha256(payload).hexdigest()
+        try:
+            artifact = _prepare_artifact_event(
+                artifact_id=artifact_id,
+                logical_name=filename.as_posix(),
+                path=output_path,
+                size_bytes=len(payload),
+                sha256=digest,
+                service_instance_id=self.service_instance_id,
+                command_id=command_id,
+                representation_ids=visible_ids,
+                scene_digest=scene_digest,
+                kind="visualization_scene",
+                role="output",
+                media_type=SCENE_ARTIFACT_MEDIA_TYPE,
+                format_name="json",
+                message="ParaView service exported a reusable scene",
+                artifact_metadata={
+                    "descriptor_fingerprint": _json_copy(
+                        cast(Mapping[str, Any], self.descriptor["fingerprint"])
+                    ),
+                    "final_revision": final_revision,
+                },
+            )
+        except Exception:
+            staged_path.unlink(missing_ok=True)
+            raise
+        self._staged_artifacts[artifact_id] = {
+            "event": artifact,
+            "staged_path": staged_path,
+            "output_path": output_path,
+            "command_id": command_id,
+            "representation_ids": list(visible_ids),
+            "scene_digest": scene_digest,
+        }
+        self._artifacts.append(artifact)
+        return {
+            "artifact": _json_copy(artifact),
+            "scene_manifest": _json_copy(manifest),
+        }
+
+    def _publish_imported_scene(
+        self,
+        manifest: Mapping[str, Any],
+        evidence: Mapping[str, Any],
+    ) -> Dict[str, Any]:
+        """Copy an accepted initial scene into this execution's artifact ledger."""
+        payload = canonical_scene_bytes(manifest)
+        manifest_digest = hashlib.sha256(payload).hexdigest()
+        artifact_id = _deterministic_id(
+            "art",
+            self.service_instance_id + "\x00initial-scene-import\x00" + manifest_digest,
+        )
+        command_id = "initial-scene-import-" + manifest_digest[:24]
+        output_path = self.output_dir / "initial-scene-import.json"
+        visible_ids = sorted(
+            representation_id
+            for representation_id, record in self._representations.items()
+            if record["visible"]
+        )
+        scene_digest = self._scene_digest()
+        artifact_metadata = {
+            "descriptor_fingerprint": _json_copy(
+                cast(Mapping[str, Any], self.descriptor["fingerprint"])
+            ),
+            "source_artifact_id": evidence["source_artifact_id"],
+            "source_final_revision": evidence["source_final_revision"],
+            "manifest_sha256": manifest_digest,
+            "imported": True,
+        }
+        checkpoint = self.begin_command()
+        try:
+            replay = _find_artifact_event(artifact_id)
+            if replay is not None:
+                _validate_artifact_replay(
+                    replay,
+                    logical_name="initial-scene-import.json",
+                    output_path=output_path,
+                    service_instance_id=self.service_instance_id,
+                    command_id=command_id,
+                    representation_ids=visible_ids,
+                    scene_digest=scene_digest,
+                    execution_id=self.execution_id,
+                    package_name=self.package_name,
+                    package_id=self.package_id,
+                    kind="visualization_scene",
+                    role="provenance",
+                    media_type=SCENE_ARTIFACT_MEDIA_TYPE,
+                    format_name="json",
+                    message="ParaView service imported a reusable scene",
+                    artifact_metadata=artifact_metadata,
+                )
+                self._artifacts.append(replay)
+            else:
+                staged_path = _stage_payload(
+                    payload,
+                    output_dir=self.output_dir,
+                    suffix=".json",
+                )
+                try:
+                    artifact = _prepare_artifact_event(
+                        artifact_id=artifact_id,
+                        logical_name="initial-scene-import.json",
+                        path=output_path,
+                        size_bytes=len(payload),
+                        sha256=manifest_digest,
+                        service_instance_id=self.service_instance_id,
+                        command_id=command_id,
+                        representation_ids=visible_ids,
+                        scene_digest=scene_digest,
+                        kind="visualization_scene",
+                        role="provenance",
+                        media_type=SCENE_ARTIFACT_MEDIA_TYPE,
+                        format_name="json",
+                        message="ParaView service imported a reusable scene",
+                        artifact_metadata=artifact_metadata,
+                    )
+                except Exception:
+                    staged_path.unlink(missing_ok=True)
+                    raise
+                self._staged_artifacts[artifact_id] = {
+                    "event": artifact,
+                    "staged_path": staged_path,
+                    "output_path": output_path,
+                    "command_id": command_id,
+                    "representation_ids": list(visible_ids),
+                    "scene_digest": scene_digest,
+                }
+                self._artifacts.append(artifact)
+            self.commit_command(checkpoint)
+        except Exception:
+            if self._transaction_open:
+                self.rollback_command(checkpoint)
+            raise
+        rendered = dict(evidence)
+        rendered["imported_artifact_id"] = artifact_id
+        return cast(Dict[str, Any], rendered)
+
+    def _paraview_version(self) -> str:
+        """Return a portable ParaView runtime version without its install path."""
+        getter = getattr(self.simple, "GetParaViewVersion", None)
+        if callable(getter):
+            value = getter()
+            if isinstance(value, str) and re.fullmatch(
+                r"[A-Za-z0-9][A-Za-z0-9._+:-]{0,127}",
+                value,
+            ):
+                return value
+        return "unknown"
+
     def _export_artifact(
         self,
         arguments: Mapping[str, Any],
@@ -2351,6 +2720,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument("--execution-id", required=True)
     parser.add_argument("--service-instance-id", required=True)
     parser.add_argument("--authorization-file", required=True)
+    parser.add_argument("--initial-scene")
     args = parser.parse_args(argv)
     bound_execution_id = os.environ.get("JARVIS_EXECUTION_ID")
     package_name = os.environ.get("JARVIS_PACKAGE_NAME")
@@ -2362,14 +2732,35 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     bearer_token = _read_authorization_token(Path(args.authorization_file))
     descriptor_path = Path(args.descriptor)
     descriptor = _load_json_file(descriptor_path)
-    backend = ParaViewBackend(
-        descriptor=descriptor,
-        output_dir=Path(args.output_dir),
-        service_instance_id=args.service_instance_id,
-        execution_id=args.execution_id,
-        package_name=package_name,
-        package_id=package_id,
-    )
+    try:
+        initial_scene = (
+            None
+            if args.initial_scene is None
+            else load_scene_manifest(Path(args.initial_scene))
+        )
+        backend = ParaViewBackend(
+            descriptor=descriptor,
+            output_dir=Path(args.output_dir),
+            service_instance_id=args.service_instance_id,
+            execution_id=args.execution_id,
+            package_name=package_name,
+            package_id=package_id,
+            initial_scene=initial_scene,
+        )
+    except SceneManifestError as exc:
+        print(
+            "JARVIS_PARAVIEW_SCENE_REJECTION "
+            + json.dumps(
+                exc.as_dict(),
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+            flush=True,
+        )
+        return 2
     controller = ServiceStateController(
         backend=backend,
         execution_id=args.execution_id,
@@ -2816,6 +3207,12 @@ def _prepare_artifact_event(
     representation_ids: Sequence[str],
     scene_digest: str,
     cluster_location: Optional[str] = None,
+    kind: str = "image",
+    role: str = "output",
+    media_type: str = "image/png",
+    format_name: str = "png",
+    message: str = "ParaView service exported an image",
+    artifact_metadata: Optional[Mapping[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Reserve a deterministic artifact event without publishing durable state."""
     artifact_path_value = os.environ.get("JARVIS_ARTIFACT_PATH")
@@ -2866,6 +3263,12 @@ def _prepare_artifact_event(
                     execution_id=cast(str, execution_id),
                     package_name=cast(str, package_name),
                     package_id=cast(str, package_id),
+                    kind=kind,
+                    role=role,
+                    media_type=media_type,
+                    format_name=format_name,
+                    message=message,
+                    artifact_metadata=artifact_metadata,
                 )
                 if marker is not None:
                     _validate_published_artifact_file(event, path)
@@ -2901,6 +3304,12 @@ def _prepare_artifact_event(
                 execution_id=cast(str, execution_id),
                 package_name=cast(str, package_name),
                 package_id=cast(str, package_id),
+                kind=kind,
+                role=role,
+                media_type=media_type,
+                format_name=format_name,
+                message=message,
+                artifact_metadata=artifact_metadata,
             )
             if marker_event.get("sequence") != sequence:
                 raise RuntimeError(
@@ -2911,6 +3320,21 @@ def _prepare_artifact_event(
             return _json_copy(marker_event)
         location = cluster_location or path.as_posix()
         _normalized_absolute_path(location)
+        metadata = {
+            "application": "paraview",
+            "service_instance_id": service_instance_id,
+            "command_id": command_id,
+            "generation_stage": "final",
+            "representation_ids": list(representation_ids),
+            "scene_digest": scene_digest,
+        }
+        if artifact_metadata is not None:
+            overlap = set(metadata) & set(artifact_metadata)
+            if overlap:
+                raise RuntimeError(
+                    "ParaView artifact metadata conflicts with reserved fields"
+                )
+            metadata.update(_json_copy(artifact_metadata))
         event = {
             "schema_version": "jarvis.artifact.v1",
             "package_name": package_name,
@@ -2918,28 +3342,21 @@ def _prepare_artifact_event(
             "execution_id": execution_id,
             "artifact_id": artifact_id,
             "logical_name": logical_name,
-            "kind": "image",
-            "role": "output",
+            "kind": kind,
+            "role": role,
             "structure": "file",
             "ownership": "shared",
             "state": "finalized",
             "location": {"kind": "cluster_path", "value": location},
-            "media_type": "image/png",
-            "format": "png",
+            "media_type": media_type,
+            "format": format_name,
             "size_bytes": size_bytes,
             "checksum": "sha256:" + sha256,
-            "message": "ParaView service exported an image",
+            "message": message,
             "revision": 1,
             "sequence": sequence,
             "observed_at_epoch": time.time(),
-            "metadata": {
-                "application": "paraview",
-                "service_instance_id": service_instance_id,
-                "command_id": command_id,
-                "generation_stage": "final",
-                "representation_ids": list(representation_ids),
-                "scene_digest": scene_digest,
-            },
+            "metadata": metadata,
         }
         if len(_artifact_event_payload(event)) > 64 * 1024:
             raise RuntimeError("ParaView artifact event exceeds the JARVIS limit")
@@ -2961,9 +3378,30 @@ def _validate_artifact_event_request(
     execution_id: str,
     package_name: str,
     package_id: str,
+    kind: str,
+    role: str,
+    media_type: str,
+    format_name: str,
+    message: str,
+    artifact_metadata: Optional[Mapping[str, Any]],
 ) -> None:
     """Require a published or recoverable event to match one exact retry."""
     metadata = event.get("metadata")
+    expected_metadata = {
+        "application": "paraview",
+        "service_instance_id": service_instance_id,
+        "command_id": command_id,
+        "generation_stage": "final",
+        "representation_ids": list(representation_ids),
+        "scene_digest": scene_digest,
+    }
+    if artifact_metadata is not None:
+        overlap = set(expected_metadata) & set(artifact_metadata)
+        if overlap:
+            raise RuntimeError(
+                "ParaView artifact metadata conflicts with reserved fields"
+            )
+        expected_metadata.update(_json_copy(artifact_metadata))
     if (
         event.get("logical_name") != logical_name
         or event.get("execution_id") != execution_id
@@ -2973,11 +3411,12 @@ def _validate_artifact_event_request(
         != {"kind": "cluster_path", "value": cluster_location or path.as_posix()}
         or event.get("size_bytes") != size_bytes
         or event.get("checksum") != "sha256:" + sha256
-        or not isinstance(metadata, dict)
-        or metadata.get("service_instance_id") != service_instance_id
-        or metadata.get("command_id") != command_id
-        or metadata.get("representation_ids") != list(representation_ids)
-        or metadata.get("scene_digest") != scene_digest
+        or event.get("kind") != kind
+        or event.get("role") != role
+        or event.get("media_type") != media_type
+        or event.get("format") != format_name
+        or event.get("message") != message
+        or metadata != expected_metadata
     ):
         raise RuntimeError(
             "deterministic ParaView artifact retry conflicts with durable state"
@@ -3139,7 +3578,7 @@ def _validated_marker_stage_path(marker: Mapping[str, Any], output_path: Path) -
         not staged_path.is_absolute()
         or staged_path.parent != output_path.parent
         or not staged_path.name.startswith(".paraview-artifact.")
-        or not staged_path.name.endswith(".tmp.png")
+        or staged_path.suffix not in {".png", ".json"}
         or staged_path == output_path
     ):
         raise RuntimeError("ParaView artifact marker staged path is unsafe")
@@ -3273,7 +3712,7 @@ def _publish_artifact_event_locked(
 def _commit_staged_artifacts(
     staged_artifacts: Mapping[str, Mapping[str, Any]],
 ) -> None:
-    """Publish one validated PNG and its append-only event at semantic commit."""
+    """Publish one validated payload and its append-only event at semantic commit."""
     if not staged_artifacts:
         return
     if len(staged_artifacts) != 1:
@@ -3379,7 +3818,7 @@ def _commit_staged_artifacts(
             _validate_published_artifact_file(event, output_path)
         else:
             if not transaction_stage.is_file() or transaction_stage.is_symlink():
-                raise RuntimeError("staged ParaView PNG is missing or unsafe")
+                raise RuntimeError("staged ParaView artifact is missing or unsafe")
             _validate_published_artifact_file(event, transaction_stage)
             os.link(transaction_stage, output_path)
             if os.name != "nt":
@@ -3397,16 +3836,38 @@ def _commit_staged_artifacts(
 def _validate_published_artifact_file(
     event: Mapping[str, Any], output_path: Path
 ) -> None:
-    """Require a durable PNG to match its exact published event."""
+    """Require a durable payload to match its exact published event."""
     if not output_path.is_file() or output_path.is_symlink():
         raise RuntimeError("published ParaView artifact file is missing or unsafe")
     payload = output_path.read_bytes()
     if (
         event.get("size_bytes") != len(payload)
         or event.get("checksum") != "sha256:" + hashlib.sha256(payload).hexdigest()
-        or not payload.startswith(b"\x89PNG\r\n\x1a\n")
     ):
         raise RuntimeError("published ParaView artifact file failed validation")
+    media_type = event.get("media_type")
+    if media_type == "image/png":
+        if not payload.startswith(b"\x89PNG\r\n\x1a\n"):
+            raise RuntimeError("published ParaView PNG failed validation")
+        return
+    if media_type == SCENE_ARTIFACT_MEDIA_TYPE:
+        try:
+            value = json.loads(
+                payload.decode("utf-8"),
+                object_pairs_hook=_reject_duplicate_keys,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            raise RuntimeError(
+                "published ParaView scene manifest is invalid JSON"
+            ) from exc
+        if (
+            not isinstance(value, dict)
+            or canonical_scene_bytes(value) != payload
+            or value.get("schema_version") != "jarvis.paraview.scene-manifest.v1"
+        ):
+            raise RuntimeError("published ParaView scene manifest failed validation")
+        return
+    raise RuntimeError("published ParaView artifact media type is unsupported")
 
 
 def _find_artifact_event(artifact_id: str) -> Optional[Dict[str, Any]]:
@@ -3547,39 +4008,50 @@ def _validate_artifact_replay(
     execution_id: str,
     package_name: str,
     package_id: str,
+    kind: str = "image",
+    role: str = "output",
+    media_type: str = "image/png",
+    format_name: str = "png",
+    message: str = "ParaView service exported an image",
+    artifact_metadata: Optional[Mapping[str, Any]] = None,
 ) -> None:
-    """Validate an on-disk event and PNG before returning replay success."""
+    """Validate an on-disk event and payload before returning replay success."""
     metadata = event.get("metadata")
     location = event.get("location")
+    expected_metadata = {
+        "application": "paraview",
+        "service_instance_id": service_instance_id,
+        "command_id": command_id,
+        "generation_stage": "final",
+        "representation_ids": list(representation_ids),
+        "scene_digest": scene_digest,
+    }
+    if artifact_metadata is not None:
+        overlap = set(expected_metadata) & set(artifact_metadata)
+        if overlap:
+            raise RuntimeError(
+                "ParaView artifact metadata conflicts with reserved fields"
+            )
+        expected_metadata.update(_json_copy(artifact_metadata))
     if (
         event.get("logical_name") != logical_name
         or event.get("execution_id") != execution_id
         or event.get("package_name") != package_name
         or event.get("package_id") != package_id
         or location != {"kind": "cluster_path", "value": output_path.as_posix()}
-        or not isinstance(metadata, dict)
-        or metadata.get("service_instance_id") != service_instance_id
-        or metadata.get("command_id") != command_id
-        or metadata.get("representation_ids") != list(representation_ids)
-        or metadata.get("scene_digest") != scene_digest
+        or event.get("kind") != kind
+        or event.get("role") != role
+        or event.get("media_type") != media_type
+        or event.get("format") != format_name
+        or event.get("message") != message
+        or metadata != expected_metadata
     ):
         raise CommandError(
             "artifact_replay_conflict",
             "published artifact does not match the retried scene command",
             status=HTTPStatus.CONFLICT,
         )
-    if not output_path.is_file() or output_path.is_symlink():
-        raise RuntimeError("published ParaView artifact file is missing or unsafe")
-    payload = output_path.read_bytes()
-    expected_size = event.get("size_bytes")
-    expected_checksum = event.get("checksum")
-    if (
-        isinstance(expected_size, bool)
-        or not isinstance(expected_size, int)
-        or len(payload) != expected_size
-        or expected_checksum != "sha256:" + hashlib.sha256(payload).hexdigest()
-    ):
-        raise RuntimeError("published ParaView artifact file failed replay validation")
+    _validate_published_artifact_file(event, output_path)
 
 
 @contextmanager
@@ -4014,6 +4486,55 @@ def _stage_png(
             temporary.unlink(missing_ok=True)
 
 
+def _stage_payload(
+    payload: bytes,
+    *,
+    output_dir: Path,
+    suffix: str,
+) -> Path:
+    """Persist one bounded private artifact payload under a transactional name."""
+    if (
+        not isinstance(payload, bytes)
+        or not payload
+        or len(payload) > MAX_EXPORTED_ARTIFACT_BYTES
+        or suffix not in {".json"}
+    ):
+        raise RuntimeError("ParaView artifact payload is invalid")
+    output_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if os.name != "nt":
+        output_dir.chmod(0o700)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=output_dir,
+        prefix=".paraview-artifact.",
+        suffix=f".tmp{suffix}",
+    )
+    temporary = Path(temporary_name)
+    descriptor_open = True
+    try:
+        try:
+            stream = os.fdopen(descriptor, "wb")
+        except BaseException:
+            os.close(descriptor)
+            descriptor_open = False
+            raise
+        descriptor_open = False
+        with stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if temporary.stat().st_size != len(payload):
+            raise RuntimeError("ParaView artifact payload changed during staging")
+        if os.name != "nt":
+            temporary.chmod(0o600)
+        return temporary
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+    finally:
+        if descriptor_open:
+            os.close(descriptor)
+
+
 def _fsync_directory(path: Path) -> None:
     """Persist one directory update where descriptor fsync is supported."""
     if os.name == "nt":
@@ -4226,6 +4747,23 @@ def _safe_relative_png(value: object) -> PurePosixPath:
         )
     if path.suffix.casefold() != ".png":
         raise CommandError("invalid_arguments", "export_artifact supports PNG output")
+    return path
+
+
+def _safe_relative_json(value: object) -> PurePosixPath:
+    rendered = _bounded_text(value, "filename", maximum=1024)
+    if "\\" in rendered:
+        raise CommandError("invalid_arguments", "filename must use POSIX separators")
+    path = PurePosixPath(rendered)
+    if path.is_absolute() or path.as_posix() != rendered or ".." in path.parts:
+        raise CommandError(
+            "invalid_arguments", "filename must be normalized and relative"
+        )
+    if path.suffix.casefold() != ".json":
+        raise CommandError(
+            "invalid_arguments",
+            "export_scene supports canonical JSON output",
+        )
     return path
 
 

--- a/builtin/builtin/paraview/service.py
+++ b/builtin/builtin/paraview/service.py
@@ -2202,9 +2202,12 @@ class ParaViewBackend:
         color = cast(Mapping[str, Any], record["color"])
         if color["mode"] == "solid":
             # ParaView 5.x reads the current association before disabling scalar
-            # coloring. Fresh displays report NONE, which its ColorBy helper rejects.
+            # coloring. Fresh displays report NONE, and invoking ColorBy on that
+            # unbound state can corrupt older offscreen runtimes. Directly setting
+            # the empty association is sufficient until a managed LUT exists.
             display.ColorArrayName = ["POINTS", ""]
-            self.simple.ColorBy(display, None)
+            if previous_proxies:
+                self.simple.ColorBy(display, None)
             self._replace_representation_transfer_proxies(representation_id, ())
             rgb = list(color["rgb"])
             display.DiffuseColor = rgb

--- a/builtin/builtin/paraview/service.py
+++ b/builtin/builtin/paraview/service.py
@@ -2190,7 +2190,15 @@ class ParaViewBackend:
         scalar_bar_setter = getattr(display, "SetScalarBarVisibility", None)
         if not callable(scalar_bar_setter):
             raise RuntimeError("ParaView display cannot control its scalar bar")
-        scalar_bar_setter(self.view, False)
+        previous_proxies = self._representation_transfer_proxies.get(
+            representation_id,
+            (),
+        )
+        # ParaView's scalar-bar helper requires an actor-bound lookup table.
+        # Fresh solid displays have none, and asking the helper to hide an
+        # unbound bar can corrupt older offscreen runtimes before ColorBy.
+        if previous_proxies:
+            scalar_bar_setter(self.view, False)
         color = cast(Mapping[str, Any], record["color"])
         if color["mode"] == "solid":
             # ParaView 5.x reads the current association before disabling scalar
@@ -2215,10 +2223,6 @@ class ParaViewBackend:
             )
         )
         self.simple.ColorBy(display, color_field, separate=True)
-        previous_proxies = self._representation_transfer_proxies.get(
-            representation_id,
-            (),
-        )
         lookup = self.simple.GetColorTransferFunction(
             field["name"],
             display,

--- a/builtin/builtin/paraview/service_http.py
+++ b/builtin/builtin/paraview/service_http.py
@@ -57,6 +57,7 @@ _OPERATIONS = frozenset(
         "set_camera",
         "inspect_selection",
         "export_artifact",
+        "export_scene",
     }
 )
 
@@ -306,14 +307,21 @@ class ServiceStateController:
 
             checkpoint = self.backend.begin_command()
             try:
-                result = self.backend.execute(operation, arguments, command_id)
+                backend_arguments = dict(arguments)
+                if operation == "export_scene":
+                    backend_arguments["_final_revision"] = current_revision + 1
+                result = self.backend.execute(
+                    operation,
+                    backend_arguments,
+                    command_id,
+                )
                 if not isinstance(result, dict):
                     raise RuntimeError("ParaView backend returned a non-object result")
                 # Export is already the exact current frame and publication is
                 # deterministic. Every scene mutation must prove a new frame.
                 candidate_frame = (
                     current_frame
-                    if operation == "export_artifact"
+                    if operation in {"export_artifact", "export_scene"}
                     else self._bounded_frame(self.backend.render_png())
                 )
                 candidate_revision = current_revision + 1

--- a/builtin/builtin/paraview/service_supervisor.py
+++ b/builtin/builtin/paraview/service_supervisor.py
@@ -43,6 +43,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument("--startup-timeout", type=float, required=True)
     parser.add_argument("--service-instance-id", required=True)
     parser.add_argument("--authorization-file", required=True)
+    parser.add_argument("--initial-scene")
     args = parser.parse_args(argv)
 
     if not 1 <= args.startup_timeout <= 600:
@@ -88,6 +89,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         "--authorization-file",
         str(authorization_path),
     ]
+    if args.initial_scene:
+        command.extend(["--initial-scene", args.initial_scene])
     stopping = threading.Event()
     lifecycle: Optional[ServiceLifecycle] = None
     process: Optional[subprocess.Popen[str]] = None

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -72,3 +72,12 @@ scripts, and owned stdout/stderr streams where those streams exist. Diagnostic
 artifacts are discoverable metadata, not an authorization to download their
 contents; relay or agent-facing content access must apply a separate bounded
 access policy.
+
+The generic ParaView service publishes canonical reusable scenes as
+`visualization_scene` file artifacts with media type
+`application/vnd.jarvis.paraview.scene+json`. A live `export_scene` command
+uses role `output`; a successfully accepted `initial_scene` is copied into the
+new execution with role `provenance`. Their metadata binds the descriptor
+fingerprint, final/source revision, exact scene checksum, and source artifact
+identity without placing authorization, ports, scheduler identity, or dataset
+member paths inside the reusable manifest.

--- a/docs/service-runtimes.md
+++ b/docs/service-runtimes.md
@@ -232,7 +232,8 @@ Supported operations are:
 - `fit_camera` over explicit visible actor IDs and explicit timesteps;
 - `set_camera` for explicit camera components;
 - `inspect_selection` against one exact actor;
-- `export_artifact` for the exact current visible actor set.
+- `export_artifact` for the exact current visible actor set;
+- `export_scene` for a canonical reusable declarative scene manifest.
 
 Commands are serialized against authoritative state. A stale
 `expected_revision` returns HTTP 409 `revision_conflict`. Repeating an exact
@@ -352,6 +353,25 @@ markers, stale sequences, changed ledger prefixes, unsafe paths, and
 pre-existing output without a marker fail explicitly. Rollback deletes only
 private staging and never removes a published event.
 
+`export_scene` accepts a normalized relative `.json` filename and an `exact` or
+`compatible` fingerprint constraint. It projects the authoritative state into
+`jarvis.paraview.scene-manifest.v1`: portable topological aliases replace
+runtime node/actor IDs; measurement-derived transfer ranges are frozen while
+their source policy remains provenance; and camera, scalar-bar, filter,
+timestep, package/runtime version, descriptor fingerprint, compatibility, and
+resource requirements remain explicit. Dataset member paths, execution and
+scheduler identity, service host/port, and authorization never enter the
+manifest. The output is a finalized `visualization_scene` JARVIS artifact with
+media type `application/vnd.jarvis.paraview.scene+json`.
+
+An accepted `initial_scene` is copied into the new execution as a finalized
+`provenance` artifact whose metadata identifies the source scene artifact,
+source final revision, manifest checksum, and current descriptor fingerprint.
+Both imported and exported scene artifacts therefore appear through
+`jarvis execution artifacts` and `ExecutionHandle.artifacts()`. JSON payloads
+use the same checksum-bound marker, link, append, recovery, and rollback
+protocol as PNG outputs.
+
 ## ParaView package configuration
 
 Service mode requires `nprocs=1` and a durable `ppl run` or `ppl submit`
@@ -362,12 +382,23 @@ pkg_type: builtin.paraview
 pkg_name: viewer
 mode: service
 dataset_descriptor: /site/descriptors/asteroid-subset.json
+initial_scene: /site/scenes/asteroid-evidence.json
 service_bind_host: 127.0.0.1
 service_advertise_host: 127.0.0.1
 service_port: 0
 service_startup_timeout: 600
 nprocs: 1
 ```
+
+`initial_scene` is optional and declared with
+`jarvis.configuration-input-binding.v1` as a regular local file. A relay may
+therefore stage a Host-local scene through its transparent input-binding
+contract. JARVIS privately copies at most 2 MiB into the owned service root,
+and the service validates the entire scene against the opened dataset before
+the health endpoint can report ready. Rejections emit
+`JARVIS_PARAVIEW_SCENE_REJECTION` followed by a bounded
+`jarvis.paraview.scene-rejection.v1` JSON record; filesystem paths and secrets
+are not included.
 
 The package resolves `pvpython` from the pipeline execution environment. It
 probes that executable and selects one supported headless backend itself:

--- a/test/unit/core/test_package_deployment_contract.py
+++ b/test/unit/core/test_package_deployment_contract.py
@@ -271,6 +271,8 @@ class _RootProbeExec:
         self.stderr = {"localhost": ""}
         if "5.12" in command or "explicit" in command:
             self.stdout["localhost"] = "--mesa\n"
+        elif "--mesa --help" in command:
+            self.exit_code["localhost"] = 1
 
     def run(self) -> "_RootProbeExec":
         """Return the completed deterministic capability probe."""

--- a/test/unit/core/test_paraview_progress.py
+++ b/test/unit/core/test_paraview_progress.py
@@ -257,7 +257,7 @@ def test_generic_paraview_batch_resolves_runtime_and_hostfile(
 
     command, exec_info = _CapturedExec.commands[0]
     assert command.startswith("/runtime/paraview/bin/pvbatch --mesa")
-    assert "--force-offscreen-rendering" not in command
+    assert command.count("--force-offscreen-rendering") == 1
     assert exec_info.hostfile is hostfile
     assert exec_info.env["JARVIS_PACKAGE_NAME"] == "builtin.paraview"
     assert exec_info.env["JARVIS_PACKAGE_ID"] == "asteroid_render"

--- a/test/unit/core/test_paraview_scene_manifest.py
+++ b/test/unit/core/test_paraview_scene_manifest.py
@@ -1,0 +1,780 @@
+"""Reusable ParaView scene import, export, and compatibility tests."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Mapping, cast
+
+import pytest
+from jarvis_cd.service_runtime import (
+    DatasetArray,
+    DatasetDescriptor,
+    DatasetMember,
+    calculate_dataset_fingerprint,
+)
+
+_BUILTIN_REPOSITORY_ROOT = Path(__file__).resolve().parents[3] / "builtin"
+sys.path.insert(0, str(_BUILTIN_REPOSITORY_ROOT))
+
+from builtin.paraview import pkg as package_module  # noqa: E402
+from builtin.paraview import service as service_module  # noqa: E402
+from builtin.paraview.scene_manifest import (  # noqa: E402
+    SCENE_ARTIFACT_MEDIA_TYPE,
+    SceneManifestError,
+    build_scene_manifest,
+    canonical_scene_bytes,
+    load_scene_manifest,
+    validate_scene_manifest,
+)
+
+
+def _descriptor() -> dict[str, Any]:
+    members = (DatasetMember(index=0, location="/cluster/deep-water.vti"),)
+    arrays = (
+        DatasetArray(
+            name="pressure",
+            association="point",
+            components=1,
+            units="Pa",
+        ),
+    )
+    fingerprint = calculate_dataset_fingerprint(
+        dataset_id="deep-water-impact-2018",
+        kind="temporal-volume",
+        format="vtk-image-data",
+        members=members,
+        arrays=arrays,
+        bounds=(0.0, 10.0, 0.0, 6.0, -2.0, 2.0),
+    )
+    return DatasetDescriptor(
+        dataset_id="deep-water-impact-2018",
+        kind="temporal-volume",
+        format="vtk-image-data",
+        members=members,
+        arrays=arrays,
+        bounds=(0.0, 10.0, 0.0, 6.0, -2.0, 2.0),
+        fingerprint=fingerprint,
+    ).to_dict()
+
+
+def _field() -> dict[str, Any]:
+    return {
+        "name": "pressure",
+        "association": "point",
+        "components": 1,
+        "units": "Pa",
+    }
+
+
+def _output(*, topology: str) -> dict[str, Any]:
+    return {
+        "topology": topology,
+        "raw_data_type": "vtkImageData",
+        "bounds": [0.0, 10.0, 0.0, 6.0, -2.0, 2.0],
+        "point_count": 256,
+        "cell_count": 128,
+        "arrays": [_field()],
+    }
+
+
+def _pipeline() -> dict[str, Any]:
+    return {
+        "timestep": {"index": 1, "value": 0.5, "count": 3},
+        "nodes": [
+            {
+                "node_id": "node_root",
+                "kind": "reader",
+                "input_node_ids": [],
+                "filter": None,
+                "output": _output(topology="volume"),
+            },
+            {
+                "node_id": "node_threshold",
+                "kind": "threshold",
+                "input_node_ids": ["node_root"],
+                "filter": {
+                    "type": "threshold",
+                    "parameters": {
+                        "name": "pressure",
+                        "association": "point",
+                        "lower": 2.0,
+                        "upper": 8.0,
+                    },
+                },
+                "output": _output(topology="volume"),
+            },
+            {
+                "node_id": "node_slice",
+                "kind": "slice",
+                "input_node_ids": ["node_threshold"],
+                "filter": {
+                    "type": "slice",
+                    "parameters": {
+                        "origin": [5.0, 3.0, 0.0],
+                        "normal": [0.0, 1.0, 0.0],
+                    },
+                },
+                "output": _output(topology="surface"),
+            },
+        ],
+        "representations": [
+            {
+                "representation_id": "rep_root",
+                "node_id": "node_root",
+                "type": "surface",
+                "visible": False,
+                "opacity": 0.15,
+                "point_size_px": None,
+                "color": {"mode": "solid", "rgb": [0.1, 0.1, 0.15]},
+            },
+            {
+                "representation_id": "rep_slice",
+                "node_id": "node_slice",
+                "type": "surface",
+                "visible": True,
+                "opacity": 0.9,
+                "point_size_px": None,
+                "color": {
+                    "mode": "field",
+                    "field": _field(),
+                    "observation": {
+                        "observed_range": [1.0, 9.0],
+                        "tuple_count": 128,
+                        "value_mode": "scalar",
+                    },
+                    "preset": "Viridis (matplotlib)",
+                    "invert": False,
+                    "scale": {"mode": "linear"},
+                    "range_policy": {
+                        "mode": "measurement_percentile",
+                        "measurement_id": "mea_pressure",
+                        "lower_percentile": 5.0,
+                        "upper_percentile": 95.0,
+                        "timestep_behavior": "freeze",
+                    },
+                    "transfer_range": [2.0, 8.0],
+                    "scalar_bar": {
+                        "visible": True,
+                        "embedded_in_frame": True,
+                    },
+                    "supported_scales": ["linear", "log"],
+                },
+            },
+        ],
+        "measurements": [],
+        "camera": {
+            "position": [14.0, 8.0, 6.0],
+            "focal_point": [5.0, 3.0, 0.0],
+            "view_up": [0.0, 0.0, 1.0],
+            "parallel_scale": 6.0,
+            "projection": "perspective",
+            "view_angle": 30.0,
+        },
+        "selection": None,
+        "artifacts": [],
+    }
+
+
+def _manifest(*, constraint: str = "exact") -> dict[str, Any]:
+    return build_scene_manifest(
+        descriptor=_descriptor(),
+        pipeline=_pipeline(),
+        final_revision=17,
+        artifact_id="art_0123456789abcdefghijkl",
+        jarvis_version="1.7.0",
+        paraview_version="5.13.3",
+        fingerprint_constraint=constraint,
+    )
+
+
+def _discovery() -> dict[str, Any]:
+    return {
+        "topology": "volume",
+        "bounds": [0.0, 10.0, 0.0, 6.0, -2.0, 2.0],
+        "arrays": [_field()],
+        "timestep_count": 3,
+    }
+
+
+def test_canonical_scene_round_trip_preserves_effective_graph_and_provenance() -> None:
+    """Exported JSON validates unchanged and freezes measurement-derived ranges."""
+    manifest = _manifest()
+
+    validated = validate_scene_manifest(
+        json.loads(canonical_scene_bytes(manifest)),
+        descriptor=_descriptor(),
+        discovery=_discovery(),
+    )
+
+    assert validated == manifest
+    assert validated["scene"]["filters"] == manifest["scene"]["filters"]
+    assert validated["scene"]["actors"] == manifest["scene"]["actors"]
+    field_actor = validated["scene"]["actors"][1]
+    assert field_actor["color"]["range_policy"] == {
+        "mode": "fixed",
+        "range": [2.0, 8.0],
+        "timestep_behavior": "freeze",
+    }
+    assert field_actor["range_provenance"]["source_policy"]["mode"] == (
+        "measurement_percentile"
+    )
+    assert field_actor["color"]["scalar_bar_visible"] is True
+    assert validated["scene"]["camera"] == _pipeline()["camera"]
+
+
+@pytest.mark.parametrize(
+    ("mutate", "code"),
+    [
+        (
+            lambda value: value["dataset_binding"].update(topology="points"),
+            "topology_mismatch",
+        ),
+        (
+            lambda value: value["dataset_binding"].update(
+                bounds=[0.0, 9.0, 0.0, 6.0, -2.0, 2.0]
+            ),
+            "bounds_mismatch",
+        ),
+        (
+            lambda value: value["dataset_binding"]["required_fields"][0].update(
+                name="stale_pressure"
+            ),
+            "stale_field",
+        ),
+        (
+            lambda value: value["compatibility"].update(
+                required_plugins=["site.CustomFilter"]
+            ),
+            "unsupported_plugin",
+        ),
+        (
+            lambda value: value["compatibility"]["resource_requirements"].update(
+                nodes=33
+            ),
+            "resource_limit",
+        ),
+        (
+            lambda value: value["scene"]["camera"].update(
+                focal_point=value["scene"]["camera"]["position"]
+            ),
+            "invalid_camera",
+        ),
+        (
+            lambda value: value["scene"]["filters"][0]["parameters"].update(
+                lower=9.0, upper=2.0
+            ),
+            "invalid_filter",
+        ),
+    ],
+)
+def test_scene_preflight_rejects_incompatible_or_unbounded_content(
+    mutate: Any,
+    code: str,
+) -> None:
+    manifest = _manifest()
+    mutate(manifest)
+
+    with pytest.raises(SceneManifestError) as captured:
+        validate_scene_manifest(
+            manifest,
+            descriptor=_descriptor(),
+            discovery=_discovery(),
+        )
+
+    assert captured.value.code == code
+    assert captured.value.as_dict()["schema_version"] == (
+        "jarvis.paraview.scene-rejection.v1"
+    )
+
+
+def test_exact_fingerprint_rejects_different_descriptor_but_compatible_can_open() -> (
+    None
+):
+    descriptor = _descriptor()
+    descriptor["dataset_id"] = "compatible-copy"
+    intrinsic = {key: item for key, item in descriptor.items() if key != "fingerprint"}
+    descriptor["fingerprint"] = {
+        "algorithm": "sha256",
+        "digest": hashlib.sha256(
+            json.dumps(
+                intrinsic,
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+        ).hexdigest(),
+    }
+    with pytest.raises(SceneManifestError) as captured:
+        validate_scene_manifest(
+            _manifest(),
+            descriptor=descriptor,
+            discovery=_discovery(),
+        )
+    assert captured.value.code == "descriptor_fingerprint_mismatch"
+
+    compatible = validate_scene_manifest(
+        _manifest(constraint="compatible"),
+        descriptor=descriptor,
+        discovery=_discovery(),
+    )
+    assert compatible["dataset_binding"]["fingerprint_constraint"] == "compatible"
+
+
+def test_scene_manifest_file_rejects_symlink_and_duplicate_keys(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "scene.json"
+    source.write_bytes(canonical_scene_bytes(_manifest()))
+    assert load_scene_manifest(source.resolve()) == _manifest()
+
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema_version":"one","schema_version":"two"}')
+    with pytest.raises(SceneManifestError) as captured:
+        load_scene_manifest(duplicate.resolve())
+    assert captured.value.code == "invalid_manifest"
+
+    link = tmp_path / "linked.json"
+    try:
+        link.symlink_to(source)
+    except OSError:
+        return
+    with pytest.raises(SceneManifestError) as captured:
+        load_scene_manifest(link.absolute())
+    assert captured.value.code == "unsafe_scene_path"
+
+
+class _ImportBackend:
+    """Minimal transactional surface that records real importer semantics."""
+
+    _import_scene_manifest = service_module.ParaViewBackend._import_scene_manifest
+
+    def __init__(self) -> None:
+        self.descriptor = _descriptor()
+        self._nodes: dict[str, dict[str, Any]] = {
+            "node_root": {
+                "node_id": "node_root",
+                "output": _output(topology="volume"),
+            }
+        }
+        self._timesteps = [0.0, 0.5, 1.0]
+        self._transaction_open = False
+        self.calls: list[tuple[str, Mapping[str, Any]]] = []
+        self.created_nodes: dict[str, str] = {}
+        self.rollback_calls = 0
+
+    def begin_command(self) -> object:
+        self._transaction_open = True
+        return {}
+
+    def commit_command(self, _checkpoint: object) -> None:
+        self._transaction_open = False
+
+    def rollback_command(self, _checkpoint: object) -> None:
+        self.rollback_calls += 1
+        self._transaction_open = False
+
+    def _set_timestep(
+        self,
+        arguments: Mapping[str, Any],
+        _command_id: str,
+    ) -> dict[str, Any]:
+        self.calls.append(("set_timestep", copy.deepcopy(arguments)))
+        return {"timestep": dict(arguments)}
+
+    def _create_filter(
+        self,
+        arguments: Mapping[str, Any],
+        _command_id: str,
+    ) -> dict[str, Any]:
+        self.calls.append(("create_filter", copy.deepcopy(arguments)))
+        node_id = f"node_imported_{len(self.created_nodes) + 1}"
+        self.created_nodes[node_id] = cast(str, arguments["input_node_id"])
+        return {"node": {"node_id": node_id}}
+
+    def _set_representation(
+        self,
+        arguments: Mapping[str, Any],
+        _command_id: str,
+    ) -> dict[str, Any]:
+        self.calls.append(("set_representation", copy.deepcopy(arguments)))
+        return {"representation": dict(arguments)}
+
+    def _set_camera(
+        self,
+        arguments: Mapping[str, Any],
+        _command_id: str,
+    ) -> dict[str, Any]:
+        self.calls.append(("set_camera", copy.deepcopy(arguments)))
+        return {"camera": dict(arguments)}
+
+
+def test_import_replays_preflighted_graph_atomically_and_keeps_revision_semantics() -> (
+    None
+):
+    backend = _ImportBackend()
+
+    evidence = backend._import_scene_manifest(_manifest())
+
+    assert [name for name, _arguments in backend.calls] == [
+        "set_timestep",
+        "create_filter",
+        "create_filter",
+        "set_representation",
+        "set_representation",
+        "set_camera",
+    ]
+    first_filter = backend.calls[1][1]
+    second_filter = backend.calls[2][1]
+    assert first_filter["input_node_id"] == "node_root"
+    assert second_filter["input_node_id"] == "node_imported_1"
+    assert backend.calls[3][1]["representation_id"] == "rep_root"
+    assert backend.calls[4][1]["representation_id"] is None
+    assert backend._transaction_open is False
+    assert backend.rollback_calls == 0
+    assert evidence["source_final_revision"] == 17
+    assert evidence["descriptor_fingerprint"] == _descriptor()["fingerprint"]
+
+
+class _RevisionBackend:
+    """Valid state backend proving export does not disable later edits."""
+
+    execution_id = "exec-scene"
+    package_name = "builtin.paraview"
+    package_id = "viewer"
+    service_instance_id = "srv-scene"
+
+    def __init__(self) -> None:
+        self.index = 0
+        self.last_export_arguments: dict[str, Any] | None = None
+
+    def dataset_state(self) -> dict[str, Any]:
+        return {
+            "descriptor": _descriptor(),
+            "discovery": {
+                "arrays": [_field()],
+                "bounds": [0.0, 10.0, 0.0, 6.0, -2.0, 2.0],
+                "timestep_values": [0.0, 0.5, 1.0],
+            },
+        }
+
+    def pipeline_state(self) -> dict[str, Any]:
+        pipeline = _pipeline()
+        pipeline["nodes"] = [pipeline["nodes"][0]]
+        pipeline["representations"] = [pipeline["representations"][0]]
+        pipeline["timestep"] = {
+            "index": self.index,
+            "value": [0.0, 0.5, 1.0][self.index],
+            "count": 3,
+        }
+        return pipeline
+
+    def execute(
+        self,
+        operation: str,
+        arguments: Mapping[str, Any],
+        _command_id: str,
+    ) -> dict[str, Any]:
+        if operation == "export_scene":
+            self.last_export_arguments = dict(arguments)
+            return {"artifact": {"artifact_id": "art_scene"}}
+        self.index = cast(int, arguments["index"])
+        return {"timestep": self.index}
+
+    def render_png(self) -> bytes:
+        return b"\x89PNG\r\n\x1a\nscene"
+
+    def begin_command(self) -> object:
+        return self.index
+
+    def commit_command(self, _checkpoint: object) -> None:
+        return
+
+    def rollback_command(self, checkpoint: object) -> None:
+        self.index = cast(int, checkpoint)
+
+
+def test_export_revision_continues_into_normal_temporal_edit() -> None:
+    backend = _RevisionBackend()
+    controller = service_module.ServiceStateController(
+        backend=backend,
+        execution_id=backend.execution_id,
+        package_name=backend.package_name,
+        package_id=backend.package_id,
+        service_instance_id=backend.service_instance_id,
+    )
+
+    exported = controller.command(
+        {
+            "schema_version": "jarvis.paraview.command.v2",
+            "command_id": "export-scene",
+            "operation": "export_scene",
+            "expected_revision": 1,
+            "arguments": {
+                "filename": "scenes/deep-water.json",
+                "fingerprint_constraint": "exact",
+            },
+        }
+    )
+    edited = controller.command(
+        {
+            "schema_version": "jarvis.paraview.command.v2",
+            "command_id": "advance-time",
+            "operation": "set_timestep",
+            "expected_revision": 2,
+            "arguments": {"index": 2},
+        }
+    )
+
+    assert backend.last_export_arguments == {
+        "filename": "scenes/deep-water.json",
+        "fingerprint_constraint": "exact",
+        "_final_revision": 2,
+    }
+    assert exported["state"]["revision"] == 2
+    assert edited["state"]["revision"] == 3
+    assert edited["state"]["pipeline"]["timestep"]["index"] == 2
+
+
+class _ArtifactBackend:
+    """File-backed export surface using production artifact transactions."""
+
+    _export_scene = service_module.ParaViewBackend._export_scene
+    _scene_digest = service_module.ParaViewBackend._scene_digest
+    _validate_staged_artifact_identities = (
+        service_module.ParaViewBackend._validate_staged_artifact_identities
+    )
+
+    def __init__(self, output_dir: Path) -> None:
+        self.output_dir = output_dir
+        self.output_dir.mkdir()
+        self.descriptor = _descriptor()
+        self.service_instance_id = "srv-scene-artifact"
+        self.execution_id = "exec-scene-artifact"
+        self.package_name = "builtin.paraview"
+        self.package_id = "viewer"
+        self._artifacts: list[dict[str, Any]] = []
+        self._staged_artifacts: dict[str, dict[str, Any]] = {}
+        self._representations = {
+            "rep_root": {"visible": True},
+            "rep_slice": {"visible": True},
+        }
+
+    def pipeline_state(self) -> dict[str, Any]:
+        pipeline = _pipeline()
+        pipeline["artifacts"] = copy.deepcopy(self._artifacts)
+        return pipeline
+
+    def _paraview_version(self) -> str:
+        return "5.13.3"
+
+
+class _ImportedArtifactBackend(_ArtifactBackend):
+    """Commit imported-scene provenance through the production ledger helpers."""
+
+    _publish_imported_scene = service_module.ParaViewBackend._publish_imported_scene
+
+    def __init__(self, output_dir: Path) -> None:
+        super().__init__(output_dir)
+        self._transaction_open = False
+        self._checkpoint_artifacts: list[dict[str, Any]] = []
+
+    def begin_command(self) -> object:
+        self._transaction_open = True
+        self._checkpoint_artifacts = copy.deepcopy(self._artifacts)
+        return {}
+
+    def commit_command(self, _checkpoint: object) -> None:
+        self._validate_staged_artifact_identities()
+        service_module._commit_staged_artifacts(self._staged_artifacts)
+        self._staged_artifacts = {}
+        self._transaction_open = False
+
+    def rollback_command(self, _checkpoint: object) -> None:
+        for staged in self._staged_artifacts.values():
+            staged_path = staged.get("staged_path")
+            if isinstance(staged_path, Path):
+                staged_path.unlink(missing_ok=True)
+        self._staged_artifacts = {}
+        self._artifacts = self._checkpoint_artifacts
+        self._transaction_open = False
+
+
+def _prepare_with_portable_cluster_location(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepare_artifact = service_module._prepare_artifact_event
+
+    def prepare_with_cluster_location(**kwargs: Any) -> dict[str, Any]:
+        kwargs["cluster_location"] = (
+            "/cluster/jarvis/scenes/" + cast(Path, kwargs["path"]).name
+        )
+        return prepare_artifact(**kwargs)
+
+    monkeypatch.setattr(
+        service_module,
+        "_prepare_artifact_event",
+        prepare_with_cluster_location,
+    )
+
+
+def test_export_scene_publishes_queryable_artifact_without_transient_secrets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact_path = (tmp_path / "artifacts.jsonl").resolve()
+    monkeypatch.setenv("JARVIS_ARTIFACT_PATH", str(artifact_path))
+    monkeypatch.setenv("JARVIS_EXECUTION_ID", "exec-scene-artifact")
+    monkeypatch.setenv("JARVIS_PACKAGE_NAME", "builtin.paraview")
+    monkeypatch.setenv("JARVIS_PACKAGE_ID", "viewer")
+    monkeypatch.setenv("JARVIS_SERVICE_AUTHORIZATION", "secret-token-must-not-leak")
+    _prepare_with_portable_cluster_location(monkeypatch)
+    backend = _ArtifactBackend(tmp_path / "output")
+
+    result = backend._export_scene(
+        {
+            "filename": "scenes/deep-water.json",
+            "fingerprint_constraint": "exact",
+            "_final_revision": 22,
+        },
+        "export-scene-artifact",
+    )
+    backend._validate_staged_artifact_identities()
+    service_module._commit_staged_artifacts(backend._staged_artifacts)
+
+    scene_path = tmp_path / "output" / "scenes" / "deep-water.json"
+    manifest = json.loads(scene_path.read_text(encoding="utf-8"))
+    event = json.loads(artifact_path.read_text(encoding="utf-8"))
+    rendered = scene_path.read_text(encoding="utf-8")
+    assert result["artifact"]["kind"] == "visualization_scene"
+    assert event["media_type"] == SCENE_ARTIFACT_MEDIA_TYPE
+    assert event["metadata"]["final_revision"] == 22
+    assert event["metadata"]["descriptor_fingerprint"] == (_descriptor()["fingerprint"])
+    assert manifest["source"]["artifact_id"] == event["artifact_id"]
+    assert manifest["source"]["final_revision"] == 22
+    assert "/cluster/" not in rendered
+    assert str(tmp_path) not in rendered
+    assert "exec-scene-artifact" not in rendered
+    assert "srv-scene-artifact" not in rendered
+    assert "secret-token-must-not-leak" not in rendered
+    assert "service_port" not in rendered
+
+
+def test_imported_scene_is_queryable_provenance_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact_path = (tmp_path / "artifacts.jsonl").resolve()
+    monkeypatch.setenv("JARVIS_ARTIFACT_PATH", str(artifact_path))
+    monkeypatch.setenv("JARVIS_EXECUTION_ID", "exec-scene-artifact")
+    monkeypatch.setenv("JARVIS_PACKAGE_NAME", "builtin.paraview")
+    monkeypatch.setenv("JARVIS_PACKAGE_ID", "viewer")
+    _prepare_with_portable_cluster_location(monkeypatch)
+    backend = _ImportedArtifactBackend(tmp_path / "output")
+    source = _manifest()
+    evidence = {
+        "source_artifact_id": source["source"]["artifact_id"],
+        "source_final_revision": source["source"]["final_revision"],
+        "manifest_sha256": hashlib.sha256(canonical_scene_bytes(source)).hexdigest(),
+        "descriptor_fingerprint": _descriptor()["fingerprint"],
+    }
+
+    imported = backend._publish_imported_scene(source, evidence)
+
+    copied = tmp_path / "output" / "initial-scene-import.json"
+    event = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert copied.read_bytes() == canonical_scene_bytes(source)
+    assert event["artifact_id"] == imported["imported_artifact_id"]
+    assert event["kind"] == "visualization_scene"
+    assert event["role"] == "provenance"
+    assert event["metadata"]["imported"] is True
+    assert event["metadata"]["source_artifact_id"] == (source["source"]["artifact_id"])
+    assert event["metadata"]["source_final_revision"] == 17
+
+
+def test_package_advertises_initial_scene_as_optional_declared_file_input() -> None:
+    package = object.__new__(package_module.Paraview)
+    menu = {item["name"]: item for item in package._configure_menu()}
+
+    assert menu["initial_scene"]["default"] == ""
+    assert menu["initial_scene"]["input_binding"] == {
+        "schema_version": "jarvis.configuration-input-binding.v1",
+        "kind": "local_file",
+        "structure": "regular_file",
+    }
+
+
+def test_empty_scene_default_does_not_require_initial_scene() -> None:
+    package = object.__new__(package_module.Paraview)
+    package.config = {
+        "mode": "service",
+        "dataset_descriptor": json.dumps(_descriptor()),
+        "initial_scene": "",
+    }
+
+    package._configure()
+
+
+def test_structured_scene_rejection_never_echoes_unsafe_input_path(
+    tmp_path: Path,
+) -> None:
+    missing = (tmp_path / "private" / "missing.json").resolve()
+    with pytest.raises(SceneManifestError) as captured:
+        load_scene_manifest(missing)
+
+    rendered = json.dumps(captured.value.as_dict(), sort_keys=True)
+    assert captured.value.code == "unsafe_scene_path"
+    assert str(missing) not in rendered
+    assert os.fspath(tmp_path) not in rendered
+
+
+def test_service_emits_structured_scene_rejection_before_readiness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    descriptor_path = tmp_path / "descriptor.json"
+    descriptor_path.write_text(json.dumps(_descriptor()), encoding="utf-8")
+    authorization_path = (tmp_path / "authorization.token").resolve()
+    authorization_path.write_text("a" * 64 + "\n", encoding="ascii")
+    if os.name != "nt":
+        authorization_path.chmod(0o600)
+    missing = (tmp_path / "private" / "missing-scene.json").resolve()
+    monkeypatch.setenv("JARVIS_EXECUTION_ID", "exec-scene-rejection")
+    monkeypatch.setenv("JARVIS_PACKAGE_NAME", "builtin.paraview")
+    monkeypatch.setenv("JARVIS_PACKAGE_ID", "viewer")
+
+    result = service_module.main(
+        [
+            "--descriptor",
+            str(descriptor_path.resolve()),
+            "--output-dir",
+            str((tmp_path / "output").resolve()),
+            "--bind-host",
+            "127.0.0.1",
+            "--port",
+            "18080",
+            "--execution-id",
+            "exec-scene-rejection",
+            "--service-instance-id",
+            "srv-scene-rejection",
+            "--authorization-file",
+            str(authorization_path),
+            "--initial-scene",
+            str(missing),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert captured.out == ""
+    prefix = "JARVIS_PARAVIEW_SCENE_REJECTION "
+    assert captured.err.startswith(prefix)
+    evidence = json.loads(captured.err.removeprefix(prefix))
+    assert evidence["code"] == "unsafe_scene_path"
+    assert str(missing) not in captured.err

--- a/test/unit/core/test_paraview_scene_v2.py
+++ b/test/unit/core/test_paraview_scene_v2.py
@@ -471,7 +471,7 @@ def test_solid_color_normalizes_unset_paraview_association() -> None:
 
     assert display.scalar_bar_calls == []
     assert display.ColorArrayName == ["POINTS", ""]
-    assert simple.color_calls[-1] == (display, None, False)
+    assert simple.color_calls == []
     assert display.DiffuseColor == [0.8, 0.8, 0.8]
 
 
@@ -736,6 +736,7 @@ def test_field_change_and_solid_color_retire_exact_transfer_proxies() -> None:
     assert (display, "temperature") not in simple.opacities
     assert representation_id not in backend._representation_transfer_proxies
     assert display.scalar_bar_calls[-1] is False
+    assert simple.color_calls[-1] == (display, None, False)
 
 
 def test_failed_field_change_restores_old_transfer_proxies_without_leak() -> None:

--- a/test/unit/core/test_paraview_scene_v2.py
+++ b/test/unit/core/test_paraview_scene_v2.py
@@ -463,12 +463,13 @@ def test_same_node_supports_independent_surface_and_point_actors() -> None:
 
 
 def test_solid_color_normalizes_unset_paraview_association() -> None:
-    """Solid actors disable scalar coloring from a fresh ParaView display."""
+    """Fresh solid actors never toggle a scalar bar without a bound lookup table."""
     backend, simple, _source = _representation_backend()
     display = backend._representation_displays["rep_root"]
 
     backend._apply_representation_record(backend._representations["rep_root"])
 
+    assert display.scalar_bar_calls == []
     assert display.ColorArrayName == ["POINTS", ""]
     assert simple.color_calls[-1] == (display, None, False)
     assert display.DiffuseColor == [0.8, 0.8, 0.8]

--- a/test/unit/core/test_paraview_service.py
+++ b/test/unit/core/test_paraview_service.py
@@ -2281,8 +2281,7 @@ def test_package_service_mode_stages_generic_runtime_and_owned_output(
     command, exec_info = _CapturedExec.commands[0]
     assert "service_supervisor.py" in command
     assert "/runtime/paraview/bin/pvpython" in command
-    assert "--pvpython-options=--mesa" in command
-    assert "--force-offscreen-rendering" not in command
+    assert "--pvpython-options=--mesa --force-offscreen-rendering" in command
     assert "--bind-host 127.0.0.1" in command
     assert "--advertise-host 127.0.0.1" in command
     assert "--startup-timeout 600" in command
@@ -2317,7 +2316,7 @@ def test_package_service_mode_stages_generic_runtime_and_owned_output(
     package._start_service(dict(package.mod_env))
     deduplicated_command, _ = _CapturedExec.commands[1]
     assert deduplicated_command.count("--mesa") == 1
-    assert "--force-offscreen-rendering" not in deduplicated_command
+    assert deduplicated_command.count("--force-offscreen-rendering") == 1
     assert "--startup-timeout 30" in deduplicated_command
     assert [call[0] for call in _ResolvedWhich.calls] == ["pvpython", "pvpython"]
     assert _ResolvedWhich.calls[0][1].env["PATH"] == "/runtime/paraview/bin"
@@ -2409,8 +2408,8 @@ def test_package_parameters_describe_live_view_service_mode() -> None:
     assert "pvbatch_options" not in parameters
 
 
-def test_package_selects_one_deterministic_headless_backend() -> None:
-    """Mesa is preferred when available, with force-offscreen as fallback."""
+def test_package_selects_all_compatible_headless_controls() -> None:
+    """Mesa selection and forced offscreen rendering remain complementary."""
     both = package_module._ParaViewRuntime(
         executable="/runtime/bin/pvpython",
         capabilities=frozenset({"--force-offscreen-rendering", "--mesa"}),
@@ -2420,9 +2419,40 @@ def test_package_selects_one_deterministic_headless_backend() -> None:
         capabilities=frozenset({"--force-offscreen-rendering"}),
     )
 
-    assert both.arguments(force_offscreen=True) == ("--mesa",)
+    assert both.arguments(force_offscreen=True) == (
+        "--mesa",
+        "--force-offscreen-rendering",
+    )
     assert fallback.arguments(force_offscreen=True) == ("--force-offscreen-rendering",)
     assert both.arguments(force_offscreen=False) == ()
+
+
+def test_package_probes_hidden_mesa_wrapper_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A launcher wrapper may accept Mesa while omitting it from delegated help."""
+    package = cast(Any, object.__new__(package_module.Paraview))
+    package.config = {"cwd": ""}
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: object())
+    _ResolvedWhich.calls = []
+    monkeypatch.setattr(package_module, "Which", _ResolvedWhich)
+    monkeypatch.setattr(package_module, "Exec", _CapturedExec)
+    monkeypatch.setattr(
+        _CapturedExec,
+        "help_text",
+        "--force-offscreen-rendering\n",
+    )
+
+    runtime = package._resolve_runtime(
+        "service",
+        {"PATH": "/runtime/paraview/bin"},
+    )
+
+    assert runtime.capabilities == frozenset({"--mesa", "--force-offscreen-rendering"})
+    assert runtime.arguments(force_offscreen=True) == (
+        "--mesa",
+        "--force-offscreen-rendering",
+    )
 
 
 @pytest.mark.parametrize(

--- a/test/unit/core/test_paraview_service.py
+++ b/test/unit/core/test_paraview_service.py
@@ -2297,6 +2297,7 @@ def test_package_service_mode_stages_generic_runtime_and_owned_output(
     service_root = service_roots[0]
     assert (service_root / "service.py").is_file()
     assert (service_root / "service_http.py").is_file()
+    assert (service_root / "scene_manifest.py").is_file()
     assert (service_root / "service_supervisor.py").is_file()
     assert (service_root / "output").is_dir()
     authorization_file = service_root / "authorization.token"


### PR DESCRIPTION
## Summary
- declare optional `initial_scene` as a synchronized regular-file input for ParaView service mode
- preflight and atomically import canonical, path-free scene manifests before readiness
- add revisioned `export_scene` with durable output and imported-scene provenance artifacts
- preserve empty-scene behavior and subsequent live edits/timestep playback

## Verification
- `uv run pytest -q` (1444 passed, 3 subtests passed)
- `uv run pytest -q test/unit/core/test_paraview_scene_manifest.py test/unit/core/test_paraview_service.py test/unit/core/test_paraview_scene_v2.py test/unit/core/test_paraview_artifacts.py test/unit/core/test_paraview_progress.py test/unit/core/test_package_deployment_contract.py test/unit/core/test_configuration_input_materialization.py` (158 passed)
- `uv run ruff check --fix ...` and `uv run ruff format ...`
- `uv run pyright builtin/builtin/paraview/scene_manifest.py builtin/builtin/paraview/service.py builtin/builtin/paraview/service_http.py builtin/builtin/paraview/service_supervisor.py builtin/builtin/paraview/pkg.py`

Closes #183