### PR TITLE
feat: add Gray-Scott morphology analysis

### DIFF
--- a/builtin/builtin/adios2_gray_scott_analysis/INSTALL.md
+++ b/builtin/builtin/adios2_gray_scott_analysis/INSTALL.md
@@ -1,0 +1,5 @@
+# Installation
+
+The installed-executable profile requires `gray-scott-analyze` on `PATH` with an ADIOS2 runtime.
+
+The source-bundle profile requires CMake, an MPI C++ compiler, and ADIOS2 development libraries. JARVIS verifies and stages the complete source bundle in package-owned storage, configures it with CMake, and builds only the `gray-scott-analyze` target.

--- a/builtin/builtin/adios2_gray_scott_analysis/README.md
+++ b/builtin/builtin/adios2_gray_scott_analysis/README.md
@@ -1,0 +1,7 @@
+# ADIOS2 Gray-Scott Analysis
+
+`builtin.adios2_gray_scott_analysis` compares the final three-dimensional fields from two completed ADIOS2 Gray-Scott BP datasets. It reports per-field morphology and a paired V-field comparison as one validated JSON artifact.
+
+The package can run an installed `gray-scott-analyze` executable or build only that target from a digest-verified input bundle. The bundle must declare exactly one `build_spec`, exactly one `analysis_source`, and the two selected configurations as `scientific_input` files.
+
+This is an application package. It does not infer datasets, configurations, or thresholds, and it does not replace the Gray-Scott simulation package.

--- a/builtin/builtin/adios2_gray_scott_analysis/USE.md
+++ b/builtin/builtin/adios2_gray_scott_analysis/USE.md
@@ -1,0 +1,11 @@
+# Usage
+
+Add `builtin.adios2_gray_scott_analysis` after two Gray-Scott simulations have completed. Configure:
+
+- `low_input` and `high_input` as the exact absolute BP collection paths.
+- `low_configuration` and `high_configuration` as absolute JSON files for the installed profile, or as manifest-relative `scientific_input` members for the source-bundle profile.
+- `active_threshold` as the V concentration threshold used to classify active cells.
+- `output_file` as the JSON comparison destination.
+- `input_bundle` only when building the analyzer from verified source.
+
+JARVIS validates both datasets and configurations before launch. Successful process exit is accepted only when the analyzer produces the closed `jarvis.gray-scott-morphology.v1` result bound to both input configurations and the requested threshold.

--- a/builtin/builtin/adios2_gray_scott_analysis/artifacts.py
+++ b/builtin/builtin/adios2_gray_scott_analysis/artifacts.py
@@ -1,0 +1,247 @@
+"""Artifact semantics for paired Gray-Scott morphology analysis."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+
+_RESULT_SCHEMA = "jarvis.gray-scott-morphology.v1"
+_CASE_FIELDS = {
+    "configuration",
+    "element_count",
+    "final_simulation_step",
+    "output_steps",
+    "shape",
+    "u",
+    "v",
+}
+_METRIC_FIELDS = {
+    "active_fraction",
+    "active_threshold",
+    "component_count",
+    "interface_density",
+    "largest_component_fraction_of_active",
+    "max",
+    "mean",
+    "min",
+    "standard_deviation",
+    "surface_to_active",
+}
+_COMPARISON_FIELDS = {
+    "max_absolute_v_difference",
+    "pearson_v_correlation",
+    "relative_v_l2_difference",
+    "v_rms_difference",
+}
+
+
+@dataclass
+class GrayScottAnalysisArtifactAdapter:
+    """Report the closed paired morphology comparison after process exit."""
+
+    output_path: PurePosixPath
+    active_threshold: float
+    low_input: str
+    high_input: str
+    artifact_id: str = field(default_factory=new_artifact_id)
+    _terminal: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Return no provisional record for the bounded JSON output."""
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Finalize using successful-exit semantics."""
+        return self.finalize_artifacts_for_exit(0)
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Emit one finalized or explicitly incomplete comparison record."""
+        if self._terminal:
+            return []
+        self._terminal = True
+        valid, size_bytes = _valid_result(
+            Path(self.output_path.as_posix()), self.active_threshold
+        )
+        finalized = return_code == 0 and valid
+        return [
+            ArtifactObservation(
+                artifact_id=self.artifact_id,
+                logical_name="gray-scott-morphology-comparison",
+                kind="scientific_analysis",
+                role=ArtifactRole.VALIDATION,
+                structure=ArtifactStructure.FILE,
+                ownership=ArtifactOwnership.SHARED,
+                state=ArtifactState.FINALIZED
+                if finalized
+                else ArtifactState.INCOMPLETE,
+                location=ArtifactLocation.cluster_path(self.output_path)
+                if valid
+                else None,
+                media_type="application/json",
+                format=_RESULT_SCHEMA,
+                size_bytes=size_bytes,
+                message=(
+                    "Gray-Scott morphology comparison finalized"
+                    if finalized
+                    else "Gray-Scott morphology comparison is missing or incomplete"
+                ),
+                metadata={
+                    "active_threshold": self.active_threshold,
+                    "application": "gray_scott",
+                    "analysis": "paired_morphology",
+                    "high_input": self.high_input,
+                    "low_input": self.low_input,
+                    "return_code": return_code,
+                },
+            )
+        ]
+
+    def reset_artifacts(self) -> None:
+        """Allow one later execution lifecycle to report a fresh result."""
+        self._terminal = False
+
+
+def _finite_number(value: object) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(float(value))
+    )
+
+
+def _valid_case(value: object, active_threshold: float | None) -> bool:
+    if not isinstance(value, dict) or set(value) != _CASE_FIELDS:
+        return False
+    shape = value["shape"]
+    if (
+        not isinstance(value["configuration"], dict)
+        or isinstance(value["element_count"], bool)
+        or not isinstance(value["element_count"], int)
+        or value["element_count"] <= 0
+        or isinstance(value["final_simulation_step"], bool)
+        or not isinstance(value["final_simulation_step"], int)
+        or value["final_simulation_step"] < 0
+        or isinstance(value["output_steps"], bool)
+        or not isinstance(value["output_steps"], int)
+        or value["output_steps"] <= 0
+        or not isinstance(shape, list)
+        or len(shape) != 3
+        or any(
+            isinstance(item, bool) or not isinstance(item, int) or item <= 0
+            for item in shape
+        )
+    ):
+        return False
+    if math.prod(shape) != value["element_count"]:
+        return False
+    for field_name in ("u", "v"):
+        metrics = value[field_name]
+        if not isinstance(metrics, dict) or set(metrics) != _METRIC_FIELDS:
+            return False
+        if (
+            isinstance(metrics["component_count"], bool)
+            or not isinstance(metrics["component_count"], int)
+            or metrics["component_count"] < 0
+            or not all(
+                _finite_number(metrics[name])
+                for name in _METRIC_FIELDS - {"component_count"}
+            )
+        ):
+            return False
+        if (
+            active_threshold is not None
+            and metrics["active_threshold"] != active_threshold
+        ):
+            return False
+    return True
+
+
+def _valid_result(
+    path: Path,
+    active_threshold: float | None = None,
+) -> tuple[bool, int | None]:
+    try:
+        status = path.lstat()
+        if (
+            path.is_symlink()
+            or not path.is_file()
+            or not 0 < status.st_size <= 16 * 1024 * 1024
+        ):
+            return False, None
+        value = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+        valid = (
+            isinstance(value, dict)
+            and set(value) == {"schema_version", "cases", "comparison"}
+            and value.get("schema_version") == _RESULT_SCHEMA
+            and isinstance(value.get("cases"), dict)
+            and isinstance(value.get("comparison"), dict)
+        )
+        if valid:
+            cases = value["cases"]
+            comparison = value["comparison"]
+            valid = (
+                set(cases) == {"feed_low", "feed_high"}
+                and set(comparison) == _COMPARISON_FIELDS
+                and all(_finite_number(comparison[name]) for name in comparison)
+                and all(
+                    _valid_case(cases[name], active_threshold)
+                    for name in ("feed_low", "feed_high")
+                )
+            )
+        return valid, status.st_size if valid else None
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False, None
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> GrayScottAnalysisArtifactAdapter | None:
+    """Create artifact semantics only for the maintained analysis package."""
+    if package.get("pkg_type") != "builtin.adios2_gray_scott_analysis":
+        return None
+    output = _absolute_posix_path(package.get("output_file"))
+    threshold = package.get("active_threshold", 0.1)
+    if (
+        isinstance(threshold, bool)
+        or not isinstance(threshold, (int, float))
+        or not math.isfinite(float(threshold))
+        or float(threshold) < 0
+    ):
+        raise ValueError("Gray-Scott analysis threshold must be non-negative")
+    low_input = package.get("low_input")
+    high_input = package.get("high_input")
+    if not isinstance(low_input, str) or not isinstance(high_input, str):
+        raise ValueError("Gray-Scott analysis artifact inputs must be paths")
+    return GrayScottAnalysisArtifactAdapter(
+        output, float(threshold), low_input, high_input
+    )
+
+
+def _absolute_posix_path(value: object) -> PurePosixPath:
+    if not isinstance(value, str) or not value:
+        raise ValueError("Gray-Scott analysis artifact output must be an absolute path")
+    path = PurePosixPath(value)
+    if not path.is_absolute() or path.as_posix() != value or ".." in path.parts:
+        raise ValueError(
+            "Gray-Scott analysis artifact output must be a normalized absolute path"
+        )
+    return path
+
+
+__all__ = ["GrayScottAnalysisArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/adios2_gray_scott_analysis/pkg.py
+++ b/builtin/builtin/adios2_gray_scott_analysis/pkg.py
@@ -453,12 +453,6 @@ class Adios2GrayScottAnalysis(Application):
 
     def _configure(self, **kwargs: Any) -> None:
         super()._configure(**kwargs)
-        output = self.resolve_shared_path(
-            self.config.get("output_file"),
-            field="output_file",
-            default="gray-scott-morphology.json",
-        )
-        cast(dict[str, Any], self.config)["output_file"] = str(output)
         self._validate_configuration()
         configured = self.config.get("input_bundle")
         if configured not in (None, ""):
@@ -514,8 +508,9 @@ class Adios2GrayScottAnalysis(Application):
             self.config.get("high_input"), label="high_input", directory=True
         )
         output = self.config.get("output_file")
