### PR TITLE
feat: add replayable Montage input artifacts

### DIFF
--- a/builtin/builtin/montage/README.md
+++ b/builtin/builtin/montage/README.md
@@ -1,60 +1,36 @@
-# montage
+# Montage
 
-NASA/IPAC Montage astronomical mosaic engine — 10-stage pipeline
-(mImgtbl → mProjExec → mImgtbl → mOverlaps → mDiffExec → mFitExec →
-mBgModel → mBgExec → mImgtbl → mAdd). The SIF pre-stages the M17
-J-band 0.2° benchmark; `/opt/run_mosaic.sh` runs the chain.
+`builtin.montage` runs NASA/IPAC Montage mosaics through two explicit profiles.
 
-## Native workflow parameters (`_configure_menu`)
+## Offline three-band profile
 
-| Parameter | Default | Effect on I/O | Effect on compute |
-|---|---|---|---|
-| `region` / `band` / `size` | `M17` / `j` / `0.2` | bigger `size` → more raw FITS tiles → more bytes through mProjExec / mAdd | bigger `size` → quadratic-ish mProjExec compute |
-| `mosaic_replicates` | `1` | runs the full 10-stage pipeline N times into `host-<host>/rep_NNN/` — **linear** I/O | each rep redoes interpolation + add |
-| `scratch_dir` | `${HOME}/montage-scratch` | scratch is the projection working tree; ends up at NFS scratch when `size > 0.2°` | n/a |
-| `out` | `${HOME}/montage_out` | final FITS staging dir | n/a |
+Supply `j_bundle`, `h_bundle`, and `k_bundle` together. Each value is a
+digest-verified `jarvis.package-input-bundle.v1` archive whose manifest:
 
-**Compute-dominated stages**: `mProjExec` (image reprojection
-interpolation) is the wall-time hog at any non-trivial size. `mAdd` and
-`mBgExec` are I/O-heavy. `mImgtbl` and the `*.tbl` index passes are
-metadata-only.
+- selects a `mosaic_header` entrypoint;
+- declares one or more `fits_source` files under a single directory; and
+- contains no undeclared files or links.
 
-## I/O-only benchmark mode (bind-mount override)
+The package stages each bundle into the execution-owned shared directory,
+runs `mExec` and `mExamine` independently for J, H, and K, renders a J/H/K PNG
+with `mViewer`, and validates every product before writing
+`montage-result.json`. It finalizes exactly these durable artifacts:
 
-```yaml
-container_binds:
-  - ${HOME}/jarvis-bench-scripts/montage_io_only.sh:/opt/run_mosaic.sh
-env:
-  MONTAGE_N_TILES:  "20"    # how many projected + corrected tiles to write
-  MONTAGE_TILE_MB:  "512"   # each tile's size
-  MONTAGE_MOSAIC_MB: "512"  # final mosaic.fits size
-```
+- `montage-j.fits`, `montage-h.fits`, and `montage-k.fits`;
+- `montage-jhk.png`; and
+- `montage-result.json` using schema `jarvis.montage-result.v1`.
 
-Writes the same directory layout the real `/opt/run_mosaic.sh`
-produces (`projected/*.fits`, `corrected/*.fits`, `mosaic.fits`, plus
-the seven `.tbl` index files) without running `mProjExec` or `mAdd`.
+Every command failure is propagated. The profile performs no runtime Internet
+discovery or acquisition and supports agent-free replay from the same bundle
+digests.
 
-### Per-rep budget = 2 × N_TILES × TILE_MB + MOSAIC_MB
+## Legacy archive profile
 
-Default = 2 × 20 × 512 + 512 = 20,992 MiB ≈ **20.5 GiB/rep**.
+When all three bundles are empty, Montage retains the earlier single-band
+archive workflow. `region`, `band`, and `size` control the archive request. A
+native execution uses the package-owned `run_mosaic.sh`; a container execution
+uses the built image. If data are not already staged, this profile may access
+IRSA at runtime and is therefore not equivalent to the offline profile.
 
-## Tuning matrix
-
-| Goal | Knob | Rule of thumb |
-|---|---|---|
-| **More I/O per rep (I/O-only)** | bump `MONTAGE_TILE_MB` or `MONTAGE_N_TILES` | linear |
-| **More I/O total (I/O-only)** | bump `mosaic_replicates` | linear |
-| **More I/O (native)** | bump `size` (triggers runtime IRSA fetch); or bump `mosaic_replicates` | size: super-linear data growth |
-| **Less interpolation compute** | use I/O-only bind-mount | wall ≈ I/O bytes ÷ NFS bw |
-| **Different image archive** | tweak `region` + `band`; needs network reach from compute nodes | varies |
-
-## Measured calibration (ares, 4-node SLURM, NFS-backed bind-mount out)
-
-| Variant | mosaic_replicates | per-rep MB | Wall | I/O |
-|---|---|---|---|---|
-| Native (M17 0.2°) | 80 | ~24 | 565 s (9.4 m) | ~1.9 GB |
-| Native (M17 0.2°) | 30 | ~24 | 421 s (7.0 m) | ~720 MB |
-| Native (M17 0.2°) | 20 | ~24 | 260 s (4.3 m) | ~480 MB |
-| **I/O-proxy** | **1** | **20.5 GiB** | **141 s (2.4 m)** | **22 GB** ✓ |
-
-YAML lives at `builtin/pipelines/ares/montage_apptainer_test.yaml`.
+Relative `out` paths resolve below the JARVIS package shared directory. The
+default `.` keeps outputs in the durable execution-owned package root.

--- a/builtin/builtin/montage/artifacts.py
+++ b/builtin/builtin/montage/artifacts.py
@@ -1,0 +1,238 @@
+"""Generated-artifact semantics for the builtin Montage package."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+
+_RESULT_SCHEMA = "jarvis.montage-result.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class _Product:
+    logical_name: str
+    filename: str
+    kind: str
+    role: ArtifactRole
+    media_type: str
+    format_name: str
+
+
+_PRODUCTS = (
+    _Product(
+        "montage-j-mosaic",
+        "montage-j.fits",
+        "scientific_dataset",
+        ArtifactRole.OUTPUT,
+        "image/fits",
+        "fits",
+    ),
+    _Product(
+        "montage-h-mosaic",
+        "montage-h.fits",
+        "scientific_dataset",
+        ArtifactRole.OUTPUT,
+        "image/fits",
+        "fits",
+    ),
+    _Product(
+        "montage-k-mosaic",
+        "montage-k.fits",
+        "scientific_dataset",
+        ArtifactRole.OUTPUT,
+        "image/fits",
+        "fits",
+    ),
+    _Product(
+        "montage-three-band-composite",
+        "montage-jhk.png",
+        "scientific_visualization",
+        ArtifactRole.OUTPUT,
+        "image/png",
+        "png",
+    ),
+    _Product(
+        "montage-result",
+        "montage-result.json",
+        "validation_report",
+        ArtifactRole.VALIDATION,
+        "application/json",
+        _RESULT_SCHEMA,
+    ),
+)
+
+
+@dataclass
+class MontageArtifactAdapter:
+    """Report the exact offline three-band product set at process exit."""
+
+    output_dir: PurePosixPath
+    region: str
+    _finalized: bool = False
+    _artifact_ids: dict[str, str] = field(
+        default_factory=lambda: {
+            product.logical_name: new_artifact_id() for product in _PRODUCTS
+        }
+    )
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Return no provisional records for bounded batch outputs."""
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Finalize products using successful-exit semantics."""
+        return self.finalize_artifacts_for_exit(0)
+
+    def finalize_artifacts_for_exit(
+        self,
+        return_code: int,
+    ) -> list[ArtifactObservation]:
+        """Report present, validated products or explicit incomplete records."""
+        if self._finalized:
+            return []
+        self._finalized = True
+        output = Path(self.output_dir.as_posix())
+        return [
+            self._observation(product, output, return_code) for product in _PRODUCTS
+        ]
+
+    def reset_artifacts(self) -> None:
+        """Allow one later process lifecycle to rediscover the product set."""
+        self._finalized = False
+
+    def _observation(
+        self,
+        product: _Product,
+        output: Path,
+        return_code: int,
+    ) -> ArtifactObservation:
+        path = output / product.filename
+        valid, size_bytes = _validate_product(path, product)
+        finalized = return_code == 0 and valid
+        state = ArtifactState.FINALIZED if finalized else ArtifactState.INCOMPLETE
+        return ArtifactObservation(
+            artifact_id=self._artifact_ids[product.logical_name],
+            logical_name=product.logical_name,
+            kind=product.kind,
+            role=product.role,
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=(
+                ArtifactLocation.cluster_path(self.output_dir / product.filename)
+                if valid
+                else None
+            ),
+            media_type=product.media_type,
+            format=product.format_name,
+            size_bytes=size_bytes,
+            message=(
+                f"{product.logical_name} finalized after successful Montage exit"
+                if finalized
+                else f"{product.logical_name} is missing or incomplete"
+            ),
+            metadata={
+                "application": "montage",
+                "region": self.region,
+                "return_code": return_code,
+            },
+        )
+
+
+def _validate_product(path: Path, product: _Product) -> tuple[bool, int | None]:
+    """Validate one regular product without following symlinks."""
+    try:
+        status = path.lstat()
+        if path.is_symlink() or not path.is_file():
+            return False, None
+        size = status.st_size
+        if product.format_name == "fits":
+            with path.open("rb") as stream:
+                valid = (
+                    2880 <= size <= 512 * 1024 * 1024 and stream.read(8) == b"SIMPLE  "
+                )
+        elif product.format_name == "png":
+            with path.open("rb") as stream:
+                valid = (
+                    1024 < size <= 128 * 1024 * 1024
+                    and stream.read(8) == b"\x89PNG\r\n\x1a\n"
+                )
+        else:
+            valid = False
+            if 0 < size <= 1024 * 1024:
+                payload = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+                valid = (
+                    isinstance(payload, dict)
+                    and payload.get("schema_version") == _RESULT_SCHEMA
+                )
+        return valid, size if valid else None
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return False, None
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> MontageArtifactAdapter | None:
+    """Create artifacts only for the complete offline builtin profile."""
+    if package.get("pkg_type") != "builtin.montage":
+        return None
+    configured = tuple(package.get(f"{band}_bundle") for band in ("j", "h", "k"))
+    if not all(isinstance(value, str) and value for value in configured):
+        return None
+    output_dir = _configured_output_dir(
+        package.get("out"),
+        shared_dir=package.get("shared_dir"),
+        runtime_cwd=package.get("runtime_cwd"),
+    )
+    region = package.get("region", "M17")
+    if not isinstance(region, str) or not region:
+        raise ValueError("Montage artifacts require a region label")
+    return MontageArtifactAdapter(output_dir=output_dir, region=region)
+
+
+def _configured_output_dir(
+    value: object,
+    *,
+    shared_dir: object,
+    runtime_cwd: object,
+) -> PurePosixPath:
+    """Resolve output below JARVIS-owned shared or runtime context."""
+    raw = os.path.expandvars(str(value or "."))
+    path = PurePosixPath(raw)
+    if not path.is_absolute():
+        base = _absolute_path(shared_dir) or _absolute_path(runtime_cwd)
+        if base is None:
+            raise ValueError(
+                "relative Montage output requires a shared directory or runtime cwd"
+            )
+        path = base / path
+    if not path.is_absolute() or ".." in path.parts:
+        raise ValueError("Montage artifact output must be a normalized absolute path")
+    return path
+
+
+def _absolute_path(value: object) -> PurePosixPath | None:
+    """Return one normalized absolute POSIX path when supplied."""
+    if not isinstance(value, str) or not value:
+        return None
+    path = PurePosixPath(value)
+    if not path.is_absolute() or ".." in path.parts:
+        return None
+    return path
+
+
+__all__ = ["MontageArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/montage/pkg.py
+++ b/builtin/builtin/montage/pkg.py
@@ -1,310 +1,710 @@
-"""
-This module provides classes and methods to launch the Montage application.
-Montage is an astronomical image mosaic engine that assembles FITS images
-into custom mosaics. It is developed by the NASA/IPAC Infrared Science
-Archive at Caltech.
-"""
+"""Deploy bounded native or containerized Montage mosaic workflows."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import shlex
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo, LocalExecInfo
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.runtime_callback import RuntimePhaseLineCallback
+from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
+
+_BANDS = ("j", "h", "k")
+_RESULT_SCHEMA = "jarvis.montage-result.v1"
+_RESULT_NAME = "montage-result.json"
+_COMPOSITE_NAME = "montage-jhk.png"
+_STATUS_FIELD = re.compile(r'(\w+)=(?:"([^"]*)"|([^,\]\s]+))')
 
 
 class Montage(Application):
