### PR TITLE
feat: add portable Gray-Scott source bundles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,8 +81,11 @@ jobs:
             builtin/builtin/paraview/artifacts.py \
             builtin/builtin/gray_scott/progress.py \
             builtin/builtin/gray_scott/artifacts.py \
+            builtin/builtin/adios2_gray_scott/pkg.py \
             builtin/builtin/adios2_gray_scott/progress.py \
-            builtin/builtin/adios2_gray_scott/artifacts.py
+            builtin/builtin/adios2_gray_scott/artifacts.py \
+            builtin/builtin/adios2_pdf_calc/pkg.py \
+            builtin/builtin/adios2_pdf_calc/artifacts.py
 
       - name: Lint runtime contracts
         run: |
@@ -98,7 +101,8 @@ jobs:
             builtin/builtin/lammps/artifacts.py \
             builtin/builtin/paraview/artifacts.py \
             builtin/builtin/gray_scott \
-            builtin/builtin/adios2_gray_scott
+            builtin/builtin/adios2_gray_scott \
+            builtin/builtin/adios2_pdf_calc
           uv run --frozen ruff format --check \
             jarvis_cd/artifacts \
             jarvis_cd/core/scheduler.py \
@@ -108,8 +112,11 @@ jobs:
             builtin/builtin/paraview/artifacts.py \
             builtin/builtin/gray_scott/progress.py \
             builtin/builtin/gray_scott/artifacts.py \
+            builtin/builtin/adios2_gray_scott/pkg.py \
             builtin/builtin/adios2_gray_scott/progress.py \
-            builtin/builtin/adios2_gray_scott/artifacts.py
+            builtin/builtin/adios2_gray_scott/artifacts.py \
+            builtin/builtin/adios2_pdf_calc/pkg.py \
+            builtin/builtin/adios2_pdf_calc/artifacts.py
 
       - name: Run tests with coverage
         run: bash ci/run_tests.sh

--- a/builtin/builtin/adios2_gray_scott/README.md
+++ b/builtin/builtin/adios2_gray_scott/README.md
@@ -43,6 +43,34 @@ V: the activator chemical, which is produced during the reaction and also remove
 | **Noise(noise)** | add noise for the simulation | 0.01~0.1 |
 | **I/O frequency(plotgap)** | the frequecey of I/O between simulation steps  | 1~10 |
 
+## Portable source and configuration bundles
+
+`input_bundle` selects the source-build profile. The value is a regular tar
+archive using the closed `jarvis.package-input-bundle.v1` manifest. The
+manifest must declare exactly one `build_spec`, at least one
+`scientific_input`, and the `adios2_configuration` referenced by each selected
+scientific input. Source and license members may use descriptive roles such as
+`upstream_source` and `upstream_license`.
+
+`configuration_path` selects one manifest-declared `scientific_input` by a
+confined POSIX-relative path. When it is empty, the manifest entrypoint is
+used. JARVIS verifies every archive member digest and validates the selected
+Gray-Scott JSON before scheduler submission. Output, checkpoint, restart, and
+ADIOS2 paths in bundle configurations must be relative, so their materialized
+locations remain owned by the execution.
+
+```bash
+jarvis ppl append adios2_gray_scott \
+  input_bundle=/staged/gray-scott-source.tar \
+  configuration_path=config/feed-low.json \
+  nprocs=4 ppn=4
+```
+
+The source build requires CMake, MPI compilers, and an MPI-enabled ADIOS2
+development installation. JARVIS configures and builds the `gray-scott` target
+inside the package's execution-owned workspace. Internet source discovery and
+mutable checkout paths are not used.
+
 
 
 

--- a/builtin/builtin/adios2_gray_scott/pkg.py
+++ b/builtin/builtin/adios2_gray_scott/pkg.py
@@ -1,41 +1,219 @@
-"""
-This module provides classes and methods to launch the Gray Scott application.
-Gray Scott is a 3D 7-point stencil code for modeling the diffusion of two
-substances.
-"""
+"""Launch the ADIOS2 Gray-Scott reaction-diffusion application."""
 
-from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
-from jarvis_cd.shell.process import Mkdir, Rm
-from jarvis_cd.util.config_parser import JsonFile
+from __future__ import annotations
+
+import json
+import math
 import os
 import shlex
