### PR TITLE
feat: support explicit interceptor package links

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -802,6 +802,30 @@ jarvis ppl append builtin.ior benchmark_run
 jarvis ppl append my_repo.custom_app my_app
 ```
 
+`ppl append` determines package behavior from the selected class. Classes derived
+from `Interceptor` are stored as named pipeline interceptors. Applications and
+services select interceptor aliases explicitly through their common
+`interceptors` setting:
+
+```bash
+# Configure two independent instances of the same interceptor.
+jarvis ppl append builtin.darshan darshan_ior \
+  log_dir=/tmp/ior_logs job_id=ior
+jarvis ppl append builtin.darshan darshan_clio \
+  log_dir=/tmp/clio_logs job_id=clio
+
+# Apply each instance only to its intended package.
+jarvis ppl append builtin.ior ior \
+  'interceptors=["darshan_ior"]'
+jarvis ppl append my_repo.clio_core clio \
+  'interceptors=["darshan_clio"]'
+```
+
+Interceptor aliases share the pipeline package namespace. JARVIS verifies that
+every referenced alias exists and derives from `Interceptor` before saving or
+starting the pipeline. Removing an interceptor that is still referenced fails
+instead of silently running the target package without interception.
+
 #### Remove Packages from Pipeline
 ```bash
 # Remove package by instance name

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -2344,6 +2344,8 @@ class Pipeline:
         if not self.name:
             raise ValueError("Pipeline name not set")
 
+        self._validate_interceptor_links()
+
         pipeline_dir = self._pipeline_storage_dir()
         pipeline_dir.mkdir(parents=True, exist_ok=True)
 
@@ -2537,6 +2539,7 @@ class Pipeline:
         """Start all packages in the pipeline"""
         from jarvis_cd.util.logger import logger
 
+        self._validate_interceptor_links()
         logger.pipeline(f"Starting pipeline: {self.name}")
 
         # Store started instances for later access (e.g., _get_stat)
@@ -3280,8 +3283,11 @@ class Pipeline:
         else:
             pkg_id = pkg_name
 
-        # Check for duplicate package IDs
-        existing_ids = [pkg["pkg_id"] for pkg in self.packages]
+        # Package and interceptor aliases share one pipeline namespace.
+        existing_ids = {
+            *(pkg["pkg_id"] for pkg in self.packages),
+            *self.interceptors.keys(),
+        }
         if pkg_id in existing_ids:
             raise ValueError(f"Package ID already exists in pipeline: {pkg_id}")
 
@@ -3297,11 +3303,12 @@ class Pipeline:
             "config": default_config,
         }
 
+        # Load once both to parse package-owned configuration and to identify
+        # whether this definition is an Application, Service, or Interceptor.
+        pkg_instance = self._load_package_instance(package_entry, self.env)
+
         # Apply configuration arguments if provided (before validation)
         if config_args:
-            # Load package instance
-            pkg_instance = self._load_package_instance(package_entry, self.env)
-
             argparse = pkg_instance.get_argparse()
             try:
                 # Use PkgArgParse to parse and convert arguments
@@ -3325,13 +3332,23 @@ class Pipeline:
         # Validate that all required parameters have values (after applying config_args)
         self._validate_required_config(package_spec, package_entry["config"])
 
-        # Add package to pipeline
-        self.packages.append(package_entry)
+        from jarvis_cd.core.pkg import Interceptor
+
+        if isinstance(pkg_instance, Interceptor):
+            nested = package_entry["config"].get("interceptors", [])
+            if nested:
+                raise ValueError("Interceptor packages cannot reference interceptors")
+            self.interceptors[pkg_id] = package_entry
+            added_kind = "interceptor"
+        else:
+            self._validate_package_interceptor_references(package_entry)
+            self.packages.append(package_entry)
+            added_kind = "package"
 
         # Save updated configuration
         self.save()
 
-        print(f"Added package {package_spec} as {pkg_id} to pipeline")
+        print(f"Added {added_kind} {package_spec} as {pkg_id} to pipeline")
 
     def rm(self, package_spec: str):
         """
@@ -3339,18 +3356,31 @@ class Pipeline:
 
         :param package_spec: Package specification to remove (pkg_id)
         """
-        # Find and remove the package
-        package_found = False
-
+        # Find and remove an application/service package.
+        removed_package = None
         for i, pkg_def in enumerate(self.packages):
             if pkg_def["pkg_id"] == package_spec:
                 removed_package = self.packages.pop(i)
-                package_found = True
                 break
 