-    """
-    Montage container package supporting both default (bare-metal) and
-    container deployment.
+    """Run Montage with offline supplied inputs or its legacy archive profile."""
 
-    Set deploy_mode='container' to build and run Montage inside a
-    Docker/Podman/Apptainer container.
-    Set deploy_mode='default' to use system-installed Montage binaries.
-    """
-
-    def _init(self):
+    def _init(self) -> None:
         pass
 
-    def _configure_menu(self):
-        return [
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        menu: list[dict[str, Any]] = [
             {
-                'name': 'nprocs',
-                'msg': 'Number of MPI processes',
-                'type': int,
-                'default': 1,
+                "name": "nprocs",
+                "msg": "Number of MPI processes reserved for the workflow",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'ppn',
-                'msg': 'Processes per node',
-                'type': int,
-                'default': 1,
+                "name": "ppn",
+                "msg": "Processes per node reserved for the workflow",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'region',
-                'msg': 'Target region name (e.g., M17, M31)',
-                'type': str,
-                'default': 'M17',
+                "name": "region",
+                "msg": "Printable astronomical target or region label",
+                "type": str,
+                "default": "M17",
             },
             {
-                'name': 'band',
-                'msg': '2MASS band (j, h, k)',
-                'type': str,
-                'default': 'j',
+                "name": "band",
+                "msg": "2MASS band for the legacy archive profile (j, h, or k)",
+                "type": str,
+                "default": "j",
             },
             {
-                'name': 'size',
-                'msg': ('Region size in degrees (square box centered on '
-                        'the region). 0.2° produces tens of MB; 1.0° a '
-                        'few GB; 2.0° tens of GB. Triggers runtime fetch '
-                        'from 2MASS/IRSA when != 0.2 (the default that '
-                        'the SIF pre-stages at build time).'),
-                'type': float,
-                'default': 0.2,
+                "name": "size",
+                "msg": "Square legacy archive region size in degrees",
+                "type": float,
+                "default": 0.2,
             },
             {
-                'name': 'scratch_dir',
-                'msg': ('Scratch dir inside the container for Montage '
-                        'intermediates (projected/diffs/corrected). '
-                        'Default ~/montage-scratch — keep off /tmp '
-                        'because intermediates can be tens of GB.'),
-                'type': str,
-                'default': '${HOME}/montage-scratch',
+                "name": "scratch_dir",
+                "msg": "Legacy container scratch directory",
+                "type": str,
+                "default": "${HOME}/montage-scratch",
             },
             {
-                'name': 'parallel_scratch_root',
-                'msg': ('Root dir for per-rep MONTAGE_SCRATCH_DIR when '
-                        'parallel_reps > 1. Each rep gets '
-                        '`<root>/montage-scratch-<rep>`. Default '
-                        '/dev/shm keeps intermediates on tmpfs (fastest). '
-                        'Point at a FUSE mount (e.g. /mnt/dumbwarp/scratch) '
-                        'when you specifically want every mProjExec / '
-                        'mDiffExec / mAdd read+write to traverse that '
-                        'adapter instead of node-local tmpfs.'),
-                'type': str,
-                'default': '/dev/shm',
+                "name": "parallel_scratch_root",
+                "msg": "Legacy container per-replicate scratch root",
+                "type": str,
+                "default": "/dev/shm",
             },
             {
-                'name': 'out',
-                'msg': 'Output directory for mosaic results',
-                'type': str,
-                'default': '${HOME}/montage_out',
+                "name": "out",
+                "msg": (
+                    "Output directory. Relative paths resolve below the package "
+                    "shared directory; '.' is the durable execution-owned root."
+                ),
+                "type": str,
+                "default": ".",
             },
             {
-                'name': 'mosaic_replicates',
-                'msg': ('Run the full Montage 10-stage mosaic this many '
-                        'times back-to-back in one container exec, each '
-                        'into rep_NNN/ under `out`. Use this to amplify '
-                        'total I/O when the chosen region+size produces '
-                        'a smaller mosaic than the benchmark target.'),
-                'type': int,
-                'default': 1,
+                "name": "mosaic_replicates",
+                "msg": "Legacy container mosaic replicate count",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'parallel_reps',
-                'msg': ('Per-host replicate concurrency. When > 1, the '
-                        'replicates loop fans across hosts via '
-                        'PsshExecInfo and each host runs this many in '
-                        'parallel using `wait -n` batching. Default 1 '
-                        'preserves the original host[0]-only sequential '
-                        'loop.'),
-                'type': int,
-                'default': 1,
+                "name": "parallel_reps",
+                "msg": "Legacy container per-host replicate concurrency",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'omp_threads',
-                'msg': ('OMP_NUM_THREADS for each parallel replicate. Set '
-                        'to roughly cores_per_node / parallel_reps so '
-                        'concurrent mProjExec/mAddExec instances on a '
-                        'single host don\'t oversubscribe. 0 = unset.'),
-                'type': int,
-                'default': 0,
+                "name": "omp_threads",
+                "msg": "Legacy container OpenMP threads per replicate; zero leaves it unset",
+                "type": int,
+                "default": 0,
             },
             {
-                'name': 'base_image',
-                'msg': 'Base Docker image for build container',
-                'type': str,
-                'default': 'sci-hpc-base',
+                "name": "base_image",
+                "msg": "Base image used only by the legacy container profile",
+                "type": str,
+                "default": "sci-hpc-base",
             },
         ]
+        for band in _BANDS:
+            menu.append(
+                {
+                    "name": f"{band}_bundle",
+                    "msg": (
+                        f"Optional digest-verified {band.upper()}-band FITS bundle. "
+                        "The manifest entrypoint is the mosaic header and files "
+                        "with role fits_source form the offline source collection. "
+                        "J, H, and K bundles must be supplied together."
+                    ),
+                    "type": str,
+                    "default": "",
+                    "input_binding": ConfigurationInputBinding(
+                        kind="local_file",
+                        structure="regular_file",
+                    ).to_dict(),
+                }
+            )
+        return menu
 
-    # ------------------------------------------------------------------
-    # Container Dockerfile generators
-    # ------------------------------------------------------------------
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe the offline and legacy Montage execution profiles."""
+        probes = tuple(
+            probe_program(
+                program,
+                environment=self._deployment_environment(),
+                arguments=(),
+            )
+            for program in ("mExec", "mExamine", "mViewer")
+        )
+        usable = all(probe.status.usable is True for probe in probes)
+        unavailable = next(
+            (probe.status for probe in probes if probe.status.usable is False),
+            None,
+        )
+        status = (
+            RuntimeStatus("ready", "all_montage_commands_available")
+            if usable
+            else unavailable
+            or RuntimeStatus("unknown", "montage_commands_not_fully_probed")
+        )
+        runtime = RuntimeRequirement(
+            requirement_id="montage",
+            description="Montage 6 FITS mosaic, statistics, and rendering commands",
+            required_capabilities=(
+                "fits_mosaic",
+                "image_statistics",
+                "three_band_composite",
+            ),
+            available_capabilities=(
+                ("fits_mosaic", "image_statistics", "three_band_composite")
+                if usable
+                else ()
+            ),
+            status=status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="spack",
+                    query_kind="spec",
+                    query_value="montage@6.0",
+                ),
+            ),
+        )
+        completed = ReadinessContract(
+            mechanism="process_exit",
+            condition="successful_exit",
+        )
+        return PackageDeploymentContract(
+            package="builtin.montage",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="legacy_archive",
+                    execution_kind="batch",
+                    when=tuple(
+                        ConfigurationCondition(f"{band}_bundle", "is_empty")
+                        for band in _BANDS
+                    ),
+                    runtime_requirements=("montage",),
+                    readiness=completed,
+                    description=(
+                        "Legacy single-band profile that may acquire archive data at "
+                        "runtime and therefore is not suitable for offline replay."
+                    ),
+                ),
+                ExecutionProfile(
+                    name="offline_three_band",
+                    execution_kind="batch",
+                    when=tuple(
+                        ConfigurationCondition(f"{band}_bundle", "is_not_empty")
+                        for band in _BANDS
+                    ),
+                    runtime_requirements=("montage",),
+                    readiness=completed,
+                    description=(
+                        "Network-independent J/H/K workflow using three immutable "
+                        "FITS collections and one fixed mosaic header per bundle."
+                    ),
+                ),
+            ),
+            runtime_requirements=(runtime,),
+            configuration_rules=tuple(
+                ConfigurationRule(
+                    when=(ConfigurationCondition(f"{band}_bundle", "is_not_empty"),),
+                    requires=tuple(
+                        ConfigurationCondition(f"{other}_bundle", "is_not_empty")
+                        for other in _BANDS
+                        if other != band
+                    ),
+                    description="Offline Montage requires all three J, H, and K bundles.",
+                )
+                for band in _BANDS
+            ),
+        )
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _build_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
             return None
-        base = self.config.get('base_image', 'sci-hpc-base')
-        # Inline run_mosaic.sh into build.sh as base64 so the container
-        # build is self-contained. jarvis's aux-file copy step in
-        # pipeline.py runs `docker cp` with hide_output=True and does not
-        # check exit codes, so a silently-failed copy manifests here as
-        # "cp: cannot stat 'run_mosaic.sh'" deep in the build.
         import base64
-        import os
-        run_mosaic_path = os.path.join(self.pkg_dir, 'run_mosaic.sh')
-        with open(run_mosaic_path, 'rb') as f:
-            run_mosaic_b64 = base64.b64encode(f.read()).decode('ascii')
-        content = self._read_build_script('build.sh', {
-            'BASE_IMAGE': base,
-            'RUN_MOSAIC_B64': run_mosaic_b64,
-        })
-        return content, 'default'
 
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+        package_dir = self.pkg_dir
+        if not isinstance(package_dir, str) or not package_dir:
+            raise RuntimeError("Montage container build requires its package directory")
+        run_mosaic_path = os.path.join(package_dir, "run_mosaic.sh")
+        with open(run_mosaic_path, "rb") as stream:
+            run_mosaic_b64 = base64.b64encode(stream.read()).decode("ascii")
+        content = self._read_build_script(
+            "build.sh",
+            {
+                "BASE_IMAGE": self.config.get("base_image", "sci-hpc-base"),
+                "RUN_MOSAIC_B64": run_mosaic_b64,
+            },
+        )
+        return content, "default"
+
+    def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
             return None
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': 'ubuntu:24.04',
-        })
-        return content, 'default'
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {
+                "BUILD_IMAGE": self.build_image_name(),
+                "DEPLOY_BASE": "ubuntu:24.04",
+            },
+        )
+        return content, "default"
 
-    # ------------------------------------------------------------------
-    # Configuration
-    # ------------------------------------------------------------------
-
-    def _configure(self, **kwargs):
-        """
-        Configure Montage.
-
-        Calls super()._configure() which updates self.config and (when
-        deploy_mode == 'container') triggers build_phase / build_deploy_phase.
-
-        In default mode, also creates the output directory on all nodes.
-        Always propagates MONTAGE_* env vars so the run_mosaic.sh inside
-        the SIF picks up region/band/size/scratch_dir/out overrides
-        without rebuilding the image.
-        """
+    def _configure(self, **kwargs: Any) -> None:
+        """Validate profile selection and prepare the package-owned output."""
         super()._configure(**kwargs)
+        self._validate_configuration()
+        self.setenv("MONTAGE_REGION", str(self.config.get("region", "M17")))
+        self.setenv("MONTAGE_BAND", str(self.config.get("band", "j")).upper())
+        self.setenv("MONTAGE_SIZE", str(self.config.get("size", 0.2)))
+        self.setenv("MONTAGE_OUT", self._output_dir())
+        self.setenv(
+            "MONTAGE_SCRATCH_DIR",
+            str(self.config.get("scratch_dir", "${HOME}/montage-scratch")),
+        )
+        if self.config.get("deploy_mode", "default") == "default":
+            self._ensure_output_dir()
 
-        # Propagate config knobs to run_mosaic.sh via env vars (it reads
-        # MONTAGE_REGION / MONTAGE_BAND / MONTAGE_SIZE / MONTAGE_OUT /
-        # MONTAGE_SCRATCH_DIR; see updated run_mosaic.sh).
-        self.setenv('MONTAGE_REGION', str(self.config.get('region', 'M17')))
-        self.setenv('MONTAGE_BAND', str(self.config.get('band', 'j')).upper())
-        self.setenv('MONTAGE_SIZE', str(self.config.get('size', 0.2)))
-        if self.config.get('out'):
-            self.setenv('MONTAGE_OUT', str(self.config['out']))
-        if self.config.get('scratch_dir'):
-            self.setenv('MONTAGE_SCRATCH_DIR', str(self.config['scratch_dir']))
+    def _configured_bundles(self) -> dict[str, str]:
+        """Return configured offline bundle paths after type validation."""
+        configured: dict[str, str] = {}
+        for band in _BANDS:
+            value = self.config.get(f"{band}_bundle")
+            if value in (None, ""):
+                continue
+            if not isinstance(value, str):
+                raise TypeError(f"{band}_bundle must be a path string")
+            configured[band] = value
+        return configured
 
-        if self.config.get('deploy_mode') == 'default':
-            if self.config['out']:
-                Mkdir(self.config['out'],
-                      PsshExecInfo(hostfile=self.hostfile,
-                                   env=self.env)).run()
+    def _validate_configuration(self) -> None:
+        """Reject ambiguous, unsafe, or unsupported profile combinations."""
+        bundles = self._configured_bundles()
+        if bundles and set(bundles) != set(_BANDS):
+            raise ValueError("offline Montage requires all three J, H, and K bundles")
+        if bundles and self.config.get("deploy_mode", "default") != "default":
+            raise ValueError("offline Montage bundles support native execution only")
+        region = self.config.get("region", "M17")
+        if (
+            not isinstance(region, str)
+            or not region.strip()
+            or len(region) > 128
+            or any(ord(character) < 32 for character in region)
+        ):
+            raise ValueError("region must be a bounded printable label")
+        if not bundles:
+            band = str(self.config.get("band", "j")).casefold()
+            if band not in _BANDS:
+                raise ValueError("band must be j, h, or k")
+            size = self.config.get("size", 0.2)
+            if (
+                isinstance(size, bool)
+                or not isinstance(size, (int, float))
+                or size <= 0
+            ):
+                raise ValueError("size must be positive")
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
+    def _output_dir(self) -> str:
+        """Resolve the durable output directory under package authority."""
+        return str(self.resolve_shared_path(self.config.get("out"), field="out"))
 
-    def start(self):
-        """
-        Launch Montage.
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        """Use local execution for one host and PSSH only for legacy fan-out."""
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
 
-        In container mode, runs /opt/run_mosaic.sh via LocalExecInfo inside
-        the deploy container. In default mode, runs the mosaic script locally.
-        """
-        if self.config.get('deploy_mode') == 'container':
-            replicates = max(
-                int(self.config.get('mosaic_replicates', 1) or 1), 1)
-            parallel = max(
-                int(self.config.get('parallel_reps', 1) or 1), 1)
-            omp = int(self.config.get('omp_threads', 0) or 0)
-            out_root = self.config.get('out')
+    def _ensure_output_dir(self) -> None:
+        """Create the output on each participating host and propagate failures."""
+        result = Mkdir(
+            self._output_dir(),
+            self._node_exec_info(env=self.env),
+        ).run()
+        self._require_success(result, "Montage output directory creation")
 
-            if parallel <= 1:
-                # Single-host sequential path (original).
-                if replicates == 1:
-                    cmd = (
-                        "host_tag=$(hostname -s 2>/dev/null || echo localhost); "
-                        f"/opt/run_mosaic.sh "
-                        f"  /opt/montage-bench/raw_images "
-                        f"  /opt/montage-bench/region.hdr "
-                        f"  '{out_root}/host-'$host_tag"
-                    )
-                else:
-                    cmd = (
-                        "set -e; "
-                        "host_tag=$(hostname -s 2>/dev/null || echo localhost); "
-                        f"for i in $(seq 1 {replicates}); do "
-                        f"  rep=$(printf 'rep_%03d' \"$i\"); "
-                        f"  echo \"=== montage replicate $rep host=$host_tag ($i/{replicates}) ===\"; "
-                        f"  /opt/run_mosaic.sh "
-                        f"    /opt/montage-bench/raw_images "
-                        f"    /opt/montage-bench/region.hdr "
-                        f"    '{out_root}/host-'$host_tag/$rep || exit 1; "
-                        f"done"
-                    )
-                Exec(cmd, LocalExecInfo(
-                    env=self.mod_env,
-                    container=self._container_engine,
-                    container_image=self.deploy_image_name(),
-                    shared_dir=self.shared_dir,
-                    private_dir=self.private_dir,
-                )).run()
-                return
+    @staticmethod
+    def _require_success(result: Any, label: str) -> None:
+        """Raise when any participating host reports command failure."""
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"{label} failed: {failures}")
 
-            # parallel_reps > 1: PsshExecInfo fan-out + per-host parallel
-            # batching. Each host runs ceil(replicates/nhosts) reps; rep
-            # tags include hostname to avoid output collisions on shared
-            # storage. MONTAGE_SCRATCH_DIR is per-rep so concurrent
-            # mProjExec invocations don't trample each other's intermediates.
-            nhosts = max(len(self.hostfile.hosts), 1) if self.hostfile else 1
-            local_reps = (replicates + nhosts - 1) // nhosts
-            scratch_root = (self.config.get('parallel_scratch_root')
-                            or '/dev/shm').rstrip('/')
-            omp_export = (
-                f"export OMP_NUM_THREADS={omp}; " if omp > 0 else ""
+    @staticmethod
+    def _bundle_raw_directory(bundle: MaterializedInputBundle) -> PurePosixPath:
+        """Require one nonempty, single-directory FITS source collection."""
+        fits = tuple(
+            PurePosixPath(item.path)
+            for item in bundle.manifest.files
+            if item.role == "fits_source"
+        )
+        if not fits:
+            raise ValueError("Montage input bundle requires at least one fits_source")
+        parents = {path.parent for path in fits}
+        if len(parents) != 1:
+            raise ValueError("Montage fits_source files must share one directory")
+        entrypoint = next(
+            (
+                item
+                for item in bundle.manifest.files
+                if item.path == bundle.manifest.entrypoint
+            ),
+            None,
+        )
+        if entrypoint is None or entrypoint.role not in {
+            "mosaic_header",
+            "scientific_input",
+        }:
+            raise ValueError("Montage bundle entrypoint must be a mosaic_header")
+        return parents.pop()
+
+    def _prepare_offline_inputs(
+        self,
+    ) -> tuple[dict[str, tuple[Path, Path]], dict[str, str]]:
+        """Extract and stage the exact J/H/K bundle bytes for one execution."""
+        output = Path(self._output_dir())
+        prepared: dict[str, tuple[Path, Path]] = {}
+        digests: dict[str, str] = {}
+        for band, configured in self._configured_bundles().items():
+            bundle = extract_input_bundle(configured, output / "input-bundles")
+            raw_relative = self._bundle_raw_directory(bundle)
+            destination = output / f"inputs-{band}"
+            header = stage_input_bundle(bundle, destination)
+            prepared[band] = (destination / Path(raw_relative.as_posix()), header)
+            digests[band] = bundle.bundle_sha256
+        return prepared, digests
+
+    @staticmethod
+    def _parse_statistics(text: str, *, band: str, mosaic: str) -> dict[str, Any]:
+        """Parse one successful structured mExamine status record."""
+        records = [
+            line.strip()
+            for line in text.splitlines()
+            if line.strip().startswith("[struct")
+        ]
+        if len(records) != 1:
+            raise RuntimeError(
+                f"Montage {band.upper()} statistics require one mExamine record"
             )
-            cmd = (
-                f"set -e; "
-                f"{omp_export}"
-                f"LOCAL={local_reps}; "
-                f"PAR={parallel}; "
-                f"OUT='{out_root}'; "
-                f"H=$(hostname -s); "
-                f"echo \"[montage-parallel] host=$H reps=$LOCAL parallel=$PAR omp=${{OMP_NUM_THREADS:-default}}\"; "
-                f"PIDS=(); "
-                f"for i in $(seq 1 $LOCAL); do "
-                f"  ( "
-                f"    rep=$(printf 'rep_%03d-%s' \"$i\" \"$H\"); "
-                f"    out=\"$OUT/$rep\"; "
-                f"    MONTAGE_SCRATCH_DIR=\"{scratch_root}/montage-scratch-$rep\" "
-                f"    /opt/run_mosaic.sh "
-                f"      /opt/montage-bench/raw_images "
-                f"      /opt/montage-bench/region.hdr "
-                f"      \"$out\" "
-                f"      && echo \"[montage-parallel] host=$H $rep DONE\" "
-                f"      || {{ echo \"[montage-parallel] host=$H $rep FAILED\" >&2; exit 1; }} "
-                f"  ) & "
-                f"  PIDS+=($!); "
-                f"  if [ \"${{#PIDS[@]}}\" -ge $PAR ]; then "
-                f"    wait -n; "
-                f"    PIDS=(\"${{PIDS[@]:1}}\"); "
-                f"  fi; "
-                f"done; "
-                f"wait"
+        fields = {
+            name: quoted if quoted else unquoted
+            for name, quoted, unquoted in _STATUS_FIELD.findall(records[0])
+        }
+        if fields.get("stat") != "OK":
+            raise RuntimeError(f"Montage {band.upper()} mExamine did not succeed")
+        try:
+            npixel = int(fields["npixel"])
+            nnull = int(fields["nnull"])
+            mean_flux = float(fields["aveflux"])
+            rms_flux = float(fields["rmsflux"])
+        except (KeyError, ValueError) as error:
+            raise RuntimeError("Montage mExamine omitted numeric statistics") from error
+        if (
+            npixel <= 0
+            or nnull < 0
+            or nnull >= npixel
+            or not math.isfinite(mean_flux)
+            or not math.isfinite(rms_flux)
+            or rms_flux <= 0
+        ):
+            raise RuntimeError("Montage mExamine statistics are not usable")
+        return {
+            "band": band.upper(),
+            "mean_flux": mean_flux,
+            "mosaic": mosaic,
+            "non_null_pixels": npixel - nnull,
+            "null_pixels": nnull,
+            "pixels": npixel,
+            "rms_flux": rms_flux,
+        }
+
+    @staticmethod
+    def _validate_fits(path: Path) -> None:
+        """Require a bounded regular FITS product with the canonical card prefix."""
+        valid = False
+        if not path.is_symlink() and path.is_file():
+            size = path.stat().st_size
+            if 2880 <= size <= 512 * 1024 * 1024:
+                with path.open("rb") as stream:
+                    valid = stream.read(8) == b"SIMPLE  "
+        if not valid:
+            raise RuntimeError(
+                f"Montage FITS product is missing or invalid: {path.name}"
             )
-            Exec(cmd, PsshExecInfo(
+
+    @staticmethod
+    def _validate_composite(path: Path) -> None:
+        """Require a bounded regular PNG composite."""
+        valid = False
+        if not path.is_symlink() and path.is_file():
+            size = path.stat().st_size
+            if 1024 < size <= 128 * 1024 * 1024:
+                with path.open("rb") as stream:
+                    valid = stream.read(8) == b"\x89PNG\r\n\x1a\n"
+        if not valid:
+            raise RuntimeError("Montage three-band composite is missing or invalid")
+
+    def _write_result(
+        self,
+        output: Path,
+        bundle_digests: dict[str, str],
+    ) -> dict[str, Any]:
+        """Validate products and atomically write the general result document."""
+        bands: list[dict[str, Any]] = []
+        for band in _BANDS:
+            mosaic = output / f"montage-{band}.fits"
+            self._validate_fits(mosaic)
+            statistics = output / f"montage-{band}-statistics.txt"
+            if statistics.is_symlink() or not statistics.is_file():
+                raise RuntimeError(f"Montage {band.upper()} statistics are missing")
+            bands.append(
+                self._parse_statistics(
+                    statistics.read_text(encoding="utf-8", errors="strict"),
+                    band=band,
+                    mosaic=mosaic.name,
+                )
+            )
+        composite = output / _COMPOSITE_NAME
+        self._validate_composite(composite)
+        document: dict[str, Any] = {
+            "bands": bands,
+            "composite": _COMPOSITE_NAME,
+            "input_bundle_sha256": bundle_digests,
+            "region": self.config.get("region", "M17"),
+            "schema_version": _RESULT_SCHEMA,
+        }
+        destination = output / _RESULT_NAME
+        if destination.exists() or destination.is_symlink():
+            raise RuntimeError("Montage result destination already exists")
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{destination.name}.",
+            dir=output,
+        )
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as stream:
+                json.dump(document, stream, indent=2, sort_keys=True)
+                stream.write("\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, destination)
+        finally:
+            temporary.unlink(missing_ok=True)
+        return document
+
+    def _run_offline(self) -> None:
+        """Run the replayable J/H/K mosaic and composite profile."""
+        self._validate_configuration()
+        self._ensure_output_dir()
+        prepared, digests = self._prepare_offline_inputs()
+        output = Path(self._output_dir())
+        callback = self.runtime_line_callback()
+        intermediate = (
+            RuntimePhaseLineCallback(callback, terminal=False)
+            if callback is not None
+            else None
+        )
+        info = LocalExecInfo(
+            env=self.mod_env,
+            cwd=str(output),
+            timeout=1800,
+            line_callback=intermediate,
+        )
+        for band in _BANDS:
+            raw, header = prepared[band]
+            workspace = output / f"work-{band}"
+            workspace.mkdir(mode=0o700)
+            mosaic = output / f"montage-{band}.fits"
+            command = " ".join(
+                (
+                    "mExec",
+                    "-r",
+                    shlex.quote(str(raw)),
+                    "-f",
+                    shlex.quote(str(header)),
+                    "-o",
+                    shlex.quote(str(mosaic)),
+                    "2MASS",
+                    band.upper(),
+                    shlex.quote(str(workspace)),
+                )
+            )
+            self._require_success(
+                Exec(command, info).run(), f"Montage {band.upper()} mosaic"
+            )
+            statistics = output / f"montage-{band}-statistics.txt"
+            examine = (
+                f"mExamine {shlex.quote(str(mosaic))} > {shlex.quote(str(statistics))}"
+            )
+            self._require_success(
+                Exec(examine, info).run(),
+                f"Montage {band.upper()} statistics",
+            )
+        composite = output / _COMPOSITE_NAME
+        viewer = " ".join(
+            (
+                "mViewer",
+                "-blue",
+                shlex.quote(str(output / "montage-j.fits")),
+                "-1s max gaussian-log",
+                "-green",
+                shlex.quote(str(output / "montage-h.fits")),
+                "-1s max gaussian-log",
+                "-red",
+                shlex.quote(str(output / "montage-k.fits")),
+                "-1s max gaussian-log",
+                "-out",
+                shlex.quote(str(composite)),
+            )
+        )
+        self._require_success(Exec(viewer, info).run(), "Montage J/H/K composite")
+        self._write_result(output, digests)
+        terminal = (
+            RuntimePhaseLineCallback(callback, terminal=True)
+            if callback is not None
+            else None
+        )
+        final_info = LocalExecInfo(
+            env=self.mod_env,
+            cwd=str(output),
+            timeout=30,
+            line_callback=terminal,
+        )
+        summary = (
+            f"JARVIS_MONTAGE_RESULT schema={_RESULT_SCHEMA} "
+            f"region={self.config.get('region', 'M17')} bands=J,H,K "
+            f"composite={_COMPOSITE_NAME}"
+        )
+        self._require_success(
+            Exec(f"printf '%s\\n' {shlex.quote(summary)}", final_info).run(),
+            "Montage result finalization",
+        )
+
+    def _run_legacy_native(self) -> None:
+        """Run the network-dependent single-band profile under package storage."""
+        self._ensure_output_dir()
+        output = Path(self._output_dir())
+        raw = output / "archive-input"
+        header = output / "region.hdr"
+        script = Path(str(self.pkg_dir)) / "run_mosaic.sh"
+        command = " ".join(
+            (
+                "bash",
+                shlex.quote(str(script)),
+                shlex.quote(str(raw)),
+                shlex.quote(str(header)),
+                shlex.quote(str(output)),
+            )
+        )
+        result = Exec(
+            command,
+            LocalExecInfo(
+                env=self.mod_env,
+                cwd=str(output),
+                line_callback=self.runtime_line_callback(),
+            ),
+        ).run()
+        self._require_success(result, "Montage legacy archive mosaic")
+
+    def _run_legacy_container(self) -> None:
+        """Preserve the existing container replication workflow."""
+        self._ensure_output_dir()
+        replicates = self._positive_integer("mosaic_replicates", 1)
+        parallel = self._positive_integer("parallel_reps", 1)
+        output = self._output_dir()
+        if parallel <= 1:
+            command = (
+                "set -e; host_tag=$(hostname -s 2>/dev/null || echo localhost); "
+                f"for i in $(seq 1 {replicates}); do "
+                "rep=$(printf 'rep_%03d' \"$i\"); "
+                f"/opt/run_mosaic.sh /opt/montage-bench/raw_images "
+                f"/opt/montage-bench/region.hdr {shlex.quote(output)}/$rep; done"
+            )
+            info: LocalExecInfo | PsshExecInfo = LocalExecInfo(
+                env=self.mod_env,
+                container=self._container_engine,
+                container_image=self.deploy_image_name(),
+                shared_dir=self.shared_dir,
+                private_dir=self.private_dir,
+                line_callback=self.runtime_line_callback(),
+            )
+        else:
+            scratch = str(
+                self.config.get("parallel_scratch_root") or "/dev/shm"
+            ).rstrip("/")
+            raw_omp = self.config.get("omp_threads", 0)
+            if isinstance(raw_omp, bool) or not isinstance(raw_omp, int) or raw_omp < 0:
+                raise ValueError("omp_threads must be a non-negative integer")
+            omp = raw_omp
+            omp_export = f"export OMP_NUM_THREADS={omp}; " if omp > 0 else ""
+            command = (
+                f"set -e; {omp_export}OUT={shlex.quote(output)}; H=$(hostname -s); "
+                f"for i in $(seq 1 {replicates}); do "
+                'rep=$(printf \'rep_%03d-%s\' "$i" "$H"); '
+                f"MONTAGE_SCRATCH_DIR={shlex.quote(scratch)}/montage-scratch-$rep "
+                "/opt/run_mosaic.sh /opt/montage-bench/raw_images "
+                '/opt/montage-bench/region.hdr "$OUT/$rep"; done'
+            )
+            info = PsshExecInfo(
                 hostfile=self.hostfile,
                 container=self._container_engine,
                 container_image=self.deploy_image_name(),
                 shared_dir=self.shared_dir,
                 private_dir=self.private_dir,
                 env=self.mod_env,
-            )).run()
+                line_callback=self.runtime_line_callback(),
+            )
+        self._require_success(Exec(command, info).run(), "Montage container workflow")
+
+    def _positive_integer(self, name: str, default: int) -> int:
+        """Return one positive integer configuration value."""
+        value = self.config.get(name, default)
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{name} must be a positive integer")
+        return value
+
+    def start(self) -> None:
+        """Run exactly one validated Montage profile and propagate failures."""
+        self._validate_configuration()
+        if self._configured_bundles():
+            self._run_offline()
+        elif self.config.get("deploy_mode") == "container":
+            self._run_legacy_container()
         else:
-            cmd = '/opt/run_mosaic.sh'
-            Exec(cmd, LocalExecInfo(
-                env=self.mod_env,
-                cwd=self.config.get('out'),
-            )).run()
+            self._run_legacy_native()
 
-    def stop(self):
-        """Stop Montage (no-op -- runs to completion)."""
-        pass
+    def stop(self) -> None:
+        """Do nothing because every Montage profile is bounded batch work."""
 
-    def clean(self):
-        """Remove Montage output directory."""
-        if self.config['out']:
-            Rm(self.config['out'] + '*',
-               PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+    def clean(self) -> None:
+        """Remove only the resolved package-owned output directory."""
+        output = Path(self._output_dir())
+        if output == Path(output.anchor):
+            raise ValueError("refusing to clean a filesystem root as Montage output")
+        result = Rm(
+            str(output),
+            self._node_exec_info(env=self.env),
+            recursive=True,
+        ).run()
+        self._require_success(result, "Montage output cleanup")

--- a/builtin/builtin/montage/pkg.py
+++ b/builtin/builtin/montage/pkg.py
@@ -7,6 +7,7 @@ import math
 import os
 import re
 import shlex
+import shutil
 import tempfile
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -381,19 +382,71 @@ class Montage(Application):
 
     def _prepare_offline_inputs(
         self,
-    ) -> tuple[dict[str, tuple[Path, Path]], dict[str, str]]:
-        """Extract and stage the exact J/H/K bundle bytes for one execution."""
+    ) -> tuple[
+        dict[str, tuple[MaterializedInputBundle, PurePosixPath]],
+        dict[str, str],
+    ]:
+        """Extract and validate the exact J/H/K bundle bytes for one execution."""
         output = Path(self._output_dir())
-        prepared: dict[str, tuple[Path, Path]] = {}
+        prepared: dict[str, tuple[MaterializedInputBundle, PurePosixPath]] = {}
         digests: dict[str, str] = {}
+        common_header: bytes | None = None
         for band, configured in self._configured_bundles().items():
             bundle = extract_input_bundle(configured, output / "input-bundles")
             raw_relative = self._bundle_raw_directory(bundle)
-            destination = output / f"inputs-{band}"
-            header = stage_input_bundle(bundle, destination)
-            prepared[band] = (destination / Path(raw_relative.as_posix()), header)
+            header_bytes = bundle.entrypoint.read_bytes()
+            if common_header is None:
+                common_header = header_bytes
+            elif header_bytes != common_header:
+                raise ValueError(
+                    "Montage J, H, and K bundles must share one mosaic header"
+                )
+            prepared[band] = (bundle, raw_relative)
             digests[band] = bundle.bundle_sha256
         return prepared, digests
+
+    @staticmethod
+    def _short_scratch_parent() -> Path:
+        """Select a writable real directory for Montage's bounded path workspace."""
+        candidates = (Path("/dev/shm"), Path(tempfile.gettempdir()))
+        for candidate in candidates:
+            try:
+                if (
+                    candidate.is_dir()
+                    and not candidate.is_symlink()
+                    and os.access(candidate, os.W_OK | os.X_OK)
+                ):
+                    return candidate
+            except OSError:
+                continue
+        raise RuntimeError("Montage requires a writable local scratch directory")
+
+    @staticmethod
+    def _publish_scratch_file(source: Path, destination: Path) -> None:
+        """Atomically copy one regular scratch product into durable package storage."""
+        if source.is_symlink() or not source.is_file():
+            raise RuntimeError(f"Montage scratch product is missing: {source.name}")
+        if destination.exists() or destination.is_symlink():
+            raise RuntimeError(
+                f"Montage durable product already exists: {destination.name}"
+            )
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{destination.name}.",
+            dir=destination.parent,
+        )
+        temporary = Path(temporary_name)
+        try:
+            with (
+                source.open("rb") as source_stream,
+                os.fdopen(descriptor, "wb") as destination_stream,
+            ):
+                shutil.copyfileobj(source_stream, destination_stream)
+                destination_stream.flush()
+                os.fsync(destination_stream.fileno())
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, destination)
+        finally:
+            temporary.unlink(missing_ok=True)
 
     @staticmethod
     def _parse_statistics(text: str, *, band: str, mosaic: str) -> dict[str, Any]:
@@ -526,60 +579,99 @@ class Montage(Application):
             if callback is not None
             else None
         )
-        info = LocalExecInfo(
-            env=self.mod_env,
-            cwd=str(output),
-            timeout=1800,
-            line_callback=intermediate,
-        )
-        for band in _BANDS:
-            raw, header = prepared[band]
-            workspace = output / f"work-{band}"
-            workspace.mkdir(mode=0o700)
-            mosaic = output / f"montage-{band}.fits"
-            command = " ".join(
+        scratch_parent = self._short_scratch_parent()
+        with tempfile.TemporaryDirectory(prefix="jm-", dir=scratch_parent) as name:
+            scratch = Path(name)
+            if len(str(scratch)) >= 128:
+                raise RuntimeError(
+                    "Montage local scratch path exceeds its safe execution bound"
+                )
+            for band in _BANDS:
+                bundle, raw_relative = prepared[band]
+                band_scratch = scratch / band
+                band_scratch.mkdir(mode=0o700)
+                staged = band_scratch / "staged"
+                header = stage_input_bundle(bundle, staged)
+                raw_argument = (PurePosixPath("staged") / raw_relative).as_posix()
+                header_argument = header.relative_to(band_scratch).as_posix()
+                if max(len(raw_argument), len(header_argument)) >= 96:
+                    raise RuntimeError(
+                        "Montage bundle paths exceed its safe execution bound"
+                    )
+                info = LocalExecInfo(
+                    env=self.mod_env,
+                    cwd=str(band_scratch),
+                    timeout=1800,
+                    line_callback=intermediate,
+                )
+                command = " ".join(
+                    (
+                        "mExec",
+                        "-r",
+                        shlex.quote(raw_argument),
+                        "-f",
+                        shlex.quote(header_argument),
+                        "-o",
+                        "mosaic.fits",
+                        "2MASS",
+                        band.upper(),
+                        "workspace",
+                    )
+                )
+                self._require_success(
+                    Exec(command, info).run(), f"Montage {band.upper()} mosaic"
+                )
+                scratch_mosaic = band_scratch / "mosaic.fits"
+                self._validate_fits(scratch_mosaic)
+                self._require_success(
+                    Exec("mExamine mosaic.fits > statistics.txt", info).run(),
+                    f"Montage {band.upper()} statistics",
+                )
+                scratch_statistics = band_scratch / "statistics.txt"
+                if scratch_statistics.is_symlink() or not scratch_statistics.is_file():
+                    raise RuntimeError(f"Montage {band.upper()} statistics are missing")
+                self._parse_statistics(
+                    scratch_statistics.read_text(encoding="utf-8", errors="strict"),
+                    band=band,
+                    mosaic=f"montage-{band}.fits",
+                )
+                self._publish_scratch_file(
+                    scratch_mosaic,
+                    output / f"montage-{band}.fits",
+                )
+                self._publish_scratch_file(
+                    scratch_statistics,
+                    output / f"montage-{band}-statistics.txt",
+                )
+
+            composite = scratch / _COMPOSITE_NAME
+            viewer = " ".join(
                 (
-                    "mExec",
-                    "-r",
-                    shlex.quote(str(raw)),
-                    "-f",
-                    shlex.quote(str(header)),
-                    "-o",
-                    shlex.quote(str(mosaic)),
-                    "2MASS",
-                    band.upper(),
-                    shlex.quote(str(workspace)),
+                    "mViewer",
+                    "-blue",
+                    "j/mosaic.fits",
+                    "-1s max gaussian-log",
+                    "-green",
+                    "h/mosaic.fits",
+                    "-1s max gaussian-log",
+                    "-red",
+                    "k/mosaic.fits",
+                    "-1s max gaussian-log",
+                    "-out",
+                    _COMPOSITE_NAME,
                 )
             )
+            viewer_info = LocalExecInfo(
+                env=self.mod_env,
+                cwd=str(scratch),
+                timeout=1800,
+                line_callback=intermediate,
+            )
             self._require_success(
-                Exec(command, info).run(), f"Montage {band.upper()} mosaic"
+                Exec(viewer, viewer_info).run(), "Montage J/H/K composite"
             )
-            statistics = output / f"montage-{band}-statistics.txt"
-            examine = (
-                f"mExamine {shlex.quote(str(mosaic))} > {shlex.quote(str(statistics))}"
-            )
-            self._require_success(
-                Exec(examine, info).run(),
-                f"Montage {band.upper()} statistics",
-            )
-        composite = output / _COMPOSITE_NAME
-        viewer = " ".join(
-            (
-                "mViewer",
-                "-blue",
-                shlex.quote(str(output / "montage-j.fits")),
-                "-1s max gaussian-log",
-                "-green",
-                shlex.quote(str(output / "montage-h.fits")),
-                "-1s max gaussian-log",
-                "-red",
-                shlex.quote(str(output / "montage-k.fits")),
-                "-1s max gaussian-log",
-                "-out",
-                shlex.quote(str(composite)),
-            )
-        )
-        self._require_success(Exec(viewer, info).run(), "Montage J/H/K composite")
+            self._validate_composite(composite)
+            self._publish_scratch_file(composite, output / _COMPOSITE_NAME)
         self._write_result(output, digests)
         terminal = (
             RuntimePhaseLineCallback(callback, terminal=True)

--- a/builtin/builtin/montage/pkg.py
+++ b/builtin/builtin/montage/pkg.py
@@ -151,6 +151,7 @@ class Montage(Application):
                 program,
                 environment=self._deployment_environment(),
                 arguments=(),
+                accepted_return_codes=(0, 1),
             )
             for program in ("mExec", "mExamine", "mViewer")
         )