-from typing import Any
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, NamedTuple, cast
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
+from jarvis_cd.shell.process import Mkdir, Rm
+from jarvis_cd.util.config_parser import JsonFile
+
+_SCIENTIFIC_INPUT_ROLE = "scientific_input"
+_BUILD_SPEC_ROLE = "build_spec"
+_ADIOS_CONFIG_ROLE = "adios2_configuration"
+_CONFIGURATION_REQUIRED_FIELDS = {
+    "Du",
+    "Dv",
+    "F",
+    "L",
+    "adios_config",
+    "adios_memory_selection",
+    "adios_span",
+    "checkpoint",
+    "checkpoint_freq",
+    "checkpoint_output",
+    "dt",
+    "k",
+    "mesh_type",
+    "noise",
+    "output",
+    "plotgap",
+    "steps",
+}
+_CONFIGURATION_OPTIONAL_FIELDS = {"restart", "restart_input"}
+
+
+class GrayScottBundleConfiguration(NamedTuple):
+    """Validated paths and scientific values selected from one input bundle."""
+
+    path: Path
+    values: Mapping[str, object]
+    build_spec: Path
+    adios_config: Path
+
+
+def _safe_bundle_member(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise ValueError(f"{label} must name a declared scientific_input member")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{label} must name a declared scientific_input member")
+    return path.as_posix()
+
+
+def _relative_output_path(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise ValueError(f"{label} must be a relative bundle path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{label} must be a relative bundle path")
+    return path.as_posix()
+
+
+def _finite_number(
+    values: Mapping[str, object],
+    name: str,
+    *,
+    positive: bool,
+) -> float:
+    value = values[name]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"Gray-Scott {name} must be numeric")
+    parsed = float(value)
+    if (
+        not math.isfinite(parsed)
+        or (positive and parsed <= 0)
+        or (not positive and parsed < 0)
+    ):
+        qualifier = "positive" if positive else "non-negative"
+        raise ValueError(f"Gray-Scott {name} must be finite and {qualifier}")
+    return parsed
+
+
+def _positive_integer(values: Mapping[str, object], name: str) -> int:
+    value = values[name]
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"Gray-Scott {name} must be a positive integer")
+    return value
+
+
+def _validate_scientific_configuration(values: object) -> Mapping[str, object]:
+    if not isinstance(values, dict):
+        raise ValueError("Gray-Scott scientific configuration must be a JSON object")
+    fields = set(values)
+    missing = _CONFIGURATION_REQUIRED_FIELDS - fields
+    unknown = fields - _CONFIGURATION_REQUIRED_FIELDS - _CONFIGURATION_OPTIONAL_FIELDS
+    if missing or unknown:
+        raise ValueError(
+            "Gray-Scott scientific configuration fields are invalid: "
+            f"missing={sorted(missing)}, unknown={sorted(unknown)}"
+        )
+    for name in ("Du", "Dv", "dt"):
+        _finite_number(values, name, positive=True)
+    for name in ("F", "k", "noise"):
+        _finite_number(values, name, positive=False)
+    for name in ("L", "steps", "plotgap", "checkpoint_freq"):
+        _positive_integer(values, name)
+    if values["plotgap"] > values["steps"]:
+        raise ValueError("Gray-Scott plotgap cannot exceed steps")
+    for name in (
+        "checkpoint",
+        "adios_span",
+        "adios_memory_selection",
+    ):
+        if not isinstance(values[name], bool):
+            raise ValueError(f"Gray-Scott {name} must be boolean")
+    restart = values.get("restart", False)
+    if not isinstance(restart, bool):
+        raise ValueError("Gray-Scott restart must be boolean")
+    mesh_type = values["mesh_type"]
+    if not isinstance(mesh_type, str) or not mesh_type.strip():
+        raise ValueError("Gray-Scott mesh_type must be a non-empty string")
+    _relative_output_path(values["output"], label="Gray-Scott output")
+    _relative_output_path(
+        values["checkpoint_output"], label="Gray-Scott checkpoint output"
+    )
+    if restart:
+        _relative_output_path(
+            values.get("restart_input"), label="Gray-Scott restart input"
+        )
+    return values
+
+
+def resolve_bundle_configuration(
+    bundle: MaterializedInputBundle,
+    configuration_path: str,
+) -> GrayScottBundleConfiguration:
+    """Resolve and validate one scientific configuration from a verified bundle."""
+
+    selected_path = _safe_bundle_member(
+        configuration_path or bundle.manifest.entrypoint,
+        label="configuration_path",
+    )
+    roles = {item.path: item.role for item in bundle.manifest.files}
+    if roles.get(selected_path) != _SCIENTIFIC_INPUT_ROLE:
+        raise ValueError(
+            "configuration_path must name a declared scientific_input member"
+        )
+    build_specs = [path for path, role in roles.items() if role == _BUILD_SPEC_ROLE]
+    if len(build_specs) != 1:
+        raise ValueError("Gray-Scott input bundle requires exactly one build_spec")
+    selected = bundle.root / PurePosixPath(selected_path)
+    try:
+        values = json.loads(selected.read_text(encoding="utf-8", errors="strict"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            "Gray-Scott scientific configuration is not valid JSON"
+        ) from exc
+    validated = _validate_scientific_configuration(values)
+    adios_path = _safe_bundle_member(
+        validated["adios_config"],
+        label="Gray-Scott adios_config",
+    )
+    if roles.get(adios_path) != _ADIOS_CONFIG_ROLE:
+        raise ValueError(
+            "Gray-Scott adios_config must name a declared adios2_configuration member"
+        )
+    return GrayScottBundleConfiguration(
+        path=selected,
+        values=validated,
+        build_spec=bundle.root / PurePosixPath(build_specs[0]),
+        adios_config=bundle.root / PurePosixPath(adios_path),
+    )
+
+
+def _combined_probe_status(*statuses: RuntimeStatus) -> RuntimeStatus:
+    if statuses and all(status.usable is True for status in statuses):
+        return RuntimeStatus("ready", "runtime_probe_succeeded")
+    if any(status.usable is False for status in statuses):
+        return RuntimeStatus("unavailable", "software_not_found")
+    return RuntimeStatus("unknown", "runtime_probe_inconclusive")
 
 
 class Adios2GrayScott(Application):
-    """
-    This class provides methods to launch the GrayScott application.
-    """
+    """Run an installed or digest-bound source build of ADIOS2 Gray-Scott."""
 
-    def _init(self):
-        """
-        Initialize paths
-        """
+    def _init(self) -> None:
         self.adios2_xml_path = f"{self.shared_dir}/adios2.xml"
         self.settings_json_path = f"{self.shared_dir}/settings-files.json"
         self.var_json_path = f"{self.shared_dir}/var.json"
         self.operator_json_path = f"{self.shared_dir}/operator.json"
-        self.process = None  # Store process handle for async execution
+        self.process: Any = None
 
-    def _configure_menu(self):
-        """
-        Create a CLI menu for the configurator method.
-        For thorough documentation of these parameters, view:
-        https://github.com/scs-lab/jarvis-util/wiki/3.-Argument-Parsing
-
-        :return: List(dict)
-        """
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
             {
                 "name": "nprocs",
@@ -43,129 +221,106 @@ class Adios2GrayScott(Application):
                 "type": int,
                 "default": 4,
             },
-            {
-                "name": "ppn",
-                "msg": "Processes per node",
-                "type": int,
-                "default": 16,
-            },
+            {"name": "ppn", "msg": "Processes per node", "type": int, "default": 16},
             {
                 "name": "executable",
-                "msg": "ADIOS2 Gray-Scott producer executable or absolute path",
+                "msg": "Installed ADIOS2 Gray-Scott executable available through PATH",
                 "type": str,
                 "default": "adios2-gray-scott",
             },
             {
-                "name": "L",
-                "msg": "Grid size of cube",
-                "type": int,
-                "default": 32,
+                "name": "input_bundle",
+                "msg": (
+                    "Optional digest-verified source and scientific-configuration "
+                    "bundle. Its manifest must declare one build_spec, an ADIOS2 "
+                    "configuration, and one or more scientific_input files."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                "name": "Du",
-                "msg": "Diffusion rate of substance U",
-                "type": float,
-                "default": 0.2,
+                "name": "configuration_path",
+                "msg": (
+                    "Relative scientific_input member selected from input_bundle; "
+                    "empty selects the manifest entrypoint"
+                ),
+                "type": str,
+                "default": "",
             },
-            {
-                "name": "Dv",
-                "msg": "Diffusion rate of substance V",
-                "type": float,
-                "default": 0.1,
-            },
-            {
-                "name": "F",
-                "msg": "Feed rate of U",
-                "type": float,
-                "default": 0.01,
-            },
-            {
-                "name": "k",
-                "msg": "Kill rate of V",
-                "type": float,
-                "default": 0.05,
-            },
-            {
-                "name": "dt",
-                "msg": "Timestep",
-                "type": float,
-                "default": 2.0,
-            },
+            {"name": "L", "msg": "Grid size of cube", "type": int, "default": 32},
+            {"name": "Du", "msg": "Diffusion rate of U", "type": float, "default": 0.2},
+            {"name": "Dv", "msg": "Diffusion rate of V", "type": float, "default": 0.1},
+            {"name": "F", "msg": "Feed rate of U", "type": float, "default": 0.01},
+            {"name": "k", "msg": "Kill rate of V", "type": float, "default": 0.05},
+            {"name": "dt", "msg": "Timestep", "type": float, "default": 2.0},
             {
                 "name": "steps",
-                "msg": "Total number of steps to simulate",
+                "msg": "Total simulation steps",
                 "type": int,
                 "default": 100,
             },
             {
                 "name": "plotgap",
-                "msg": "Number of steps between output",
+                "msg": "Steps between outputs",
                 "type": int,
                 "default": 10,
             },
-            {
-                "name": "noise",
-                "msg": "Amount of noise",
-                "type": float,
-                "default": 0.01,
-            },
-            {
-                "name": "out_file",
-                "msg": "Absolute path to output file",
-                "type": str,
-                "default": None,
-            },
+            {"name": "noise", "msg": "Initial noise", "type": float, "default": 0.01},
+            {"name": "out_file", "msg": "Output dataset", "type": str, "default": None},
             {
                 "name": "checkpoint",
-                "msg": "Perform checkpoints",
+                "msg": "Write checkpoints",
                 "type": bool,
                 "default": True,
             },
             {
                 "name": "checkpoint_freq",
-                "msg": "Frequency of the checkpoints",
+                "msg": "Checkpoint interval",
                 "type": int,
                 "default": 70,
             },
             {
                 "name": "checkpoint_output",
-                "msg": "Output location of the checkpoint",
+                "msg": "Checkpoint dataset",
                 "type": str,
                 "default": "ckpt.bp",
             },
             {
                 "name": "restart",
-                "msg": "Perform restarts",
+                "msg": "Restart from a checkpoint",
                 "type": bool,
                 "default": False,
             },
             {
                 "name": "restart_input",
-                "msg": "Input for the restart",
+                "msg": "Restart checkpoint",
                 "type": str,
                 "default": "ckpt.bp",
             },
             {
                 "name": "adios_span",
-                "msg": "???",
+                "msg": "Enable ADIOS span mode",
                 "type": bool,
                 "default": False,
             },
             {
                 "name": "adios_memory_selection",
-                "msg": "???",
+                "msg": "Enable ADIOS memory selection",
                 "type": bool,
                 "default": False,
             },
             {
                 "name": "mesh_type",
-                "msg": "???",
+                "msg": "Mesh representation",
                 "type": str,
                 "default": "image",
             },
             {
                 "name": "engine",
-                "msg": "Engine to be used",
+                "msg": "ADIOS2 engine",
                 "choices": [
                     "bp5",
                     "hermes",
@@ -180,108 +335,200 @@ class Adios2GrayScott(Application):
             },
             {
                 "name": "full_run",
-                "msg": "Whill postprocessing be executed?",
+                "msg": "Execute postprocessing",
                 "type": bool,
                 "default": True,
             },
-            {
-                "name": "limit",
-                "msg": "Limit the value of data to track",
-                "type": int,
-                "default": 0,
-            },
+            {"name": "limit", "msg": "Value-tracking limit", "type": int, "default": 0},
             {
                 "name": "db_path",
-                "msg": "Path where the DB will be stored",
+                "msg": "Metadata database path",
                 "type": str,
                 "default": "benchmark_metadata.db",
             },
             {
                 "name": "Execution_order",
-                "msg": "Path where the bp5 will be stored",
+                "msg": "IOWarp execution order",
                 "type": str,
                 "default": "1",
             },
             {
                 "name": "run_async",
-                "msg": "Run in background for parallel execution with consumer",
+                "msg": "Run producer asynchronously",
                 "type": bool,
                 "default": False,
             },
         ]
 
-    # jarvis pkg config adios2_gray_scott ppn=20 full_run=true engine=hermes db_path=/mnt/nvme/jcernudagarcia/metadata.db out_file=gs.bp nprocs=1
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        environment = self._deployment_environment()
+        installed_probe = probe_program(
+            "adios2-gray-scott", environment=environment, arguments=("--help",)
+        )
+        cmake_probe = probe_program(
+            "cmake", environment=environment, arguments=("--version",)
+        )
+        adios_probe = probe_program(
+            "adios2-config", environment=environment, arguments=("--version",)
+        )
+        mpi_c_probe = probe_program(
+            "mpicc", environment=environment, arguments=("--version",)
+        )
+        mpi_cxx_probe = probe_program(
+            "mpic++", environment=environment, arguments=("--version",)
+        )
+        source_status = _combined_probe_status(
+            cmake_probe.status,
+            adios_probe.status,
+            mpi_c_probe.status,
+            mpi_cxx_probe.status,
+        )
+        installed_capabilities = (
+            ("mpi_execution", "reaction_diffusion")
+            if installed_probe.status.usable is True
+            else ()
+        )
+        source_capabilities = (
+            ("mpi_execution", "reaction_diffusion", "source_build")
+            if source_status.usable is True
+            else ()
+        )
+        completed = ReadinessContract("process_exit", "successful_exit")
+        return PackageDeploymentContract(
+            package="builtin.adios2_gray_scott",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="installed_executable",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    runtime_requirements=("gray_scott_installed",),
+                    readiness=completed,
+                    description="Run an installed Gray-Scott producer using package parameters.",
+                ),
+                ExecutionProfile(
+                    name="source_bundle",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    runtime_requirements=("gray_scott_source_build",),
+                    readiness=completed,
+                    description=(
+                        "Build verified source and run one manifest-declared "
+                        "scientific configuration in an execution-owned workspace."
+                    ),
+                ),
+            ),
+            runtime_requirements=(
+                RuntimeRequirement(
+                    requirement_id="gray_scott_installed",
+                    description="Installed MPI ADIOS2 Gray-Scott producer",
+                    required_capabilities=("mpi_execution", "reaction_diffusion"),
+                    available_capabilities=installed_capabilities,
+                    status=installed_probe.status,
+                ),
+                RuntimeRequirement(
+                    requirement_id="gray_scott_source_build",
+                    description="CMake and MPI-enabled ADIOS2 development runtime",
+                    required_capabilities=(
+                        "mpi_execution",
+                        "reaction_diffusion",
+                        "source_build",
+                    ),
+                    available_capabilities=source_capabilities,
+                    status=source_status,
+                    provider_resolutions=(
+                        ProviderResolution("spack", "spec", "adios2+mpi"),
+                        ProviderResolution("spack", "spec", "cmake"),
+                        ProviderResolution("spack", "spec", "openmpi"),
+                    ),
+                ),
+            ),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    requires=(
+                        ConfigurationCondition("configuration_path", "is_empty"),
+                    ),
+                    description="configuration_path is valid only with input_bundle.",
+                ),
+            ),
+        )
 