-        if not package_found:
+        # Interceptors are addressed through the same generic package identity.
+        if removed_package is None and package_spec in self.interceptors:
+            dependents = [
+                pkg["pkg_id"]
+                for pkg in self.packages
+                if package_spec in pkg.get("config", {}).get("interceptors", [])
+            ]
+            if dependents:
+                raise ValueError(
+                    f"Cannot remove interceptor '{package_spec}'; referenced by: "
+                    + ", ".join(dependents)
+                )
+            removed_package = self.interceptors.pop(package_spec)
+
+        if removed_package is None:
             # List available packages to help the user
             available_ids = [pkg["pkg_id"] for pkg in self.packages]
+            available_ids.extend(self.interceptors)
             if available_ids:
                 print(f"Package '{package_spec}' not found in pipeline.")
                 print(f"Available packages: {', '.join(available_ids)}")
@@ -3398,12 +3428,7 @@ class Pipeline:
         :param config_args: Configuration arguments as command-line args (e.g., ['--nprocs', '4', 'block=32m'])
         :raises ValueError: If an argument is unknown or package configuration fails
         """
-        # Find package in pipeline
-        pkg_def = None
-        for pkg in self.packages:
-            if pkg["pkg_id"] == pkg_id:
-                pkg_def = pkg
-                break
+        pkg_def = self._find_package_definition(pkg_id)
 
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
@@ -3461,12 +3486,7 @@ class Pipeline:
 
         :param pkg_id: Package ID to show README for
         """
-        # Find package in pipeline
-        pkg_def = None
-        for pkg in self.packages:
-            if pkg["pkg_id"] == pkg_id:
-                pkg_def = pkg
-                break
+        pkg_def = self._find_package_definition(pkg_id)
 
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
@@ -3480,7 +3500,7 @@ class Pipeline:
 
     def show_package_build_script(self, pkg_id: str):
         """Print the build.sh script for a package within this pipeline."""
-        pkg_def = next((p for p in self.packages if p["pkg_id"] == pkg_id), None)
+        pkg_def = self._find_package_definition(pkg_id)
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
         try:
@@ -3491,7 +3511,7 @@ class Pipeline:
 
     def show_package_deploy_dockerfile(self, pkg_id: str):
         """Print Dockerfile.deploy for a package within this pipeline."""
-        pkg_def = next((p for p in self.packages if p["pkg_id"] == pkg_id), None)
+        pkg_def = self._find_package_definition(pkg_id)
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
         try:
