### PR TITLE
feat: add digest-verified package input bundles

### DIFF
--- a/builtin/builtin/lammps/README.md
+++ b/builtin/builtin/lammps/README.md
@@ -15,3 +15,20 @@ custom partitioning (chunks) for binning, and static or dynamic grouping of atom
 
 ## lammps tutorial
 Please refer to this [website](https://docs.lammps.org/) for more details.
+
+## Multi-file inputs
+
+Use `script` for one self-contained input file. Use `input_bundle` when the input refers to
+potentials, included scripts, data files, or other neighboring files:
+
+```bash
+jarvis ppl append builtin.lammps copper \
+  input_bundle=/path/to/copper-inputs.tar \
+  nprocs=4 ppn=4 out=copper-results
+```
+
+The archive must follow the
+[JARVIS package input-bundle contract](../../../docs/input-bundles.md). JARVIS verifies its
+closed manifest, file sizes, and SHA-256 digests, then copies the payload into the
+execution-owned output directory before launching LAMMPS from that directory. `script` and
+`input_bundle` are mutually exclusive.

--- a/builtin/builtin/lammps/artifacts.py
+++ b/builtin/builtin/lammps/artifacts.py
@@ -19,6 +19,7 @@ from jarvis_cd.artifacts import (
     new_artifact_id,
 )
 from jarvis_cd.artifacts.schema import JsonValue
+from jarvis_cd.input_bundle import extract_input_bundle
 
 _MAX_DIRECTORY_ENTRIES = 4096
 _MAX_SCRIPT_BYTES = 1024 * 1024
@@ -303,6 +304,20 @@ def adapter_from_package(package: dict[str, Any]) -> LammpsArtifactAdapter | Non
         else _optional_absolute_path(package.get("runtime_cwd"))
     )
     script_path = _configured_script_path(package.get("script"), script_base)
+    input_bundle = package.get("input_bundle")
+    if isinstance(input_bundle, str) and input_bundle:
+        shared_dir = _optional_absolute_path(package.get("shared_dir"))
+        if shared_dir is None:
+            raise ValueError(
+                "LAMMPS input-bundle artifacts require a package shared directory"
+            )
+        if script_path is not None:
+            raise ValueError("LAMMPS script and input_bundle cannot be combined")
+        materialized = extract_input_bundle(
+            input_bundle,
+            Path(shared_dir.as_posix()) / "input-bundles",
+        )
+        script_path = materialized.entrypoint
     return LammpsArtifactAdapter(output_dir=output_dir, script_path=script_path)
 
 

--- a/builtin/builtin/lammps/pkg.py
+++ b/builtin/builtin/lammps/pkg.py
@@ -24,6 +24,7 @@ from jarvis_cd.deployment import (
     RuntimeStatus,
     probe_program,
 )
+from jarvis_cd.input_bundle import extract_input_bundle, stage_input_bundle
 from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
 
@@ -65,6 +66,21 @@ class Lammps(Application):
                     "commands; for the standard reduced Lennard-Jones single-type "
                     "case, use `mass 1 1.0`. Empty selects the package-owned bounded "
                     "Lennard-Jones workload."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file",