-        if not isinstance(output, str) or not Path(output).is_absolute():
-            raise ValueError("output_file must resolve to an absolute path")
+        if not isinstance(output, str) or not output:
+            raise ValueError("output_file must be a non-empty path")
+        self._output_path()
         if self.config.get("input_bundle") in (None, ""):
             self._absolute_existing_path(
                 self.config.get("low_configuration"),
@@ -527,6 +522,14 @@ class Adios2GrayScottAnalysis(Application):
                 label="high_configuration",
                 directory=False,
             )
+
+    def _output_path(self) -> Path:
+        """Resolve the configured result beneath the package shared directory."""
+        return self.resolve_shared_path(
+            self.config.get("output_file"),
+            field="output_file",
+            default="gray-scott-morphology.json",
+        )
 
     def _prepare_bundle_run(self) -> tuple[str, Path, Path, Path]:
         configured = self.config.get("input_bundle")
@@ -569,6 +572,8 @@ class Adios2GrayScottAnalysis(Application):
     def start(self) -> None:
         """Build if requested, analyze both inputs, and validate the result."""
         self._validate_configuration()
+        output = self._output_path()
+        cast(dict[str, Any], self.config)["output_file"] = str(output)
         configured = self.config.get("input_bundle")
         if configured not in (None, ""):
             executable, low_config, high_config, cwd = self._prepare_bundle_run()
@@ -584,14 +589,13 @@ class Adios2GrayScottAnalysis(Application):
                 label="high_configuration",
                 directory=False,
             )
-            cwd = Path(str(self.config["output_file"])).parent
+            cwd = output.parent
         low_input = self._absolute_existing_path(
             self.config["low_input"], label="low_input", directory=True
         )
         high_input = self._absolute_existing_path(
             self.config["high_input"], label="high_input", directory=True
         )