@@ -3507,12 +3527,7 @@ class Pipeline:
         :param pkg_id: Package ID to show paths for
         :param path_flags: Dictionary of path flags to show
         """
-        # Find package in pipeline
-        pkg_def = None
-        for pkg in self.packages:
-            if pkg["pkg_id"] == pkg_id:
-                pkg_def = pkg
-                break
+        pkg_def = self._find_package_definition(pkg_id)
 
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
@@ -3647,6 +3662,8 @@ class Pipeline:
                     self.env = {}
         else:
             self.env = {}
+
+        self._validate_interceptor_links()
 
     def _load_from_file(self, load_type: str, pipeline_file: str):
         """Load pipeline from a file"""
@@ -3892,8 +3909,8 @@ class Pipeline:
             package_entry = self._process_package_definition(pkg_def, pkg_id)
             self.packages.append(package_entry)
 
-        # Validate that interceptor and package IDs are unique
-        self._validate_unique_ids()
+        # Validate type-correct interceptor definitions and explicit links.
+        self._validate_interceptor_links()
 
         # Propagate base_deploy_mode -> per-package deploy_mode
         self._propagate_deploy_mode()
@@ -4137,6 +4154,68 @@ class Pipeline:
                 f"Package and interceptor IDs must be unique within the pipeline."
             )
 
+    def _find_package_definition(self, pkg_id: str) -> Optional[Dict[str, Any]]:
+        """Return one application, service, or interceptor definition by alias."""
+        for package in self.packages:
+            if package["pkg_id"] == pkg_id:
+                return package
+        return self.interceptors.get(pkg_id)
+
+    def get_pkg(self, pkg_id: str) -> Optional[Dict[str, Any]]:
+        """Return one pipeline member regardless of its JARVIS package kind.
+
+        Generic clients can use this method after ``append`` without knowing
+        whether JARVIS stored the selected class as an application, service, or
+        interceptor.
+
+        :param pkg_id: Pipeline-local package alias.
+        :return: The stored package definition, or ``None`` when absent.
+        """
+        return self._find_package_definition(pkg_id)
+
+    def _validate_package_interceptor_references(self, package: Dict[str, Any]) -> None:
+        """Validate one package's explicit references to pipeline interceptors."""
+        package_id = str(package.get("pkg_id", "unknown"))
+        references = package.get("config", {}).get("interceptors", [])
+        if not isinstance(references, list):
+            raise ValueError(
+                f"Package '{package_id}' interceptors must be a list of aliases"
+            )
+        if not all(
+            isinstance(reference, str) and reference for reference in references
+        ):
+            raise ValueError(
+                f"Package '{package_id}' interceptor aliases must be non-empty strings"
+            )
+        if len(set(references)) != len(references):
+            raise ValueError(f"Package '{package_id}' repeats an interceptor reference")
+        missing = [
+            reference for reference in references if reference not in self.interceptors
+        ]
+        if missing:
+            raise ValueError(
+                f"Package '{package_id}' references unknown interceptor: {missing[0]}"
+            )
+
+    def _validate_interceptor_links(self) -> None:
+        """Fail closed unless all interceptor definitions and links are valid."""
+        from jarvis_cd.core.pkg import Interceptor
+
+        self._validate_unique_ids()
+        for interceptor_id, definition in self.interceptors.items():
+            instance = self._load_package_instance(definition, self.env)
+            if not isinstance(instance, Interceptor):
+                raise ValueError(
+                    f"Pipeline interceptor '{interceptor_id}' is not an Interceptor package"
+                )
+            nested = definition.get("config", {}).get("interceptors", [])
+            if nested:
+                raise ValueError(
+                    f"Interceptor package '{interceptor_id}' cannot reference interceptors"
+                )
+        for package in self.packages:
+            self._validate_package_interceptor_references(package)
+
     def _validate_required_config(self, package_spec: str, config: Dict[str, Any]):
         """
         Validate that all required configuration parameters have values.
@@ -4206,45 +4285,39 @@ class Pipeline:
         )
 
         for interceptor_name in interceptors_list:
-            try:
-                # Find interceptor in pipeline-level interceptors
-                if interceptor_name not in self.interceptors:
-                    logger.error(
-                        f"Warning: Interceptor '{interceptor_name}' not found in pipeline interceptors"
-                    )
-                    continue
-
-                interceptor_def = self.interceptors[interceptor_name]
-
-                # Print BEGIN message with full interceptor type
-                logger.success(f"[{interceptor_def['pkg_type']}] [MODIFY_ENV] BEGIN")
-
-                # Load interceptor instance
-                interceptor_instance = self._load_package_instance(
-                    interceptor_def, self.env
+            if interceptor_name not in self.interceptors:
+                raise RuntimeError(
+                    f"Package '{pkg_def['pkg_id']}' references unknown interceptor "
+                    f"'{interceptor_name}'"
                 )
 
-                # Verify it's an interceptor and has modify_env method
-                if not hasattr(interceptor_instance, "modify_env"):
-                    logger.error(
-                        f"Warning: Package '{interceptor_name}' does not have modify_env() method"
-                    )
-                    continue
+            interceptor_def = self.interceptors[interceptor_name]
+            logger.success(f"[{interceptor_def['pkg_type']}] [MODIFY_ENV] BEGIN")
 
-                # Share the same mod_env reference between interceptor and package
-                interceptor_instance.mod_env = pkg_instance.mod_env
-                interceptor_instance.env = pkg_instance.env
+            interceptor_instance = self._load_package_instance(
+                interceptor_def, self.env
+            )
+            from jarvis_cd.core.pkg import Interceptor
 
-                # Call modify_env on the interceptor to modify the shared environment
+            if not isinstance(interceptor_instance, Interceptor):
+                raise RuntimeError(
+                    f"Pipeline interceptor '{interceptor_name}' is not an "
+                    "Interceptor package"
+                )
+
+            # The package executor consumes mod_env, so the interceptor mutates
+            # that exact object rather than a pipeline-global environment.
+            interceptor_instance.mod_env = pkg_instance.mod_env
+            interceptor_instance.env = pkg_instance.env
+            try:
                 interceptor_instance.modify_env()
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Interceptor '{interceptor_name}' failed for package "
+                    f"'{pkg_def['pkg_id']}': {exc}"
+                ) from exc
 
-                # The mod_env is shared, so changes are automatically applied to the package
-
-                # Print END message
-                logger.success(f"[{interceptor_def['pkg_type']}] [MODIFY_ENV] END")
-
-            except Exception as e:
-                logger.error(f"Error applying interceptor '{interceptor_name}': {e}")
+            logger.success(f"[{interceptor_def['pkg_type']}] [MODIFY_ENV] END")
 
     def _generate_pipeline_container_yaml(self):
         """

