### PR TITLE
feat(iowarp/clio-core #526): reproducible performance evaluation pipelines

### DIFF
--- a/test/unit/shell/test_exec_factory_container.py
+++ b/test/unit/shell/test_exec_factory_container.py
@@ -52,20 +52,23 @@ class TestPrepareContainerApptainer(unittest.TestCase):
         return make_exec(info)
 
     def test_apptainer_wraps_with_apptainer_exec(self):
-        """container='apptainer', container_image='myimg', shared_dir set →
-        wrapped cmd contains 'apptainer exec' and 'myimg.sif'."""
+        """container='apptainer' → wrapped cmd execs into the running
+        instance: contains 'apptainer exec' and 'instance://myimg' (the
+        container_image doubles as the instance name)."""
         exec_obj = self._make_apptainer_exec(
             container_image='myimg', shared_dir='/shared')
         wrapped_cmd, _ = exec_obj._prepare_container('echo hello')
         self.assertIn('apptainer exec', wrapped_cmd)
-        self.assertIn('myimg.sif', wrapped_cmd)
+        self.assertIn('instance://myimg', wrapped_cmd)
 
-    def test_apptainer_wraps_with_shared_dir_path(self):
-        """When shared_dir is set, SIF path is resolved from the parent of shared_dir."""
+    def test_apptainer_uses_instance_name_not_sif_path(self):
+        """The wrapped command targets the long-running instance by name
+        (instance://<image>); shared_dir no longer injects a .sif path."""
         exec_obj = self._make_apptainer_exec(
             container_image='myimg', shared_dir='/shared/mypkg')
         wrapped_cmd, _ = exec_obj._prepare_container('echo hello')
-        self.assertIn('/shared/myimg.sif', wrapped_cmd)
+        self.assertIn('instance://myimg', wrapped_cmd)
+        self.assertNotIn('.sif', wrapped_cmd)
 
     def test_apptainer_passes_env_vars(self):
         """container='apptainer', env={'MY_VAR': 'val'} → wrapped cmd contains
@@ -89,8 +92,9 @@ class TestPrepareContainerApptainer(unittest.TestCase):
         _, returned_info = exec_obj._prepare_container('echo hello')
         self.assertEqual(returned_info.env, {})
 
-    def test_apptainer_gpu_flag(self):
-        """When gpu=True, '--nv' appears in the wrapped command."""
+    def test_apptainer_gpu_flag_not_forwarded(self):
+        """--nv is applied at `apptainer instance start` time, not on exec,
+        so it is deliberately NOT forwarded into the wrapped exec command."""
         info = ExecInfo(
             exec_type=ExecType.LOCAL,
             container='apptainer',
@@ -99,7 +103,8 @@ class TestPrepareContainerApptainer(unittest.TestCase):
         )
         exec_obj = make_exec(info)
         wrapped_cmd, _ = exec_obj._prepare_container('echo hello')
-        self.assertIn('--nv', wrapped_cmd)
+        self.assertNotIn('--nv', wrapped_cmd)
+        self.assertIn('instance://gpuimg', wrapped_cmd)
 
     def test_apptainer_no_gpu_flag_when_false(self):
         """When gpu=False, '--nv' does NOT appear."""
@@ -107,11 +112,13 @@ class TestPrepareContainerApptainer(unittest.TestCase):
         wrapped_cmd, _ = exec_obj._prepare_container('echo hello')
         self.assertNotIn('--nv', wrapped_cmd)
 
-    def test_apptainer_bind_mounts(self):
-        """bind_mounts entries appear as '--bind ...' in the wrapped command."""
+    def test_apptainer_bind_mounts_not_forwarded(self):
+        """Bind mounts are applied at instance-start time and are silently
+        ignored on a running instance, so they are NOT forwarded on exec."""
         exec_obj = self._make_apptainer_exec(bind_mounts=['/host/path:/container/path'])
         wrapped_cmd, _ = exec_obj._prepare_container('echo hello')
-        self.assertIn('--bind /host/path:/container/path', wrapped_cmd)
+        self.assertNotIn('--bind', wrapped_cmd)
+        self.assertIn('instance://myimg', wrapped_cmd)
 
 
 class TestPrepareContainerDocker(unittest.TestCase):


### PR DESCRIPTION
## Body

### What this is

Host-side jarvis support for running benchmark sweeps inside an Apptainer
container on an HPC cluster. It is the launcher half of the IOWarp
performance-evaluation work for clio-core
[#526](https://github.com/iowarp/clio-core/issues/526) — the pipeline YAMLs and
the CLIO packages they drive live in a
[companion clio-core PR](https://github.com/iowarp/clio-core/pull/854) and depend on this one.

Everything here is additive: no existing pipeline changes behavior. The
Apptainer path activates only on `container_engine: apptainer`, `run_timeout` is
opt-in, and the new builtin packages are new files. The one behavioral fix
(`.runtime` stats, below) turns blank CSV columns into populated ones.

Validated end-to-end on Ares: **24/24** single-node combos and **3/3**
distributed combos green, with non-blank throughput columns.

### Why Apptainer

Docker's layered image store is expensive on a quota'd shared filesystem and its
daemon needs root, so it is frequently unusable on a cluster even where it is
installed. Apptainer runs rootless out of a single SIF file the user owns. The
model differs from Docker/Podman — there is no compose file — so it needed its
own deploy path rather than a flag on the existing one.

### Changes

**Core — Apptainer deploy mode** (`jarvis_cd/core/pipeline.py`)

- `apptainer instance start` with `--fakeroot`, bind mounts, and a writable
  `--overlay`.
- **`container_overlay_root`** (new key). The default overlay upper dir lives
  under `shared_dir`, which is fine single-node but *cannot* work multi-node:
  overlayfs rejects a shared/NFS upper layer, and concurrent instance starts
  race on the same session dir. Setting this to a node-local path (e.g.
  `/mnt/nvme/$USER`) puts the upper dir at `<root>/<pipeline>/overlay` per host.
  Multi-node without it now **hard-errors with a message naming the fix**
  instead of corrupting silently.
- **`container_overlay: false`** drops `--overlay` entirely.
- **`PATH` propagation over pssh.** `ssh` carries no environment, so the four
  container-lifecycle `PsshExecInfo` sites (start / compose up / stop / kill)
  now pass the head node's `PATH`. Without this a remote node cannot find
  `apptainer` unless it happens to be in the login shell's rc files. `PATH`
  only — never `LD_LIBRARY_PATH`, which would put managed libs in front of
  apptainer's starter.

**Core — per-package `.runtime` stat** (`pkg.py`, `pipeline.py`, `pipeline_test.py`)

Fixes a pre-existing bug that predates this work: the `.runtime` column in
`ppl test` CSV output was always blank. Two causes, both fixed:

1. Packages read `self.start_time`, which **was never assigned anywhere** — a
   phantom attribute. `Pkg.__init__` now defines `self.runtime`, timed around
   `start()` in a `finally` so the failure path is measured too.
2. `_load_package_instance` builds a **fresh object per phase**, so `start()`
   and `_get_stat()` run on different instances. The measurement is parked on
   `Pipeline.pkg_runtimes[pkg_id]` and replayed onto the fresh instance —
   *after* `_ensure_directories()`, since that is what calls the package's own
   `_init()`, which could otherwise clobber the replay.

`self.start_time` is kept, permanently `None`, and documented as deprecated:
`PipelineTest` swallows `_get_stat` exceptions with warn-and-continue, so an
`AttributeError` in one out-of-tree package would silently discard **all** of
its stats. The 9 builtin packages defining `_get_stat` are updated to
`self.runtime` — that is complete coverage, no stragglers.

**Core — `run_timeout`** (`pipeline_test.py`)

Optional per-combination wall-clock budget, `None` by default (historical
unbounded behavior). On expiry the run is torn down under its *own* bounded
deadline — the hang that tripped the timeout can wedge `stop()` too, and
without teardown the next combination silently benchmarks the previous run's
leftover processes.

**Core — Slurm `#SBATCH` variable expansion** (`scheduler.py`)

Slurm does not expand env vars in directives, so an unexpanded `${HOME}` in
`output:`/`error:` is taken literally relative to `WorkDir`, the file cannot be
opened, and **the job fails at launch with no logs**. Now expanded host-side via
`os.path.expandvars`, which leaves Slurm patterns (`%j`, `%x`) and unset vars
untouched — matching how jarvis already expands vars in `container_binds` and
`tmp_bind_root`.

**Shell — OpenMPI 4/5 launcher naming** (`exec_factory.py`, `mpi_exec.py`)

OpenMPI ≤4 (ORTE) calls the ssh launcher `rsh`; OpenMPI 5 (PRRTE) renamed it
`ssh`, along with `plm_rsh_agent` → `plm_ssh_agent`. The mpirun command is
assembled on the host but runs inside the container, so the in-container OMPI
version is not reliably knowable. Two fixes:

- Exclude the *slurm* plm (`--mca plm ^slurm`) rather than naming the ssh
  launcher. This defeats srun-based launch — which would spawn `prted`
  **outside** the container — and lets either runtime auto-select its own ssh
  launcher under whichever name it uses.
- Emit **both** agent/args names. Each runtime honors the one it knows; an
  unrecognized `--mca` name warns, it is not fatal.

**Util — `container_utils.py`** (new)

jarvis wraps a command into the container only when the `ExecInfo` carries a
container engine — the framework never injects this, so every package must
thread it through each `ExecInfo` it builds. This is the shared implementation
of that pattern for builtin and out-of-tree packages alike:

- `container_kwargs(pkg)` — routes an Exec into the run's instance; a safe no-op
  when the package is not containerized, so it can be splatted unconditionally.
- `eff_hostfile(pkg)` + `single_instance_menu_opt()` — head-node-only pinning.
  Some packages in a multi-node pipeline are singletons, not distributed
  workloads (a redis metadata store, a JuiceFS mount, a single-client baseline).
  Unpinned they fan out to all N nodes and race on shared filesystems —
  concurrent `rm -rf`/`mkdir` of one data dir yields `Directory not empty` and a
  half-torn state that breaks the *next* sweep combo. Off by default.
- `flatten_stdout` / `all_hosts_ok` — normalize dict-or-scalar Exec results.

**Builtin packages**

- `juicefs` (new) — format + FUSE mount + deploy Dockerfile, with README.
- `redis` / `redis-benchmark` — container-aware, `single_instance` pinning,
  config fixes, READMEs.
- `ior` — `num_nodes` subsetting (first N hosts, applied *before* the
  `single_instance` collapse), container-mode paths, and a completion assertion
  so a silently-truncated run is not scored as a pass.

**Docker** — `docker/perf_eval.Dockerfile` and `build_perf_eval_image.sh`, which
builds the image and converts it to a SIF staged in the jarvis containers cache.

**Docs** — `pipelines.md` (Apptainer section + `container_engine` key),
`pipeline_tests.md` (`run_timeout`), `package_dev_guide.md`.

**Tests** — 5 new files: Apptainer container deploy, `.runtime` stat replay,
Slurm directive expansion, the OpenMPI launcher flags, and the new builtins;
plus extensions to `test_pipeline_test.py`.

### Verification

Full suite run against this branch and against an `upstream/dev` baseline
worktree, with `jarvis_cd.__file__` checked to confirm imports resolved into the
right tree:

- **0 new failures.**
- **42 previously-failing tests now pass** (the `.runtime` fix).
- 14 failures are pre-existing on `dev` and untouched by this branch.

`_timed_start` was additionally exercised directly on both the success path and
the raising path to confirm the `finally` records a duration when `start()`
throws.

### Reviewer notes

- **Merge order:** this PR should land before the clio-core companion, which
  imports `jarvis_cd.util.container_utils`.
- `.devcontainer/devcontainer.json` adds `IS_SANDBOX=1` to `remoteEnv`. Happy to
  drop it if it is not wanted in the shared devcontainer.
- `self.start_time` is intentionally retained as dead-but-defined. Removing it
  is a breaking change for any out-of-tree package still reading it, and the
  failure mode is silent stat loss rather than a visible error.