--- a/builtin/builtin/montage/run_mosaic.sh
+++ b/builtin/builtin/montage/run_mosaic.sh
@@ -19,6 +19,9 @@ RAW_DIR="${1:-/opt/montage-bench/raw_images}"
 HDR="${2:-/opt/montage-bench/region.hdr}"
 OUT="${3:-${HOME}/montage_out}"
 HOSTS="${4:-}"
+REGION="${MONTAGE_REGION:-M17}"
+BAND="${MONTAGE_BAND:-J}"
+SIZE="${MONTAGE_SIZE:-0.2}"
 
 mkdir -p "$OUT"/{projected,diffs,corrected}
 
@@ -28,7 +31,7 @@ mkdir -p "$OUT"/{projected,diffs,corrected}
 # reachable now. Bounded so a persistent outage fails fast with a clear
 # message instead of hanging the pipeline start.
 if [ ! -s "$HDR" ] || [ -z "$(ls -A "$RAW_DIR" 2>/dev/null)" ]; then
-    echo "Benchmark region not pre-staged; fetching M17 J-band at runtime..."
+    echo "Archive region not pre-staged; fetching ${REGION} ${BAND}-band at runtime..."
     mkdir -p "$RAW_DIR"
     cd "$(dirname "$HDR")"
     # Montage's homegrown HTTP fetcher (svc/svc.c) can't parse