--- a/test/unit/core/test_pipeline_coverage.py
+++ b/test/unit/core/test_pipeline_coverage.py
@@ -147,6 +147,22 @@ class TestPipelineCoverage(unittest.TestCase):
         except Exception as e:
             self.fail(f"rm() raised unexpectedly: {e}")
 
+    def test_rm_rejects_referenced_interceptor(self):
+        """An interceptor cannot be removed while a package still references it."""
+        pipeline = self._make_pipeline("rm_interceptor_in_use")
+        pipeline.append("builtin.example_interceptor", package_alias="monitor")
+        pipeline.append(
+            "builtin.echo",
+            package_alias="workload",
+            config_args=['interceptors=["monitor"]'],
+        )
+
+        with self.assertRaisesRegex(ValueError, "referenced by: workload"):
+            pipeline.rm("monitor")
+
+        reloaded = Pipeline("rm_interceptor_in_use")
+        self.assertIn("monitor", reloaded.interceptors)
+
     # ------------------------------------------------------------------
     # status()
     # ------------------------------------------------------------------
@@ -238,6 +254,129 @@ class TestPipelineCoverage(unittest.TestCase):
         reloaded = Pipeline("append_valid")
         self.assertEqual(reloaded.packages[0]["config"]["retry_count"], 4)
 
+    def test_append_routes_interceptor_without_implicit_attachment(self):
+        """Appending an Interceptor stores it separately without changing applications."""
+        pipeline = self._make_pipeline("append_interceptor")
+
+        pipeline.append(
+            "builtin.example_interceptor",
+            package_alias="monitor",
+            config_args=["debug_mode=false"],
+        )
+        pipeline.append("builtin.echo", package_alias="workload")
+
+        self.assertEqual(pipeline.packages[0]["pkg_id"], "workload")
+        self.assertEqual(pipeline.packages[0]["config"]["interceptors"], [])
+        self.assertEqual(
+            pipeline.interceptors["monitor"]["pkg_type"],
+            "builtin.example_interceptor",
+        )
+        self.assertIs(pipeline.get_pkg("monitor"), pipeline.interceptors["monitor"])
+
+        reloaded = Pipeline("append_interceptor")
+        self.assertEqual(reloaded.packages[0]["config"]["interceptors"], [])
+        self.assertEqual(
+            reloaded.interceptors["monitor"]["config"]["debug_mode"], False
+        )
+
+    def test_append_supports_selective_named_interceptor_instances(self):
+        """Applications can select independently configured interceptor aliases."""
+        pipeline = self._make_pipeline("append_interceptor_selection")
+
+        pipeline.append(
+            "builtin.darshan",
+            package_alias="darshan_ior",
+            config_args=["log_dir=/tmp/ior_logs", "job_id=ior"],
+        )
+        pipeline.append(
+            "builtin.darshan",
+            package_alias="darshan_clio",
+            config_args=["log_dir=/tmp/clio_logs", "job_id=clio"],
+        )
+        pipeline.append(
+            "builtin.ior",
+            package_alias="ior",
+            config_args=['interceptors=["darshan_ior"]'],
+        )
+        pipeline.append(
+            "builtin.echo",
+            package_alias="clio",
+            config_args=['interceptors=["darshan_clio"]'],
+        )
+
+        self.assertEqual(
+            pipeline.interceptors["darshan_ior"]["config"]["log_dir"],
+            "/tmp/ior_logs",
+        )
+        self.assertEqual(
+            pipeline.interceptors["darshan_clio"]["config"]["log_dir"],
+            "/tmp/clio_logs",
+        )
+        self.assertEqual(
+            pipeline.packages[0]["config"]["interceptors"], ["darshan_ior"]
+        )
+        self.assertEqual(
+            pipeline.packages[1]["config"]["interceptors"], ["darshan_clio"]
+        )
+
+    def test_append_rejects_unknown_interceptor_reference_atomically(self):
+        """An application cannot reference an interceptor absent from the pipeline."""
+        pipeline = self._make_pipeline("append_interceptor_missing")
+
+        with self.assertRaisesRegex(ValueError, "unknown interceptor"):
+            pipeline.append(
+                "builtin.echo",
+                package_alias="workload",
+                config_args=['interceptors=["missing"]'],
+            )
+
+        self.assertEqual(pipeline.packages, [])
+
+    def test_save_rejects_non_interceptor_in_interceptor_section(self):
+        """A top-level interceptor definition must derive from Interceptor."""
+        pipeline = self._make_pipeline("invalid_interceptor_type")
+        pipeline.interceptors["not_an_interceptor"] = {
+            "pkg_type": "builtin.echo",
+            "pkg_id": "not_an_interceptor",
+            "pkg_name": "echo",
+            "global_id": "invalid_interceptor_type.not_an_interceptor",
+            "config": pipeline._get_package_default_config("builtin.echo"),
+        }
+
+        with self.assertRaisesRegex(ValueError, "is not an Interceptor package"):
+            pipeline.save()
+
+    def test_interceptor_modifies_only_the_explicitly_linked_package(self):
+        """Runtime environment mutation follows explicit package references."""
+        pipeline = self._make_pipeline("interceptor_runtime_link")
+        pipeline.append(
+            "builtin.example_interceptor",
+            package_alias="monitor",
+            config_args=["library_path=/tmp/libmonitor.so"],
+        )
+        pipeline.append("builtin.echo", package_alias="plain")
+        pipeline.append(
+            "builtin.echo",
+            package_alias="observed",
+            config_args=['interceptors=["monitor"]'],
+        )
+
+        plain = pipeline._load_package_instance(pipeline.packages[0], pipeline.env)
+        observed = pipeline._load_package_instance(pipeline.packages[1], pipeline.env)
+        pipeline._apply_interceptors_to_package(plain, pipeline.packages[0])
+        pipeline._apply_interceptors_to_package(observed, pipeline.packages[1])
+
+        self.assertNotIn("LD_PRELOAD", plain.mod_env)
+        self.assertEqual(observed.mod_env["LD_PRELOAD"], "/tmp/libmonitor.so")
+
+    def test_append_rejects_cross_kind_alias_collision(self):
+        """Package and interceptor IDs share one pipeline namespace."""
+        pipeline = self._make_pipeline("append_interceptor_collision")
+        pipeline.append("builtin.example_interceptor", package_alias="shared")
+
+        with self.assertRaisesRegex(ValueError, "already exists"):
+            pipeline.append("builtin.echo", package_alias="shared")
+
     # ------------------------------------------------------------------
     # configure_package()
     # ------------------------------------------------------------------