-        output = Path(str(self.config["output_file"]))
         output.parent.mkdir(parents=True, exist_ok=True)
         threshold = _finite_number(
             self.config.get("active_threshold"), label="active_threshold"

--- a/builtin/builtin/adios2_gray_scott_analysis/pkg.py
+++ b/builtin/builtin/adios2_gray_scott_analysis/pkg.py
@@ -1,0 +1,662 @@
+"""Run a paired morphology analysis over ADIOS2 Gray-Scott outputs."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import shlex
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, NamedTuple, cast
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
+from jarvis_cd.shell.process import Rm
+
+_RESULT_SCHEMA = "jarvis.gray-scott-morphology.v1"
+_BUILD_SPEC_ROLE = "build_spec"
+_ANALYSIS_SOURCE_ROLE = "analysis_source"
+_SCIENTIFIC_INPUT_ROLE = "scientific_input"
+_CONFIGURATION_REQUIRED_FIELDS = {
+    "Du",
+    "Dv",
+    "F",
+    "L",
+    "adios_config",
+    "adios_memory_selection",
+    "adios_span",
+    "checkpoint",
+    "checkpoint_freq",
+    "checkpoint_output",
+    "dt",
+    "k",
+    "mesh_type",
+    "noise",
+    "output",
+    "plotgap",
+    "steps",
+}
+_CONFIGURATION_OPTIONAL_FIELDS = {"restart", "restart_input"}
+_CASE_FIELDS = {
+    "configuration",
+    "element_count",
+    "final_simulation_step",
+    "output_steps",
+    "shape",
+    "u",
+    "v",
+}
+_METRIC_FIELDS = {
+    "active_fraction",
+    "active_threshold",
+    "component_count",
+    "interface_density",
+    "largest_component_fraction_of_active",
+    "max",
+    "mean",
+    "min",
+    "standard_deviation",
+    "surface_to_active",
+}
+_COMPARISON_FIELDS = {
+    "max_absolute_v_difference",
+    "pearson_v_correlation",
+    "relative_v_l2_difference",
+    "v_rms_difference",
+}
+
+
+class AnalysisConfiguration(NamedTuple):
+    """One manifest-bound Gray-Scott configuration."""
+
+    path: Path
+    values: Mapping[str, object]
+
+
+class GrayScottAnalysisBundle(NamedTuple):
+    """Build inputs and paired scientific configurations from one bundle."""
+
+    build_spec: Path
+    analysis_source: Path
+    low: AnalysisConfiguration
+    high: AnalysisConfiguration
+
+
+def _safe_bundle_member(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise ValueError(f"{label} must name a declared scientific_input member")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{label} must name a declared scientific_input member")
+    return path.as_posix()
+
+
+def _finite_number(value: object, *, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{label} must be numeric")
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"{label} must be finite")
+    return parsed
+
+
+def _positive_integer(value: object, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+def _validate_configuration_document(value: object) -> Mapping[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError("Gray-Scott configuration must be a JSON object")
+    fields = set(value)
+    missing = _CONFIGURATION_REQUIRED_FIELDS - fields
+    unknown = fields - _CONFIGURATION_REQUIRED_FIELDS - _CONFIGURATION_OPTIONAL_FIELDS
+    if missing or unknown:
+        raise ValueError(
+            "Gray-Scott configuration fields are invalid: "
+            f"missing={sorted(missing)}, unknown={sorted(unknown)}"
+        )
+    for name in ("Du", "Dv", "dt"):
+        if _finite_number(value[name], label=f"Gray-Scott {name}") <= 0:
+            raise ValueError(f"Gray-Scott {name} must be positive")
+    for name in ("F", "k", "noise"):
+        if _finite_number(value[name], label=f"Gray-Scott {name}") < 0:
+            raise ValueError(f"Gray-Scott {name} must be non-negative")
+    for name in ("L", "steps", "plotgap", "checkpoint_freq"):
+        _positive_integer(value[name], label=f"Gray-Scott {name}")
+    if cast(int, value["plotgap"]) > cast(int, value["steps"]):
+        raise ValueError("Gray-Scott plotgap cannot exceed steps")
+    for name in ("checkpoint", "adios_span", "adios_memory_selection"):
+        if not isinstance(value[name], bool):
+            raise ValueError(f"Gray-Scott {name} must be boolean")
+    if "restart" in value and not isinstance(value["restart"], bool):
+        raise ValueError("Gray-Scott restart must be boolean")
+    for name in ("adios_config", "checkpoint_output", "mesh_type", "output"):
+        if not isinstance(value[name], str) or not value[name]:
+            raise ValueError(f"Gray-Scott {name} must be a non-empty string")
+    return value
+
+
+def _load_configuration(path: Path) -> Mapping[str, object]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("Gray-Scott configuration is not valid UTF-8 JSON") from exc
+    return _validate_configuration_document(value)
+
+
+def resolve_analysis_bundle(
+    bundle: MaterializedInputBundle,
+    low_configuration: str,
+    high_configuration: str,
+) -> GrayScottAnalysisBundle:
+    """Resolve the sole analyzer build and two declared configurations."""
+    roles = {item.path: item.role for item in bundle.manifest.files}
+    build_specs = [path for path, role in roles.items() if role == _BUILD_SPEC_ROLE]
+    analysis_sources = [
+        path for path, role in roles.items() if role == _ANALYSIS_SOURCE_ROLE
+    ]
+    if len(build_specs) != 1:
+        raise ValueError("Gray-Scott analysis bundle requires one build_spec")
+    if len(analysis_sources) != 1:
+        raise ValueError("Gray-Scott analysis bundle requires one analysis_source")
+    low_member = _safe_bundle_member(low_configuration, label="low_configuration")
+    high_member = _safe_bundle_member(high_configuration, label="high_configuration")
+    if low_member == high_member:
+        raise ValueError("paired Gray-Scott configurations must be distinct")
+    for label, member in (
+        ("low_configuration", low_member),
+        ("high_configuration", high_member),
+    ):
+        if roles.get(member) != _SCIENTIFIC_INPUT_ROLE:
+            raise ValueError(f"{label} must name a declared scientific_input member")
+    low_path = bundle.root / PurePosixPath(low_member)
+    high_path = bundle.root / PurePosixPath(high_member)
+    return GrayScottAnalysisBundle(
+        build_spec=bundle.root / PurePosixPath(build_specs[0]),
+        analysis_source=bundle.root / PurePosixPath(analysis_sources[0]),
+        low=AnalysisConfiguration(low_path, _load_configuration(low_path)),
+        high=AnalysisConfiguration(high_path, _load_configuration(high_path)),
+    )
+
+
+def _validate_metrics(value: object, *, threshold: float, label: str) -> None:
+    if not isinstance(value, dict) or set(value) != _METRIC_FIELDS:
+        raise ValueError(f"{label} metric fields are invalid")
+    for name in _METRIC_FIELDS - {"component_count"}:
+        _finite_number(value[name], label=f"{label}.{name}")
+    if value["active_threshold"] != threshold:
+        raise ValueError(f"{label} active threshold differs from the request")
+    if (
+        isinstance(value["component_count"], bool)
+        or not isinstance(value["component_count"], int)
+        or value["component_count"] < 0
+    ):
+        raise ValueError(f"{label}.component_count must be a non-negative integer")
+
+
+def _validate_case(
+    value: object,
+    expected_configuration: Mapping[str, object],
+    *,
+    threshold: float,
+    label: str,
+) -> None:
+    if not isinstance(value, dict) or set(value) != _CASE_FIELDS:
+        raise ValueError(f"{label} result fields are invalid")
+    if value["configuration"] != expected_configuration:
+        raise ValueError(f"{label} configuration differs from the bound input")
+    _positive_integer(value["element_count"], label=f"{label}.element_count")
+    if (
+        isinstance(value["final_simulation_step"], bool)
+        or not isinstance(value["final_simulation_step"], int)
+        or value["final_simulation_step"] < 0
+    ):
+        raise ValueError(f"{label}.final_simulation_step must be non-negative")
+    _positive_integer(value["output_steps"], label=f"{label}.output_steps")
+    shape = value["shape"]
+    if not isinstance(shape, list) or len(shape) != 3:
+        raise ValueError(f"{label}.shape must have three dimensions")
+    for index, extent in enumerate(shape):
+        _positive_integer(extent, label=f"{label}.shape[{index}]")
+    if math.prod(cast(list[int], shape)) != value["element_count"]:
+        raise ValueError(f"{label}.shape does not match element_count")
+    _validate_metrics(value["u"], threshold=threshold, label=f"{label}.u")
+    _validate_metrics(value["v"], threshold=threshold, label=f"{label}.v")
+
+
+def validate_result_document(
+    path: Path,
+    low_configuration: Mapping[str, object],
+    high_configuration: Mapping[str, object],
+    *,
+    active_threshold: float,
+) -> dict[str, Any]:
+    """Validate a closed result bound to both configurations and threshold."""
+    try:
+        status = path.lstat()
+        if (
+            path.is_symlink()
+            or not path.is_file()
+            or not 0 < status.st_size <= 16 * 1024 * 1024
+        ):
+            raise ValueError("Gray-Scott analysis result is not a bounded regular file")
+        value = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("Gray-Scott analysis result is not valid UTF-8 JSON") from exc
+    if not isinstance(value, dict) or set(value) != {
+        "schema_version",
+        "cases",
+        "comparison",
+    }:
+        raise ValueError("Gray-Scott analysis result fields are invalid")
+    if value["schema_version"] != _RESULT_SCHEMA:
+        raise ValueError("Gray-Scott analysis result schema is invalid")
+    cases = value["cases"]
+    if not isinstance(cases, dict) or set(cases) != {"feed_low", "feed_high"}:
+        raise ValueError("Gray-Scott analysis cases are invalid")
+    _validate_case(
+        cases["feed_low"],
+        low_configuration,
+        threshold=active_threshold,
+        label="feed_low",
+    )
+    _validate_case(
+        cases["feed_high"],
+        high_configuration,
+        threshold=active_threshold,
+        label="feed_high",
+    )
+    comparison = value["comparison"]
+    if not isinstance(comparison, dict) or set(comparison) != _COMPARISON_FIELDS:
+        raise ValueError("Gray-Scott comparison fields are invalid")
+    for name in _COMPARISON_FIELDS:
+        _finite_number(comparison[name], label=f"comparison.{name}")
+    return cast(dict[str, Any], value)
+
+
+def _combined_probe_status(*statuses: RuntimeStatus) -> RuntimeStatus:
+    if statuses and all(status.usable is True for status in statuses):
+        return RuntimeStatus("ready", "runtime_probe_succeeded")
+    if any(status.usable is False for status in statuses):
+        return RuntimeStatus("unavailable", "software_not_found")
+    return RuntimeStatus("unknown", "runtime_probe_inconclusive")
+
+
+class Adios2GrayScottAnalysis(Application):
+    """Compare morphology from two completed Gray-Scott BP datasets."""
+
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "nprocs",
+                "msg": "Analyzer process count",
+                "type": int,
+                "default": 1,
+            },
+            {
+                "name": "ppn",
+                "msg": "Analyzer processes per node",
+                "type": int,
+                "default": 1,
+            },
+            {
+                "name": "executable",
+                "msg": "Installed gray-scott-analyze executable",
+                "type": str,
+                "default": "gray-scott-analyze",
+            },
+            {
+                "name": "input_bundle",
+                "msg": "Optional digest-verified analyzer source and paired configuration bundle",
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
+            },
+            {
+                "name": "low_input",
+                "msg": "Completed low-feed ADIOS2 BP dataset",
+                "type": str,
+                "default": None,
+            },
+            {
+                "name": "low_configuration",
+                "msg": "Low-feed configuration path or scientific_input bundle member",
+                "type": str,
+                "default": None,
+            },
+            {
+                "name": "high_input",
+                "msg": "Completed high-feed ADIOS2 BP dataset",
+                "type": str,
+                "default": None,
+            },
+            {
+                "name": "high_configuration",
+                "msg": "High-feed configuration path or scientific_input bundle member",
+                "type": str,
+                "default": None,
+            },
+            {
+                "name": "active_threshold",
+                "msg": "V concentration threshold used for morphology",
+                "type": float,
+                "default": 0.1,
+            },
+            {
+                "name": "output_file",
+                "msg": "Closed JSON morphology comparison",
+                "type": str,
+                "default": "gray-scott-morphology.json",
+            },
+        ]
+
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        environment = self._deployment_environment()
+        installed = probe_program(
+            "gray-scott-analyze",
+            environment=environment,
+            arguments=("--help",),
+            accepted_return_codes=(0, 1),
+        )
+        source = _combined_probe_status(
+            probe_program(
+                "cmake", environment=environment, arguments=("--version",)
+            ).status,
+            probe_program(
+                "adios2-config", environment=environment, arguments=("--version",)
+            ).status,
+            probe_program(
+                "mpic++", environment=environment, arguments=("--version",)
+            ).status,
+        )
+        completed = ReadinessContract("process_exit", "successful_exit")
+        return PackageDeploymentContract(
+            package="builtin.adios2_gray_scott_analysis",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="installed_executable",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    runtime_requirements=("gray_scott_analysis_installed",),
+                    readiness=completed,
+                    description="Analyze two completed BP datasets with an installed executable.",
+                ),
+                ExecutionProfile(
+                    name="source_bundle",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    runtime_requirements=("gray_scott_analysis_source_build",),
+                    readiness=completed,
+                    description="Build one verified analyzer target and compare two completed BP datasets.",
+                ),
+            ),
+            runtime_requirements=(
+                RuntimeRequirement(
+                    requirement_id="gray_scott_analysis_installed",
+                    description="Installed ADIOS2 Gray-Scott morphology analyzer",
+                    required_capabilities=("gray_scott_morphology",),
+                    available_capabilities=(
+                        ("gray_scott_morphology",)
+                        if installed.status.usable is True
+                        else ()
+                    ),
+                    status=installed.status,
+                ),
+                RuntimeRequirement(
+                    requirement_id="gray_scott_analysis_source_build",
+                    description="CMake, C++ compiler, and ADIOS2 development runtime",
+                    required_capabilities=("gray_scott_morphology", "source_build"),
+                    available_capabilities=(
+                        ("gray_scott_morphology", "source_build")
+                        if source.usable is True
+                        else ()
+                    ),
+                    status=source,
+                    provider_resolutions=(
+                        ProviderResolution("spack", "spec", "adios2"),
+                        ProviderResolution("spack", "spec", "cmake"),
+                    ),
+                ),
+            ),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    requires=(
+                        ConfigurationCondition("low_configuration", "is_not_empty"),
+                        ConfigurationCondition("high_configuration", "is_not_empty"),
+                    ),
+                    description="Installed analysis requires two external configuration files.",
+                ),
+            ),
+        )
+
+    def _configure(self, **kwargs: Any) -> None:
+        super()._configure(**kwargs)
+        output = self.resolve_shared_path(
+            self.config.get("output_file"),
+            field="output_file",
+            default="gray-scott-morphology.json",
+        )
+        cast(dict[str, Any], self.config)["output_file"] = str(output)
+        self._validate_configuration()
+        configured = self.config.get("input_bundle")
+        if configured not in (None, ""):
+            if not isinstance(configured, str):
+                raise TypeError("input_bundle must be a path string")
+            bundle = extract_input_bundle(
+                configured, self._shared_root() / "input-bundles"
+            )
+            resolve_analysis_bundle(
+                bundle,
+                str(self.config["low_configuration"]),
+                str(self.config["high_configuration"]),
+            )
+
+    def _shared_root(self) -> Path:
+        shared_dir = self.shared_dir
+        if not isinstance(shared_dir, (str, os.PathLike)) or not os.fspath(shared_dir):
+            raise RuntimeError(
+                "Gray-Scott analysis requires a package shared directory"
+            )
+        return Path(shared_dir)
+
+    @staticmethod
+    def _absolute_existing_path(value: object, *, label: str, directory: bool) -> Path:
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{label} is required")
+        path = Path(os.path.expandvars(value))
+        if not path.is_absolute() or path.is_symlink():
+            raise ValueError(f"{label} must be a normalized absolute path")
+        if directory and not path.is_dir():
+            raise ValueError(f"{label} must be an existing BP directory")
+        if not directory and not path.is_file():
+            raise ValueError(f"{label} must be an existing regular file")
+        return path.resolve(strict=True)
+
+    def _validate_configuration(self) -> None:
+        for name in ("nprocs", "ppn"):
+            _positive_integer(self.config.get(name), label=name)
+        threshold = _finite_number(
+            self.config.get("active_threshold"), label="active_threshold"
+        )
+        if threshold < 0:
+            raise ValueError("active_threshold must be non-negative")
+        executable = self.config.get("executable")
+        if not isinstance(executable, str) or not executable.strip():
+            raise ValueError(
+                "Gray-Scott analysis executable must be a non-empty string"
+            )
+        self._absolute_existing_path(
+            self.config.get("low_input"), label="low_input", directory=True
+        )
+        self._absolute_existing_path(
+            self.config.get("high_input"), label="high_input", directory=True
+        )
+        output = self.config.get("output_file")
+        if not isinstance(output, str) or not Path(output).is_absolute():
+            raise ValueError("output_file must resolve to an absolute path")
+        if self.config.get("input_bundle") in (None, ""):
+            self._absolute_existing_path(
+                self.config.get("low_configuration"),
+                label="low_configuration",
+                directory=False,
+            )
+            self._absolute_existing_path(
+                self.config.get("high_configuration"),
+                label="high_configuration",
+                directory=False,
+            )
+
+    def _prepare_bundle_run(self) -> tuple[str, Path, Path, Path]:
+        configured = self.config.get("input_bundle")
+        if not isinstance(configured, str) or not configured:
+            raise RuntimeError("Gray-Scott analysis input bundle was not persisted")
+        bundle = extract_input_bundle(configured, self._shared_root() / "input-bundles")
+        selected = resolve_analysis_bundle(
+            bundle,
+            str(self.config.get("low_configuration") or ""),
+            str(self.config.get("high_configuration") or ""),
+        )
+        run_dir = self.resolve_shared_path("run", field="input_bundle workspace")
+        stage_input_bundle(bundle, run_dir)
+        build_dir = run_dir / "build"
+        source_dir = (run_dir / selected.build_spec.relative_to(bundle.root)).parent
+        local_info = LocalExecInfo(env=self.mod_env, cwd=str(run_dir), timeout=900)
+        configure = " ".join(
+            (
+                "cmake",
+                "-S",
+                shlex.quote(str(source_dir)),
+                "-B",
+                shlex.quote(str(build_dir)),
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_C_COMPILER=mpicc",
+                "-DCMAKE_CXX_COMPILER=mpic++",
+            )
+        )
+        self._raise_for_exec_failure(
+            Exec(configure, local_info).run(), operation="Gray-Scott analysis configure"
+        )
+        build = f"cmake --build {shlex.quote(str(build_dir))} --parallel 4 --target gray-scott-analyze"
+        self._raise_for_exec_failure(
+            Exec(build, local_info).run(), operation="Gray-Scott analysis build"
+        )
+        low = run_dir / selected.low.path.relative_to(bundle.root)
+        high = run_dir / selected.high.path.relative_to(bundle.root)
+        return str(build_dir / "bin" / "gray-scott-analyze"), low, high, run_dir
+
+    def start(self) -> None:
+        """Build if requested, analyze both inputs, and validate the result."""
+        self._validate_configuration()
+        configured = self.config.get("input_bundle")
+        if configured not in (None, ""):
+            executable, low_config, high_config, cwd = self._prepare_bundle_run()
+        else:
+            executable = str(self.config["executable"])
+            low_config = self._absolute_existing_path(
+                self.config["low_configuration"],
+                label="low_configuration",
+                directory=False,
+            )
+            high_config = self._absolute_existing_path(
+                self.config["high_configuration"],
+                label="high_configuration",
+                directory=False,
+            )
+            cwd = Path(str(self.config["output_file"])).parent
+        low_input = self._absolute_existing_path(
+            self.config["low_input"], label="low_input", directory=True
+        )
+        high_input = self._absolute_existing_path(
+            self.config["high_input"], label="high_input", directory=True
+        )
+        output = Path(str(self.config["output_file"]))
+        output.parent.mkdir(parents=True, exist_ok=True)
+        threshold = _finite_number(
+            self.config.get("active_threshold"), label="active_threshold"
+        )
+        command = " ".join(
+            shlex.quote(str(value))
+            for value in (
+                executable,
+                low_input,
+                low_config,
+                high_input,
+                high_config,
+                threshold,
+                output,
+            )
+        )
+        result = Exec(
+            command,
+            MpiExecInfo(
+                nprocs=self.config["nprocs"],
+                ppn=self.config["ppn"],
+                hostfile=self.hostfile,
+                env=self.mod_env,
+                cwd=str(cwd),
+                line_callback=self.runtime_line_callback(),
+            ),
+        ).run()
+        self._raise_for_exec_failure(result, operation="Gray-Scott analysis")
+        validate_result_document(
+            output,
+            _load_configuration(low_config),
+            _load_configuration(high_config),
+            active_threshold=threshold,
+        )
+
+    @staticmethod
+    def _raise_for_exec_failure(result: Any, *, operation: str) -> None:
+        exit_codes = getattr(result, "exit_code", None)
+        if not isinstance(exit_codes, dict) or not exit_codes:
+            raise RuntimeError(f"{operation} returned no process exit status")
+        failures = {
+            str(host): code
+            for host, code in exit_codes.items()
+            if isinstance(code, bool) or not isinstance(code, int) or code != 0
+        }
+        if failures:
+            details = ", ".join(
+                f"{host}={code!r}" for host, code in sorted(failures.items())
+            )
+            raise RuntimeError(f"{operation} failed with exit status: {details}")
+
+    def stop(self) -> None:
+        """The morphology analyzer is a bounded batch application."""
+
+    def clean(self) -> None:
+        """Remove the configured comparison result."""
+        output = self.config.get("output_file")
+        if isinstance(output, str) and output:
+            Rm(output, PsshExecInfo(hostfile=self.hostfile)).run()
+
+
+__all__ = [
+    "Adios2GrayScottAnalysis",
+    "AnalysisConfiguration",
+    "GrayScottAnalysisBundle",
+    "resolve_analysis_bundle",
+    "validate_result_document",
+]

--- a/test/unit/core/test_adios2_gray_scott_analysis.py
+++ b/test/unit/core/test_adios2_gray_scott_analysis.py
@@ -1,0 +1,319 @@
+"""Tests for reusable paired Gray-Scott morphology analysis."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+    extract_input_bundle,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "adios2_gray_scott_analysis"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_adios2_gray_scott_analysis_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load package: {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _configuration(*, feed: float, kill: float, output: str) -> bytes:
+    return json.dumps(
+        {
+            "Du": 0.2,
+            "Dv": 0.1,
+            "F": feed,
+            "L": 64,
+            "adios_config": "adios2.xml",
+            "adios_memory_selection": False,
+            "adios_span": False,
+            "checkpoint": False,
+            "checkpoint_freq": 2000,
+            "checkpoint_output": f"checkpoint-{output}",
+            "dt": 2.0,
+            "k": kill,
+            "mesh_type": "image",
+            "noise": 0.0,
+            "output": output,
+            "plotgap": 100,
+            "steps": 1000,
+        },
+        sort_keys=True,
+    ).encode()
+
+
+def _write_bundle(destination: Path, *, analysis_role: str = "analysis_source") -> Path:
+    files = {
+        "CMakeLists.txt": (
+            "build_spec",
+            b"project(gray_scott_analysis)\nadd_executable(gray-scott-analyze analysis.cpp)\n",
+        ),
+        "analysis.cpp": (analysis_role, b"int main() { return 0; }\n"),
+        "config/high.json": (
+            "scientific_input",
+            _configuration(feed=0.03, kill=0.0545, output="high.bp"),
+        ),
+        "config/low.json": (
+            "scientific_input",
+            _configuration(feed=0.02, kill=0.048, output="low.bp"),
+        ),
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "config/low.json",
+        "files": [
+            {
+                "path": name,
+                "role": role,
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, (role, payload) in sorted(files.items())
+        ],
+    }
+    manifest_payload = json.dumps(manifest, sort_keys=True).encode()
+    with tarfile.open(destination, mode="w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(manifest_payload)
+        archive.addfile(info, io.BytesIO(manifest_payload))
+        for name, (_role, payload) in sorted(files.items()):
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def _metrics(threshold: float) -> dict[str, float | int]:
+    return {
+        "active_fraction": 0.2,
+        "active_threshold": threshold,
+        "component_count": 3,
+        "interface_density": 0.12,
+        "largest_component_fraction_of_active": 0.8,
+        "max": 0.7,
+        "mean": 0.2,
+        "min": 0.0,
+        "standard_deviation": 0.15,
+        "surface_to_active": 1.2,
+    }
+
+
+def _result(
+    low: dict[str, Any], high: dict[str, Any], threshold: float
+) -> dict[str, Any]:
+    return {
+        "cases": {
+            "feed_high": {
+                "configuration": high,
+                "element_count": 64**3,
+                "final_simulation_step": 1000,
+                "output_steps": 10,
+                "shape": [64, 64, 64],
+                "u": _metrics(threshold),
+                "v": _metrics(threshold),
+            },
+            "feed_low": {
+                "configuration": low,
+                "element_count": 64**3,
+                "final_simulation_step": 1000,
+                "output_steps": 10,
+                "shape": [64, 64, 64],
+                "u": _metrics(threshold),
+                "v": _metrics(threshold),
+            },
+        },
+        "comparison": {
+            "max_absolute_v_difference": 0.5,
+            "pearson_v_correlation": 0.25,
+            "relative_v_l2_difference": 0.8,
+            "v_rms_difference": 0.2,
+        },
+        "schema_version": "jarvis.gray-scott-morphology.v1",
+    }
+
+
+def test_analysis_bundle_resolves_declared_source_and_configuration(
+    tmp_path: Path,
+) -> None:
+    """The build and paired configurations come only from declared bundle roles."""
+    module = _module()
+    archive = _write_bundle(tmp_path / "gray-scott.tar")
+    bundle = extract_input_bundle(archive, tmp_path / "materialized")
+
+    selected = module.resolve_analysis_bundle(
+        bundle,
+        "config/low.json",
+        "config/high.json",
+    )
+
+    assert selected.build_spec == bundle.root / "CMakeLists.txt"
+    assert selected.analysis_source == bundle.root / "analysis.cpp"
+    assert selected.low.values["F"] == 0.02
+    assert selected.high.values["F"] == 0.03
+
+    mistyped = _write_bundle(tmp_path / "mistyped.tar", analysis_role="upstream_source")
+    invalid = extract_input_bundle(mistyped, tmp_path / "invalid")
+    with pytest.raises(ValueError, match="one analysis_source"):
+        module.resolve_analysis_bundle(invalid, "config/low.json", "config/high.json")
+
+
+def test_analysis_result_is_closed_and_bound_to_inputs(tmp_path: Path) -> None:
+    """Result validation binds both configuration documents and the threshold."""
+    module = _module()
+    low = json.loads(_configuration(feed=0.02, kill=0.048, output="low.bp"))
+    high = json.loads(_configuration(feed=0.03, kill=0.0545, output="high.bp"))
+    result_path = tmp_path / "result.json"
+    result_path.write_text(json.dumps(_result(low, high, 0.1)), encoding="utf-8")
+
+    result = module.validate_result_document(
+        result_path,
+        low,
+        high,
+        active_threshold=0.1,
+    )
+
+    assert result["comparison"]["v_rms_difference"] == 0.2
+    changed = _result(low, high, 0.2)
+    result_path.write_text(json.dumps(changed), encoding="utf-8")
+    with pytest.raises(ValueError, match="threshold"):
+        module.validate_result_document(
+            result_path,
+            low,
+            high,
+            active_threshold=0.1,
+        )
+
+
+def test_analysis_menu_and_deployment_expose_source_bundle_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agents see paired data, paired configurations, threshold, and result output."""
+    module = _module()
+    package = object.__new__(module.Adios2GrayScottAnalysis)
+    package.config = {"input_bundle": "/inputs/gray-scott.tar"}
+    package.env = {}
+    package.mod_env = {}
+    monkeypatch.setattr(
+        module,
+        "probe_program",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            status=module.RuntimeStatus("ready", "runtime_probe_succeeded")
+        ),
+    )
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    document = package.describe_deployment()
+
+    assert menu["input_bundle"]["input_binding"]["kind"] == "local_file"
+    assert menu["active_threshold"]["default"] == 0.1
+    assert menu["low_input"]["default"] is None
+    assert menu["high_input"]["default"] is None
+    assert document is not None
+    assert {profile["name"] for profile in document["execution_profiles"]} == {
+        "installed_executable",
+        "source_bundle",
+    }
+
+
+class _SuccessfulExec:
+    calls: list[tuple[str, Any]] = []
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.calls.append((command, exec_info))
+        self.exit_code = {"ares": 0}
+
+    def run(self) -> "_SuccessfulExec":
+        return self
+
+
+class _FailedExec:
+    def __init__(self, _command: str, _exec_info: Any) -> None:
+        self.exit_code = {"ares": 7}
+
+    def run(self) -> "_FailedExec":
+        return self
+
+
+def test_analysis_bundle_builds_only_the_declared_analysis_target(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Source builds are confined to one staged tree and one analysis target."""
+    module = _module()
+    archive = _write_bundle(tmp_path / "gray-scott.tar")
+    package = object.__new__(module.Adios2GrayScottAnalysis)
+    package.shared_dir = str(tmp_path / "shared")
+    package.mod_env = {}
+    package.config = {
+        "input_bundle": str(archive),
+        "low_configuration": "config/low.json",
+        "high_configuration": "config/high.json",
+    }
+    _SuccessfulExec.calls = []
+    monkeypatch.setattr(module, "Exec", _SuccessfulExec)
+
+    executable, low, high, cwd = package._prepare_bundle_run()
+
+    run = (tmp_path / "shared" / "run").resolve()
+    assert executable == str(run / "build" / "bin" / "gray-scott-analyze")
+    assert low == run / "config" / "low.json"
+    assert high == run / "config" / "high.json"
+    assert cwd == run
+    assert _SuccessfulExec.calls[-1][0].endswith(
+        "--parallel 4 --target gray-scott-analyze"
+    )
+
+
+def test_analysis_propagates_native_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A failed analyzer cannot be converted into a successful package execution."""
+    module = _module()
+    low_input = tmp_path / "low.bp"
+    high_input = tmp_path / "high.bp"
+    low_input.mkdir()
+    high_input.mkdir()
+    low_config = tmp_path / "low.json"
+    high_config = tmp_path / "high.json"
+    low_config.write_bytes(_configuration(feed=0.02, kill=0.048, output="low.bp"))
+    high_config.write_bytes(_configuration(feed=0.03, kill=0.0545, output="high.bp"))
+    package = object.__new__(module.Adios2GrayScottAnalysis)
+    package.config = {
+        "active_threshold": 0.1,
+        "executable": "gray-scott-analyze",
+        "high_configuration": str(high_config),
+        "high_input": str(high_input),
+        "input_bundle": "",
+        "low_configuration": str(low_config),
+        "low_input": str(low_input),
+        "nprocs": 1,
+        "output_file": str(tmp_path / "result.json"),
+        "ppn": 1,
+    }
+    package.mod_env = {}
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: None)
+    package.runtime_line_callback = lambda: None
+    monkeypatch.setattr(module, "Exec", _FailedExec)
+
+    with pytest.raises(RuntimeError, match="Gray-Scott analysis.*ares=7"):
+        package.start()

--- a/test/unit/core/test_adios2_gray_scott_analysis.py
+++ b/test/unit/core/test_adios2_gray_scott_analysis.py
@@ -234,6 +234,40 @@ def test_analysis_menu_and_deployment_expose_source_bundle_profile(
     }
 
 
+def test_analysis_configuration_preserves_agent_supplied_output_value(
+    tmp_path: Path,
+) -> None:
+    """Configuration persistence retains the value verified by the MCP client."""
+    module = _module()
+    low_input = tmp_path / "low.bp"
+    high_input = tmp_path / "high.bp"
+    low_input.mkdir()
+    high_input.mkdir()
+    low_config = tmp_path / "low.json"
+    high_config = tmp_path / "high.json"
+    low_config.write_bytes(_configuration(feed=0.02, kill=0.048, output="low.bp"))
+    high_config.write_bytes(_configuration(feed=0.03, kill=0.0545, output="high.bp"))
+    package = object.__new__(module.Adios2GrayScottAnalysis)
+    package.shared_dir = str(tmp_path / "shared")
+    package.config = {
+        "active_threshold": 0.1,
+        "executable": "gray-scott-analyze",
+        "high_configuration": str(high_config),
+        "high_input": str(high_input),
+        "input_bundle": "",
+        "low_configuration": str(low_config),
+        "low_input": str(low_input),
+        "nprocs": 1,
+        "output_file": "result.json",
+        "ppn": 1,
+    }
+
+    package._configure(**package.config)
+
+    assert package.config["output_file"] == "result.json"
+    assert package._output_path() == (tmp_path / "shared" / "result.json").resolve()
+
+
 class _SuccessfulExec:
     calls: list[tuple[str, Any]] = []
 

--- a/test/unit/core/test_adios2_gray_scott_analysis_artifacts.py
+++ b/test/unit/core/test_adios2_gray_scott_analysis_artifacts.py
@@ -1,0 +1,158 @@
+"""Tests for paired Gray-Scott analysis artifact semantics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import (
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "adios2_gray_scott_analysis"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def _result(path: Path, schema: str = "jarvis.gray-scott-morphology.v1") -> None:
+    metrics = {
+        "active_fraction": 0.2,
+        "active_threshold": 0.1,
+        "component_count": 2,
+        "interface_density": 0.1,
+        "largest_component_fraction_of_active": 0.8,
+        "max": 0.7,
+        "mean": 0.2,
+        "min": 0.0,
+        "standard_deviation": 0.1,
+        "surface_to_active": 1.0,
+    }
+    case = {
+        "configuration": {"F": 0.02},
+        "element_count": 8,
+        "final_simulation_step": 100,
+        "output_steps": 10,
+        "shape": [2, 2, 2],
+        "u": metrics,
+        "v": metrics,
+    }
+    path.write_text(
+        json.dumps(
+            {
+                "cases": {"feed_high": case, "feed_low": case},
+                "comparison": {
+                    "max_absolute_v_difference": 0.5,
+                    "pearson_v_correlation": 0.2,
+                    "relative_v_l2_difference": 0.8,
+                    "v_rms_difference": 0.3,
+                },
+                "schema_version": schema,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_analysis_finalizes_one_typed_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Successful exit exposes the validated JSON result as scientific analysis."""
+    output = tmp_path / "result.json"
+    _result(output)
+    module = _module()
+    assert module._valid_result(output, 0.1) == (True, output.stat().st_size)
+    monkeypatch.setattr(
+        module,
+        "_valid_result",
+        lambda _path, _threshold: (True, output.stat().st_size),
+    )
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_gray_scott_analysis",
+            "output_file": "/execution/shared/result.json",
+            "active_threshold": 0.1,
+            "low_input": "/datasets/low.bp",
+            "high_input": "/datasets/high.bp",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert len(observations) == 1
+    result = observations[0]
+    assert result.state is ArtifactState.FINALIZED
+    assert result.logical_name == "gray-scott-morphology-comparison"
+    assert result.role is ArtifactRole.VALIDATION
+    assert result.structure is ArtifactStructure.FILE
+    assert result.ownership is ArtifactOwnership.SHARED
+    assert result.location is not None
+    assert result.location.value == "/execution/shared/result.json"
+    assert result.format == "jarvis.gray-scott-morphology.v1"
+    assert result.metadata["active_threshold"] == 0.1
+
+
+def test_analysis_rejects_missing_or_wrong_schema_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Missing, malformed, or wrong-schema bytes remain explicitly incomplete."""
+    output = tmp_path / "result.json"
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_gray_scott_analysis",
+            "output_file": "/execution/shared/result.json",
+            "active_threshold": 0.1,
+            "low_input": "/datasets/low.bp",
+            "high_input": "/datasets/high.bp",
+        }
+    )
+    assert adapter is not None
+    assert module._valid_result(output, 0.1) == (False, None)
+
+    _result(output, schema="wrong")
+    assert module._valid_result(output, 0.1) == (False, None)
+    _result(output)
+    changed = json.loads(output.read_text(encoding="utf-8"))
+    changed["cases"]["feed_high"]["v"]["active_threshold"] = 0.2
+    output.write_text(json.dumps(changed), encoding="utf-8")
+    assert module._valid_result(output, 0.1) == (False, None)
+    monkeypatch.setattr(
+        module, "_valid_result", lambda _path, _threshold: (False, None)
+    )
+    assert adapter.finalize_artifacts_for_exit(0)[0].state is ArtifactState.INCOMPLETE
+
+
+def test_analysis_factory_is_package_local_and_requires_absolute_output() -> None:
+    """Artifact authority is exact and never inferred from another package."""
+    module = _module()
+    assert (
+        module.adapter_from_package({"pkg_type": "builtin.adios2_gray_scott"}) is None
+    )
+    try:
+        module.adapter_from_package(
+            {
+                "pkg_type": "builtin.adios2_gray_scott_analysis",
+                "output_file": "relative.json",
+            }
+        )
+    except ValueError as error:
+        assert "absolute" in str(error)
+    else:
+        raise AssertionError("relative analysis output was accepted")


### PR DESCRIPTION
## What changed

- adds a maintained `builtin.adios2_gray_scott_analysis` application for paired morphology analysis of completed ADIOS2 Gray-Scott BP datasets
- supports installed-executable and digest-verified source-bundle profiles
- binds the result to both scientific configurations and the requested active threshold
- preserves the agent-supplied output setting while resolving it safely beneath execution-owned storage at runtime
- reports one typed `jarvis.gray-scott-morphology.v1` validation artifact
- documents installation and usage

## Why

The maintained Gray-Scott producer can generate scientific outputs, but reusable paired morphology analysis was previously available only inside a benchmark adapter. This package makes that scientific analysis an agent-facing JARVIS capability without duplicating the producer or encoding benchmark-specific launch logic.

The first live candidate exposed a persistence-contract defect: configuration normalized a relative output path before the MCP checked that the requested setting had persisted. The follow-up preserves the requested value, validates its safe resolution, and resolves the execution path only at runtime.

## Validation

- initial package and regression slice: `69 passed`
- focused persistence-fix and package regression slice: `9 passed`
- scoped Ruff check and format check passed
- scoped Pyright passed with 0 errors and 0 warnings
- exact commit `b86aa9eeee781f777ed0fa8d8f16df10f98208b0` live-validated through the official FastMCP client and cluster-local JARVIS MCP server on Ares
- Slurm jobs `22634` and `22635` finalized distinct low/high BP5 datasets; `22636` finalized PDF Calc output; `22637` finalized the paired morphology artifact
- morphology execution `jarvis_b8fe79feaed94e6288d00f00a2493319` returned 0 and produced a 3,330-byte `jarvis.gray-scott-morphology.v1` artifact with independently acquired SHA-256 `2672eb1b369a4050f7feb2319cdfa635bf868b0bd13d8d06c4e6a5ae8a878e21`
- the comparison is nondegenerate: relative V-field L2 difference `0.745447`, RMS difference `0.139003`, maximum absolute difference `0.291441`, and Pearson correlation `0.183101`

This PR is intentionally stacked on `feat/montage-input-artifacts` and remains draft. Do not merge it as a standalone completed campaign.