@@ -38,9 +41,9 @@ if [ ! -s "$HDR" ] || [ -z "$(ls -A "$RAW_DIR" 2>/dev/null)" ]; then
     # mArchiveExec with a curl loop — libcurl handles authenticated
     # proxies, so the FITS pulls work behind a squid with creds.
     env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY \
-        mHdr "M17" 0.2 "$(basename "$HDR")"
+        mHdr "$REGION" "$SIZE" "$(basename "$HDR")"
     env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY \
-        mArchiveList 2mass J "M17" 0.2 0.2 remote.tbl
+        mArchiveList 2mass "$BAND" "$REGION" "$SIZE" "$SIZE" remote.tbl
     fetched=0
     while read -r url; do
         fname=$(basename "$url")

--- a/jarvis_cd/deployment.py
+++ b/jarvis_cd/deployment.py
@@ -262,6 +262,7 @@ def probe_program(
     *,
     environment: Mapping[str, str],
     arguments: Sequence[str] = ("--help",),
+    accepted_return_codes: Sequence[int] = (0,),
     timeout_seconds: float = 15,
 ) -> ProgramProbeResult:
     """Probe a program through ``PATH`` without exposing its resolved location.
@@ -273,6 +274,14 @@ def probe_program(
     _validate_text(program, "runtime program")
     if _looks_absolute(program):
         raise ValueError("runtime probes must use a semantic program name")
+    accepted = tuple(accepted_return_codes)
+    if not accepted or any(
+        isinstance(code, bool) or not isinstance(code, int) or not 0 <= code <= 255
+        for code in accepted
+    ):
+        raise ValueError("accepted runtime probe return codes must be bounded integers")
+    if len(set(accepted)) != len(accepted):
+        raise ValueError("accepted runtime probe return codes must be unique")
     if timeout_seconds <= 0:
         raise ValueError("runtime probe timeout must be positive")
     resolved = which(program, path=environment.get("PATH"))
@@ -291,7 +300,7 @@ def probe_program(
         )
     except (OSError, subprocess.SubprocessError):
         return ProgramProbeResult(RuntimeStatus("unavailable", "runtime_probe_failed"))
-    if completed.returncode != 0:
+    if completed.returncode not in accepted:
         return ProgramProbeResult(RuntimeStatus("unavailable", "runtime_probe_failed"))
     return ProgramProbeResult(
         RuntimeStatus("ready", "runtime_probe_succeeded"),

--- a/test/unit/core/test_montage_artifacts.py
+++ b/test/unit/core/test_montage_artifacts.py
@@ -1,0 +1,126 @@
+"""Generated-artifact tests for the builtin Montage package."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import (
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "montage"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def _products(root: Path) -> None:
+    for band in ("j", "h", "k"):
+        (root / f"montage-{band}.fits").write_bytes(b"SIMPLE  " + bytes(4096))
+    (root / "montage-jhk.png").write_bytes(b"\x89PNG\r\n\x1a\n" + bytes(2048))
+    (root / "montage-result.json").write_text(
+        json.dumps({"schema_version": "jarvis.montage-result.v1"}) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_montage_success_finalizes_only_declared_products(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The provider reports FITS, composite, and result products without crawling."""
+    _products(tmp_path)
+    (tmp_path / "unrelated.txt").write_text("ignore\n", encoding="utf-8")
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.montage",
+            "out": "/execution/shared/montage",
+            "j_bundle": "/inputs/j.tar",
+            "h_bundle": "/inputs/h.tar",
+            "k_bundle": "/inputs/k.tar",
+            "region": "M31",
+        }
+    )
+    monkeypatch.setattr(module, "Path", lambda _value: tmp_path)
+
+    assert adapter is not None
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert adapter.finalize_artifacts_for_exit(0) == []
+    assert {item.logical_name for item in observations} == {
+        "montage-j-mosaic",
+        "montage-h-mosaic",
+        "montage-k-mosaic",
+        "montage-three-band-composite",
+        "montage-result",
+    }
+    assert {item.state for item in observations} == {ArtifactState.FINALIZED}
+    assert sum(item.role is ArtifactRole.OUTPUT for item in observations) == 4
+    result = next(
+        item for item in observations if item.logical_name == "montage-result"
+    )
+    assert result.role is ArtifactRole.VALIDATION
+    assert result.structure is ArtifactStructure.FILE
+
+
+def test_montage_missing_product_is_incomplete_even_after_zero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Process exit alone cannot claim a complete three-band product set."""
+    _products(tmp_path)
+    (tmp_path / "montage-k.fits").unlink()
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.montage",
+            "out": "/execution/shared/montage",
+            "j_bundle": "/inputs/j.tar",
+            "h_bundle": "/inputs/h.tar",
+            "k_bundle": "/inputs/k.tar",
+            "region": "M31",
+        }
+    )
+    monkeypatch.setattr(module, "Path", lambda _value: tmp_path)
+
+    assert adapter is not None
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    missing = next(
+        item for item in observations if item.logical_name == "montage-k-mosaic"
+    )
+    assert missing.state is ArtifactState.INCOMPLETE
+    assert missing.location is None
+
+
+def test_montage_factory_confines_relative_output_to_shared_root() -> None:
+    """Artifacts cannot escape the package-owned shared output namespace."""
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.montage",
+            "out": ".",
+            "shared_dir": "/execution/shared/montage",
+            "j_bundle": "/inputs/j.tar",
+            "h_bundle": "/inputs/h.tar",
+            "k_bundle": "/inputs/k.tar",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.output_dir.as_posix() == "/execution/shared/montage"
+    assert module.adapter_from_package({"pkg_type": "builtin.lammps"}) is None