+                    structure="regular_file",
+                ).to_dict(),
+            },
+            {
+                "name": "input_bundle",
+                "msg": (
+                    "Optional digest-verified JARVIS package input bundle. The "
+                    "manifest entrypoint is the LAMMPS input script and every "
+                    "support file is staged into the execution-owned output "
+                    "directory. Cannot be combined with script."
                 ),
                 "type": str,
                 "default": "",
@@ -169,7 +185,10 @@ class Lammps(Application):
                 ExecutionProfile(
                     name="generated_workload",
                     execution_kind="batch",
-                    when=(ConfigurationCondition("script", "is_empty"),),
+                    when=(
+                        ConfigurationCondition("script", "is_empty"),
+                        ConfigurationCondition("input_bundle", "is_empty"),
+                    ),
                     runtime_requirements=("lammps",),
                     readiness=completed,
                     description=(
@@ -180,7 +199,10 @@ class Lammps(Application):
                 ExecutionProfile(
                     name="input_script",
                     execution_kind="batch",
-                    when=(ConfigurationCondition("script", "is_not_empty"),),
+                    when=(
+                        ConfigurationCondition("script", "is_not_empty"),
+                        ConfigurationCondition("input_bundle", "is_empty"),
+                    ),
                     runtime_requirements=("lammps",),
                     readiness=completed,
                     description=(
@@ -193,11 +215,29 @@ class Lammps(Application):
                         "use `mass 1 1.0`."
                     ),
                 ),
+                ExecutionProfile(
+                    name="input_bundle",
+                    execution_kind="batch",
+                    when=(
+                        ConfigurationCondition("script", "is_empty"),
+                        ConfigurationCondition("input_bundle", "is_not_empty"),
+                    ),
+                    runtime_requirements=("lammps",),
+                    readiness=completed,
+                    description=(
+                        "Digest-verified multi-file LAMMPS input set whose "
+                        "manifest entrypoint and support files are staged into "
+                        "one execution-owned working directory."
+                    ),
+                ),
             ),
             runtime_requirements=(runtime,),
             configuration_rules=(
                 ConfigurationRule(
-                    when=(ConfigurationCondition("script", "is_empty"),),
+                    when=(
+                        ConfigurationCondition("script", "is_empty"),
+                        ConfigurationCondition("input_bundle", "is_empty"),
+                    ),
                     requires=(
                         ConfigurationCondition("io_dump_interval", "greater_than", 0),
                         ConfigurationCondition("io_lattice_size", "greater_than", 0),
@@ -291,9 +331,16 @@ class Lammps(Application):
     def _validate_workload_configuration(self) -> None:
         """Ensure every launch selects a real user or generated input."""
         script = self.config.get("script")
+        input_bundle = self.config.get("input_bundle")
+        if script not in (None, "") and input_bundle not in (None, ""):
+            raise ValueError("script and input_bundle cannot be combined")
         if script not in (None, ""):
             if not isinstance(script, str):
                 raise TypeError("script must be a path string")
+            return
+        if input_bundle not in (None, ""):
+            if not isinstance(input_bundle, str):
+                raise TypeError("input_bundle must be a path string")
             return
         raw_values: dict[str, object] = {
             "io_dump_interval": self.config.get("io_dump_interval", 100),
@@ -443,6 +490,25 @@ class Lammps(Application):
                 temporary_path.unlink()
         return str(script_path)
 
+    def _input_script(self) -> str | None:
+        """Resolve a caller script, stage a bundle, or create the default input."""
+
+        self._validate_workload_configuration()
+        configured_bundle: object = self.config.get("input_bundle")
+        if configured_bundle not in (None, ""):
+            if not isinstance(configured_bundle, str):
+                raise TypeError("input_bundle must be a path string")
+            if self.shared_dir is None:
+                raise RuntimeError(
+                    "LAMMPS input bundles require a pipeline shared directory"
+                )
+            bundle = extract_input_bundle(
+                configured_bundle,
+                Path(self.shared_dir) / "input-bundles",
+            )
+            return str(stage_input_bundle(bundle, self._output_dir()))
+        return self._generated_input_script()
+
     def start(self) -> None:
         """
         Launch LAMMPS.
@@ -451,7 +517,7 @@ class Lammps(Application):
         container mode, MpiExecInfo with hostfile for default mode.
         """
         self._validate_legacy_runtime_configuration()
-        script_path = self._generated_input_script()
+        script_path = self._input_script()
         self._ensure_output_dir()
         self._remove_stale_log()
         line_callback = self.progress_line_callback()
@@ -466,7 +532,7 @@ class Lammps(Application):
             lammps_command = " ".join(cmd)
             output_dir = shlex.quote(os.path.dirname(self._log_path()))
             container_command = shlex.quote(
-                f"mkdir -p {output_dir} && exec {lammps_command}"
+                f"mkdir -p {output_dir} && cd {output_dir} && exec {lammps_command}"
             )
             result = Exec(
                 f"bash -c {container_command}",

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Jarvis-CD is a unified platform for deploying scientific applications, storage s
 ## Reference
 
 - [Package Deployment Contracts](package-deployment.md) - Versioned execution, runtime resolution, configuration, and readiness metadata
+- [Package Input Bundles](input-bundles.md) - Digest-verified multi-file application inputs and mutable run staging
 - [Pipeline Configuration](pipelines.md) — Full YAML format, install managers (container/spack), environment management, multi-node, devcontainers
 - [Package Development Guide](package_dev_guide.md) — Create new packages, Dockerfile templates, container and spack support
 - [Pipeline Tests](pipeline_tests.md) — Automated testing with grid search and parameter sweeps

--- a/docs/input-bundles.md
+++ b/docs/input-bundles.md
@@ -1,0 +1,63 @@
+# Package Input Bundles
+
+JARVIS package input bundles carry a caller-supplied multi-file application input as one
+digest-verifiable regular file. They are intended for applications whose entrypoint refers
+to neighboring support files, such as a LAMMPS input script and potential, an OpenFOAM case
+tree, or a WRF namelist and sounding.
+
+The bundle is a tar-compatible archive containing only regular files. It must include
+`jarvis-input-manifest.json` at its root:
+
+```json
+{
+  "schema_version": "jarvis.package-input-bundle.v1",
+  "entrypoint": "in.copper",
+  "files": [
+    {
+      "path": "in.copper",
+      "role": "lammps_input",
+      "sha256": "<64 lowercase hexadecimal characters>",
+      "size_bytes": 1280
+    },
+    {
+      "path": "Cu.eam",
+      "role": "potential",
+      "sha256": "<64 lowercase hexadecimal characters>",
+      "size_bytes": 36588
+    }
+  ]
+}
+```
+
+The manifest is closed: it has exactly `schema_version`, `entrypoint`, and `files`.
+Each file has exactly `path`, `role`, `sha256`, and `size_bytes`. Paths use relative POSIX
+syntax and cannot contain `.` or `..` components. The entrypoint must name one declared
+file. Roles are package-defined semantic labels and may repeat.
+
+JARVIS rejects links, devices, duplicate paths, undeclared archive members, size or digest
+mismatches, unsupported schemas, and configured safety-bound violations. A verified archive
+is extracted atomically below a content-addressed package directory. Applications that need
+a mutable working tree use `stage_input_bundle`; it copies every verified payload without
+overwriting existing paths.
+
+Packages expose a bundle through an ordinary configuration setting with a
+`jarvis.configuration-input-binding.v1` local regular-file descriptor. This lets clients
+materialize the archive itself before the package verifies and expands its contents.
+
+## Python API
+
+```python
+from pathlib import Path
+
+from jarvis_cd.input_bundle import extract_input_bundle, stage_input_bundle
+
+materialized = extract_input_bundle(
+    "/local-or-materialized/inputs.tar",
+    Path(package.shared_dir) / "input-bundles",
+)
+entrypoint = stage_input_bundle(materialized, package_output_directory)
+```
+
+`extract_input_bundle` is idempotent for an unchanged archive and unchanged materialized
+tree. `stage_input_bundle` is intentionally not idempotent: an existing destination file is
+a collision and fails closed rather than reusing or overwriting a prior run.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -825,6 +825,9 @@ Interceptor aliases share the pipeline package namespace. JARVIS verifies that
 every referenced alias exists and derives from `Interceptor` before saving or
 starting the pipeline. Removing an interceptor that is still referenced fails
 instead of silently running the target package without interception.
+The common `interceptors` setting is included in agent-visible package metadata
+for applications and services, while interceptor packages hide it because
+nested interception is invalid.
 
 #### Remove Packages from Pipeline
 ```bash

--- a/jarvis_cd/core/pkg.py
+++ b/jarvis_cd/core/pkg.py
@@ -876,8 +876,13 @@ class Pkg:
         # These controls remain part of the CLI and persisted package config,
         # but generic agents should reason from the package-owned deployment
         # contract instead of choosing installers, paths, or debug machinery.
+        # Explicit interceptor selection is different: it is a semantic edge in
+        # the pipeline graph and therefore must be discoverable for applications
+        # and services. Interceptors cannot themselves reference interceptors.
         for parameter in common_menu:
-            parameter["agent_visible"] = False
+            parameter["agent_visible"] = parameter[
+                "name"
+            ] == "interceptors" and not isinstance(self, Interceptor)
 
         # Combine package-specific and common menus
         return package_menu + common_menu

--- a/jarvis_cd/input_bundle.py
+++ b/jarvis_cd/input_bundle.py
@@ -1,0 +1,559 @@
+"""Digest-verified materialization for package-owned multi-file inputs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import stat
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import IO, Mapping, cast
+
+from jarvis_cd.util.private_path import reject_private_path_redirection
+
+INPUT_BUNDLE_SCHEMA_VERSION = "jarvis.package-input-bundle.v1"
+INPUT_BUNDLE_MANIFEST_NAME = "jarvis-input-manifest.json"
+_COMPLETION_MARKER_NAME = ".jarvis-input-bundle.json"
+_SHA256_CHARACTERS = frozenset("0123456789abcdef")
+
+
+class InputBundleError(ValueError):
+    """Raised when a package input bundle is malformed, unsafe, or changed."""
+
+
+@dataclass(frozen=True, slots=True)
+class InputBundleFile:
+    """One digest-bound regular file declared by an input bundle."""
+
+    path: str
+    role: str
+    sha256: str
+    size_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class InputBundleManifest:
+    """The closed, validated manifest carried by an input bundle."""
+
+    entrypoint: str
+    files: tuple[InputBundleFile, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializedInputBundle:
+    """A completely verified input bundle below a package-owned root."""
+
+    root: Path
+    entrypoint: Path
+    manifest: InputBundleManifest
+    bundle_sha256: str
+
+
+def extract_input_bundle(
+    bundle: str | os.PathLike[str],
+    destination_root: str | os.PathLike[str],
+    *,
+    max_archive_bytes: int = 512 * 1024 * 1024,
+    max_total_bytes: int = 4 * 1024 * 1024 * 1024,
+    max_files: int = 4096,
+) -> MaterializedInputBundle:
+    """Validate and atomically extract one package input bundle.
+
+    The archive must contain only regular files and exactly one closed v1
+    manifest. Member paths are relative POSIX paths, links are prohibited, and
+    every declared byte count and SHA-256 digest is verified before publication.
+    Reusing a bundle is idempotent only while the materialized tree remains
+    byte-identical to its manifest.
+
+    :param bundle: Regular tar-compatible archive to materialize.
+    :param destination_root: Package-owned directory for content-addressed trees.
+    :param max_archive_bytes: Maximum compressed archive size.
+    :param max_total_bytes: Maximum declared uncompressed payload size.
+    :param max_files: Maximum declared payload file count.
+    :return: The verified content-addressed materialization.
+    :raises InputBundleError: If any safety, identity, or bound check fails.
+    """
+
+    _validate_positive_bound(max_archive_bytes, "max_archive_bytes")
+    _validate_positive_bound(max_total_bytes, "max_total_bytes")
+    _validate_positive_bound(max_files, "max_files")
+    source = _safe_regular_file(bundle, max_bytes=max_archive_bytes)
+    bundle_sha256 = _sha256_file(source)
+    destination_parent = _safe_destination_root(destination_root)
+    destination = destination_parent / bundle_sha256
+    marker = destination / _COMPLETION_MARKER_NAME
+    if destination.exists():
+        return _load_existing_bundle(
+            destination,
+            source=source,
+            marker=marker,
+            bundle_sha256=bundle_sha256,
+            max_files=max_files,
+            max_total_bytes=max_total_bytes,
+        )
+
+    temporary = Path(
+        tempfile.mkdtemp(prefix=f".{bundle_sha256}.", dir=destination_parent)
+    )
+    try:
+        manifest = _extract_archive(
+            source,
+            temporary,
+            max_files=max_files,
+            max_total_bytes=max_total_bytes,
+        )
+        marker_payload = {
+            "bundle_sha256": bundle_sha256,
+            "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        }
+        marker_path = temporary / _COMPLETION_MARKER_NAME
+        marker_path.write_text(
+            json.dumps(marker_payload, sort_keys=True, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(marker_path, 0o600)
+        try:
+            os.replace(temporary, destination)
+        except OSError:
+            if not destination.exists():
+                raise
+            # Another execution may have published the same digest while this
+            # one was verifying it. Publication is atomic, so reuse only after
+            # validating that winner against the same source and bounds.
+            shutil.rmtree(temporary, ignore_errors=True)
+            return _load_existing_bundle(
+                destination,
+                source=source,
+                marker=marker,
+                bundle_sha256=bundle_sha256,
+                max_files=max_files,
+                max_total_bytes=max_total_bytes,
+            )
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    _validate_materialized(destination, manifest)
+    return MaterializedInputBundle(
+        root=destination,
+        entrypoint=destination / PurePosixPath(manifest.entrypoint),
+        manifest=manifest,
+        bundle_sha256=bundle_sha256,
+    )
+
+
+def stage_input_bundle(
+    bundle: MaterializedInputBundle,
+    destination_root: str | os.PathLike[str],
+) -> Path:
+    """Copy verified bundle payloads into one new mutable run workspace.
+
+    Package inputs remain immutable in their content-addressed materialization.
+    Applications that write beside their inputs receive private copies in the
+    execution-owned output directory. Existing files are never overwritten.
+
+    :param bundle: Previously verified input-bundle materialization.
+    :param destination_root: Package-owned mutable working directory.
+    :return: The staged entrypoint path.
+    :raises InputBundleError: If a destination collides or any source changed.
+    """
+
+    _validate_materialized(bundle.root, bundle.manifest)
+    destination = _safe_destination_root(destination_root)
+    staged: list[Path] = []
+    try:
+        for item in bundle.manifest.files:
+            source = bundle.root / PurePosixPath(item.path)
+            target = destination / PurePosixPath(item.path)
+            if target.exists() or target.is_symlink():
+                raise InputBundleError(
+                    f"input bundle staging destination already exists: {item.path}"
+                )
+            with source.open("rb") as stream:
+                _copy_member(
+                    stream,
+                    target,
+                    expected_size=item.size_bytes,
+                    expected_sha256=item.sha256,
+                )
+            staged.append(target)
+    except Exception:
+        for path in reversed(staged):
+            path.unlink(missing_ok=True)
+        raise
+    return destination / PurePosixPath(bundle.manifest.entrypoint)
+
+
+def _validate_positive_bound(value: int, name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise InputBundleError(f"{name} must be a positive integer")
+
+
+def _safe_regular_file(
+    value: str | os.PathLike[str],
+    *,
+    max_bytes: int,
+) -> Path:
+    raw = os.path.expanduser(os.path.expandvars(os.fspath(value)))
+    if not raw or any(ord(character) < 32 for character in raw):
+        raise InputBundleError("input bundle must be a printable path")
+    path = Path(os.path.abspath(raw))
+    try:
+        reject_private_path_redirection(path)
+        status = path.lstat()
+    except (OSError, RuntimeError) as exc:
+        raise InputBundleError("input bundle is not a readable regular file") from exc
+    if (
+        not stat.S_ISREG(status.st_mode)
+        or path.is_symlink()
+        or status.st_size <= 0
+        or status.st_size > max_bytes
+    ):
+        raise InputBundleError("input bundle archive size or type is invalid")
+    return path
+
+
+def _safe_destination_root(value: str | os.PathLike[str]) -> Path:
+    root = Path(os.path.abspath(Path(value).expanduser()))
+    try:
+        reject_private_path_redirection(root)
+        root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        reject_private_path_redirection(root)
+    except (OSError, RuntimeError) as exc:
+        raise InputBundleError("input bundle destination root is unsafe") from exc
+    if not root.is_dir() or root.is_symlink():
+        raise InputBundleError("input bundle destination root must be a real directory")
+    return root
+
+
+def _sha256_file(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(chunk_size):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_relative_path(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 1024:
+        raise InputBundleError(f"{field} must be a non-empty bounded string")
+    if "\\" in value:
+        raise InputBundleError(f"{field} must use POSIX separators")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise InputBundleError(f"{field} must be a confined relative path")
+    return path.as_posix()
+
+
+def _parse_manifest(payload: bytes, *, max_files: int) -> InputBundleManifest:
+    try:
+        raw = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise InputBundleError("input bundle manifest is not valid UTF-8 JSON") from exc
+    if not isinstance(raw, dict) or set(raw) != {
+        "schema_version",
+        "entrypoint",
+        "files",
+    }:
+        raise InputBundleError(
+            "input bundle manifest fields are not the closed v1 contract"
+        )
+    if raw["schema_version"] != INPUT_BUNDLE_SCHEMA_VERSION:
+        raise InputBundleError("unsupported input bundle manifest schema")
+    raw_files = raw["files"]
+    if not isinstance(raw_files, list) or not 1 <= len(raw_files) <= max_files:
+        raise InputBundleError("input bundle files must be a non-empty bounded list")
+    files: list[InputBundleFile] = []
+    seen: set[str] = set()
+    for index, raw_file in enumerate(raw_files):
+        if not isinstance(raw_file, dict) or set(raw_file) != {
+            "path",
+            "role",
+            "sha256",
+            "size_bytes",
+        }:
+            raise InputBundleError(f"input bundle file {index} fields are invalid")
+        path = _safe_relative_path(raw_file["path"], field=f"files[{index}].path")
+        role = raw_file["role"]
+        sha256 = raw_file["sha256"]
+        size_bytes = raw_file["size_bytes"]
+        if (
+            path in {INPUT_BUNDLE_MANIFEST_NAME, _COMPLETION_MARKER_NAME}
+            or path in seen
+        ):
+            raise InputBundleError(f"duplicate or reserved input bundle path: {path}")
+        if not isinstance(role, str) or not role or len(role) > 128:
+            raise InputBundleError(f"files[{index}].role is invalid")
+        if (
+            not isinstance(sha256, str)
+            or len(sha256) != 64
+            or not set(sha256).issubset(_SHA256_CHARACTERS)
+        ):
+            raise InputBundleError(f"files[{index}].sha256 is invalid")
+        if (
+            not isinstance(size_bytes, int)
+            or isinstance(size_bytes, bool)
+            or size_bytes < 0
+        ):
+            raise InputBundleError(f"files[{index}].size_bytes is invalid")
+        seen.add(path)
+        files.append(
+            InputBundleFile(
+                path=path,
+                role=cast(str, role),
+                sha256=cast(str, sha256),
+                size_bytes=cast(int, size_bytes),
+            )
+        )
+    entrypoint = _safe_relative_path(raw["entrypoint"], field="entrypoint")
+    if entrypoint not in seen:
+        raise InputBundleError("input bundle entrypoint is not a declared file")
+    return InputBundleManifest(entrypoint=entrypoint, files=tuple(files))
+
+
+def _extract_archive(
+    source: Path,
+    temporary: Path,
+    *,
+    max_files: int,
+    max_total_bytes: int,
+) -> InputBundleManifest:
+    try:
+        archive = tarfile.open(source, mode="r:*")
+    except (OSError, tarfile.TarError) as exc:
+        raise InputBundleError("input bundle is not a readable tar archive") from exc
+    with archive:
+        members = _bounded_archive_members(archive, max_files=max_files)
+        by_name: dict[str, tarfile.TarInfo] = {}
+        for member in members:
+            name = _safe_relative_path(member.name, field="archive member")
+            if name in by_name:
+                raise InputBundleError(f"duplicate input bundle member: {name}")
+            if not member.isfile():
+                raise InputBundleError(
+                    f"input bundle member is not a regular file: {name}"
+                )
+            by_name[name] = member
+        manifest_member = by_name.get(INPUT_BUNDLE_MANIFEST_NAME)
+        if manifest_member is None or manifest_member.size > 1024 * 1024:
+            raise InputBundleError("input bundle manifest is missing or oversized")
+        manifest_stream = archive.extractfile(manifest_member)
+        if manifest_stream is None:
+            raise InputBundleError("input bundle manifest could not be read")
+        manifest_payload = manifest_stream.read(1024 * 1024 + 1)
+        manifest = _parse_manifest(manifest_payload, max_files=max_files)
+        declared = {item.path: item for item in manifest.files}
+        if set(by_name) != {INPUT_BUNDLE_MANIFEST_NAME, *declared}:
+            raise InputBundleError(
+                "input bundle members do not exactly match the manifest"
+            )
+        if sum(item.size_bytes for item in manifest.files) > max_total_bytes:
+            raise InputBundleError("input bundle payload exceeds the allowed bound")
+        manifest_path = temporary / INPUT_BUNDLE_MANIFEST_NAME
+        manifest_path.write_bytes(manifest_payload)
+        os.chmod(manifest_path, 0o600)
+        for item in manifest.files:
+            member = by_name[item.path]
+            if member.size != item.size_bytes:
+                raise InputBundleError(
+                    f"input bundle member size differs from manifest: {item.path}"
+                )
+            stream = archive.extractfile(member)
+            if stream is None:
+                raise InputBundleError(
+                    f"input bundle member could not be read: {item.path}"
+                )
+            _copy_member(
+                stream,
+                temporary / PurePosixPath(item.path),
+                expected_size=item.size_bytes,
+                expected_sha256=item.sha256,
+            )
+    return manifest
+
+
+def _bounded_archive_members(
+    archive: tarfile.TarFile,
+    *,
+    max_files: int,
+) -> tuple[tarfile.TarInfo, ...]:
+    """Read at most the permitted number of tar headers.
+
+    ``TarFile.getmembers`` materializes every header before the caller can
+    enforce a bound. Iteration lets malformed archives fail as soon as the
+    manifest plus the maximum payload count has been exceeded.
+    """
+
+    members: list[tarfile.TarInfo] = []
+    try:
+        for member in archive:
+            members.append(member)
+            if len(members) > max_files + 1:
+                raise InputBundleError(
+                    "input bundle member count is outside the allowed bound"
+                )
+    except tarfile.TarError as exc:
+        raise InputBundleError("input bundle archive headers are invalid") from exc
+    if len(members) < 2:
+        raise InputBundleError("input bundle member count is outside the allowed bound")
+    return tuple(members)
+
+
+def _read_archive_manifest(
+    source: Path,
+    *,
+    max_files: int,
+) -> InputBundleManifest:
+    """Read and validate the source archive's closed manifest contract."""
+
+    try:
+        archive = tarfile.open(source, mode="r:*")
+    except (OSError, tarfile.TarError) as exc:
+        raise InputBundleError("input bundle is not a readable tar archive") from exc
+    with archive:
+        members = _bounded_archive_members(archive, max_files=max_files)
+        manifest_member: tarfile.TarInfo | None = None
+        seen: set[str] = set()
+        for member in members:
+            name = _safe_relative_path(member.name, field="archive member")
+            if name in seen:
+                raise InputBundleError(f"duplicate input bundle member: {name}")
+            if not member.isfile():
+                raise InputBundleError(
+                    f"input bundle member is not a regular file: {name}"
+                )
+            seen.add(name)
+            if name == INPUT_BUNDLE_MANIFEST_NAME:
+                manifest_member = member
+        if manifest_member is None or manifest_member.size > 1024 * 1024:
+            raise InputBundleError("input bundle manifest is missing or oversized")
+        stream = archive.extractfile(manifest_member)
+        if stream is None:
+            raise InputBundleError("input bundle manifest could not be read")
+        payload = stream.read(1024 * 1024 + 1)
+    return _parse_manifest(payload, max_files=max_files)
+
+
+def _copy_member(
+    source: IO[bytes],
+    destination: Path,
+    *,
+    expected_size: int,
+    expected_sha256: str,
+) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    digest = hashlib.sha256()
+    written = 0
+    try:
+        with destination.open("xb") as stream:
+            os.chmod(destination, 0o600)
+            while chunk := source.read(1024 * 1024):
+                written += len(chunk)
+                if written > expected_size:
+                    raise InputBundleError(
+                        f"input bundle member exceeds declared size: {destination}"
+                    )
+                digest.update(chunk)
+                stream.write(chunk)
+    except OSError as exc:
+        raise InputBundleError(
+            f"input bundle member could not be materialized: {destination}"
+        ) from exc
+    if written != expected_size or digest.hexdigest() != expected_sha256:
+        raise InputBundleError(
+            f"input bundle member digest or size mismatch: {destination}"
+        )
+
+
+def _load_existing_bundle(
+    destination: Path,
+    *,
+    source: Path,
+    marker: Path,
+    bundle_sha256: str,
+    max_files: int,
+    max_total_bytes: int,
+) -> MaterializedInputBundle:
+    try:
+        reject_private_path_redirection(destination)
+        recorded = json.loads(marker.read_text(encoding="utf-8"))
+        manifest = _parse_manifest(
+            (destination / INPUT_BUNDLE_MANIFEST_NAME).read_bytes(),
+            max_files=max_files,
+        )
+        source_manifest = _read_archive_manifest(source, max_files=max_files)
+    except (InputBundleError, OSError, RuntimeError, json.JSONDecodeError) as exc:
+        raise InputBundleError(
+            "existing input bundle destination is incomplete"
+        ) from exc
+    expected_marker: Mapping[str, str] = {
+        "bundle_sha256": bundle_sha256,
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+    }
+    if recorded != expected_marker:
+        raise InputBundleError(
+            "existing input bundle destination has the wrong identity"
+        )
+    if manifest != source_manifest:
+        raise InputBundleError(
+            "existing input bundle manifest differs from the source archive"
+        )
+    if sum(item.size_bytes for item in manifest.files) > max_total_bytes:
+        raise InputBundleError("input bundle payload exceeds the allowed bound")
+    _validate_materialized(destination, manifest)
+    return MaterializedInputBundle(
+        root=destination,
+        entrypoint=destination / PurePosixPath(manifest.entrypoint),
+        manifest=manifest,
+        bundle_sha256=bundle_sha256,
+    )
+
+
+def _validate_materialized(root: Path, manifest: InputBundleManifest) -> None:
+    expected = {
+        INPUT_BUNDLE_MANIFEST_NAME,
+        _COMPLETION_MARKER_NAME,
+        *(item.path for item in manifest.files),
+    }
+    try:
+        reject_private_path_redirection(root)
+        observed: set[str] = set()
+        for path in root.rglob("*"):
+            if path.is_symlink():
+                raise InputBundleError("materialized input bundle contains a link")
+            if path.is_file():
+                observed.add(path.relative_to(root).as_posix())
+        if observed != expected:
+            raise InputBundleError(
+                "materialized input bundle contains unexpected or missing files"
+            )
+        for item in manifest.files:
+            path = root / PurePosixPath(item.path)
+            status = path.lstat()
+            if (
+                not stat.S_ISREG(status.st_mode)
+                or status.st_size != item.size_bytes
+                or _sha256_file(path) != item.sha256
+            ):
+                raise InputBundleError(
+                    f"materialized input bundle member changed: {item.path}"
+                )
+    except OSError as exc:
+        raise InputBundleError(
+            "materialized input bundle could not be verified"
+        ) from exc
+
+
+__all__ = [
+    "INPUT_BUNDLE_MANIFEST_NAME",
+    "INPUT_BUNDLE_SCHEMA_VERSION",
+    "InputBundleError",
+    "InputBundleFile",
+    "InputBundleManifest",
+    "MaterializedInputBundle",
+    "extract_input_bundle",
+    "stage_input_bundle",
+]

--- a/test/unit/core/test_input_bundle.py
+++ b/test/unit/core/test_input_bundle.py
@@ -1,0 +1,247 @@
+"""Security and identity tests for package input-bundle materialization."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import shutil
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+    InputBundleError,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _write_bundle(
+    destination: Path,
+    files: dict[str, bytes],
+    *,
+    entrypoint: str,
+    mutate_manifest: object | None = None,
+    extra_member: tuple[tarfile.TarInfo, bytes] | None = None,
+) -> Path:
+    manifest: object = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": entrypoint,
+        "files": [
+            {
+                "path": name,
+                "role": "package_input",
+                "sha256": _sha256(payload),
+                "size_bytes": len(payload),
+            }
+            for name, payload in sorted(files.items())
+        ],
+    }
+    if mutate_manifest is not None:
+        manifest = mutate_manifest
+    manifest_payload = json.dumps(manifest, sort_keys=True).encode("utf-8")
+    with tarfile.open(destination, mode="w") as archive:
+        manifest_info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        manifest_info.size = len(manifest_payload)
+        archive.addfile(manifest_info, io.BytesIO(manifest_payload))
+        for name, payload in sorted(files.items()):
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+        if extra_member is not None:
+            info, payload = extra_member
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def test_extract_input_bundle_is_digest_bound_and_idempotent(tmp_path: Path) -> None:
+    archive = _write_bundle(
+        tmp_path / "inputs.tar",
+        {
+            "in/run.lmp": b"include support/potential.eam\n",
+            "support/potential.eam": b"EAM",
+        },
+        entrypoint="in/run.lmp",
+    )
+
+    first = extract_input_bundle(archive, tmp_path / "materialized")
+    second = extract_input_bundle(archive, tmp_path / "materialized")
+
+    assert first == second
+    assert first.root.name == _sha256(archive.read_bytes())
+    assert first.entrypoint.read_bytes() == b"include support/potential.eam\n"
+    assert (first.root / "support" / "potential.eam").read_bytes() == b"EAM"
+    assert first.manifest.entrypoint == "in/run.lmp"
+
+
+def test_extract_input_bundle_rejects_links_and_path_traversal(tmp_path: Path) -> None:
+    link = tarfile.TarInfo("linked")
+    link.type = tarfile.SYMTYPE
+    link.linkname = "entrypoint"
+    archive = _write_bundle(
+        tmp_path / "link.tar",
+        {"entrypoint": b"run"},
+        entrypoint="entrypoint",
+        extra_member=(link, b""),
+    )
+    with pytest.raises(InputBundleError, match="not a regular file"):
+        extract_input_bundle(archive, tmp_path / "linked-output")
+
+    traversal = tarfile.TarInfo("../escape")
+    traversal.size = 1
+    archive = _write_bundle(
+        tmp_path / "traversal.tar",
+        {"entrypoint": b"run"},
+        entrypoint="entrypoint",
+        extra_member=(traversal, b"x"),
+    )
+    with pytest.raises(InputBundleError, match="confined relative path"):
+        extract_input_bundle(archive, tmp_path / "traversal-output")
+
+
+def test_extract_input_bundle_rejects_manifest_and_payload_mismatch(
+    tmp_path: Path,
+) -> None:
+    malformed = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "entrypoint",
+        "files": [
+            {
+                "path": "entrypoint",
+                "role": "package_input",
+                "sha256": "0" * 64,
+                "size_bytes": 3,
+            }
+        ],
+    }
+    archive = _write_bundle(
+        tmp_path / "mismatch.tar",
+        {"entrypoint": b"run"},
+        entrypoint="entrypoint",
+        mutate_manifest=malformed,
+    )
+
+    with pytest.raises(InputBundleError, match="digest or size mismatch"):
+        extract_input_bundle(archive, tmp_path / "output")
+
+
+def test_extract_input_bundle_detects_changed_materialization(tmp_path: Path) -> None:
+    archive = _write_bundle(
+        tmp_path / "inputs.tar",
+        {"entrypoint": b"run"},
+        entrypoint="entrypoint",
+    )
+    materialized = extract_input_bundle(archive, tmp_path / "output")
+    materialized.entrypoint.write_bytes(b"changed")
+
+    with pytest.raises(InputBundleError, match="member changed"):
+        extract_input_bundle(archive, tmp_path / "output")
+
+
+def test_extract_input_bundle_rejects_coordinated_materialization_rewrite(
+    tmp_path: Path,
+) -> None:
+    archive = _write_bundle(
+        tmp_path / "inputs.tar",
+        {"entrypoint": b"run"},
+        entrypoint="entrypoint",
+    )
+    materialized = extract_input_bundle(archive, tmp_path / "output")
+    changed = b"changed"
+    materialized.entrypoint.write_bytes(changed)
+    rewritten_manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "entrypoint",
+        "files": [
+            {
+                "path": "entrypoint",
+                "role": "package_input",
+                "sha256": _sha256(changed),
+                "size_bytes": len(changed),
+            }
+        ],
+    }
+    (materialized.root / INPUT_BUNDLE_MANIFEST_NAME).write_text(
+        json.dumps(rewritten_manifest, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(InputBundleError, match="differs from the source archive"):
+        extract_input_bundle(archive, tmp_path / "output")
+
+
+def test_extract_input_bundle_reapplies_bounds_when_reusing(tmp_path: Path) -> None:
+    archive = _write_bundle(
+        tmp_path / "inputs.tar",
+        {"entrypoint": b"run"},
+        entrypoint="entrypoint",
+    )
+    extract_input_bundle(archive, tmp_path / "output")
+
+    with pytest.raises(InputBundleError, match="payload exceeds"):
+        extract_input_bundle(archive, tmp_path / "output", max_total_bytes=1)
+
+
+def test_extract_input_bundle_reuses_concurrent_atomic_publication(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = _write_bundle(
+        tmp_path / "inputs.tar",
+        {"entrypoint": b"run"},
+        entrypoint="entrypoint",
+    )
+
+    def publish_competitor(source: Path, destination: Path) -> None:
+        shutil.copytree(source, destination)
+        raise FileExistsError("concurrent publication")
+
+    monkeypatch.setattr("jarvis_cd.input_bundle.os.replace", publish_competitor)
+
+    materialized = extract_input_bundle(archive, tmp_path / "output")
+
+    assert materialized.entrypoint.read_bytes() == b"run"
+    assert not any(
+        path.name.startswith(f".{materialized.bundle_sha256}.")
+        for path in (tmp_path / "output").iterdir()
+    )
+
+
+def test_stage_input_bundle_copies_payload_without_overwriting(tmp_path: Path) -> None:
+    archive = _write_bundle(
+        tmp_path / "inputs.tar",
+        {"in/run.lmp": b"run 1\n", "potential.eam": b"EAM"},
+        entrypoint="in/run.lmp",
+    )
+    materialized = extract_input_bundle(archive, tmp_path / "materialized")
+
+    entrypoint = stage_input_bundle(materialized, tmp_path / "run")
+
+    assert entrypoint == tmp_path / "run" / "in" / "run.lmp"
+    assert entrypoint.read_bytes() == b"run 1\n"
+    assert (tmp_path / "run" / "potential.eam").read_bytes() == b"EAM"
+    with pytest.raises(InputBundleError, match="already exists"):
+        stage_input_bundle(materialized, tmp_path / "run")
+
+
+def test_extract_input_bundle_enforces_declared_bounds(tmp_path: Path) -> None:
+    archive = _write_bundle(
+        tmp_path / "inputs.tar",
+        {"entrypoint": b"run", "second": b"file"},
+        entrypoint="entrypoint",
+    )
+
+    with pytest.raises(InputBundleError, match="member count"):
+        extract_input_bundle(archive, tmp_path / "file-bound", max_files=1)
+    with pytest.raises(InputBundleError, match="payload exceeds"):
+        extract_input_bundle(archive, tmp_path / "byte-bound", max_total_bytes=1)
+    with pytest.raises(InputBundleError, match="archive size or type"):
+        extract_input_bundle(archive, tmp_path / "archive-bound", max_archive_bytes=1)

--- a/test/unit/core/test_lammps_artifacts.py
+++ b/test/unit/core/test_lammps_artifacts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -162,6 +162,35 @@ def test_lammps_default_artifacts_resolve_to_execution_package_shared_root() -> 
 
     assert adapter is not None
     assert adapter.output_dir.as_posix() == "/execution/shared/lammps"
+
+
+def test_lammps_bundle_entrypoint_drives_declared_output_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Artifact semantics inspect the same manifest entrypoint LAMMPS executes."""
+
+    script = tmp_path / "materialized" / "in.copper"
+    script.parent.mkdir()
+    script.write_text("write_data copper.data\n", encoding="utf-8")
+    module = _module()
+    monkeypatch.setattr(
+        module,
+        "extract_input_bundle",
+        lambda _bundle, _destination: SimpleNamespace(entrypoint=script),
+    )
+
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.lammps",
+            "input_bundle": "/staged/copper.tar",
+            "out": "/execution/shared/lammps",
+            "shared_dir": "/execution/shared/lammps",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.script_path == script
 
 
 def test_container_lammps_reports_only_host_visible_output() -> None:

--- a/test/unit/core/test_lammps_package_runtime.py
+++ b/test/unit/core/test_lammps_package_runtime.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
+import io
+import json
 import shlex
+import tarfile
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -10,6 +14,10 @@ from typing import Any
 
 import pytest
 
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+)
 from jarvis_cd.shell import LocalExecInfo, PsshExecInfo
 from jarvis_cd.util.hostfile import Hostfile
 
@@ -38,12 +46,14 @@ class _CapturedExec:
     """Capture a package launch without executing the application."""
 
     commands: list[str] = []
+    exec_infos: list[Any] = []
 
     def __init__(self, command: str, exec_info: Any) -> None:
         self.command = command
         self.exec_info = exec_info
         self.exit_code = {"localhost": 0}
         self.commands.append(command)
+        self.exec_infos.append(exec_info)
 
     def run(self) -> _CapturedExec:
         """Record the launch only."""
@@ -105,6 +115,7 @@ def _capture_output_directory_creation(
     """Keep package launch tests isolated from PSSH output creation."""
     _CapturedMkdir.paths = []
     _CapturedRm.calls = []
+    _CapturedExec.exec_infos = []
     monkeypatch.setattr(lammps_package, "Mkdir", _CapturedMkdir)
     monkeypatch.setattr(lammps_package, "Rm", _CapturedRm)
 
@@ -117,6 +128,41 @@ def test_portable_defaults_use_package_shared_output_and_cpu() -> None:
     assert menu["out"]["default"] == "."
     assert "JARVIS package shared directory" in menu["out"]["msg"]
     assert menu["kokkos_gpu"]["default"] is False
+    assert menu["input_bundle"]["default"] == ""
+    assert menu["input_bundle"]["input_binding"]["kind"] == "local_file"
+
+
+def _write_lammps_input_bundle(destination: Path) -> Path:
+    files = {
+        "in.copper": b"pair_style eam\npair_coeff * * Cu.eam\nrun 0\n",
+        "Cu.eam": b"potential\n",
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "in.copper",
+        "files": [
+            {
+                "path": name,
+                "role": role,
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, role, payload in (
+                ("in.copper", "lammps_input", files["in.copper"]),
+                ("Cu.eam", "potential", files["Cu.eam"]),
+            )
+        ],
+    }
+    manifest_payload = json.dumps(manifest, sort_keys=True).encode("utf-8")
+    with tarfile.open(destination, mode="w") as archive:
+        manifest_info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        manifest_info.size = len(manifest_payload)
+        archive.addfile(manifest_info, io.BytesIO(manifest_payload))
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
 
 
 def test_default_output_resolves_inside_execution_package_shared_root(
@@ -278,6 +324,60 @@ def test_default_launch_generates_package_owned_lennard_jones_input(
     assert f"-in {shlex.quote(str(generated))}" in _CapturedExec.commands[1]
 
 
+def test_default_launch_stages_multi_file_input_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """LAMMPS receives its entrypoint and support files in one owned cwd."""
+
+    output_dir = tmp_path / "output"
+    bundle = _write_lammps_input_bundle(tmp_path / "copper.tar")
+    package = object.__new__(lammps_package.Lammps)
+    package.config = {
+        "input_bundle": str(bundle),
+        "kokkos_gpu": False,
+        "nprocs": 2,
+        "out": str(output_dir),
+        "ppn": 2,
+        "script": "",
+    }
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: None)
+    package.env = {}
+    package.mod_env = {}
+    package.shared_dir = tmp_path / "shared"
+    _CapturedExec.commands = []
+    monkeypatch.setattr(lammps_package, "Exec", _CapturedExec)
+
+    package.start()
+
+    staged_script = output_dir / "in.copper"
+    assert staged_script.read_bytes().startswith(b"pair_style eam")
+    assert (output_dir / "Cu.eam").read_bytes() == b"potential\n"
+    assert f"-in {shlex.quote(str(staged_script))}" in _CapturedExec.commands[1]
+    assert _CapturedExec.exec_infos[-1].cwd == str(output_dir.resolve())
+
+
+def test_input_bundle_is_mutually_exclusive_with_script(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Ambiguous caller inputs fail before directory or process side effects."""
+
+    package = object.__new__(lammps_package.Lammps)
+    package.config = {
+        "input_bundle": str(tmp_path / "inputs.tar"),
+        "script": str(tmp_path / "in.lmp"),
+    }
+    package.shared_dir = tmp_path / "shared"
+    _CapturedExec.commands = []
+    monkeypatch.setattr(lammps_package, "Exec", _CapturedExec)
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
 def test_generated_inputs_are_content_addressed_for_concurrent_executions(
     tmp_path: Path,
 ) -> None:
@@ -381,8 +481,9 @@ def test_container_launch_creates_log_directory_before_lammps(
     assert _CapturedExec.commands[0] == f"rm -f {shlex.quote(str(expected_log))}"
     argv = shlex.split(_CapturedExec.commands[1])
     assert argv[:2] == ["bash", "-c"]
+    output = shlex.quote(str(output_dir.resolve()))
     expected_prefix = (
-        f"mkdir -p {shlex.quote(str(output_dir.resolve()))} "
+        f"mkdir -p {output} && cd {output} "
         f"&& exec /usr/local/bin/lmp -log {shlex.quote(str(expected_log))}"
     )
     assert argv[2].startswith(expected_prefix + " -in ")

--- a/test/unit/core/test_package_deployment_contract.py
+++ b/test/unit/core/test_package_deployment_contract.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import pytest
 
-from jarvis_cd.core.pkg import Pkg
+from jarvis_cd.core.pkg import Interceptor, Pkg
 from jarvis_cd.deployment import (
     ConfigurationCondition,
     ConfigurationInputBinding,
@@ -43,21 +43,36 @@ def test_legacy_package_has_no_inferred_deployment_contract() -> None:
     assert package.describe_deployment() is None
 
 
-def test_common_implementation_controls_are_not_agent_visible() -> None:
-    """Generic agents see semantic package inputs, not JARVIS admin controls."""
+def test_only_explicit_interceptor_links_are_agent_visible_common_settings() -> None:
+    """Generic agents see graph edges but not JARVIS administration controls."""
     package = object.__new__(Pkg)
 
     parameters = package.configure_menu()
+    by_name = {parameter["name"]: parameter for parameter in parameters}
 
     assert parameters
-    assert all(parameter["agent_visible"] is False for parameter in parameters)
-    assert {parameter["name"] for parameter in parameters} >= {
+    assert by_name["interceptors"]["agent_visible"] is True
+    assert all(
+        parameter["agent_visible"] is False
+        for parameter in parameters
+        if parameter["name"] != "interceptors"
+    )
+    assert set(by_name) >= {
         "install_method",
         "install_query",
         "install",
         "hostfile",
         "timeout",
     }
+
+
+def test_interceptor_packages_do_not_advertise_nested_interceptor_links() -> None:
+    """An interceptor never invites an invalid nested-interceptor configuration."""
+    package = object.__new__(Interceptor)
+
+    parameters = {item["name"]: item for item in package.configure_menu()}
+
+    assert parameters["interceptors"]["agent_visible"] is False
 
 
 def test_standalone_descriptor_preserves_canonical_package_identity(

--- a/test/unit/core/test_package_deployment_contract.py
+++ b/test/unit/core/test_package_deployment_contract.py
@@ -161,6 +161,12 @@ def test_lammps_contract_defaults_to_generated_batch_and_spack_resolution(
         "kind": "local_file",
         "structure": "regular_file",
     }
+    assert menu["input_bundle"]["default"] == ""
+    assert menu["input_bundle"]["input_binding"] == {
+        "schema_version": "jarvis.configuration-input-binding.v1",
+        "kind": "local_file",
+        "structure": "regular_file",
+    }
     assert "`lattice fcc <density>`" in menu["script"]["msg"]
     assert "`region ... units lattice`" in menu["script"]["msg"]
     assert (
@@ -175,7 +181,11 @@ def test_lammps_contract_defaults_to_generated_batch_and_spack_resolution(
     assert {
         (profile["name"], profile["execution_kind"])
         for profile in document["execution_profiles"]
-    } == {("generated_workload", "batch"), ("input_script", "batch")}
+    } == {
+        ("generated_workload", "batch"),
+        ("input_script", "batch"),
+        ("input_bundle", "batch"),
+    }
     profiles = {profile["name"]: profile for profile in document["execution_profiles"]}
     assert profiles["generated_workload"]["description"] == (
         "Built-in bounded Lennard-Jones smoke workload with a package-generated "
@@ -187,6 +197,7 @@ def test_lammps_contract_defaults_to_generated_batch_and_spack_resolution(
         in profiles["input_script"]["description"]
     )
     assert "`mass 1 1.0`" in profiles["input_script"]["description"]
+    assert "Digest-verified multi-file" in profiles["input_bundle"]["description"]
     runtime = document["runtime_requirements"][0]
     assert runtime["status"] == {
         "state": "ready",


### PR DESCRIPTION
## Summary

- add a closed, digest-verified multi-file package input-bundle contract
- materialize bundles atomically with path, type, size, count, and SHA-256 validation
- add canonical LAMMPS multi-file input support without a benchmark-specific package
- stage application inputs into an execution-owned mutable working directory

## Safety properties

- rejects links, devices, traversal, duplicate or undeclared paths, stale materializations, and bound violations
- reapplies source-manifest and quota checks on reuse
- handles concurrent publication by validating the winning immutable materialization
- never overwrites run-workspace files

## Verification

- `uv run --no-sync --no-cache pytest -q test/unit/core/test_input_bundle.py test/unit/core/test_configuration_input_materialization.py test/unit/core/test_lammps_package_runtime.py test/unit/core/test_lammps_artifacts.py test/unit/core/test_package_deployment_contract.py` (49 passed)
- `uv run --no-sync --no-cache ruff check ...` (passed)
- `uv run --no-sync --no-cache ruff format --check ...` (passed)
- `uv run --no-sync --no-cache pyright jarvis_cd/input_bundle.py builtin/builtin/lammps/pkg.py builtin/builtin/lammps/artifacts.py` (0 errors)

## Stack

This draft is stacked on #187 because package input qualification is being developed alongside the explicit package-kind and interceptor semantics. It should target `main` after #187 lands.