@@ -256,6 +395,16 @@ class TestPipelineCoverage(unittest.TestCase):
         # Reload pipeline and confirm nprocs was persisted
         pipeline2 = Pipeline("cfgpkg_test")
         self.assertEqual(pipeline2.packages[0]["config"].get("nprocs"), 8)
+
+    def test_configure_package_updates_interceptor_config(self):
+        """Generic package configuration also addresses Interceptor instances."""
+        pipeline = self._make_pipeline("cfg_interceptor")
+        pipeline.append("builtin.example_interceptor", package_alias="monitor")
+
+        pipeline.configure_package("monitor", ["debug_mode=false"])
+
+        reloaded = Pipeline("cfg_interceptor")
+        self.assertIs(reloaded.interceptors["monitor"]["config"]["debug_mode"], False)
 
     def test_configure_package_can_reset_a_value_to_its_default(self):
         """Explicit default values replace an earlier non-default value."""


### PR DESCRIPTION
## What changed

- route classes derived from `Interceptor` into the pipeline's named interceptor registry through the generic `ppl append` path
- keep interceptor attachment explicit through each application or service package's `interceptors` alias list
- validate package kinds, aliases, references, and nested links during append, save, reload, and start
- make generic package lookup, configuration, inspection, and removal work for interceptors
- fail closed when an interceptor is missing, has the wrong kind, or fails to modify the target environment
- document independently configured interceptor instances and selective package linkage

## Why

The persisted pipeline format already modeled interceptors as named nodes with explicit per-package references, but the generic authoring path appended every selected class as an ordinary package. That prevented clients from safely constructing selective links and caused invalid runtime links to be logged and skipped. The updated path preserves the explicit graph, including multiple differently configured instances of the same interceptor.

## Validation

- `uv run --no-sync --no-cache pytest -q test/unit/core/test_pipeline_coverage.py test/unit/core/test_pkg_methods.py test/unit/core/test_route_pkg.py test/unit/core/test_pipeline_integration.py test/unit/core/test_spack_install.py test/unit/core/test_repository_additional.py` (135 passed, no skips)
- CI-scoped `pyright` command (0 errors)
- `ruff check` on the changed runtime and tests
- `ruff format --check` on the changed test file

A full unfiltered Windows unit-tree run was stopped after making no observable progress for roughly eleven minutes; the focused and adjacent package/pipeline surface above is green, and repository CI will run the Linux unit suite.