--- a/test/unit/core/test_montage_package.py
+++ b/test/unit/core/test_montage_package.py
@@ -1,0 +1,285 @@
+"""Runtime-contract tests for the builtin Montage package."""
+
+from __future__ import annotations
+
+import shlex
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def _load_package() -> ModuleType:
+    """Load builtin Montage without repository registration."""
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "montage"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_builtin_montage", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load the Montage package from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+montage_package = _load_package()
+
+
+class _RuntimeCallback:
+    """Capture the one terminal process finalization."""
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+        self.finalizations: list[int] = []
+
+    def __call__(self, _stream: str, line: str) -> None:
+        self.lines.append(line)
+
+    def finalize_process(self, return_code: int) -> None:
+        self.finalizations.append(return_code)
+
+
+class _CapturedExec:
+    """Execute no external programs while materializing expected products."""
+
+    commands: list[str] = []
+    failures: dict[str, int] = {}
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": self.failures.get(command, 0)}
+        self.commands.append(command)
+
+    def run(self) -> _CapturedExec:
+        """Materialize products corresponding to a successful Montage command."""
+        return_code = self.exit_code["localhost"]
+        if return_code == 0:
+            tokens = shlex.split(self.command)
+            if tokens and tokens[0] == "mExec":
+                output = Path(tokens[tokens.index("-o") + 1])
+                output.write_bytes(b"SIMPLE  " + bytes(4096))
+            elif tokens and tokens[0] == "mExamine":
+                stats = Path(tokens[tokens.index(">") + 1])
+                stats.write_text(
+                    '[struct stat="OK", npixel=4096, nnull=32, '
+                    "aveflux=1.25, rmsflux=0.50]\n",
+                    encoding="utf-8",
+                )
+            elif tokens and tokens[0] == "mViewer":
+                composite = Path(tokens[tokens.index("-out") + 1])
+                composite.write_bytes(b"\x89PNG\r\n\x1a\n" + bytes(2048))
+        callback = getattr(self.exec_info, "line_callback", None)
+        if callback is not None:
+            callback("stdout", f"{self.command}\n")
+            callback.finalize_process(return_code)
+        return self
+
+
+def _bundle(tmp_path: Path, band: str) -> SimpleNamespace:
+    """Create one verified-bundle-shaped test object."""
+    root = tmp_path / f"materialized-{band}"
+    source = root / band / f"source-{band}.fits"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"SIMPLE  " + bytes(4096))
+    header = root / "region.hdr"
+    header.write_text("SIMPLE mosaic header\n", encoding="utf-8")
+    return SimpleNamespace(
+        band=band,
+        bundle_sha256=band * 64,
+        entrypoint=header,
+        manifest=SimpleNamespace(
+            entrypoint="region.hdr",
+            files=(
+                SimpleNamespace(path=f"{band}/source-{band}.fits", role="fits_source"),
+                SimpleNamespace(path="region.hdr", role="mosaic_header"),
+            ),
+        ),
+        root=root,
+    )
+
+
+def _package(tmp_path: Path, **updates: object) -> Any:
+    """Build a minimally configured Montage package."""
+    package = object.__new__(montage_package.Montage)
+    package.shared_dir = str(tmp_path / "shared")
+    package.private_dir = str(tmp_path / "private")
+    package.get_hostfile = lambda: None
+    package.env = {"PATH": "/runtime/bin"}
+    package.mod_env = dict(package.env)
+    package.config = {
+        "deploy_mode": "default",
+        "region": "M31",
+        "band": "j",
+        "size": 0.2,
+        "out": ".",
+        "j_bundle": "/inputs/j.tar",
+        "h_bundle": "/inputs/h.tar",
+        "k_bundle": "/inputs/k.tar",
+        "nprocs": 1,
+        "ppn": 1,
+    }
+    package.config.update(updates)
+    return package
+
+
+def test_montage_contract_discloses_offline_three_band_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agents can discover a network-independent supplied-input profile."""
+    package = object.__new__(montage_package.Montage)
+    package.config = {"deploy_mode": "default"}
+    package.mod_env = {"PATH": "/runtime/bin"}
+    package.env = dict(package.mod_env)
+    package._deployment_environment = lambda: package.mod_env
+    monkeypatch.setattr(
+        montage_package,
+        "probe_program",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            status=montage_package.RuntimeStatus("ready", "test")
+        ),
+    )
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    contract = package._deployment_contract().to_dict()
+
+    for band in ("j", "h", "k"):
+        assert menu[f"{band}_bundle"]["input_binding"]["kind"] == "local_file"
+    profiles = {item["name"]: item for item in contract["execution_profiles"]}
+    offline = profiles["offline_three_band"]
+    assert offline["execution_kind"] == "batch"
+    assert {item["parameter"] for item in offline["when"]} == {
+        "j_bundle",
+        "h_bundle",
+        "k_bundle",
+    }
+    runtime = contract["runtime_requirements"][0]
+    assert runtime["provider_resolutions"][0]["query"]["value"] == "montage@6.0"
+
+
+def test_montage_rejects_partial_offline_and_container_configuration(
+    tmp_path: Path,
+) -> None:
+    """Offline inputs are all-or-none and never trigger a container build."""
+    partial = _package(tmp_path, h_bundle="", k_bundle="")
+    with pytest.raises(ValueError, match="all three"):
+        partial._validate_configuration()
+    container = _package(tmp_path, deploy_mode="container")
+    with pytest.raises(ValueError, match="native execution"):
+        container._validate_configuration()
+
+
+def test_legacy_script_uses_configured_archive_coordinates() -> None:
+    """Legacy acquisition cannot silently fall back to fixed M17/J coordinates."""
+    script = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "montage"
+        / "run_mosaic.sh"
+    ).read_text(encoding="utf-8")
+
+    assert 'REGION="${MONTAGE_REGION:-M17}"' in script
+    assert 'BAND="${MONTAGE_BAND:-J}"' in script
+    assert 'SIZE="${MONTAGE_SIZE:-0.2}"' in script
+    assert 'mHdr "$REGION" "$SIZE"' in script
+    assert 'mArchiveList 2mass "$BAND" "$REGION" "$SIZE" "$SIZE"' in script
+
+
+def test_montage_offline_profile_runs_three_bands_and_finalizes_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The maintained profile stages inputs, validates outputs, and closes once."""
+    package = _package(tmp_path)
+    callback = _RuntimeCallback()
+    package.runtime_line_callback = lambda: callback
+    bundles = {
+        f"/inputs/{band}.tar": _bundle(tmp_path, band) for band in ("j", "h", "k")
+    }
+
+    def stage(bundle: SimpleNamespace, destination: Path) -> Path:
+        destination.mkdir(parents=True, exist_ok=True)
+        source = destination / bundle.band / f"source-{bundle.band}.fits"
+        source.parent.mkdir(parents=True)
+        source.write_bytes(b"SIMPLE  " + bytes(4096))
+        header = destination / "region.hdr"
+        header.write_text("SIMPLE mosaic header\n", encoding="utf-8")
+        return header
+
+    _CapturedExec.commands = []
+    _CapturedExec.failures = {}
+    monkeypatch.setattr(montage_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(
+        montage_package,
+        "extract_input_bundle",
+        lambda path, _destination: bundles[path],
+    )
+    monkeypatch.setattr(montage_package, "stage_input_bundle", stage)
+
+    package.start()
+
+    assert sum(command.startswith("mExec ") for command in _CapturedExec.commands) == 3
+    assert (
+        sum(command.startswith("mExamine ") for command in _CapturedExec.commands) == 3
+    )
+    assert (
+        sum(command.startswith("mViewer ") for command in _CapturedExec.commands) == 1
+    )
+    assert callback.finalizations == [0]
+    output = Path(package.shared_dir)
+    assert (output / "montage-j.fits").is_file()
+    assert (output / "montage-h.fits").is_file()
+    assert (output / "montage-k.fits").is_file()
+    assert (output / "montage-jhk.png").is_file()
+    assert (output / "montage-result.json").is_file()
+
+
+def test_montage_propagates_the_first_command_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A failed Montage command cannot become scheduler success."""
+    package = _package(tmp_path)
+    package.runtime_line_callback = _RuntimeCallback
+    bundles = {
+        f"/inputs/{band}.tar": _bundle(tmp_path, band) for band in ("j", "h", "k")
+    }
+    monkeypatch.setattr(montage_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(
+        montage_package,
+        "extract_input_bundle",
+        lambda path, _destination: bundles[path],
+    )
+    monkeypatch.setattr(
+        montage_package,
+        "stage_input_bundle",
+        lambda bundle, destination: destination / bundle.manifest.entrypoint,
+    )
+    _CapturedExec.commands = []
+    _CapturedExec.failures = {}
+    output = Path(package.shared_dir)
+    failed_command = " ".join(
+        (
+            "mExec",
+            "-r",
+            shlex.quote(str(output / "inputs-j" / "j")),
+            "-f",
+            shlex.quote(str(output / "inputs-j" / "region.hdr")),
+            "-o",
+            shlex.quote(str(output / "montage-j.fits")),
+            "2MASS",
+            "J",
+            shlex.quote(str(output / "work-j")),
+        )
+    )
+    _CapturedExec.failures[failed_command] = 7
+
+    with pytest.raises(RuntimeError, match="Montage J mosaic failed"):
+        package.start()

--- a/test/unit/core/test_montage_package.py
+++ b/test/unit/core/test_montage_package.py
@@ -49,6 +49,7 @@ class _CapturedExec:
     """Execute no external programs while materializing expected products."""
 
     commands: list[str] = []
+    working_directories: list[str] = []
     failures: dict[str, int] = {}
 
     def __init__(self, command: str, exec_info: Any) -> None:
@@ -56,24 +57,30 @@ class _CapturedExec:
         self.exec_info = exec_info
         self.exit_code = {"localhost": self.failures.get(command, 0)}
         self.commands.append(command)
+        self.working_directories.append(str(exec_info.cwd))
 
     def run(self) -> _CapturedExec:
         """Materialize products corresponding to a successful Montage command."""
         return_code = self.exit_code["localhost"]
         if return_code == 0:
             tokens = shlex.split(self.command)
+
+            def resolve(value: str) -> Path:
+                path = Path(value)
+                return path if path.is_absolute() else Path(self.exec_info.cwd) / path
+
             if tokens and tokens[0] == "mExec":
-                output = Path(tokens[tokens.index("-o") + 1])
+                output = resolve(tokens[tokens.index("-o") + 1])
                 output.write_bytes(b"SIMPLE  " + bytes(4096))
             elif tokens and tokens[0] == "mExamine":
-                stats = Path(tokens[tokens.index(">") + 1])
+                stats = resolve(tokens[tokens.index(">") + 1])
                 stats.write_text(
                     '[struct stat="OK", npixel=4096, nnull=32, '
                     "aveflux=1.25, rmsflux=0.50]\n",
                     encoding="utf-8",
                 )
             elif tokens and tokens[0] == "mViewer":
-                composite = Path(tokens[tokens.index("-out") + 1])
+                composite = resolve(tokens[tokens.index("-out") + 1])
                 composite.write_bytes(b"\x89PNG\r\n\x1a\n" + bytes(2048))
         callback = getattr(self.exec_info, "line_callback", None)
         if callback is not None:
@@ -103,6 +110,17 @@ def _bundle(tmp_path: Path, band: str) -> SimpleNamespace:
         ),
         root=root,
     )
+
+
+def _stage_bundle(bundle: SimpleNamespace, destination: Path) -> Path:
+    """Stage one bundle-shaped fixture into a mutable scratch directory."""
+    destination.mkdir(parents=True, exist_ok=True)
+    source = destination / bundle.band / f"source-{bundle.band}.fits"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"SIMPLE  " + bytes(4096))
+    header = destination / "region.hdr"
+    header.write_text("SIMPLE mosaic header\n", encoding="utf-8")
+    return header
 
 
 def _package(tmp_path: Path, **updates: object) -> Any:
@@ -204,16 +222,8 @@ def test_montage_offline_profile_runs_three_bands_and_finalizes_once(
         f"/inputs/{band}.tar": _bundle(tmp_path, band) for band in ("j", "h", "k")
     }
 
-    def stage(bundle: SimpleNamespace, destination: Path) -> Path:
-        destination.mkdir(parents=True, exist_ok=True)
-        source = destination / bundle.band / f"source-{bundle.band}.fits"
-        source.parent.mkdir(parents=True)
-        source.write_bytes(b"SIMPLE  " + bytes(4096))
-        header = destination / "region.hdr"
-        header.write_text("SIMPLE mosaic header\n", encoding="utf-8")
-        return header
-
     _CapturedExec.commands = []
+    _CapturedExec.working_directories = []
     _CapturedExec.failures = {}
     monkeypatch.setattr(montage_package, "Exec", _CapturedExec)
     monkeypatch.setattr(
@@ -221,8 +231,7 @@ def test_montage_offline_profile_runs_three_bands_and_finalizes_once(
         "extract_input_bundle",
         lambda path, _destination: bundles[path],
     )
-    monkeypatch.setattr(montage_package, "stage_input_bundle", stage)
-
+    monkeypatch.setattr(montage_package, "stage_input_bundle", _stage_bundle)
     package.start()
 
     assert sum(command.startswith("mExec ") for command in _CapturedExec.commands) == 3
@@ -233,6 +242,26 @@ def test_montage_offline_profile_runs_three_bands_and_finalizes_once(
         sum(command.startswith("mViewer ") for command in _CapturedExec.commands) == 1
     )
     assert callback.finalizations == [0]
+    mexec_invocations = [
+        (command, Path(cwd))
+        for command, cwd in zip(
+            _CapturedExec.commands,
+            _CapturedExec.working_directories,
+            strict=True,
+        )
+        if command.startswith("mExec ")
+    ]
+    assert {
+        shlex.split(command)[shlex.split(command).index("-r") + 1]
+        for command, _ in mexec_invocations
+    } == {"staged/j", "staged/h", "staged/k"}
+    assert all(
+        "-f staged/region.hdr -o mosaic.fits" in command
+        for command, _ in mexec_invocations
+    )
+    assert all(cwd != Path(package.shared_dir) for _, cwd in mexec_invocations)
+    assert all(len(str(cwd)) < 128 for _, cwd in mexec_invocations)
+    assert all(not cwd.exists() for _, cwd in mexec_invocations)
     output = Path(package.shared_dir)
     assert (output / "montage-j.fits").is_file()
     assert (output / "montage-h.fits").is_file()
@@ -257,29 +286,42 @@ def test_montage_propagates_the_first_command_failure(
         "extract_input_bundle",
         lambda path, _destination: bundles[path],
     )
-    monkeypatch.setattr(
-        montage_package,
-        "stage_input_bundle",
-        lambda bundle, destination: destination / bundle.manifest.entrypoint,
-    )
+    monkeypatch.setattr(montage_package, "stage_input_bundle", _stage_bundle)
     _CapturedExec.commands = []
+    _CapturedExec.working_directories = []
     _CapturedExec.failures = {}
-    output = Path(package.shared_dir)
-    failed_command = " ".join(
-        (
-            "mExec",
-            "-r",
-            shlex.quote(str(output / "inputs-j" / "j")),
-            "-f",
-            shlex.quote(str(output / "inputs-j" / "region.hdr")),
-            "-o",
-            shlex.quote(str(output / "montage-j.fits")),
-            "2MASS",
-            "J",
-            shlex.quote(str(output / "work-j")),
-        )
+    failed_command = (
+        "mExec -r staged/j -f staged/region.hdr -o mosaic.fits 2MASS J workspace"
     )
     _CapturedExec.failures[failed_command] = 7
 
     with pytest.raises(RuntimeError, match="Montage J mosaic failed"):
         package.start()
+    assert _CapturedExec.working_directories
+    assert all(
+        not Path(directory).exists() for directory in _CapturedExec.working_directories
+    )
+
+
+def test_montage_rejects_different_band_headers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A three-band run cannot silently combine different mosaic regions."""
+    package = _package(tmp_path)
+    Path(package.shared_dir).mkdir(parents=True)
+    bundles = {
+        f"/inputs/{band}.tar": _bundle(tmp_path, band) for band in ("j", "h", "k")
+    }
+    bundles["/inputs/h.tar"].entrypoint.write_text(
+        "different mosaic header\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        montage_package,
+        "extract_input_bundle",
+        lambda path, _destination: bundles[path],
+    )
+
+    with pytest.raises(ValueError, match="share one mosaic header"):
+        package._prepare_offline_inputs()

--- a/test/unit/core/test_package_deployment_contract.py
+++ b/test/unit/core/test_package_deployment_contract.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import pytest
 
+import jarvis_cd.deployment as deployment_module
 from jarvis_cd.core.pkg import Interceptor, Pkg
 from jarvis_cd.deployment import (
     ConfigurationCondition,
@@ -21,13 +22,14 @@ from jarvis_cd.deployment import (
     ReadinessContract,
     RuntimeRequirement,
     RuntimeStatus,
+    probe_program,
 )
 
 _BUILTIN_REPOSITORY_ROOT = Path(__file__).resolve().parents[3] / "builtin"
 sys.path.insert(0, str(_BUILTIN_REPOSITORY_ROOT))
 
-from builtin.lammps import pkg as lammps_module  # noqa: E402
-from builtin.paraview import pkg as paraview_module  # noqa: E402
+from builtin.lammps import pkg as lammps_module  # pyright: ignore[reportMissingImports]  # noqa: E402
+from builtin.paraview import pkg as paraview_module  # pyright: ignore[reportMissingImports]  # noqa: E402
 from jarvis_cd.core.config import Jarvis  # noqa: E402
 
 
@@ -150,6 +152,48 @@ def test_configuration_input_binding_is_closed_and_machine_readable() -> None:
             kind="local_file",
             structure="regular_file",
             schema_version="jarvis.configuration-input-binding.v2",
+        )
+
+
+def test_program_probe_can_accept_a_documented_usage_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI tools that use exit 1 for side-effect-free usage remain probeable."""
+    monkeypatch.setattr(
+        deployment_module,
+        "which",
+        lambda _program, *, path: "/runtime/bin/mExec" if path else None,
+    )
+    monkeypatch.setattr(
+        deployment_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=1,
+            stdout='[struct stat="ERROR", msg="Usage: mExec ..."]\n',
+            stderr="",
+        ),
+    )
+
+    accepted = probe_program(
+        "mExec",
+        environment={"PATH": "/runtime/bin"},
+        arguments=(),
+        accepted_return_codes=(0, 1),
+    )
+    strict = probe_program(
+        "mExec",
+        environment={"PATH": "/runtime/bin"},
+        arguments=(),
+    )
+
+    assert accepted.status.usable is True
+    assert "Usage: mExec" in accepted.output
+    assert strict.status.usable is False
+    with pytest.raises(ValueError, match="bounded integers"):
+        probe_program(
+            "mExec",
+            environment={"PATH": "/runtime/bin"},
+            accepted_return_codes=(),
         )
 
 


### PR DESCRIPTION
## What changed

- adds a network-independent three-band Montage profile driven by three digest-verified J/H/K input bundles
- validates and records exact J, H, and K FITS mosaics, a rendered PNG composite, and a machine-readable result document
- exposes pinned Montage 6 deployment and input-binding semantics to generic clients
- propagates command and product-validation failures while preserving the existing archive-driven profile

## Why

The existing package encoded a container-oriented archive example and did not provide a reusable supplied-input workflow with durable artifact semantics. Scientific deployments need to replay a fixed FITS corpus without runtime acquisition and preserve the resulting mosaics and visualization through the normal JARVIS contracts.

## Validation

- `uv run --no-sync --no-cache pytest -q test/unit/core/test_montage_package.py test/unit/core/test_montage_artifacts.py test/unit/core/test_package_deployment_contract.py test/unit/core/test_artifact_spi.py test/unit/core/test_runtime_phase_callback.py` (37 passed)
- focused interceptor graph suite (9 passed)
- Ruff check and format checks pass for all changed Python files
- Pyright reports zero errors for all changed Python files
- three benchmark J/H/K archives pass the real `jarvis_cd.input_bundle.extract_input_bundle` implementation

The broader `test/unit/core` run was stopped after entering an unrelated silent long-running test and is not claimed as green here. CI and live Ares qualification are still pending. This PR remains draft and is stacked on #190.