### PR TITLE
feat: harden DLIO runtime and artifacts

### DIFF
--- a/builtin/builtin/dlio_benchmark/README.md
+++ b/builtin/builtin/dlio_benchmark/README.md
@@ -1,57 +1,68 @@
-DLIO is an I/O benchmark for Deep Learning, aiming at emulating the I/O behavior of various deep learning applications.
+# DLIO Benchmark
 
-# Installation
+`builtin.dlio_benchmark` runs one native
+[DLIO Benchmark](https://github.com/argonne-lcf/dlio_benchmark) workload
+configuration under MPI. The package expects `dlio_benchmark` and the MPI
+launcher to be resolved in the JARVIS pipeline environment before execution.
+It does not install Python dependencies or discover software at run time.
+
+The package owns the mechanics shared by DLIO studies:
+
+- optional dataset generation followed by one training I/O phase;
+- explicit dataset, output, and checkpoint locations;
+- typed reader, dataset, epoch, computation, and checkpoint controls;
+- checked MPI and cache-policy process status;
+- native output, generated dataset, and checkpoint artifact lifecycles.
+
+Scientific sweeps and comparisons remain explicit pipeline composition. For
+example, compare reader concurrency by adding separately named DLIO steps with
+different `read_threads` values and a shared, pre-generated dataset. This keeps
+every measured cell visible in the pipeline rather than hiding a study inside
+the package.
+
+## Cache policy
+
+`cache_policy=none` is the portable default and makes no cold-cache claim.
+`cache_policy=sync` flushes dirty buffers without evicting the page cache.
+`cache_policy=drop_caches` is an explicit privileged request. It uses
+noninteractive `sudo -n` and fails the package if the site has not authorized
+the operation. The package never silently falls back between policies.
+
+## Important settings
+
+| Setting | Default | Meaning |
+|---|---:|---|
+| `workload` | `unet3d_a100` | Installed DLIO workload profile |
+| `generate_data` | `false` | Generate data before the training I/O phase |
+| `data_path` | empty | `data/<workload>` below package shared storage |
+| `output_path` | `output` | Native DLIO output collection |
+| `read_threads` | unset | Reader threads per rank |
+| `nprocs` / `ppn` | `8` / `8` | MPI ranks and ranks per node |
+| `timeout_seconds` | `3600` | Maximum runtime for each MPI phase |
+| `checkpoint` | `true` | Enable checkpoint writes for supported workloads |
+| `checkpoint_path` | empty | `checkpoints/<workload>` below package shared storage |
+| `cache_policy` | `none` | `none`, `sync`, or `drop_caches` |
+
+Additional typed controls cover training-file count, samples per file, record
+and resize lengths, batch size, training and evaluation phases, epochs, emulated
+computation time, model checkpoint size, checkpoint timing, `fsync`, and
+DFTracer enablement.
+
+## Example
 
 ```bash
-git clone https://github.com/argonne-lcf/dlio_benchmark
-cd dlio_benchmark/
-pip install .
-```
-
-# DLIO
-
-## 1. Create a Resource Graph
-
-If you haven't already, create a resource graph. This only needs to be done
-once throughout the lifetime of Jarvis. No need to repeat if you have already
-done this for a different pipeline.
-
-If you are running distributed tests, set path to the hostfile you are  using.
-```bash
-jarvis hostfile set /path/to/hostfile
-```
-
-Next, collect the resources from each of those pkgs. Walkthrough will give
-a command line tutorial on how to build the hostfile.
-```bash
-jarvis resource-graph build +walkthrough
-```
-
-## 2. Create a Pipeline
-
-The Jarvis pipeline will store all configuration data.
-```bash
-jarvis pipeline create dlio_test
-```
-
-## 4. Add pkgs to the Pipeline
-
-Create a Jarvis pipeline
-```bash
-jarvis pipeline append dlio_benchmark workload=unet3d_a100 generate_data=True data_path=/path/to/generated_data checkpoint_path=/path/to/checkpoints
-```
-Note: you can modify the dlio_benchmark configuration file by changing the modifying the dlio_benchmark.yaml file directly, and then execute `jarvis ppl update` to update the configuration. 
-
-## 5. Run Experiment
-
-Run the experiment
-```bash
+jarvis pipeline create dlio-study
+jarvis pipeline append dlio_benchmark \
+  workload=resnet50_v100 \
+  generate_data=true \
+  num_files_train=256 \
+  read_threads=4 \
+  checkpoint_size_bytes=104857600 \
+  cache_policy=sync \
+  nprocs=4 ppn=4
 jarvis pipeline run
 ```
 
-## 6. Clean Data
-
-Clean produced data
-```bash
-jarvis pipeline clean
-```
+The output is a normal JARVIS batch execution. A zero native process exit
+finalizes the declared artifact collections; a nonzero exit leaves them
+explicitly incomplete and fails the package.

--- a/builtin/builtin/dlio_benchmark/artifacts.py
+++ b/builtin/builtin/dlio_benchmark/artifacts.py
@@ -1,0 +1,195 @@
+"""Artifact semantics owned by builtin DLIO Benchmark."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts.provider import ArtifactObservation
+from jarvis_cd.artifacts.schema import (
+    ArtifactLocation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+
+
+@dataclass(slots=True)
+class DlioBenchmarkArtifactAdapter:
+    """Track native DLIO datasets, measurements, and checkpoints."""
+
+    workload: str
+    cache_policy: str
+    data_path: PurePosixPath | None
+    output_path: PurePosixPath
+    checkpoint_path: PurePosixPath | None
+    data_artifact_id: str = field(default_factory=new_artifact_id)
+    output_artifact_id: str = field(default_factory=new_artifact_id)
+    checkpoint_artifact_id: str = field(default_factory=new_artifact_id)
+    _started: bool = False
+    _terminal: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Announce configured products when the native process starts writing."""
+        if self._started or self._terminal or not text:
+            return []
+        self._started = True
+        return self._observations(ArtifactState.PRODUCING)
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Wait for the authoritative process status before terminalization."""
+        return []
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Finalize or mark every declared product incomplete from process exit."""
+        if self._terminal:
+            return []
+        self._terminal = True
+        state = (
+            ArtifactState.FINALIZED if return_code == 0 else ArtifactState.INCOMPLETE
+        )
+        return self._observations(state, return_code=return_code)
+
+    def reset_artifacts(self) -> None:
+        """Reset stream state when JARVIS replaces the owned output stream."""
+        self._started = False
+        self._terminal = False
+
+    def _observations(
+        self,
+        state: ArtifactState,
+        *,
+        return_code: int | None = None,
+    ) -> list[ArtifactObservation]:
+        metadata: dict[str, str | int] = {
+            "application": "dlio",
+            "workload": self.workload,
+            "cache_policy": self.cache_policy,
+        }
+        if return_code is not None:
+            metadata["return_code"] = return_code
+        observations: list[ArtifactObservation] = []
+        if self.data_path is not None:
+            observations.append(
+                self._observation(
+                    artifact_id=self.data_artifact_id,
+                    logical_name="dlio-generated-dataset",
+                    kind="scientific_dataset",
+                    role=ArtifactRole.INTERMEDIATE,
+                    path=self.data_path,
+                    state=state,
+                    format_name="dlio-generated-dataset",
+                    metadata=metadata,
+                )
+            )
+        observations.append(
+            self._observation(
+                artifact_id=self.output_artifact_id,
+                logical_name="dlio-native-results",
+                kind="scientific_measurement",
+                role=ArtifactRole.OUTPUT,
+                path=self.output_path,
+                state=state,
+                format_name="dlio-native-output-directory",
+                metadata=metadata,
+            )
+        )
+        if self.checkpoint_path is not None:
+            observations.append(
+                self._observation(
+                    artifact_id=self.checkpoint_artifact_id,
+                    logical_name="dlio-checkpoints",
+                    kind="model_checkpoint",
+                    role=ArtifactRole.CHECKPOINT,
+                    path=self.checkpoint_path,
+                    state=state,
+                    format_name="dlio-checkpoint-collection",
+                    metadata=metadata,
+                )
+            )
+        return observations
+
+    @staticmethod
+    def _observation(
+        *,
+        artifact_id: str,
+        logical_name: str,
+        kind: str,
+        role: ArtifactRole,
+        path: PurePosixPath,
+        state: ArtifactState,
+        format_name: str,
+        metadata: dict[str, str | int],
+    ) -> ArtifactObservation:
+        """Build one stable lifecycle revision."""
+        if state is ArtifactState.FINALIZED:
+            message = f"{logical_name} finalized after successful DLIO exit"
+        elif state is ArtifactState.INCOMPLETE:
+            message = f"{logical_name} incomplete after DLIO process failure"
+        else:
+            message = f"{logical_name} is being produced"
+        return ArtifactObservation(
+            artifact_id=artifact_id,
+            logical_name=logical_name,
+            kind=kind,
+            role=role,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(path),
+            media_type="application/octet-stream",
+            format=format_name,
+            message=message,
+            metadata=metadata,
+        )
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> DlioBenchmarkArtifactAdapter | None:
+    """Create native DLIO artifact semantics from normalized package config."""
+    if package.get("pkg_type") != "builtin.dlio_benchmark":
+        return None
+    workload = package.get("workload")
+    if not isinstance(workload, str) or not workload:
+        raise ValueError("DLIO artifact provider requires a workload")
+    cache_policy = package.get("cache_policy", "none")
+    if not isinstance(cache_policy, str) or not cache_policy:
+        raise ValueError("DLIO artifact provider requires an explicit cache policy")
+    output_path = _absolute_path(package.get("output_path"), field="output_path")
+    data_path = (
+        _absolute_path(package.get("data_path"), field="data_path")
+        if package.get("generate_data") is True
+        else None
+    )
+    checkpoint_path = (
+        _absolute_path(package.get("checkpoint_path"), field="checkpoint_path")
+        if package.get("checkpoint_supported") is True
+        and package.get("checkpoint") is True
+        else None
+    )
+    return DlioBenchmarkArtifactAdapter(
+        workload=workload,
+        cache_policy=cache_policy,
+        data_path=data_path,
+        output_path=output_path,
+        checkpoint_path=checkpoint_path,
+    )
+
+
+def _absolute_path(value: object, *, field: str) -> PurePosixPath:
+    """Require one normalized absolute cluster artifact path."""
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"DLIO {field} must be a non-empty absolute path")
+    path = PurePosixPath(value)
+    if not path.is_absolute() or path.as_posix() != value or ".." in path.parts:
+        raise ValueError(f"DLIO {field} must be a normalized absolute path")
+    return path
+
+
+__all__ = ["DlioBenchmarkArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/dlio_benchmark/pkg.py
+++ b/builtin/builtin/dlio_benchmark/pkg.py
@@ -1,276 +1,614 @@
-"""
-This module provides classes and methods to launch the DlioBenchmark application.
-DlioBenchmark is ....
-"""
-from jarvis_cd.core.pkg import Application, Color
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
+"""Launch native DLIO Benchmark workloads with explicit execution semantics."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+from typing import Any, cast
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Rm
+from jarvis_cd.runtime_callback import RuntimePhaseLineCallback
+
+_WORKLOAD_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+_CACHE_POLICIES = ("none", "sync", "drop_caches")
 
 
 class DlioBenchmark(Application):
-    """
-    This class provides methods to launch the DlioBenchmark application.
-    """
-    def _init(self):
-        """
-        Initialize paths
-        """
-        pass
+    """Run one configured DLIO data-generation and training I/O workload."""
 
-    def _configure_menu(self):
-        """
-        Create a CLI menu for the configurator method.
-        For thorough documentation of these parameters, view:
-        https://github.com/scs-lab/jarvis-util/wiki/3.-Argument-Parsing
+    def _init(self) -> None:
+        """Initialize the bounded batch package."""
 
-        :return: List(dict)
-        """
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        """Return agent-visible DLIO workload and execution controls."""
         return [
-            # workload related configurations
             {
-                'name': 'workload',  # The name of the parameter
-                'msg': 'specify the workload name',  # Describe this parameter
-                'type': str,  # What is the parameter type?
-                'default': 'unet3d_a100',  # What is the default value if not required?
-                'choices': [],
-                'args': [],
+                "name": "workload",
+                "msg": "Installed DLIO workload profile name",
+                "type": str,
+                "default": "unet3d_a100",
+                "choices": [],
+                "args": [],
             },
             {
-                'name': 'generate_data',
-                'msg': 'Does require to generate data before training?',
-                'type': bool,
-                'default': False,
-                'choices': [],
-                'args': [],
+                "name": "generate_data",
+                "msg": "Generate the configured dataset before the training I/O phase",
+                "type": bool,
+                "default": False,
+                "choices": [],
+                "args": [],
             },
             {
-                'name': 'checkpoint_supported',
-                'msg': 'Does the workload support checkpointing?',
-                'type': bool,
-                'default': True,
-                'choices': [],
-                'args': [],
-            }, 
-            {
-                'name': 'checkpoint',
-                'msg': 'Enable/disable checkpoint',
-                'type': bool,
-                'default': True,
-                'choices': [],
-                'args': [],
-            }, 
-            # dataset related configurations
-            {
-                'name': 'data_path',
-                'msg': 'The path of the dataset',
-                'type': str,
-                'default': None,
-                'choices': [],
-                'args': [],
+                "name": "evaluation",
+                "msg": "Run the selected workload's evaluation I/O phase",
+                "type": bool,
+                "default": False,
+                "choices": [],
+                "args": [],
             },
             {
-                'name': 'num_files_train',
-                'msg': 'Number of files used for training',
-                'type': int,
-                'default': None,
-                'choices': [],
-                'args': [],
-            },
-            # reader related configurations
-            {
-                'name': 'batch_size',
-                'msg': 'Number of samples read per iteration',
-                'type': int,
-                'default': None,
-                'choices': [],
-                'args': [],
+                "name": "checkpoint_supported",
+                "msg": "Whether the selected workload has checkpoint configuration",
+                "type": bool,
+                "default": True,
+                "choices": [],
+                "args": [],
             },
             {
-                'name': 'read_threads',
-                'msg': 'Number of read threads in dataloader',
-                'type': int,
-                'default': None,
-                'choices': [],
-                'args': [],
-            }, 
-            # train related configurations
-            {
-                'name': 'epochs',
-                'msg': 'Number of epochs to run',
-                'type': int,
-                'default': None,
-                'choices': [],
-                'args': [],
-            },
-            # checkpoint related configurations
-            {
-                'name': 'checkpoint_path',
-                'msg': 'Path of the checkpoint files',
-                'type': str,
-                'default': None,
-                'choices': [],
-                'args': [],
-            }, 
-            {
-                'name': 'checkpoint_after_epoch',
-                'msg': 'Checkpoint after the specified epoch id',
-                'type': int,
-                'default': None,
-                'choices': [],
-                'args': [],
-            }, 
-            {
-                'name': 'epochs_between_checkpoints',
-                'msg': 'Checkpoint interval (unit: epochs)',
-                'type': int,
-                'default': None,
-                'choices': [],
-                'args': [],
-            }, 
-            # process related configuration
-            {
-                'name': 'nprocs',
-                'msg': 'Number of processes',
-                'type': int,
-                'default': 8,
+                "name": "checkpoint",
+                "msg": "Write checkpoints during the training I/O phase",
+                "type": bool,
+                "default": True,
+                "choices": [],
+                "args": [],
             },
             {
-                'name': 'ppn',
-                'msg': 'The number of processes per node',
-                'type': int,
-                'default': 8,
+                "name": "data_path",
+                "msg": (
+                    "Dataset directory. Empty uses data/<workload> below the "
+                    "execution-owned package shared directory."
+                ),
+                "type": str,
+                "default": "",
+                "choices": [],
+                "args": [],
             },
-            # Run with tracing or not
             {
-                'name': 'tracing',
-                'msg': 'Enable/disable tracing (running with/without DFTracer)',
-                'type': bool,
-                'default': False,
-            }, 
+                "name": "output_path",
+                "msg": (
+                    "Native DLIO output directory. Relative paths resolve below "
+                    "the execution-owned package shared directory."
+                ),
+                "type": str,
+                "default": "output",
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "checkpoint_path",
+                "msg": (
+                    "Checkpoint directory. Empty uses checkpoints/<workload> below "
+                    "the execution-owned package shared directory."
+                ),
+                "type": str,
+                "default": "",
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "num_files_train",
+                "msg": "Number of files in the training dataset",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "num_samples_per_file",
+                "msg": "Samples represented by each generated training file",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "record_length_bytes",
+                "msg": "Generated training-record payload size in bytes",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "record_length_bytes_resize",
+                "msg": (
+                    "Generated record resize target in bytes; empty uses "
+                    "record_length_bytes when that value is set"
+                ),
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "batch_size",
+                "msg": "Samples read per training iteration",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "read_threads",
+                "msg": "Reader threads per DLIO rank",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "epochs",
+                "msg": "Training I/O epochs",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "train_computation_time",
+                "msg": "Emulated computation time in seconds per training iteration",
+                "type": float,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "checkpoint_size_bytes",
+                "msg": "Emulated model checkpoint size in bytes",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "checkpoint_fsync",
+                "msg": "Require DLIO to fsync checkpoint writes",
+                "type": bool,
+                "default": False,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "checkpoint_after_epoch",
+                "msg": "First epoch after which DLIO writes a checkpoint",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "epochs_between_checkpoints",
+                "msg": "Number of epochs between checkpoints",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "nprocs",
+                "msg": "Number of MPI ranks",
+                "type": int,
+                "default": 8,
+            },
+            {
+                "name": "ppn",
+                "msg": "MPI ranks per node",
+                "type": int,
+                "default": 8,
+            },
+            {
+                "name": "timeout_seconds",
+                "msg": "Maximum runtime in seconds for each DLIO MPI phase",
+                "type": int,
+                "default": 3600,
+            },
+            {
+                "name": "tracing",
+                "msg": "Enable DFTracer through its runtime environment contract",
+                "type": bool,
+                "default": False,
+            },
+            {
+                "name": "cache_policy",
+                "msg": (
+                    "Cache handling before training: none, unprivileged sync, or "
+                    "explicit noninteractive privileged drop_caches"
+                ),
+                "type": str,
+                "default": "none",
+                "choices": list(_CACHE_POLICIES),
+                "args": [],
+            },
         ]
 
-    def _configure(self, **kwargs):
-        """
-        Converts the Jarvis configuration to application-specific configuration.
-        E.g., OrangeFS produces an orangefs.xml file.
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe the pre-resolved native DLIO runtime and batch completion."""
+        probe = probe_program(
+            "dlio_benchmark",
+            environment=self._deployment_environment(),
+            arguments=("--help",),
+        )
+        capabilities = (
+            ("distributed_training_io", "native_dlio_outputs")
+            if probe.status.usable is True
+            else ()
+        )
+        runtime = RuntimeRequirement(
+            requirement_id="dlio",
+            description=(
+                "DLIO Benchmark runtime resolved in the pipeline environment before "
+                "execution"
+            ),
+            required_capabilities=("distributed_training_io", "native_dlio_outputs"),
+            available_capabilities=capabilities,
+            status=probe.status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="path",
+                    query_kind="program",
+                    query_value="dlio_benchmark",
+                ),
+            ),
+        )
+        completed = ReadinessContract(
+            mechanism="process_exit",
+            condition="successful_exit",
+        )
+        return PackageDeploymentContract(
+            package="builtin.dlio_benchmark",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="train_existing_data",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("generate_data", "equals", False),),
+                    runtime_requirements=("dlio",),
+                    readiness=completed,
+                    description=(
+                        "Run one native DLIO workload configuration against an "
+                        "existing dataset and retain its native outputs."
+                    ),
+                ),
+                ExecutionProfile(
+                    name="generate_and_train",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("generate_data", "equals", True),),
+                    runtime_requirements=("dlio",),
+                    readiness=completed,
+                    description=(
+                        "Generate the configured dataset, then run one native DLIO "
+                        "workload configuration and retain both product groups."
+                    ),
+                ),
+            ),
+            runtime_requirements=(runtime,),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("checkpoint", "equals", True),),
+                    requires=(
+                        ConfigurationCondition("checkpoint_supported", "equals", True),
+                    ),
+                    description=(
+                        "Checkpoint output can be enabled only for a workload whose "
+                        "DLIO profile supports checkpoint configuration."
+                    ),
+                ),
+            ),
+        )
 
-        :param kwargs: Configuration parameters for this pkg.
-        :return: None
-        """
-        # reconfigure data_path
-        if self.config['data_path'] is None:
-            self.config['data_path'] = f"data/{self.config['workload']}"
-        elif f"data/{self.config['workload']}" not in self.config['data_path']:
-            self.config['data_path'] = f"{self.config['data_path']}/data/{self.config['workload']}"  
+    def _configure(self, **kwargs: Any) -> None:
+        """Validate execution controls and persist normalized artifact paths."""
+        super()._configure(**kwargs)
+        self._validate_configuration()
+        config = cast(dict[str, Any], self.config)
+        config["data_path"] = str(self._data_path())
+        config["output_path"] = str(self._output_path())
+        config["checkpoint_path"] = str(self._checkpoint_path())
 
-        # reconfigure checkpoint path
-        if self.config['checkpoint_supported']:
-            if self.config['checkpoint_path'] is None:
-                self.config['checkpoint_path'] = f"checkpoints/{self.config['workload']}"
-            elif f"checkpoints/{self.config['workload']}" not in self.config['checkpoint_path']:
-                self.config['checkpoint_path'] = f"{self.config['checkpoint_path']}/checkpoints/{self.config['workload']}" 
+    def _validate_configuration(self) -> None:
+        """Reject unsafe or ambiguous values before any process is launched."""
+        config = cast(dict[str, Any], self.config)
+        if config.get("deploy_mode", "default") != "default":
+            raise ValueError("builtin.dlio_benchmark supports native execution only")
+        workload = config.get("workload")
+        if (
+            not isinstance(workload, str)
+            or _WORKLOAD_PATTERN.fullmatch(workload) is None
+        ):
+            raise ValueError("workload must be a DLIO profile token")
+        for field in (
+            "generate_data",
+            "evaluation",
+            "checkpoint_supported",
+            "checkpoint",
+            "checkpoint_fsync",
+            "tracing",
+        ):
+            if not isinstance(config.get(field), bool):
+                raise TypeError(f"{field} must be a boolean")
+        if config["checkpoint"] and not config["checkpoint_supported"]:
+            raise ValueError("checkpoint requires checkpoint_supported=true")
+        for field in ("nprocs", "ppn", "timeout_seconds"):
+            self._positive_integer(field, required=True)
+        if cast(int, config["ppn"]) > cast(int, config["nprocs"]):
+            raise ValueError("ppn cannot exceed nprocs")
+        for field in (
+            "num_files_train",
+            "num_samples_per_file",
+            "record_length_bytes",
+            "record_length_bytes_resize",
+            "batch_size",
+            "read_threads",
+            "epochs",
+            "checkpoint_size_bytes",
+            "checkpoint_after_epoch",
+            "epochs_between_checkpoints",
+        ):
+            self._positive_integer(field, required=False)
+        computation_time = config.get("train_computation_time")
+        if computation_time is not None and (
+            isinstance(computation_time, bool)
+            or not isinstance(computation_time, (int, float))
+            or computation_time < 0
+        ):
+            raise ValueError("train_computation_time must be a non-negative number")
+        cache_policy = config.get("cache_policy")
+        if cache_policy not in _CACHE_POLICIES:
+            raise ValueError(
+                "cache_policy must be one of: " + ", ".join(_CACHE_POLICIES)
+            )
+        self._data_path()
+        self._output_path()
+        self._checkpoint_path()
 
-    def start(self):
-        """
-        Launch an application. E.g., OrangeFS will launch the servers, clients,
-        and metadata services on all necessary pkgs.
+    def _positive_integer(self, field: str, *, required: bool) -> int | None:
+        """Validate one optional or required positive integer setting."""
+        value = self.config.get(field)
+        if value is None and not required:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{field} must be a positive integer")
+        return value
 
-        :return: None
-        """
-        
-        # step1: generate data if it is required before training
-        if self.config['generate_data']:
-            # construct the command
-            gen_cmd = [
-                'dlio_benchmark',
-                f'workload={self.config['workload']}',
-                f'++workload.workflow.generate_data=True',
-                f'++workload.workflow.train=False',
-                f'++workload.dataset.data_folder={self.config['data_path']}' 
-            ]
+    def _data_path(self) -> Path:
+        """Return the configured dataset directory."""
+        return self.resolve_shared_path(
+            self.config.get("data_path"),
+            field="data_path",
+            default=f"data/{self.config['workload']}",
+        )
 
-            if self.config['num_files_train'] is not None:
-                gen_cmd.append(f'++workload.dataset.num_files_train={self.config['num_files_train']}')
+    def _output_path(self) -> Path:
+        """Return the package-owned native-output directory."""
+        return self.resolve_shared_path(
+            self.config.get("output_path"),
+            field="output_path",
+            default="output",
+        )
 
-            # run the command to generate data
-            Exec(' '.join(gen_cmd),
-                MpiExecInfo(env=self.mod_env,
-                            hostfile=self.hostfile,
-                            nprocs=self.config['nprocs'],
-                            ppn=self.config['ppn'])).run()
+    def _checkpoint_path(self) -> Path:
+        """Return the configured checkpoint directory."""
+        return self.resolve_shared_path(
+            self.config.get("checkpoint_path"),
+            field="checkpoint_path",
+            default=f"checkpoints/{self.config['workload']}",
+        )
 
-        # step2: clear the system cache
-        Exec('sudo drop_caches',
-             PsshExecInfo(env=self.env,
-                        hostfile=self.hostfile)).run()
-        
-        # step3: run the benchmark with the workload
-        if self.config['tracing']:
-            self.mod_env['DFTRACER_ENABLE'] = '1'
-            self.mod_env['DFTRACER_INC_METADATA'] = '1'   
-
-        run_cmd = [
-            'dlio_benchmark',
-            f'workload={self.config['workload']}',
-            f'++workload.workflow.generate_data=False',
-            f'++workload.workflow.train=Train',
-            f'++workload.dataset.data_folder={self.config['data_path']}'  
+    def _command(self, *, generate_only: bool, output_path: Path) -> str:
+        """Build one shell-safe native DLIO invocation."""
+        workflow_checkpoint = bool(
+            not generate_only
+            and self.config["checkpoint_supported"]
+            and self.config["checkpoint"]
+        )
+        overrides = [
+            f"workload={self.config['workload']}",
+            f"++workload.workflow.generate_data={'true' if generate_only else 'false'}",
+            f"++workload.workflow.train={'false' if generate_only else 'true'}",
+            "++workload.workflow.evaluation="
+            + ("true" if self.config["evaluation"] and not generate_only else "false"),
+            f"++workload.dataset.data_folder={self._data_path()}",
+            f"++workload.output.folder={output_path}",
         ]
+        if not self.config["evaluation"]:
+            overrides.append("++workload.dataset.num_files_eval=0")
+        optional = (
+            ("num_files_train", "workload.dataset.num_files_train"),
+            ("num_samples_per_file", "workload.dataset.num_samples_per_file"),
+            ("record_length_bytes", "workload.dataset.record_length_bytes"),
+            (
+                "record_length_bytes_resize",
+                "workload.dataset.record_length_bytes_resize",
+            ),
+            ("batch_size", "workload.reader.batch_size"),
+            ("read_threads", "workload.reader.read_threads"),
+            ("epochs", "workload.train.epochs"),
+            ("train_computation_time", "workload.train.computation_time"),
+        )
+        for field, setting in optional:
+            value = self.config.get(field)
+            if field == "record_length_bytes_resize" and value is None:
+                value = self.config.get("record_length_bytes")
+            if value is not None:
+                overrides.append(f"++{setting}={value}")
+        if self.config["checkpoint_supported"]:
+            overrides.extend(
+                (
+                    "++workload.workflow.checkpoint="
+                    + ("true" if workflow_checkpoint else "false"),
+                    f"++workload.checkpoint.checkpoint_folder={self._checkpoint_path()}",
+                )
+            )
+            if not generate_only:
+                checkpoint_size = self.config.get("checkpoint_size_bytes")
+                if checkpoint_size is not None:
+                    overrides.append(
+                        f"++workload.model.model_size_bytes={checkpoint_size}"
+                    )
+                overrides.append(
+                    "++workload.checkpoint.fsync="
+                    + ("true" if self.config["checkpoint_fsync"] else "false")
+                )
+                for field, setting in (
+                    ("checkpoint_after_epoch", "checkpoint_after_epoch"),
+                    ("epochs_between_checkpoints", "epochs_between_checkpoints"),
+                ):
+                    value = self.config.get(field)
+                    if value is not None:
+                        overrides.append(f"++workload.checkpoint.{setting}={value}")
+        return " ".join(
+            ("dlio_benchmark", *(shlex.quote(value) for value in overrides))
+        )
 
-        if self.config['num_files_train'] is not None:
-            run_cmd.append(f'++workload.dataset.num_files_train={self.config['num_files_train']}')
-        
-        if self.config['batch_size'] is not None:
-            run_cmd.append(f'++workload.reader.batch_size={self.config['batch_size']}')
-        
-        if self.config['read_threads'] is not None:
-            run_cmd.append(f'++workload.reader.read_threads={self.config['read_threads']}')
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        """Return local or PSSH execution for node-scoped cache operations."""
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
 
-        if self.config['epochs'] is not None:
-            run_cmd.append(f'++workload.train.epochs={self.config['epochs']}')
-        
-        if self.config['checkpoint_supported']:
-            run_cmd.append(f'++workload.workflow.checkpoint={self.config['checkpoint']}')
-            run_cmd.append(f'++workload.checkpoint.checkpoint_folder={self.config['checkpoint_path']}')
-            if self.config['checkpoint_after_epoch'] is not None:
-                run_cmd.append(f'++workload.checkpoint.checkpoint_after_epoch={self.config['checkpoint_after_epoch']}')
-            if self.config['epochs_between_checkpoints'] is not None:
-                run_cmd.append(f'++workload.checkpoint.epochs_between_checkpoints={self.config['epochs_between_checkpoints']}') 
-        #print(f"self.env = {self.env}", flush=True)
-        # run the benchmark command
-        Exec(' '.join(run_cmd),
-             MpiExecInfo(env=self.mod_env,
-                         hostfile=self.hostfile,
-                         nprocs=self.config['nprocs'],
-                         ppn=self.config['ppn'])).run()
-        
+    @staticmethod
+    def _raise_for_exec_failure(result: Any, operation: str) -> None:
+        """Require a concrete zero status from every participating process."""
+        exit_codes = getattr(result, "exit_code", None)
+        if not isinstance(exit_codes, dict) or not exit_codes:
+            raise RuntimeError(f"{operation} returned no process exit status")
+        failures = {
+            str(host): code
+            for host, code in exit_codes.items()
+            if isinstance(code, bool) or not isinstance(code, int) or code != 0
+        }
+        if failures:
+            rendered = ", ".join(
+                f"{host}={code!r}" for host, code in sorted(failures.items())
+            )
+            raise RuntimeError(f"{operation} failed with exit status: {rendered}")
 
-    def stop(self):
-        """
-        Stop a running application. E.g., OrangeFS will terminate the servers,
-        clients, and metadata services.
+    def _apply_cache_policy(self) -> None:
+        """Apply only the exact cache policy selected by the operator or agent."""
+        policy = self.config["cache_policy"]
+        if policy == "none":
+            return
+        if policy == "sync":
+            command = "sync"
+        elif policy == "drop_caches":
+            command = "sync && sudo -n sh -c 'echo 3 > /proc/sys/vm/drop_caches'"
+        else:
+            raise ValueError(f"unsupported cache policy: {policy!r}")
+        result = Exec(command, self._node_exec_info(env=self.env, timeout=60)).run()
+        self._raise_for_exec_failure(result, f"DLIO cache policy {policy}")
 
-        :return: None
-        """
-        pass
+    def start(self) -> None:
+        """Generate optional input data, apply cache policy, and run DLIO."""
+        self._validate_configuration()
+        output_path = self._output_path()
+        training_output = output_path / "training"
+        paths = [output_path, training_output]
+        if self.config["generate_data"]:
+            paths.extend((self._data_path(), output_path / "data-generation"))
+        if self.config["checkpoint_supported"] and self.config["checkpoint"]:
+            paths.append(self._checkpoint_path())
+        for path in paths:
+            path.mkdir(parents=True, exist_ok=True)
 
-    def clean(self):
-        """
-        Destroy all data for an application. E.g., OrangeFS will delete all
-        metadata and data directories in addition to the orangefs.xml file.
+        environment = dict(self.mod_env)
+        if self.config["tracing"]:
+            environment.update(
+                {
+                    "DFTRACER_ENABLE": "1",
+                    "DFTRACER_INC_METADATA": "1",
+                }
+            )
+        callback = self.runtime_line_callback()
+        intermediate_callback = (
+            RuntimePhaseLineCallback(callback, terminal=False)
+            if callback is not None
+            else None
+        )
+        terminal_callback = (
+            RuntimePhaseLineCallback(callback, terminal=True)
+            if callback is not None
+            else None
+        )
+        try:
+            if self.config["generate_data"]:
+                generation_output = output_path / "data-generation"
+                generation = Exec(
+                    self._command(generate_only=True, output_path=generation_output),
+                    MpiExecInfo(
+                        env=environment,
+                        hostfile=self.hostfile,
+                        nprocs=self.config["nprocs"],
+                        ppn=self.config["ppn"],
+                        cwd=str(generation_output),
+                        line_callback=intermediate_callback,
+                        timeout=self.config["timeout_seconds"],
+                    ),
+                ).run()
+                self._raise_for_exec_failure(generation, "DLIO data generation")
 
-        :return: None
-        """
-        # clear data path
-        Rm(self.config['data_path'] + '*',
-           PsshExecInfo(env=self.env,
-                        hostfile=self.hostfile)).run()
+            self._apply_cache_policy()
+            workload = Exec(
+                self._command(generate_only=False, output_path=training_output),
+                MpiExecInfo(
+                    env=environment,
+                    hostfile=self.hostfile,
+                    nprocs=self.config["nprocs"],
+                    ppn=self.config["ppn"],
+                    cwd=str(training_output),
+                    line_callback=terminal_callback,
+                    timeout=self.config["timeout_seconds"],
+                ),
+            ).run()
+            self._raise_for_exec_failure(workload, "DLIO workload")
+        except Exception:
+            if terminal_callback is not None:
+                terminal_callback.finalize_process(1)
+            raise
 
-        self.log(f'Removing dataset {self.config['data_path']}', Color.YELLOW)
+    def stop(self) -> None:
+        """Do nothing because DLIO stages are bounded synchronous processes."""
 
-        # clear checkpoint
-        Rm(self.config['checkpoint_path'] + '*',
-           PsshExecInfo(env=self.env,
-                        hostfile=self.hostfile)).run()
-        
-        self.log(f'Removing checkpoints {self.config['checkpoint_path']}', Color.YELLOW)
+    def clean(self) -> None:
+        """Remove only package-owned products below the package shared root."""
+        if self.shared_dir is None:
+            raise RuntimeError("DLIO cleanup requires a package shared directory")
+        shared = Path(self.shared_dir).resolve(strict=False)
+        candidates = [self._output_path(), self._checkpoint_path()]
+        if self.config.get("generate_data"):
+            candidates.append(self._data_path())
+        owned = [str(path) for path in candidates if path.is_relative_to(shared)]
+        if not owned:
+            return
+        result = Rm(
+            owned,
+            self._node_exec_info(env=self.env),
+            recursive=True,
+        ).run()
+        self._raise_for_exec_failure(result, "DLIO package cleanup")
+
+
+__all__ = ["DlioBenchmark", "RuntimeStatus"]

--- a/jarvis_cd/runtime_callback.py
+++ b/jarvis_cd/runtime_callback.py
@@ -1,0 +1,45 @@
+"""Process-output callback ownership for multi-phase JARVIS packages."""
+
+from __future__ import annotations
+
+from typing import Callable, cast
+
+
+class RuntimePhaseLineCallback:
+    """Bind one shared runtime callback to an intermediate or terminal process.
+
+    Multi-process packages must not finalize their package-level progress and
+    artifact providers after each successful process. Intermediate phases keep
+    the shared callback open on success, while any failed phase and the declared
+    terminal phase preserve the normal process-owned finalization semantics.
+    """
+
+    def __init__(
+        self,
+        delegate: Callable[[str, str], None],
+        *,
+        terminal: bool,
+    ) -> None:
+        self._delegate = delegate
+        self._terminal = terminal
+
+    def __call__(self, stream_name: str, line: str) -> None:
+        """Forward one captured process-output line to the shared callback."""
+        self._delegate(stream_name, line)
+
+    def finalize_process(self, return_code: int) -> None:
+        """Finalize only a failed phase or the declared terminal phase."""
+        if not self._terminal and return_code == 0:
+            return
+        process_finalizer = getattr(self._delegate, "finalize_process", None)
+        finalizer = getattr(self._delegate, "finalize", None)
+        if callable(process_finalizer):
+            cast(Callable[[int], None], process_finalizer)(return_code)
+        elif callable(finalizer):
+            cast(Callable[[], None], finalizer)()
+
+    def reconcile_process_exit(self, return_code: int) -> None:
+        """Forward effective nonzero-exit reconciliation to the shared callback."""
+        reconciler = getattr(self._delegate, "reconcile_process_exit", None)
+        if callable(reconciler):
+            cast(Callable[[int], None], reconciler)(return_code)

--- a/test/unit/core/test_dlio_benchmark_artifacts.py
+++ b/test/unit/core/test_dlio_benchmark_artifacts.py
@@ -1,0 +1,111 @@
+"""Artifact lifecycle tests for builtin DLIO Benchmark."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+from jarvis_cd.artifacts import (
+    ArtifactObservation,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "dlio_benchmark"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def test_dlio_outputs_and_checkpoints_follow_process_lifecycle() -> None:
+    """Native output groups retain identity through successful completion."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.dlio_benchmark",
+            "workload": "resnet50_v100",
+            "generate_data": True,
+            "checkpoint_supported": True,
+            "checkpoint": True,
+            "data_path": "/scratch/run/dataset",
+            "output_path": "/scratch/run/output",
+            "checkpoint_path": "/scratch/run/checkpoints",
+            "cache_policy": "sync",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts("Starting DLIO benchmark\n")
+    observations += adapter.finalize_artifacts_for_exit(0)
+
+    assert {item.role for item in observations[:3]} == {
+        ArtifactRole.INTERMEDIATE,
+        ArtifactRole.OUTPUT,
+        ArtifactRole.CHECKPOINT,
+    }
+    assert all(item.state is ArtifactState.PRODUCING for item in observations[:3])
+    assert all(item.state is ArtifactState.FINALIZED for item in observations[-3:])
+    assert all(item.structure is ArtifactStructure.COLLECTION for item in observations)
+    by_role: dict[ArtifactRole, list[ArtifactObservation]] = {}
+    for item in observations:
+        by_role.setdefault(item.role, []).append(item)
+    assert all(
+        len({item.artifact_id for item in items}) == 1 for items in by_role.values()
+    )
+    output = next(
+        item for item in observations[-3:] if item.role is ArtifactRole.OUTPUT
+    )
+    assert output.location is not None
+    assert output.location.value == "/scratch/run/output"
+    assert output.metadata["cache_policy"] == "sync"
+
+
+def test_dlio_failure_marks_every_declared_product_incomplete() -> None:
+    """A nonzero owned process cannot leave finalized DLIO artifacts."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.dlio_benchmark",
+            "workload": "unet3d_a100",
+            "generate_data": False,
+            "checkpoint_supported": True,
+            "checkpoint": True,
+            "output_path": "/scratch/run/output",
+            "checkpoint_path": "/scratch/run/checkpoints",
+            "cache_policy": "none",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.finalize_artifacts_for_exit(17)
+
+    assert {item.role for item in observations} == {
+        ArtifactRole.OUTPUT,
+        ArtifactRole.CHECKPOINT,
+    }
+    assert all(item.state is ArtifactState.INCOMPLETE for item in observations)
+    assert all(item.metadata["return_code"] == 17 for item in observations)
+
+
+def test_dlio_artifacts_reject_relative_or_unsafe_paths() -> None:
+    """Artifact providers cannot turn relative settings into cluster authority."""
+    module = _module()
+
+    try:
+        module.adapter_from_package(
+            {
+                "pkg_type": "builtin.dlio_benchmark",
+                "workload": "unet3d_a100",
+                "output_path": "relative/output",
+            }
+        )
+    except ValueError as error:
+        assert "absolute" in str(error)
+    else:
+        raise AssertionError("relative DLIO output path was accepted")

--- a/test/unit/core/test_dlio_benchmark_package.py
+++ b/test/unit/core/test_dlio_benchmark_package.py
@@ -1,0 +1,280 @@
+"""Runtime-contract tests for the builtin DLIO Benchmark package."""
+
+from __future__ import annotations
+
+import shlex
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def _load_package() -> ModuleType:
+    """Load builtin DLIO without relying on repository registration."""
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "dlio_benchmark"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_builtin_dlio_benchmark", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load the DLIO package from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+dlio_package = _load_package()
+
+
+class _CapturedExec:
+    """Capture exact package commands and configurable process results."""
+
+    commands: list[str] = []
+    exec_infos: list[Any] = []
+    failures: dict[str, dict[str, object]] = {}
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = self.failures.get(command, {"localhost": 0})
+        self.commands.append(command)
+        self.exec_infos.append(exec_info)
+
+    def run(self) -> _CapturedExec:
+        """Return the captured process result."""
+        callback = getattr(self.exec_info, "line_callback", None)
+        if callback is not None:
+            callback("stdout", f"running {self.command}\n")
+            return_code = next(
+                (code for code in self.exit_code.values() if code != 0),
+                0,
+            )
+            callback.finalize_process(return_code)
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _reset_exec_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep command-level package tests independent."""
+    _CapturedExec.commands = []
+    _CapturedExec.exec_infos = []
+    _CapturedExec.failures = {}
+    monkeypatch.setattr(dlio_package, "Exec", _CapturedExec)
+
+
+def _package(tmp_path: Path, **updates: object) -> Any:
+    """Build a minimally configured package without invoking JARVIS discovery."""
+    package = object.__new__(dlio_package.DlioBenchmark)
+    package.shared_dir = str(tmp_path / "shared")
+    package.get_hostfile = lambda: None
+    package.env = {"PATH": "/runtime/bin"}
+    package.mod_env = dict(package.env)
+    package.config = {
+        "workload": "resnet50_v100",
+        "generate_data": False,
+        "evaluation": False,
+        "checkpoint_supported": True,
+        "checkpoint": True,
+        "data_path": "dataset",
+        "output_path": "output",
+        "checkpoint_path": "checkpoints",
+        "num_files_train": 32,
+        "num_samples_per_file": 2,
+        "record_length_bytes": 114660,
+        "record_length_bytes_resize": 114660,
+        "batch_size": 8,
+        "read_threads": 4,
+        "epochs": 3,
+        "train_computation_time": 0.05,
+        "checkpoint_size_bytes": 104857600,
+        "checkpoint_fsync": True,
+        "checkpoint_after_epoch": 2,
+        "epochs_between_checkpoints": 4,
+        "nprocs": 4,
+        "ppn": 4,
+        "timeout_seconds": 3600,
+        "tracing": False,
+        "cache_policy": "none",
+        "deploy_mode": "default",
+    }
+    package.config.update(updates)
+    package.runtime_line_callback = lambda: None
+    return package
+
+
+def test_agent_contract_has_safe_cache_and_runtime_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Describe a bounded runtime without silently claiming cold-cache IO."""
+    package = object.__new__(dlio_package.DlioBenchmark)
+    package.config = {"generate_data": False}
+    package.mod_env = {"PATH": "/runtime/bin"}
+    package.env = dict(package.mod_env)
+    package._deployment_environment = lambda: package.mod_env
+    monkeypatch.setattr(
+        dlio_package,
+        "probe_program",
+        lambda *args, **kwargs: SimpleNamespace(
+            status=dlio_package.RuntimeStatus("ready", "runtime_probe_succeeded")
+        ),
+    )
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    assert menu["cache_policy"]["default"] == "none"
+    assert menu["cache_policy"]["choices"] == ["none", "sync", "drop_caches"]
+    assert menu["output_path"]["default"] == "output"
+
+    contract = package._deployment_contract().to_dict()
+    assert contract["package"] == "builtin.dlio_benchmark"
+    assert contract["execution_profiles"][0]["readiness"] == {
+        "mechanism": "process_exit",
+        "condition": "successful_exit",
+    }
+    runtime = contract["runtime_requirements"][0]
+    assert runtime["id"] == "dlio"
+    assert runtime["status"]["usable"] is True
+    assert runtime["provider_resolutions"] == [
+        {
+            "provider": "path",
+            "query": {"kind": "program", "value": "dlio_benchmark"},
+        }
+    ]
+
+
+def test_command_quotes_paths_and_exposes_typed_workload_controls(
+    tmp_path: Path,
+) -> None:
+    """Build one native DLIO invocation without a shell-injection surface."""
+    package = _package(tmp_path)
+    command = package._command(generate_only=False, output_path=tmp_path / "result dir")
+
+    assert shlex.quote("workload=resnet50_v100") in command
+    assert (
+        shlex.quote(f"++workload.dataset.data_folder={tmp_path / 'shared' / 'dataset'}")
+        in command
+    )
+    assert shlex.quote(f"++workload.output.folder={tmp_path / 'result dir'}") in command
+    assert "++workload.reader.read_threads=4" in command
+    assert "++workload.dataset.num_samples_per_file=2" in command
+    assert "++workload.dataset.record_length_bytes=114660" in command
+    assert "++workload.dataset.record_length_bytes_resize=114660" in command
+    assert "++workload.workflow.evaluation=false" in command
+    assert "++workload.dataset.num_files_eval=0" in command
+    assert "++workload.workflow.train=true" in command
+    assert "++workload.train.computation_time=0.05" in command
+    assert "++workload.workflow.checkpoint=true" in command
+    assert "++workload.model.model_size_bytes=104857600" in command
+    assert "++workload.checkpoint.fsync=true" in command
+    assert "++workload.checkpoint.checkpoint_after_epoch=2" in command
+    assert "++workload.checkpoint.epochs_between_checkpoints=4" in command
+
+
+@pytest.mark.parametrize("policy, expected", [("none", []), ("sync", ["sync"])])
+def test_non_privileged_cache_policies_never_call_sudo(
+    tmp_path: Path,
+    policy: str,
+    expected: list[str],
+) -> None:
+    """The safe policies are explicit and cannot perform privileged eviction."""
+    package = _package(tmp_path, cache_policy=policy)
+
+    package._apply_cache_policy()
+
+    assert _CapturedExec.commands == expected
+    assert all("sudo" not in command for command in _CapturedExec.commands)
+
+
+def test_privileged_cache_eviction_is_explicit_and_noninteractive(
+    tmp_path: Path,
+) -> None:
+    """Cold-cache requests fail rather than hanging on an interactive password."""
+    package = _package(tmp_path, cache_policy="drop_caches")
+
+    package._apply_cache_policy()
+
+    assert _CapturedExec.commands == [
+        "sync && sudo -n sh -c 'echo 3 > /proc/sys/vm/drop_caches'"
+    ]
+
+
+def test_start_propagates_native_dlio_failure(tmp_path: Path) -> None:
+    """A failed rank makes the package fail instead of reporting completion."""
+    package = _package(tmp_path)
+    command = package._command(
+        generate_only=False,
+        output_path=package._output_path() / "training",
+    )
+    _CapturedExec.failures[command] = {"node-a": 9}
+
+    with pytest.raises(RuntimeError, match="DLIO workload.*node-a=9"):
+        package.start()
+
+    assert _CapturedExec.exec_infos[-1].timeout == 3600
+
+
+class _StrictRuntimeCallback:
+    """Reject output after package-level semantic finalization."""
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+        self.finalized: list[int] = []
+        self.closed = False
+
+    def __call__(self, stream_name: str, line: str) -> None:
+        """Record output only while the package callback remains open."""
+        if self.closed:
+            raise RuntimeError("runtime callback already finalized")
+        self.lines.append(f"{stream_name}:{line}")
+
+    def finalize_process(self, return_code: int) -> None:
+        """Close package semantics after the terminal process."""
+        self.finalized.append(return_code)
+        self.closed = True
+
+    def reconcile_process_exit(self, return_code: int) -> None:
+        """Expose the process callback protocol used by JARVIS."""
+
+
+def test_generate_and_train_share_one_callback_until_terminal_phase(
+    tmp_path: Path,
+) -> None:
+    """Data generation must not close semantics before training starts."""
+    package = _package(tmp_path, generate_data=True)
+    callback = _StrictRuntimeCallback()
+    package.runtime_line_callback = lambda: callback
+
+    package.start()
+
+    assert len(callback.lines) == 2
+    assert callback.finalized == [0]
+    assert callback.closed is True
+    assert _CapturedExec.exec_infos[0].line_callback is not callback
+    assert _CapturedExec.exec_infos[1].line_callback is not callback
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("workload", "bad workload"),
+        ("nprocs", 0),
+        ("ppn", True),
+        ("read_threads", -1),
+        ("cache_policy", "pretend-cold"),
+        ("timeout_seconds", 0),
+    ],
+)
+def test_configuration_rejects_ambiguous_or_unsafe_values(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    """Invalid scientific and execution controls fail before submission."""
+    package = _package(tmp_path, **{field: value})
+
+    with pytest.raises((TypeError, ValueError)):
+        package._validate_configuration()

--- a/test/unit/core/test_runtime_phase_callback.py
+++ b/test/unit/core/test_runtime_phase_callback.py
@@ -1,0 +1,52 @@
+"""Tests for multi-phase package runtime callback ownership."""
+
+from __future__ import annotations
+
+from jarvis_cd.runtime_callback import RuntimePhaseLineCallback
+
+
+class _RecordingCallback:
+    """Record callback forwarding and terminal lifecycle operations."""
+
+    def __init__(self) -> None:
+        self.lines: list[tuple[str, str]] = []
+        self.finalized: list[int] = []
+        self.reconciled: list[int] = []
+
+    def __call__(self, stream_name: str, line: str) -> None:
+        """Record one forwarded output line."""
+        self.lines.append((stream_name, line))
+
+    def finalize_process(self, return_code: int) -> None:
+        """Record one delegated process finalization."""
+        self.finalized.append(return_code)
+
+    def reconcile_process_exit(self, return_code: int) -> None:
+        """Record one delegated effective-exit reconciliation."""
+        self.reconciled.append(return_code)
+
+
+def test_runtime_phase_callback_defers_only_successful_intermediate_exit() -> None:
+    """One callback can span processes without hiding an intermediate failure."""
+    delegate = _RecordingCallback()
+    intermediate = RuntimePhaseLineCallback(delegate, terminal=False)
+    terminal = RuntimePhaseLineCallback(delegate, terminal=True)
+
+    intermediate("stdout", "generating\n")
+    intermediate.finalize_process(0)
+    terminal("stdout", "training\n")
+    terminal.finalize_process(0)
+
+    assert delegate.lines == [
+        ("stdout", "generating\n"),
+        ("stdout", "training\n"),
+    ]
+    assert delegate.finalized == [0]
+
+    failed_delegate = _RecordingCallback()
+    failed_intermediate = RuntimePhaseLineCallback(failed_delegate, terminal=False)
+    failed_intermediate.finalize_process(9)
+    failed_intermediate.reconcile_process_exit(9)
+
+    assert failed_delegate.finalized == [9]
+    assert failed_delegate.reconciled == [9]


### PR DESCRIPTION
## What changed

- harden `builtin.dlio_benchmark` as a maintained agent-facing package with explicit runtime, workload, MPI, dataset, reader, cache, checkpoint, timeout, and output controls
- add package-owned dataset, native-result, and checkpoint artifact collections
- add a reusable phase-aware runtime callback that remains open across successful intermediate phases and finalizes exactly once at the terminal phase
- document the exact package contract and safety boundaries

## Why

The benchmark needs a reusable maintained DLIO package, not a benchmark-only wrapper. The previous callback lifecycle was also unsafe for multi-phase applications: finalizing after data generation caused the first training message to fail and the scheduler process to terminate.

## Validation

- `45 passed` across the DLIO package, artifact SPI, deployment contract, and runtime callback tests
- Ruff check and format check passed for the changed surface
- targeted Pyright passed with zero errors
- live Ares qualification passed at exact commit `899c6234ba5ba1b6b887376f83c47dc9237c9f62`
- JARVIS execution `jarvis_c63abe06e3c64d05bd3c7a7515353687`, Slurm job `22627`, completed three ResNet50 DLIO configurations at 1, 4, and 8 reader threads
- JARVIS finalized seven package-owned collections; independent observation hashed 551 files and recomputed the native summaries and all rank outputs

This PR is intentionally stacked on `feat/gray-scott-input-analysis` and remains draft. It must not be merged independently of its prerequisite stack.