-    def _configure(self, **kwargs):
-        """
-        Converts the Jarvis configuration to application-specific configuration.
-        E.g., OrangeFS produces an orangefs.xml file.
+    def _configure(self, **kwargs: Any) -> None:
+        super()._configure(**kwargs)
+        self._validate_common_configuration()
+        config = cast(dict[str, Any], self.config)
+        configured_bundle = config.get("input_bundle")
+        if configured_bundle not in (None, ""):
+            if not isinstance(configured_bundle, str):
+                raise TypeError("input_bundle must be a path string")
+            bundle = extract_input_bundle(
+                configured_bundle, self._shared_root() / "input-bundles"
+            )
+            selected = resolve_bundle_configuration(
+                bundle, str(config.get("configuration_path") or "")
+            )
+            self._apply_scientific_values(selected.values)
+            return
+        if config.get("configuration_path") not in (None, ""):
+            raise ValueError("configuration_path requires input_bundle")
+        self._configure_generated_settings()
 
-        :param kwargs: Configuration parameters for this pkg.
-        :return: None
-        """
-        if self.config["out_file"] is None:
-            adios_dir = os.path.join(self.shared_dir, "gray-scott-output")
-            self.config["out_file"] = os.path.join(adios_dir, "data/out.bp")
-            Mkdir(adios_dir, PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
-        settings_json = {
-            "L": self.config["L"],
-            "Du": self.config["Du"],
-            "Dv": self.config["Dv"],
-            "F": self.config["F"],
-            "k": self.config["k"],
-            "dt": self.config["dt"],
-            "plotgap": self.config["plotgap"],
-            "steps": self.config["steps"],
-            "noise": self.config["noise"],
-            "output": self.config["out_file"],
-            "checkpoint": self.config["checkpoint"],
-            "checkpoint_freq": self.config["checkpoint_freq"],
-            "checkpoint_output": self.config["checkpoint_output"],
-            "restart": self.config["restart"],
-            "restart_input": self.config["restart_input"],
-            "adios_span": self.config["adios_span"],
-            "adios_memory_selection": self.config["adios_memory_selection"],
-            "mesh_type": self.config["mesh_type"],
-            "adios_config": f"{self.adios2_xml_path}",
-        }
-        output_dir = os.path.dirname(self.config["out_file"])
-        db_dir = os.path.dirname(self.config["db_path"])
+    def _shared_root(self) -> Path:
+        shared_dir = self.shared_dir
+        if not isinstance(shared_dir, (str, os.PathLike)) or not os.fspath(shared_dir):
+            raise RuntimeError("Gray-Scott requires a JARVIS package shared directory")
+        return Path(shared_dir)
+
+    def _validate_common_configuration(self) -> None:
+        for name in ("nprocs", "ppn"):
+            value = self.config.get(name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        executable = self.config.get("executable")
+        if not isinstance(executable, str) or not executable.strip():
+            raise ValueError("ADIOS2 Gray-Scott executable must be a non-empty string")
+
+    def _apply_scientific_values(self, values: Mapping[str, object]) -> None:
+        config = cast(dict[str, Any], self.config)
+        mapping = {name: name for name in values if name != "output"}
+        mapping["output"] = "out_file"
+        for source, destination in mapping.items():
+            config[destination] = values[source]
+
+    def _configure_generated_settings(self) -> None:
+        config = cast(dict[str, Any], self.config)
+        if config["out_file"] is None:
+            config["out_file"] = str(
+                self.resolve_shared_path(
+                    "gray-scott-output/data/out.bp", field="out_file"
+                )
+            )
+        output_dir = os.path.dirname(str(config["out_file"]))
+        db_dir = os.path.dirname(
+            str(self.resolve_shared_path(config["db_path"], field="db_path"))
+        )
         Mkdir(
             [output_dir, db_dir], PsshExecInfo(hostfile=self.hostfile, env=self.env)
         ).run()
+        self._write_settings(
+            Path(self.settings_json_path), config, self.adios2_xml_path
+        )
+        self._configure_adios_template()
 
-        JsonFile(self.settings_json_path).save(settings_json)
-        print(f"Using engine {self.config['engine']}")
-        if self.config["engine"].lower() in ["bp5", "bp5_derived"]:
+    def _configure_adios_template(self) -> None:
+        engine = str(self.config["engine"]).lower()
+        if engine in {"bp5", "bp5_derived"}:
             self.copy_template_file(
                 f"{self.pkg_dir}/config/adios2.xml", self.adios2_xml_path
             )
-        elif self.config["engine"].lower() == "sst":
+        elif engine == "sst":
             self.copy_template_file(
                 f"{self.pkg_dir}/config/sst.xml", self.adios2_xml_path
             )
-        elif self.config["engine"].lower() in ["hermes", "hermes_derived"]:
+        elif engine in {"hermes", "hermes_derived", "iowarp", "iowarp_derived"}:
+            template = "hermes.xml" if engine.startswith("hermes") else "iowarp.xml"
             self.copy_template_file(
-                f"{self.pkg_dir}/config/hermes.xml",
-                self.adios2_xml_path,
-                replacements={
-                    "PPN": self.config["ppn"],
-                    "VARFILE": self.var_json_path,
-                    "OPFILE": self.operator_json_path,
-                    "DBFILE": self.config["db_path"],
-                    "Order": self.config["Execution_order"],
-                },
-            )
-            self.copy_template_file(
-                f"{self.pkg_dir}/config/var.yaml", self.var_json_path
-            )
-            self.copy_template_file(
-                f"{self.pkg_dir}/config/operator.yaml", self.operator_json_path
-            )
-        elif self.config["engine"].lower() in ["iowarp", "iowarp_derived"]:
-            self.copy_template_file(
-                f"{self.pkg_dir}/config/iowarp.xml",
+                f"{self.pkg_dir}/config/{template}",
                 self.adios2_xml_path,
                 replacements={
                     "PPN": self.config["ppn"],
@@ -298,92 +545,132 @@ class Adios2GrayScott(Application):
                 f"{self.pkg_dir}/config/operator.yaml", self.operator_json_path
             )
         else:
-            raise Exception("Engine not defined")
+            raise ValueError(f"unsupported ADIOS2 engine: {engine}")
 
-    def start(self):
-        """
-        Launch an application. E.g., OrangeFS will launch the servers, clients,
-        and metadata services on all necessary pkgs.
+    @staticmethod
+    def _write_settings(
+        path: Path, values: Mapping[str, object], adios_config: str
+    ) -> None:
+        payload = {
+            "L": values["L"],
+            "Du": values["Du"],
+            "Dv": values["Dv"],
+            "F": values["F"],
+            "k": values["k"],
+            "dt": values["dt"],
+            "plotgap": values["plotgap"],
+            "steps": values["steps"],
+            "noise": values["noise"],
+            "output": values["out_file"],
+            "checkpoint": values["checkpoint"],
+            "checkpoint_freq": values["checkpoint_freq"],
+            "checkpoint_output": values["checkpoint_output"],
+            "restart": values.get("restart", False),
+            "restart_input": values.get("restart_input", "ckpt.bp"),
+            "adios_span": values["adios_span"],
+            "adios_memory_selection": values["adios_memory_selection"],
+            "mesh_type": values["mesh_type"],
+            "adios_config": adios_config,
+        }
+        JsonFile(str(path)).save(payload)
 
-        :return: None
-        """
-        # print(self.env['HERMES_CLIENT_CONF'])
-        line_callback = self.runtime_line_callback()
-        executable = self.config.get("executable", "adios2-gray-scott")
-        if not isinstance(executable, str) or not executable.strip():
-            raise ValueError("ADIOS2 Gray-Scott executable must be a non-empty string")
+    def _prepare_bundle_run(self) -> tuple[str, str]:
+        configured = self.config.get("input_bundle")
+        if not isinstance(configured, str) or not configured:
+            raise RuntimeError("Gray-Scott input bundle was not persisted")
+        bundle = extract_input_bundle(configured, self._shared_root() / "input-bundles")
+        selected = resolve_bundle_configuration(
+            bundle, str(self.config.get("configuration_path") or "")
+        )
+        run_dir = self.resolve_shared_path("run", field="input_bundle workspace")
+        stage_input_bundle(bundle, run_dir)
+        relative_configuration = selected.path.relative_to(bundle.root)
+        relative_build_spec = selected.build_spec.relative_to(bundle.root)
+        relative_adios = selected.adios_config.relative_to(bundle.root)
+        staged_values = dict(selected.values)
+        for source in ("output", "checkpoint_output", "restart_input"):
+            value = staged_values.get(source)
+            if value is not None:
+                staged_values[source] = str(run_dir / PurePosixPath(str(value)))
+        self._apply_scientific_values(staged_values)
+        self.adios2_xml_path = str(run_dir / relative_adios)
+        self.settings_json_path = str(run_dir / relative_configuration)
+        output_dir = Path(str(self.config["out_file"])).parent
+        output_dir.mkdir(parents=True, exist_ok=True)
+        if self.config.get("checkpoint"):
+            Path(str(self.config["checkpoint_output"])).parent.mkdir(
+                parents=True, exist_ok=True
+            )
+        self._write_settings(
+            Path(self.settings_json_path), self.config, self.adios2_xml_path
+        )
+        build_dir = run_dir / "build"
+        source_dir = (run_dir / relative_build_spec).parent
+        local_info = LocalExecInfo(env=self.mod_env, cwd=str(run_dir), timeout=900)
+        configure = " ".join(
+            (
+                "cmake",
+                "-S",
+                shlex.quote(str(source_dir)),
+                "-B",
+                shlex.quote(str(build_dir)),
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_C_COMPILER=mpicc",
+                "-DCMAKE_CXX_COMPILER=mpic++",
+            )
+        )
+        self._raise_for_exec_failure(
+            Exec(configure, local_info).run(), operation="Gray-Scott configure"
+        )
+        build = f"cmake --build {shlex.quote(str(build_dir))} --parallel 4 --target gray-scott"
+        self._raise_for_exec_failure(
+            Exec(build, local_info).run(), operation="Gray-Scott build"
+        )
+        return str(build_dir / "bin" / "gray-scott"), str(run_dir)
+
+    def start(self) -> None:
+        """Build when requested and launch the selected Gray-Scott simulation."""
+        configured_bundle = self.config.get("input_bundle")
+        if configured_bundle not in (None, ""):
+            executable, cwd = self._prepare_bundle_run()
+        else:
+            executable = str(self.config.get("executable") or "")
+            cwd = str(Path(self.settings_json_path).parent)
         command = f"{shlex.quote(executable)} {shlex.quote(self.settings_json_path)}"
-        if self.config["engine"].lower() in [
-            "bp5_derived",
-            "hermes_derived",
-            "iowarp_derived",
-        ]:
-            derived = 1
-            self.process = Exec(
-                f"{command} {derived}",
-                MpiExecInfo(
-                    nprocs=self.config["nprocs"],
-                    ppn=self.config["ppn"],
-                    hostfile=self.hostfile,
-                    env=self.mod_env,
-                    exec_async=self.config["run_async"],
-                    line_callback=line_callback,
-                ),
-            )
-            result = self.process.run()
-            if not self.config["run_async"]:
-                self._raise_for_exec_failure(result, operation="ADIOS2 Gray-Scott")
-        elif self.config["engine"].lower() in ["hermes", "bp5", "iowarp", "sst"]:
-            derived = 0
-            self.process = Exec(
-                f"{command} {derived}",
-                MpiExecInfo(
-                    nprocs=self.config["nprocs"],
-                    ppn=self.config["ppn"],
-                    hostfile=self.hostfile,
-                    env=self.mod_env,
-                    exec_async=self.config["run_async"],
-                    line_callback=line_callback,
-                ),
-            )
-            result = self.process.run()
-            if not self.config["run_async"]:
-                self._raise_for_exec_failure(result, operation="ADIOS2 Gray-Scott")
+        derived = int(str(self.config["engine"]).lower().endswith("_derived"))
+        self.process = Exec(
+            f"{command} {derived}",
+            MpiExecInfo(
+                nprocs=self.config["nprocs"],
+                ppn=self.config["ppn"],
+                hostfile=self.hostfile,
+                env=self.mod_env,
+                cwd=cwd,
+                exec_async=self.config["run_async"],
+                line_callback=self.runtime_line_callback(),
+            ),
+        )
+        result = self.process.run()
+        if not self.config["run_async"]:
+            self._raise_for_exec_failure(result, operation="ADIOS2 Gray-Scott")
 
-    def wait(self):
-        """
-        Wait for async process to complete.
-
-        :return: None
-        """
+    def wait(self) -> None:
+        """Wait for an asynchronous producer and propagate its terminal status."""
         if self.process:
             self.process.wait_all()
             self._raise_for_exec_failure(
-                self.process,
-                operation="ADIOS2 Gray-Scott async producer",
+                self.process, operation="ADIOS2 Gray-Scott async producer"
             )
 
-    def stop(self):
-        """
-        Stop a running application. E.g., OrangeFS will terminate the servers,
-        clients, and metadata services.
-
-        :return: None
-        """
-        # If running async, wait for completion instead of killing
+    def stop(self) -> None:
+        """Wait for asynchronous work or terminate a still-owned process."""
         if self.config.get("run_async", False) and self.process:
-            print("Waiting for async gray-scott producer to complete...")
-            self.process.wait_all()
-            self._raise_for_exec_failure(
-                self.process,
-                operation="ADIOS2 Gray-Scott async producer",
-            )
+            self.wait()
         elif self.process:
             self.process.kill_all()
 
     @staticmethod
     def _raise_for_exec_failure(result: Any, *, operation: str) -> None:
-        """Raise when an execution has no status or any host exits nonzero."""
         exit_codes = getattr(result, "exit_code", None)
         if not isinstance(exit_codes, dict) or not exit_codes:
             raise RuntimeError(f"{operation} returned no process exit status")
@@ -398,18 +685,18 @@ class Adios2GrayScott(Application):
             )
             raise RuntimeError(f"{operation} failed with exit status: {details}")
 
-    def clean(self):
-        """
-        Destroy all data for an application. E.g., OrangeFS will delete all
-        metadata and data directories in addition to the orangefs.xml file.
-
-        :return: None
-        """
-        output_file = [
-            self.config["out_file"],
-            self.config["checkpoint_output"],
-            self.config["db_path"],
+    def clean(self) -> None:
+        """Remove configured simulation output and restart state."""
+        output_file: list[object] = [
+            self.config.get("out_file"),
+            self.config.get("checkpoint_output"),
+            self.config.get("db_path"),
         ]
-
-        print(f"Removing {output_file}")
-        Rm(output_file, PsshExecInfo(hostfile=self.hostfile)).run()
+        Rm(
+            [
+                os.fspath(value)
+                for value in output_file
+                if isinstance(value, (str, os.PathLike)) and os.fspath(value)
+            ],
+            PsshExecInfo(hostfile=self.hostfile),
+        ).run()

--- a/builtin/builtin/adios2_gray_scott/pkg.py
+++ b/builtin/builtin/adios2_gray_scott/pkg.py
@@ -269,7 +269,12 @@ class Adios2GrayScott(Application):
                 "default": 10,
             },
             {"name": "noise", "msg": "Initial noise", "type": float, "default": 0.01},
-            {"name": "out_file", "msg": "Output dataset", "type": str, "default": None},
+            {
+                "name": "out_file",
+                "msg": "Optional output dataset; empty uses execution-owned storage",
+                "type": str,
+                "default": "",
+            },
             {
                 "name": "checkpoint",
                 "msg": "Write checkpoints",
@@ -497,7 +502,7 @@ class Adios2GrayScott(Application):
 
     def _configure_generated_settings(self) -> None:
         config = cast(dict[str, Any], self.config)
-        if config["out_file"] is None:
+        if not config["out_file"]:
             config["out_file"] = str(
                 self.resolve_shared_path(
                     "gray-scott-output/data/out.bp", field="out_file"

--- a/builtin/builtin/adios2_pdf_calc/README.md
+++ b/builtin/builtin/adios2_pdf_calc/README.md
@@ -17,12 +17,36 @@ PDF Calc reads ADIOS2 data produced by the Gray-Scott simulation and computes st
 |-----------|------|---------|-------------|
 | `nprocs` | int | 2 | Number of MPI processes |
 | `ppn` | int | 16 | Processes per node |
+| `executable` | str | `pdf_calc` | Installed executable resolved through `PATH` |
+| `input_bundle` | str | empty | Optional digest-verified source bundle |
 | `input_file` | str | *Required* | Input file from Gray-Scott simulation |
 | `output_file` | str | *Required* | Output file for PDF analysis results |
 | `nbins` | int | 1000 | Number of bins for PDF calculation |
 | `output_inputdata` | str | NO | Write original variables (YES/NO) |
 
 ## Usage
+
+### Digest-verified source build
+
+When `pdf_calc` is not installed, `input_bundle` may point to a regular tar
+archive using `jarvis.package-input-bundle.v1`. Its manifest must declare
+exactly one `build_spec` and one `adios2_configuration`. JARVIS verifies the
+complete archive before submission, then builds the `pdf_calc` target in an
+execution-owned workspace using CMake, MPI compilers, and the active ADIOS2
+development environment.
+
+```bash
+jarvis ppl append adios2_pdf_calc \
+  input_bundle=/staged/gray-scott-source.tar \
+  input_file=/shared/gray-scott/feed-low.bp \
+  output_file=feed-low-pdf.bp \
+  nbins=128 nprocs=1 ppn=1
+```
+
+Relative output paths are scoped to the PDF Calc package shared directory.
+Absolute input paths allow explicit consumption of a prior pipeline product.
+There is no implicit developer checkout, and a nonzero `pdf_calc` exit fails
+the package lifecycle.
 
 ### Standalone Usage
 

--- a/builtin/builtin/adios2_pdf_calc/artifacts.py
+++ b/builtin/builtin/adios2_pdf_calc/artifacts.py
@@ -1,0 +1,133 @@
+"""Artifact semantics owned by the builtin ADIOS2 PDF Calc package."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+from jarvis_cd.progress import LineBuffer
+
+_WRITER_RE = re.compile(
+    r"^PDF analysis writes using engine type:\s*(?P<engine>[A-Za-z0-9_+-]+)\s*$"
+)
+
+
+@dataclass
+class Adios2PdfCalcArtifactAdapter:
+    """Track the configured PDF analysis dataset through process completion."""
+
+    output_path: PurePosixPath
+    engine: str
+    bins: int
+    artifact_id: str = field(default_factory=new_artifact_id)
+    _lines: LineBuffer = field(default_factory=LineBuffer)
+    _announced: bool = False
+    _terminal: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Announce output only after native PDF Calc writer initialization."""
+        observations: list[ArtifactObservation] = []
+        for line in self._lines.feed(text, finalize=False):
+            match = _WRITER_RE.fullmatch(line.strip())
+            if match is None or self._terminal or self._announced:
+                continue
+            if match.group("engine").casefold() != self.engine.casefold():
+                raise ValueError(
+                    "PDF Calc reported an engine that differs from configuration"
+                )
+            self._announced = True
+            observations.append(self._observation(ArtifactState.PRODUCING))
+        return observations
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Finalize a successful stream for callers without process status."""
+        return self.finalize_artifacts_for_exit(0)
+
+    def finalize_artifacts_for_exit(
+        self,
+        return_code: int,
+    ) -> list[ArtifactObservation]:
+        """Finalize or mark incomplete from authoritative process status."""
+        if self._terminal:
+            return []
+        self._lines.feed("", finalize=True)
+        self._terminal = True
+        state = (
+            ArtifactState.FINALIZED if return_code == 0 else ArtifactState.INCOMPLETE
+        )
+        return [self._observation(state, return_code=return_code)]
+
+    def reset_artifacts(self) -> None:
+        """Reset parsing for a fresh PDF Calc execution."""
+        self._lines.reset()
+        self._announced = False
+        self._terminal = False
+
+    def _observation(
+        self,
+        state: ArtifactState,
+        *,
+        return_code: int | None = None,
+    ) -> ArtifactObservation:
+        metadata: dict[str, str | int] = {
+            "application": "gray_scott",
+            "analysis": "probability_density",
+            "engine": self.engine,
+            "bins": self.bins,
+        }
+        if return_code is not None:
+            metadata["return_code"] = return_code
+        if state is ArtifactState.FINALIZED:
+            message = "Gray-Scott PDF analysis finalized"
+        elif state is ArtifactState.INCOMPLETE:
+            message = "Gray-Scott PDF analysis is incomplete after process failure"
+        else:
+            message = "Gray-Scott PDF analysis is being produced"
+        return ArtifactObservation(
+            artifact_id=self.artifact_id,
+            logical_name="gray-scott-pdf-analysis",
+            kind="analysis_dataset",
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(self.output_path),
+            media_type="application/x-adios2-bp",
+            format=f"adios2-{self.engine.casefold()}-pdf",
+            message=message,
+            metadata=metadata,
+        )
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> Adios2PdfCalcArtifactAdapter | None:
+    """Create artifact semantics only for builtin ADIOS2 PDF Calc."""
+    if package.get("pkg_type") != "builtin.adios2_pdf_calc":
+        return None
+    output_path = _absolute_posix_path(package.get("output_file"))
+    bins = package.get("nbins", 1000)
+    if isinstance(bins, bool) or not isinstance(bins, int) or bins <= 0:
+        raise ValueError("PDF Calc artifact bins must be a positive integer")
+    engine = str(package.get("engine") or "bp5").casefold()
+    return Adios2PdfCalcArtifactAdapter(output_path, engine, bins)
+
+
+def _absolute_posix_path(value: object) -> PurePosixPath:
+    if not isinstance(value, str) or not value:
+        raise ValueError("PDF Calc artifact output must be an absolute path")
+    path = PurePosixPath(value)
+    if not path.is_absolute() or path.as_posix() != value or ".." in path.parts:
+        raise ValueError("PDF Calc artifact output must be a normalized absolute path")
+    return path

--- a/builtin/builtin/adios2_pdf_calc/pkg.py
+++ b/builtin/builtin/adios2_pdf_calc/pkg.py
@@ -1,210 +1,384 @@
-"""
-This module provides classes and methods to launch the PDF Calc application.
-PDF Calc analyzes Gray-Scott simulation output and computes the probability
-distribution function (PDF) for each 2D slice of the U and V variables.
-"""
-from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
-from jarvis_cd.shell.process import Rm
+"""Run ADIOS2 PDF Calc against a Gray-Scott scientific dataset."""
+
+from __future__ import annotations
+
 import os
+import shlex
+import shutil
+import time
+from pathlib import Path, PurePosixPath
+from typing import Any, cast
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
+from jarvis_cd.shell.process import Rm
+
+
+def _combined_probe_status(*statuses: RuntimeStatus) -> RuntimeStatus:
+    if statuses and all(status.usable is True for status in statuses):
+        return RuntimeStatus("ready", "runtime_probe_succeeded")
+    if any(status.usable is False for status in statuses):
+        return RuntimeStatus("unavailable", "software_not_found")
+    return RuntimeStatus("unknown", "runtime_probe_inconclusive")
+
+
+def _bundle_member_for_role(
+    bundle: MaterializedInputBundle,
+    role: str,
+) -> Path:
+    members = [item.path for item in bundle.manifest.files if item.role == role]
+    if len(members) != 1:
+        raise ValueError(f"PDF Calc input bundle requires exactly one {role}")
+    return bundle.root / PurePosixPath(members[0])
+
+
+def validate_pdf_source_bundle(bundle: MaterializedInputBundle) -> None:
+    """Require the source build and ADIOS2 configuration used by PDF Calc."""
+    _bundle_member_for_role(bundle, "build_spec")
+    _bundle_member_for_role(bundle, "adios2_configuration")
 
 
 class Adios2PdfCalc(Application):
-    """
-    This class provides methods to launch the PDF Calc application.
-    """
-    def _init(self):
-        """
-        Initialize paths
-        """
-        self.adios2_xml_path = f'{self.shared_dir}/adios2.xml'
-        self.adios2_xml_runtime = f'{self.private_dir}/adios2.xml'  # Copy to private dir for execution
+    """Calculate per-slice PDFs using an installed or bundle-built executable."""
 
-        # Ensure PATH is available for MPI detection
-        # This runs every time the package is loaded (including at start time)
-        import os
-        if 'PATH' not in self.env:
-            system_path = os.environ.get('PATH', '')
-            if system_path:
-                self.env['PATH'] = system_path
-                self.mod_env['PATH'] = system_path
+    def _init(self) -> None:
+        self.adios2_xml_path = f"{self.shared_dir}/adios2.xml"
 
-    def _configure_menu(self):
-        """
-        Create a CLI menu for the configurator method.
-        For thorough documentation of these parameters, view:
-        https://github.com/scs-lab/jarvis-util/wiki/3.-Argument-Parsing
-
-        :return: List(dict)
-        """
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
+            {"name": "nprocs", "msg": "Number of processes", "type": int, "default": 2},
+            {"name": "ppn", "msg": "Processes per node", "type": int, "default": 16},
             {
-                'name': 'nprocs',
-                'msg': 'Number of processes to spawn',
-                'type': int,
-                'default': 2,
+                "name": "executable",
+                "msg": "Installed pdf_calc executable available through PATH",
+                "type": str,
+                "default": "pdf_calc",
             },
             {
-                'name': 'ppn',
-                'msg': 'Processes per node',
-                'type': int,
-                'default': 16,
+                "name": "input_bundle",
+                "msg": (
+                    "Optional digest-verified PDF Calc source bundle declaring "
+                    "one build_spec and one adios2_configuration"
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                'name': 'input_file',
-                'msg': 'Input file from Gray-Scott simulation',
-                'type': str,
-                'default': None,
+                "name": "input_file",
+                "msg": "Gray-Scott input dataset",
+                "type": str,
+                "default": None,
             },
             {
-                'name': 'output_file',
-                'msg': 'Output file for PDF analysis results',
-                'type': str,
-                'default': None,
+                "name": "output_file",
+                "msg": "PDF output dataset",
+                "type": str,
+                "default": None,
             },
             {
-                'name': 'nbins',
-                'msg': 'Number of bins for PDF calculation',
-                'type': int,
-                'default': 1000,
+                "name": "nbins",
+                "msg": "Number of PDF bins",
+                "type": int,
+                "default": 1000,
             },
             {
-                'name': 'output_inputdata',
-                'msg': 'Write original variables in output (YES/NO)',
-                'type': str,
-                'default': 'NO',
+                "name": "output_inputdata",
+                "msg": "Copy original variables (YES/NO)",
+                "type": str,
+                "default": "NO",
             },
             {
-                'name': 'wait_for_producer',
-                'msg': 'Wait for producer to complete before starting',
-                'type': bool,
-                'default': True,
+                "name": "wait_for_producer",
+                "msg": "Wait for the input dataset",
+                "type": bool,
+                "default": True,
             },
             {
-                'name': 'engine',
-                'msg': 'ADIOS2 engine to use for reading',
-                'choices': ['bp5', 'sst'],
-                'type': str,
-                'default': 'bp5',
+                "name": "engine",
+                "msg": "ADIOS2 engine",
+                "choices": ["bp5", "sst"],
+                "type": str,
+                "default": "bp5",
             },
         ]
 
-    def _configure(self, **kwargs):
-        """
-        Converts the Jarvis configuration to application-specific configuration.
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        environment = self._deployment_environment()
+        installed_probe = probe_program(
+            "pdf_calc", environment=environment, arguments=("--help",)
+        )
+        cmake_probe = probe_program(
+            "cmake", environment=environment, arguments=("--version",)
+        )
+        adios_probe = probe_program(
+            "adios2-config", environment=environment, arguments=("--version",)
+        )
+        mpi_c_probe = probe_program(
+            "mpicc", environment=environment, arguments=("--version",)
+        )
+        mpi_cxx_probe = probe_program(
+            "mpic++", environment=environment, arguments=("--version",)
+        )
+        source_status = _combined_probe_status(
+            cmake_probe.status,
+            adios_probe.status,
+            mpi_c_probe.status,
+            mpi_cxx_probe.status,
+        )
+        installed_capabilities = (
+            ("mpi_execution", "probability_density")
+            if installed_probe.status.usable is True
+            else ()
+        )
+        source_capabilities = (
+            ("mpi_execution", "probability_density", "source_build")
+            if source_status.usable is True
+            else ()
+        )
+        completed = ReadinessContract("process_exit", "successful_exit")
+        return PackageDeploymentContract(
+            package="builtin.adios2_pdf_calc",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="installed_executable",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    runtime_requirements=("pdf_calc_installed",),
+                    readiness=completed,
+                ),
+                ExecutionProfile(
+                    name="source_bundle",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    runtime_requirements=("pdf_calc_source_build",),
+                    readiness=completed,
+                    description=(
+                        "Build verified PDF Calc source in an execution-owned "
+                        "workspace before analyzing the configured input dataset."
+                    ),
+                ),
+            ),
+            runtime_requirements=(
+                RuntimeRequirement(
+                    requirement_id="pdf_calc_installed",
+                    description="Installed MPI ADIOS2 PDF Calc executable",
+                    required_capabilities=("mpi_execution", "probability_density"),
+                    available_capabilities=installed_capabilities,
+                    status=installed_probe.status,
+                ),
+                RuntimeRequirement(
+                    requirement_id="pdf_calc_source_build",
+                    description="CMake and MPI-enabled ADIOS2 development runtime",
+                    required_capabilities=(
+                        "mpi_execution",
+                        "probability_density",
+                        "source_build",
+                    ),
+                    available_capabilities=source_capabilities,
+                    status=source_status,
+                    provider_resolutions=(
+                        ProviderResolution("spack", "spec", "adios2+mpi"),
+                        ProviderResolution("spack", "spec", "cmake"),
+                        ProviderResolution("spack", "spec", "openmpi"),
+                    ),
+                ),
+            ),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_file", "is_empty"),),
+                    requires=(ConfigurationCondition("input_file", "is_not_empty"),),
+                    description="PDF Calc requires one input dataset.",
+                ),
+                ConfigurationRule(
+                    when=(ConfigurationCondition("output_file", "is_empty"),),
+                    requires=(ConfigurationCondition("output_file", "is_not_empty"),),
+                    description="PDF Calc requires one output dataset.",
+                ),
+            ),
+        )
 
-        :param kwargs: Configuration parameters for this pkg.
-        :return: None
-        """
-        # Ensure pdf_calc binary location is in PATH
-        # This is needed for MPI execution to find the binary
-        import os
-        pdf_calc_bin_dir = '/workspace/external/iowarp-gray-scott/build/bin'
-        if os.path.exists(pdf_calc_bin_dir):
-            # If PATH doesn't exist in our env, initialize it from system PATH
-            if 'PATH' not in self.env:
-                system_path = os.environ.get('PATH', '')
-                if system_path:
-                    self.env['PATH'] = system_path
-                    self.mod_env['PATH'] = system_path
-            # Now prepend our bin directory
-            self.prepend_env('PATH', pdf_calc_bin_dir)
+    def _configure(self, **kwargs: Any) -> None:
+        super()._configure(**kwargs)
+        self._validate_configuration()
+        config = cast(dict[str, Any], self.config)
+        configured_bundle = config.get("input_bundle")
+        if configured_bundle not in (None, ""):
+            if not isinstance(configured_bundle, str):
+                raise TypeError("input_bundle must be a path string")
+            bundle = extract_input_bundle(
+                configured_bundle, self._shared_root() / "input-bundles"
+            )
+            validate_pdf_source_bundle(bundle)
+            return
+        template = (
+            "sst.xml" if str(self.config["engine"]).lower() == "sst" else "adios2.xml"
+        )
+        self.copy_template_file(
+            f"{self.pkg_dir}/config/{template}", self.adios2_xml_path
+        )
 
-        # Validate required parameters
-        if self.config['input_file'] is None:
-            raise ValueError('input_file parameter is required for pdf_calc')
-        if self.config['output_file'] is None:
-            raise ValueError('output_file parameter is required for pdf_calc')
+    def _shared_root(self) -> Path:
+        shared_dir = self.shared_dir
+        if not isinstance(shared_dir, (str, os.PathLike)) or not os.fspath(shared_dir):
+            raise RuntimeError("PDF Calc requires a JARVIS package shared directory")
+        return Path(shared_dir)
 
-        # Copy ADIOS2 XML configuration based on engine type
-        print(f"Using engine {self.config['engine']} for pdf_calc")
-        if self.config['engine'].lower() == 'sst':
-            # Use SST configuration for streaming
-            self.copy_template_file(f'{self.pkg_dir}/config/sst.xml',
-                                self.adios2_xml_path)
+    def _validate_configuration(self) -> None:
+        for name in ("nprocs", "ppn", "nbins"):
+            value = self.config.get(name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        for name in ("input_file", "output_file"):
+            value = self.config.get(name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{name} parameter is required for PDF Calc")
+        executable = self.config.get("executable")
+        if not isinstance(executable, str) or not executable.strip():
+            raise ValueError("PDF Calc executable must be a non-empty string")
+        output_inputdata = str(self.config.get("output_inputdata", "NO")).upper()
+        if output_inputdata not in {"YES", "NO"}:
+            raise ValueError("output_inputdata must be YES or NO")
+
+    def _prepare_bundle_run(self) -> tuple[str, Path, Path]:
+        configured = self.config.get("input_bundle")
+        if not isinstance(configured, str) or not configured:
+            raise RuntimeError("PDF Calc input bundle was not persisted")
+        bundle = extract_input_bundle(configured, self._shared_root() / "input-bundles")
+        validate_pdf_source_bundle(bundle)
+        build_spec = _bundle_member_for_role(bundle, "build_spec")
+        adios_config = _bundle_member_for_role(bundle, "adios2_configuration")
+        run_dir = self.resolve_shared_path("run", field="input_bundle workspace")
+        stage_input_bundle(bundle, run_dir)
+        staged_build_spec = run_dir / build_spec.relative_to(bundle.root)
+        staged_adios_config = run_dir / adios_config.relative_to(bundle.root)
+        runtime_adios = run_dir / "adios2.xml"
+        if staged_adios_config != runtime_adios:
+            shutil.copyfile(staged_adios_config, runtime_adios)
+        build_dir = run_dir / "build"
+        local_info = LocalExecInfo(env=self.mod_env, cwd=str(run_dir), timeout=900)
+        configure = " ".join(
+            (
+                "cmake",
+                "-S",
+                shlex.quote(str(staged_build_spec.parent)),
+                "-B",
+                shlex.quote(str(build_dir)),
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_C_COMPILER=mpicc",
+                "-DCMAKE_CXX_COMPILER=mpic++",
+            )
+        )
+        self._raise_for_exec_failure(
+            Exec(configure, local_info).run(), operation="PDF Calc configure"
+        )
+        build = f"cmake --build {shlex.quote(str(build_dir))} --parallel 4 --target pdf_calc"
+        self._raise_for_exec_failure(
+            Exec(build, local_info).run(), operation="PDF Calc build"
+        )
+        return str(build_dir / "bin" / "pdf_calc"), run_dir, runtime_adios
+
+    def start(self) -> None:
+        """Run PDF Calc and propagate its authoritative process status."""
+        self._validate_configuration()
+        config = cast(dict[str, Any], self.config)
+        configured_bundle = config.get("input_bundle")
+        if configured_bundle not in (None, ""):
+            executable, working_dir, runtime_adios = self._prepare_bundle_run()
         else:
-            # Use BP5 configuration (default)
-            self.copy_template_file(f'{self.pkg_dir}/config/adios2.xml',
-                                self.adios2_xml_path)
+            executable = str(config["executable"])
+            input_path = Path(os.path.expandvars(str(config["input_file"]))).resolve()
+            working_dir = input_path.parent
+            runtime_adios = working_dir / "adios2.xml"
+            shutil.copyfile(self.adios2_xml_path, runtime_adios)
+        input_file = Path(os.path.expandvars(str(config["input_file"]))).resolve()
+        output_value = str(config["output_file"])
+        output_file = (
+            Path(os.path.expandvars(output_value)).resolve()
+            if Path(output_value).is_absolute()
+            else self.resolve_shared_path(output_value, field="output_file")
+        )
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        config["input_file"] = str(input_file)
+        config["output_file"] = str(output_file)
+        if self.config.get("wait_for_producer", True):
+            self._wait_for_input(input_file)
+        command = " ".join(
+            (
+                shlex.quote(executable),
+                shlex.quote(str(input_file)),
+                shlex.quote(str(output_file)),
+                str(self.config["nbins"]),
+            )
+        )
+        if str(self.config["output_inputdata"]).upper() == "YES":
+            command += " YES"
+        result = Exec(
+            command,
+            MpiExecInfo(
+                nprocs=self.config["nprocs"],
+                ppn=self.config["ppn"],
+                hostfile=self.hostfile,
+                env=self.mod_env,
+                cwd=str(working_dir),
+                line_callback=self.runtime_line_callback(),
+            ),
+        ).run()
+        self._raise_for_exec_failure(result, operation="PDF Calc")
+        if not runtime_adios.is_file() and configured_bundle not in (None, ""):
+            raise RuntimeError("PDF Calc ADIOS2 configuration was not materialized")
 
-    def start(self):
-        """
-        Launch the PDF Calc application.
+    def _wait_for_input(self, input_file: Path) -> None:
+        if str(self.config["engine"]).lower() == "sst":
+            time.sleep(10)
+            return
+        for _ in range(60):
+            if input_file.exists():
+                time.sleep(5)
+                return
+            time.sleep(1)
+        raise TimeoutError("PDF Calc input dataset was not available after 60 seconds")
 
-        :return: None
-        """
-        import shutil
-        import time
+    @staticmethod
+    def _raise_for_exec_failure(result: Any, *, operation: str) -> None:
+        exit_codes = getattr(result, "exit_code", None)
+        if not isinstance(exit_codes, dict) or not exit_codes:
+            raise RuntimeError(f"{operation} returned no process exit status")
+        failures = {
+            str(host): code
+            for host, code in exit_codes.items()
+            if isinstance(code, bool) or not isinstance(code, int) or code != 0
+        }
+        if failures:
+            details = ", ".join(
+                f"{host}={code!r}" for host, code in sorted(failures.items())
+            )
+            raise RuntimeError(f"{operation} failed with exit status: {details}")
 
-        # Copy ADIOS2 XML to working directory where pdf_calc will look for it
-        working_dir = os.path.dirname(self.config['input_file'])
-        runtime_xml = os.path.join(working_dir, 'adios2.xml')
-        shutil.copy(self.adios2_xml_path, runtime_xml)
-        print(f"Copied ADIOS2 config to {runtime_xml}")
+    def stop(self) -> None:
+        """PDF Calc is a bounded batch application with no persistent process."""
 
-        # If wait_for_producer is enabled, handle differently for SST vs BP5
-        if self.config.get('wait_for_producer', True):
-            if self.config['engine'].lower() == 'sst':
-                # For SST, just wait a fixed time for producer to start streaming
-                print("Waiting 10 seconds for SST producer to initialize...")
-                time.sleep(10)
-            else:
-                # For BP5, wait for file to exist
-                print("Waiting for producer to create output file...")
-                wait_time = 0
-                max_wait = 60
-                while wait_time < max_wait:
-                    if os.path.exists(self.config['input_file']):
-                        print(f"Output file found after {wait_time} seconds")
-                        # Give a bit more time for the first timestep to be written
-                        time.sleep(5)
-                        break
-                    time.sleep(1)
-                    wait_time += 1
-
-                if wait_time >= max_wait:
-                    print(f"Warning: Output file not found after {max_wait} seconds, attempting to open anyway...")
-
-        # Build the pdf_calc command with full path
-        pdf_calc_bin = os.path.join(working_dir, 'build/bin/pdf_calc')
-        pdf_cmd = (f'{pdf_calc_bin} {self.config["input_file"]} '
-                  f'{self.config["output_file"]} '
-                  f'{self.config["nbins"]}')
-
-        # Add optional output_inputdata parameter if set to YES
-        output_inputdata = str(self.config['output_inputdata']).upper()
-        if output_inputdata == 'YES':
-            pdf_cmd += f' {output_inputdata}'
-
-        # Change to working directory before executing
-        import os as os_module
-        original_cwd = os_module.getcwd()
-        os_module.chdir(working_dir)
-
-        # Execute pdf_calc with MPI
-        Exec(pdf_cmd,
-             MpiExecInfo(nprocs=self.config['nprocs'],
-                         ppn=self.config['ppn'],
-                         hostfile=self.hostfile,
-                         env=self.mod_env)).run()
-
-        # Restore original directory
-        os_module.chdir(original_cwd)
-
-    def stop(self):
-        """
-        Stop a running application.
-
-        :return: None
-        """
-        pass
-
-    def clean(self):
-        """
-        Destroy all data for the PDF Calc application.
-
-        :return: None
-        """
-        if self.config['output_file']:
-            print(f'Removing {self.config["output_file"]}')
-            Rm(self.config['output_file'], PsshExecInfo(hostfile=self.hostfile)).run()
+    def clean(self) -> None:
+        """Remove the configured PDF output dataset."""
+        output = self.config.get("output_file")
+        if output:
+            Rm(str(output), PsshExecInfo(hostfile=self.hostfile)).run()

--- a/test/unit/core/test_adios2_gray_scott_inputs.py
+++ b/test/unit/core/test_adios2_gray_scott_inputs.py
@@ -171,6 +171,7 @@ def test_gray_scott_menu_and_deployment_expose_portable_bundle_profile(
         "structure": "regular_file",
     }
     assert menu["configuration_path"]["default"] == ""
+    assert menu["out_file"]["default"] == ""
     assert document is not None
     assert {profile["name"] for profile in document["execution_profiles"]} == {
         "installed_executable",

--- a/test/unit/core/test_adios2_gray_scott_inputs.py
+++ b/test/unit/core/test_adios2_gray_scott_inputs.py
@@ -1,0 +1,280 @@
+"""Tests for portable ADIOS2 Gray-Scott source and configuration bundles."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+    extract_input_bundle,
+)
+
+
+def _package_module(package: str) -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3] / "builtin" / "builtin" / package / "pkg.py"
+    )
+    spec = spec_from_file_location(f"test_{package}_input_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load package: {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _configuration(*, output: str = "fields.bp") -> bytes:
+    return json.dumps(
+        {
+            "Du": 0.2,
+            "Dv": 0.1,
+            "F": 0.02,
+            "L": 64,
+            "adios_config": "adios2.xml",
+            "adios_memory_selection": False,
+            "adios_span": False,
+            "checkpoint": False,
+            "checkpoint_freq": 100,
+            "checkpoint_output": "checkpoint.bp",
+            "dt": 2.0,
+            "k": 0.048,
+            "mesh_type": "image",
+            "noise": 0.0,
+            "output": output,
+            "plotgap": 10,
+            "restart": False,
+            "restart_input": "checkpoint.bp",
+            "steps": 100,
+        },
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _write_bundle(
+    destination: Path,
+    *,
+    output: str = "fields.bp",
+    selected_role: str = "scientific_input",
+) -> Path:
+    files = {
+        "CMakeLists.txt": ("build_spec", b"project(gray_scott)\n"),
+        "adios2.xml": ("adios2_configuration", b"<adios-config/>\n"),
+        "config/high.json": (selected_role, _configuration(output=output)),
+        "config/low.json": ("scientific_input", _configuration()),
+        "src/main.cpp": ("upstream_source", b"int main() { return 0; }\n"),
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "config/low.json",
+        "files": [
+            {
+                "path": name,
+                "role": role,
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, (role, payload) in sorted(files.items())
+        ],
+    }
+    manifest_payload = json.dumps(manifest, sort_keys=True).encode("utf-8")
+    with tarfile.open(destination, mode="w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(manifest_payload)
+        archive.addfile(info, io.BytesIO(manifest_payload))
+        for name, (_role, payload) in sorted(files.items()):
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def test_gray_scott_selects_only_manifest_declared_scientific_configuration(
+    tmp_path: Path,
+) -> None:
+    """A selected regime is a verified bundle member, never a free path."""
+    module = _package_module("adios2_gray_scott")
+    archive = _write_bundle(tmp_path / "gray-scott.tar")
+    bundle = extract_input_bundle(archive, tmp_path / "materialized")
+
+    selected = module.resolve_bundle_configuration(bundle, "config/high.json")
+
+    assert selected.path == bundle.root / "config" / "high.json"
+    assert selected.values["F"] == 0.02
+    assert selected.values["output"] == "fields.bp"
+    assert selected.build_spec == bundle.root / "CMakeLists.txt"
+    assert selected.adios_config == bundle.root / "adios2.xml"
+
+    with pytest.raises(ValueError, match="declared scientific_input"):
+        module.resolve_bundle_configuration(bundle, "CMakeLists.txt")
+    with pytest.raises(ValueError, match="declared scientific_input"):
+        module.resolve_bundle_configuration(bundle, "../outside.json")
+
+
+@pytest.mark.parametrize(
+    ("output", "selected_role", "message"),
+    [
+        ("/tmp/foreign.bp", "scientific_input", "relative bundle path"),
+        ("fields.bp", "upstream_source", "declared scientific_input"),
+    ],
+)
+def test_gray_scott_rejects_unsafe_or_mistyped_configuration_bundle(
+    tmp_path: Path,
+    output: str,
+    selected_role: str,
+    message: str,
+) -> None:
+    """Bundle data cannot redirect output or masquerade as scientific input."""
+    module = _package_module("adios2_gray_scott")
+    archive = _write_bundle(
+        tmp_path / "gray-scott.tar",
+        output=output,
+        selected_role=selected_role,
+    )
+    bundle = extract_input_bundle(archive, tmp_path / "materialized")
+
+    with pytest.raises(ValueError, match=message):
+        module.resolve_bundle_configuration(bundle, "config/high.json")
+
+
+def test_gray_scott_menu_and_deployment_expose_portable_bundle_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agents see one staged bundle and a confined member selector."""
+    module = _package_module("adios2_gray_scott")
+    package = object.__new__(module.Adios2GrayScott)
+    package.config = {"input_bundle": "/inputs/gray-scott.tar"}
+    package.env = {}
+    package.mod_env = {}
+    monkeypatch.setattr(
+        module,
+        "probe_program",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            status=module.RuntimeStatus("ready", "runtime_probe_succeeded")
+        ),
+    )
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    document = package.describe_deployment()
+
+    assert menu["input_bundle"]["input_binding"] == {
+        "schema_version": "jarvis.configuration-input-binding.v1",
+        "kind": "local_file",
+        "structure": "regular_file",
+    }
+    assert menu["configuration_path"]["default"] == ""
+    assert document is not None
+    assert {profile["name"] for profile in document["execution_profiles"]} == {
+        "installed_executable",
+        "source_bundle",
+    }
+    bundle_profile = next(
+        profile
+        for profile in document["execution_profiles"]
+        if profile["name"] == "source_bundle"
+    )
+    assert bundle_profile["runtime_requirements"] == ["gray_scott_source_build"]
+
+
+class _FailedExec:
+    def __init__(self, _command: str, _exec_info: Any) -> None:
+        self.exit_code = {"ares": 9}
+
+    def run(self) -> "_FailedExec":
+        return self
+
+
+class _SuccessfulExec:
+    calls: list[tuple[str, Any]] = []
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.calls.append((command, exec_info))
+        self.exit_code = {"ares": 0}
+
+    def run(self) -> "_SuccessfulExec":
+        return self
+
+
+def test_gray_scott_bundle_materializes_one_execution_owned_run(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Build and scientific paths derive only from the verified staged tree."""
+    module = _package_module("adios2_gray_scott")
+    archive = _write_bundle(tmp_path / "gray-scott.tar")
+    shared = tmp_path / "shared"
+    package = object.__new__(module.Adios2GrayScott)
+    package.shared_dir = str(shared)
+    package.mod_env = {}
+    package.config = {
+        "input_bundle": str(archive),
+        "configuration_path": "config/high.json",
+    }
+    _SuccessfulExec.calls = []
+    monkeypatch.setattr(module, "Exec", _SuccessfulExec)
+
+    executable, cwd = package._prepare_bundle_run()
+
+    run = shared / "run"
+    assert executable == str(run / "build" / "bin" / "gray-scott")
+    assert cwd == str(run.resolve())
+    assert [call[0] for call in _SuccessfulExec.calls] == [
+        (
+            f"cmake -S {module.shlex.quote(str(run.resolve()))} "
+            f"-B {module.shlex.quote(str(run.resolve() / 'build'))} "
+            "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=mpicc "
+            "-DCMAKE_CXX_COMPILER=mpic++"
+        ),
+        (
+            "cmake --build "
+            f"{module.shlex.quote(str(run.resolve() / 'build'))} "
+            "--parallel 4 --target gray-scott"
+        ),
+    ]
+    settings = json.loads((run / "config" / "high.json").read_text(encoding="utf-8"))
+    assert settings["F"] == 0.02
+    assert settings["output"] == str(run.resolve() / "fields.bp")
+    assert settings["adios_config"] == str(run.resolve() / "adios2.xml")
+    assert package.config["out_file"] == str(run.resolve() / "fields.bp")
+
+
+def test_pdf_calc_uses_explicit_executable_and_propagates_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """PDF Calc has no developer checkout path and cannot hide a failed run."""
+    module = _package_module("adios2_pdf_calc")
+    package = object.__new__(module.Adios2PdfCalc)
+    package.config = {
+        "engine": "bp5",
+        "executable": "pdf_calc",
+        "input_file": str(tmp_path / "fields.bp"),
+        "output_file": str(tmp_path / "pdf.bp"),
+        "nbins": 128,
+        "nprocs": 1,
+        "ppn": 1,
+        "output_inputdata": "NO",
+        "wait_for_producer": False,
+    }
+    package.adios2_xml_path = str(tmp_path / "adios2.xml")
+    package.shared_dir = str(tmp_path)
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: object())
+    package.mod_env = {}
+    package.runtime_line_callback = lambda: None
+    monkeypatch.setattr(module.shutil, "copyfile", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "Exec", _FailedExec)
+
+    with pytest.raises(RuntimeError, match="PDF Calc.*ares=9"):
+        package.start()
+
+    assert module.__file__ is not None
+    source = Path(module.__file__).read_text(encoding="utf-8")
+    assert "/workspace/external" not in source

--- a/test/unit/core/test_adios2_pdf_calc_artifacts.py
+++ b/test/unit/core/test_adios2_pdf_calc_artifacts.py
@@ -1,0 +1,98 @@
+"""Tests for builtin ADIOS2 PDF Calc artifact semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+from jarvis_cd.artifacts import (
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "adios2_pdf_calc"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def test_pdf_calc_finalizes_one_typed_analysis_dataset() -> None:
+    """Successful process exit promotes the declared BP output to finalized."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_pdf_calc",
+            "output_file": "/scratch/run/feed-low-pdf.bp",
+            "engine": "bp5",
+            "nbins": 128,
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts(
+        "PDF analysis writes using engine type: BP5\n"
+    )
+    observations += adapter.finalize_artifacts_for_exit(0)
+
+    assert [item.state for item in observations] == [
+        ArtifactState.PRODUCING,
+        ArtifactState.FINALIZED,
+    ]
+    final = observations[-1]
+    assert final.logical_name == "gray-scott-pdf-analysis"
+    assert final.role is ArtifactRole.OUTPUT
+    assert final.structure is ArtifactStructure.COLLECTION
+    assert final.ownership is ArtifactOwnership.SHARED
+    assert final.location is not None
+    assert final.location.value == "/scratch/run/feed-low-pdf.bp"
+    assert final.media_type == "application/x-adios2-bp"
+    assert final.format == "adios2-bp5-pdf"
+    assert final.metadata["bins"] == 128
+
+
+def test_pdf_calc_nonzero_exit_is_incomplete_and_idempotent() -> None:
+    """A process failure cannot leave a finalized analysis claim."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_pdf_calc",
+            "output_file": "/scratch/run/pdf.bp",
+            "engine": "bp5",
+            "nbins": 64,
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.finalize_artifacts_for_exit(7)
+
+    assert len(observations) == 1
+    assert observations[0].state is ArtifactState.INCOMPLETE
+    assert observations[0].metadata["return_code"] == 7
+    assert adapter.finalize_artifacts_for_exit(7) == []
+
+
+def test_pdf_calc_factory_is_package_local_and_requires_absolute_output() -> None:
+    """Artifact authority is exact and cannot be inferred from a relative path."""
+    module = _module()
+
+    assert (
+        module.adapter_from_package({"pkg_type": "builtin.adios2_gray_scott"}) is None
+    )
+    try:
+        module.adapter_from_package(
+            {
+                "pkg_type": "builtin.adios2_pdf_calc",
+                "output_file": "relative.bp",
+            }
+        )
+    except ValueError as exc:
+        assert "absolute" in str(exc)
+    else:
+        raise AssertionError("relative PDF Calc output was accepted")


### PR DESCRIPTION
## Summary
- add digest-verified source and scientific-configuration bundles to builtin ADIOS2 Gray-Scott
- remove PDF Calc's developer-checkout dependency and add checked execution plus typed artifacts
- document the agent-facing bundle contracts and extend CI type/lint coverage

## Local validation
- 49 focused JARVIS tests passed
- expanded CI pyright target: 0 errors
- scoped Ruff check and format: passed

## Live validation
Pending candidate execution on Ares. This PR is intentionally stacked on #188 and remains draft until the candidate evidence is reviewed.