### PR TITLE
feat: harden WarpX inputs and artifacts

### DIFF
--- a/builtin/builtin/warpx/artifacts.py
+++ b/builtin/builtin/warpx/artifacts.py
@@ -1,0 +1,381 @@
+"""Generated-artifact semantics for the builtin WarpX package."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import posixpath
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+from jarvis_cd.artifacts.schema import JsonValue
+from jarvis_cd.input_bundle import extract_input_bundle
+
+_MAX_DISCOVERED_ENTRIES = 4096
+_MAX_REPORTED_MEMBERS = 256
+_MAX_CHECKSUM_BYTES = 64 * 1024 * 1024
+_DIAGNOSTIC_SUFFIXES = frozenset({".csv", ".h5", ".hdf5", ".json", ".txt"})
+
+
+@dataclass(frozen=True, slots=True)
+class _DiscoveredEntry:
+    """One safe output member below the package-owned WarpX root."""
+
+    relative_path: PurePosixPath
+    is_file: bool
+    is_directory: bool
+    size_bytes: int | None
+
+
+@dataclass
+class WarpxArtifactAdapter:
+    """Discover bounded WarpX plotfiles and reduced diagnostics at exit."""
+
+    output_dir: PurePosixPath
+    input_paths: frozenset[PurePosixPath] = frozenset()
+    _finalized: bool = False
+    _collection_artifact_id: str = field(default_factory=new_artifact_id)
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for process completion before inspecting mutable outputs."""
+
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Report successfully completed WarpX outputs."""
+
+        return self._finalize(return_code=0)
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Report outputs with the authoritative process completion state."""
+
+        return self._finalize(return_code=return_code)
+
+    def reset_artifacts(self) -> None:
+        """Permit discovery after an execution stream is replaced."""
+
+        self._finalized = False
+
+    def _finalize(self, *, return_code: int) -> list[ArtifactObservation]:
+        if self._finalized:
+            return []
+        self._finalized = True
+        entries, truncated = self._discover_entries()
+        outputs = self._output_entries(entries)
+        if not outputs:
+            return []
+        state = (
+            ArtifactState.FINALIZED
+            if return_code == 0 and not truncated
+            else ArtifactState.INCOMPLETE
+        )
+        observations = [
+            self._collection_observation(outputs, state=state, truncated=truncated)
+        ]
+        observations.extend(
+            self._member_observation(entry, state=state)
+            for entry in outputs
+            if self._is_concrete_product(entry)
+        )
+        return observations
+
+    def _discover_entries(self) -> tuple[list[_DiscoveredEntry], bool]:
+        """Walk the owned output tree without following links and with a bound."""
+
+        root = self._local_output_path()
+        if not root.exists():
+            return [], False
+        if root.is_symlink() or not root.is_dir():
+            raise RuntimeError(f"WarpX output root is not a real directory: {root}")
+        discovered: list[_DiscoveredEntry] = []
+        truncated = False
+        try:
+            for current, directory_names, file_names in os.walk(
+                root, topdown=True, followlinks=False
+            ):
+                current_path = Path(current)
+                safe_directories: list[str] = []
+                for name in sorted(directory_names):
+                    path = current_path / name
+                    if path.is_symlink():
+                        continue
+                    if len(discovered) >= _MAX_DISCOVERED_ENTRIES:
+                        truncated = True
+                        break
+                    relative = PurePosixPath(path.relative_to(root).as_posix())
+                    discovered.append(_DiscoveredEntry(relative, False, True, None))
+                    safe_directories.append(name)
+                directory_names[:] = [] if truncated else safe_directories
+                if truncated:
+                    break
+                for name in sorted(file_names):
+                    path = current_path / name
+                    if path.is_symlink() or not path.is_file():
+                        continue
+                    if len(discovered) >= _MAX_DISCOVERED_ENTRIES:
+                        truncated = True
+                        break
+                    relative = PurePosixPath(path.relative_to(root).as_posix())
+                    discovered.append(
+                        _DiscoveredEntry(
+                            relative,
+                            True,
+                            False,
+                            path.stat().st_size,
+                        )
+                    )
+                if truncated:
+                    break
+        except OSError as exc:
+            raise RuntimeError(
+                f"cannot inspect WarpX output directory {root}: {exc}"
+            ) from exc
+        return discovered, truncated
+
+    def _local_output_path(self) -> Path:
+        """Project the declared cluster path into the current host filesystem."""
+
+        return Path(self.output_dir.as_posix())
+
+    def _output_entries(
+        self, entries: list[_DiscoveredEntry]
+    ) -> list[_DiscoveredEntry]:
+        """Exclude exact inputs and directories that contain only staged inputs."""
+
+        files = [
+            entry
+            for entry in entries
+            if entry.is_file and entry.relative_path not in self.input_paths
+        ]
+        concrete_directories = [
+            entry
+            for entry in entries
+            if entry.is_directory and self._is_concrete_product(entry)
+        ]
+        retained_paths = {
+            entry.relative_path for entry in (*files, *concrete_directories)
+        }
+        directories = [
+            entry
+            for entry in entries
+            if entry.is_directory
+            and any(
+                candidate != entry.relative_path
+                and candidate.is_relative_to(entry.relative_path)
+                for candidate in retained_paths
+            )
+        ]
+        selected = {entry.relative_path: entry for entry in files}
+        selected.update({entry.relative_path: entry for entry in concrete_directories})
+        selected.update({entry.relative_path: entry for entry in directories})
+        return [selected[path] for path in sorted(selected)]
+
+    @staticmethod
+    def _is_concrete_product(entry: _DiscoveredEntry) -> bool:
+        """Recognize high-confidence WarpX diagnostics and output collections."""
+
+        name = entry.relative_path.name.casefold()
+        if entry.is_directory:
+            return name.startswith(
+                ("diag", "plt", "chk", "checkpoint")
+            ) or name.endswith(".bp")
+        return PurePosixPath(name).suffix in _DIAGNOSTIC_SUFFIXES
+
+    def _collection_observation(
+        self,
+        outputs: list[_DiscoveredEntry],
+        *,
+        state: ArtifactState,
+        truncated: bool,
+    ) -> ArtifactObservation:
+        """Describe the bounded package-owned WarpX result tree."""
+
+        names: list[JsonValue] = [
+            entry.relative_path.as_posix() for entry in outputs[:_MAX_REPORTED_MEMBERS]
+        ]
+        size_bytes = sum(entry.size_bytes or 0 for entry in outputs if entry.is_file)
+        return ArtifactObservation(
+            artifact_id=self._collection_artifact_id,
+            logical_name="warpx-results",
+            kind="scientific_dataset",
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(self.output_dir),
+            format="warpx-output-tree",
+            size_bytes=size_bytes,
+            message=(
+                "WarpX output discovery reached its safety bound"
+                if truncated
+                else "WarpX output tree finalized"
+            ),
+            metadata={
+                "application": "warpx",
+                "completion_signal": "process_exit",
+                "discovery_truncated": truncated,
+                "member_count_observed": len(outputs),
+                "member_names": names,
+                "member_names_truncated": len(outputs) > len(names),
+            },
+        )
+
+    def _member_observation(
+        self, entry: _DiscoveredEntry, *, state: ArtifactState
+    ) -> ArtifactObservation:
+        """Describe one concrete WarpX plotfile or reduced diagnostic."""
+
+        format_name, media_type = _output_format(entry)
+        checksum = self._checksum(entry)
+        logical_suffix = entry.relative_path.as_posix().replace("/", "-")
+        return ArtifactObservation(
+            logical_name=f"warpx-{logical_suffix}"[:256],
+            kind="scientific_dataset",
+            role=ArtifactRole.OUTPUT,
+            structure=(
+                ArtifactStructure.FILE
+                if entry.is_file
+                else ArtifactStructure.COLLECTION
+            ),
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(
+                self.output_dir / entry.relative_path
+            ),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=entry.size_bytes,
+            checksum=checksum,
+            message="WarpX diagnostic finalized",
+            metadata={"application": "warpx"},
+        )
+
+    def _checksum(self, entry: _DiscoveredEntry) -> str | None:
+        """Hash bounded files while avoiding unbounded finalization work."""
+
+        if (
+            not entry.is_file
+            or entry.size_bytes is None
+            or entry.size_bytes > _MAX_CHECKSUM_BYTES
+        ):
+            return None
+        path = self._local_output_path() / entry.relative_path
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                digest.update(chunk)
+        return f"sha256:{digest.hexdigest()}"
+
+
+def adapter_from_package(package: dict[str, Any]) -> WarpxArtifactAdapter | None:
+    """Create artifact semantics for the builtin WarpX package."""
+
+    if package.get("pkg_type") != "builtin.warpx":
+        return None
+    output_dir = _configured_output_dir(
+        package.get("out"),
+        shared_dir=package.get("shared_dir"),
+        runtime_cwd=package.get("runtime_cwd"),
+    )
+    deploy_mode = str(package.get("effective_deploy_mode") or "default").casefold()
+    if deploy_mode == "container":
+        roots = tuple(
+            root
+            for root in (
+                _optional_absolute_path(package.get("shared_dir")),
+                _optional_absolute_path(package.get("private_dir")),
+            )
+            if root is not None
+        )
+        if not any(output_dir.is_relative_to(root) for root in roots):
+            return None
+    input_paths: set[PurePosixPath] = set()
+    input_bundle = package.get("input_bundle")
+    if isinstance(input_bundle, str) and input_bundle:
+        shared_dir = _optional_absolute_path(package.get("shared_dir"))
+        if shared_dir is None:
+            raise ValueError("WarpX input-bundle artifacts require shared_dir")
+        materialized = extract_input_bundle(
+            input_bundle, Path(shared_dir.as_posix()) / "input-bundles"
+        )
+        input_paths.update(
+            PurePosixPath(item.path) for item in materialized.manifest.files
+        )
+    configured_input = package.get("inputs")
+    if isinstance(configured_input, str) and configured_input:
+        input_paths.add(PurePosixPath(Path(configured_input).name))
+    return WarpxArtifactAdapter(output_dir, frozenset(input_paths))
+
+
+def _configured_output_dir(
+    value: object,
+    *,
+    shared_dir: object,
+    runtime_cwd: object,
+) -> PurePosixPath:
+    """Resolve the normalized absolute output directory used by the package."""
+
+    raw = "run" if value in (None, "") else value
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("WarpX artifacts require a printable output path")
+    path = PurePosixPath(raw)
+    if not path.is_absolute():
+        base = _optional_absolute_path(shared_dir)
+        if base is None:
+            base = _optional_absolute_path(runtime_cwd)
+        if base is None:
+            raise ValueError(
+                "relative WarpX artifact output requires shared_dir or runtime_cwd"
+            )
+        path = base / path
+    normalized = PurePosixPath(posixpath.normpath(path.as_posix()))
+    if not normalized.is_absolute() or ".." in normalized.parts:
+        raise ValueError("WarpX artifacts require a normalized absolute output path")
+    return normalized
+
+
+def _optional_absolute_path(value: object) -> PurePosixPath | None:
+    """Return a normalized absolute POSIX path when one is available."""
+
+    if not isinstance(value, str) or not value:
+        return None
+    path = PurePosixPath(value)
+    if not path.is_absolute() or ".." in path.parts:
+        return None
+    return path
+
+
+def _output_format(entry: _DiscoveredEntry) -> tuple[str, str | None]:
+    """Return a conservative format and media type for one WarpX product."""
+
+    name = entry.relative_path.name.casefold()
+    if entry.is_directory:
+        if name.endswith(".bp"):
+            return "adios2-bp", "application/x-adios2"
+        if name.startswith(("plt", "diag")):
+            return "amrex-plotfile", "application/x-amrex-plotfile"
+        return "warpx-output-collection", None
+    suffix = PurePosixPath(name).suffix
+    if suffix == ".json":
+        return "json", "application/json"
+    if suffix == ".csv":
+        return "csv", "text/csv"
+    if suffix in {".h5", ".hdf5"}:
+        return "hdf5", "application/x-hdf5"
+    return "warpx-reduced-diagnostic", "text/plain"
+
+
+__all__ = ["WarpxArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/warpx/pkg.py
+++ b/builtin/builtin/warpx/pkg.py
@@ -1,251 +1,529 @@
-"""
-WarpX — Exascale Particle-In-Cell plasma accelerator simulation.
-Highly parallel, GPU-optimized PIC code built on AMReX.
-"""
-from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
-from jarvis_cd.shell.process import Mkdir, Rm
+"""Launch native or containerized WarpX particle-in-cell simulations."""
+
+from __future__ import annotations
+
 import os
+import shlex
 import shutil
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
+from jarvis_cd.shell.process import Mkdir, Rm
+
+_EXECUTABLE_CANDIDATES = (
+    "warpx.3d.MPI.NOACC.DP.PDP",
+    "warpx.3d.MPI.CUDA.SP",
+    "warpx.3d",
+    "warpx",
+)
+_MAX_INPUT_BYTES = 16 * 1024 * 1024
 
 
 class Warpx(Application):
+    """Run one WarpX simulation from an example or caller-owned input.
+
+    Caller inputs are copied into a package-owned working directory before
+    launch. Multi-file studies use a digest-verified JARVIS input bundle and
+    may select any manifest-declared member as the WarpX input file. JARVIS
+    owns MPI launch, environment interception, process completion, and output
+    artifact reporting.
     """
-    Merged WarpX class supporting both default (bare-metal) and container deployment.
 
-    Set deploy_mode='container' to build and run WarpX inside a Docker/Podman/Apptainer
-    container with 3D CUDA+MPI+HDF5.  Set deploy_mode='default' to use a
-    system-installed warpx binary via MPI.
-    """
+    def _init(self) -> None:
+        self.warpx_bin: str | None = None
 
-    def _init(self):
-        self.warpx_bin = None
-
-    def _configure_menu(self):
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
             {
-                'name': 'nprocs',
-                'msg': 'Number of MPI processes',
-                'type': int,
-                'default': 2,
+                "name": "nprocs",
+                "msg": "Number of MPI processes",
+                "type": int,
+                "default": 2,
             },
             {
-                'name': 'ppn',
-                'msg': 'Processes per node',
-                'type': int,
-                'default': 2,
+                "name": "ppn",
+                "msg": "Processes per node",
+                "type": int,
+                "default": 2,
             },
             {
-                'name': 'inputs',
-                'msg': 'Path to WarpX inputs file',
-                'type': str,
-                'default': None,
+                "name": "inputs",
+                "msg": (
+                    "Optional single WarpX inputs file. JARVIS copies it into "
+                    "the execution-owned output directory before launch."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                'name': 'example',
-                'msg': 'Built-in example to run (e.g., laser_acceleration, uniform_plasma)',
-                'type': str,
-                'choices': ['laser_acceleration', 'uniform_plasma', 'custom'],
-                'default': 'laser_acceleration',
+                "name": "input_bundle",
+                "msg": (
+                    "Optional digest-verified multi-file JARVIS package input "
+                    "bundle. All manifest files are staged into the execution-"
+                    "owned output directory."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                'name': 'max_step',
-                'msg': 'Total number of time steps',
-                'type': int,
-                'default': 50,
+                "name": "input_path",
+                "msg": (
+                    "Relative manifest member to execute from input_bundle; "
+                    "empty selects the manifest entrypoint"
+                ),
+                "type": str,
+                "default": "",
             },
             {
-                'name': 'n_cell',
-                'msg': 'Base grid cells as "nx ny nz"',
-                'type': str,
-                'default': '64 64 128',
+                "name": "example",
+                "msg": "Installed WarpX example to run when no caller input is supplied",
+                "type": str,
+                "choices": ["laser_acceleration", "uniform_plasma", "custom"],
+                "default": "laser_acceleration",
             },
             {
-                'name': 'out',
-                'msg': 'Output directory for plot files',
-                'type': str,
-                'default': '/tmp/warpx_out',
+                "name": "override_input_parameters",
+                "msg": (
+                    "Apply max_step, n_cell, out, and plot_int command-line "
+                    "overrides to caller-supplied inputs"
+                ),
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'plot_int',
-                'msg': 'Plot output interval (-1 to disable)',
-                'type': int,
-                'default': 10,
+                "name": "max_step",
+                "msg": "Total number of time steps for examples or explicit overrides",
+                "type": int,
+                "default": 50,
             },
             {
-                'name': 'cuda_arch',
-                'msg': 'CUDA architecture code (80=A100, 90=H100, 70=V100)',
-                'type': int,
-                'default': 80,
+                "name": "n_cell",
+                "msg": "Base grid cells as three positive integers: nx ny nz",
+                "type": str,
+                "default": "64 64 128",
             },
             {
-                'name': 'base_image',
-                'msg': 'Base Docker image for build container',
-                'type': str,
-                'default': 'sci-hpc-base',
+                "name": "out",
+                "msg": (
+                    "Output directory. Relative paths resolve under the JARVIS "
+                    "package shared directory."
+                ),
+                "type": str,
+                "default": "run",
             },
             {
-                'name': 'use_gpu',
-                'msg': 'Build with CUDA/GPU backend (WarpX_COMPUTE=CUDA)',
-                'type': bool,
-                'default': False,
+                "name": "plot_int",
+                "msg": "Plot output interval (-1 to disable)",
+                "type": int,
+                "default": 10,
+            },
+            {
+                "name": "cuda_arch",
+                "msg": "CUDA architecture code (80=A100, 90=H100, 70=V100)",
+                "type": int,
+                "default": 80,
+            },
+            {
+                "name": "base_image",
+                "msg": "Base container image for a package-owned container build",
+                "type": str,
+                "default": "sci-hpc-base",
+            },
+            {
+                "name": "use_gpu",
+                "msg": "Build and launch the CUDA/GPU container profile",
+                "type": bool,
+                "default": False,
             },
         ]
 
-    # ------------------------------------------------------------------
-    # Container Dockerfile generators
-    # ------------------------------------------------------------------
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe WarpX runtime, input, and successful-exit semantics."""
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
-            return None
-        base = self.config.get('base_image', 'sci-hpc-base')
-        use_gpu = self.config.get('use_gpu', False) or 'sci-hpc' in base
-        cuda_arch = self.config.get('cuda_arch', 80)
-        if use_gpu:
-            content = self._read_build_script('build.sh', {
-                'BASE_IMAGE': base,
-                'CUDA_ARCH': cuda_arch,
-            })
-            return content, f'3d-cuda-{cuda_arch}'
+        if self.config.get("deploy_mode") == "container":
+            status = RuntimeStatus("unknown", "container_runtime_not_probed")
+            capabilities: tuple[str, ...] = ()
         else:
-            content = self._read_build_script('cpu/build.sh', {
-                'BASE_IMAGE': base,
-            })
-            return content, '3d-cpu'
+            program = self._discover_executable(self._deployment_environment())
+            if program is None:
+                status = RuntimeStatus("unavailable", "software_not_found")
+                capabilities = ()
+            else:
+                probe = probe_program(
+                    program,
+                    environment=self._deployment_environment(),
+                    arguments=("--help",),
+                    accepted_return_codes=(0, 1),
+                )
+                status = probe.status
+                capabilities = (
+                    ("mpi_execution", "particle_in_cell", "warpx_3d")
+                    if status.usable is True
+                    else ()
+                )
+        runtime = RuntimeRequirement(
+            requirement_id="warpx_3d",
+            description="Three-dimensional WarpX runtime available through PATH",
+            required_capabilities=("mpi_execution", "particle_in_cell", "warpx_3d"),
+            available_capabilities=capabilities,
+            status=status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="spack", query_kind="spec", query_value="warpx"
+                ),
+            ),
+        )
+        completed = ReadinessContract(
+            mechanism="process_exit", condition="successful_exit"
+        )
+        return PackageDeploymentContract(
+            package="builtin.warpx",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="installed_example",
+                    execution_kind="batch",
+                    when=(
+                        ConfigurationCondition("inputs", "is_empty"),
+                        ConfigurationCondition("input_bundle", "is_empty"),
+                    ),
+                    runtime_requirements=("warpx_3d",),
+                    readiness=completed,
+                    description="Run one installed WarpX example with explicit bounds.",
+                ),
+                ExecutionProfile(
+                    name="input_file",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("inputs", "is_not_empty"),),
+                    runtime_requirements=("warpx_3d",),
+                    readiness=completed,
+                    description=(
+                        "Run one caller-supplied WarpX input copied into an "
+                        "execution-owned working directory."
+                    ),
+                ),
+                ExecutionProfile(
+                    name="input_bundle",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    runtime_requirements=("warpx_3d",),
+                    readiness=completed,
+                    description=(
+                        "Run one manifest-selected input from a digest-verified "
+                        "multi-file bundle in an execution-owned working directory."
+                    ),
+                ),
+            ),
+            runtime_requirements=(runtime,),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    requires=(ConfigurationCondition("input_path", "is_empty"),),
+                    description="input_path is valid only with input_bundle.",
+                ),
+            ),
+        )
 
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _build_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
             return None
-        base = self.config.get('base_image', 'sci-hpc-base')
-        use_gpu = self.config.get('use_gpu', False) or 'sci-hpc' in base
-        deploy_file = 'Dockerfile.deploy' if use_gpu else 'cpu/Dockerfile.deploy'
-        deploy_base = ('nvidia/cuda:12.6.0-runtime-ubuntu24.04'
-                       if use_gpu else 'ubuntu:24.04')
-        suffix = getattr(self, '_build_suffix', '')
-        content = self._read_dockerfile(deploy_file, {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': deploy_base,
-        })
+        base = self.config.get("base_image", "sci-hpc-base")
+        use_gpu = self.config.get("use_gpu", False) or "sci-hpc" in str(base)
+        cuda_arch = self.config.get("cuda_arch", 80)
+        if use_gpu:
+            content = self._read_build_script(
+                "build.sh", {"BASE_IMAGE": base, "CUDA_ARCH": cuda_arch}
+            )
+            return content, f"3d-cuda-{cuda_arch}"
+        content = self._read_build_script("cpu/build.sh", {"BASE_IMAGE": base})
+        return content, "3d-cpu"
+
+    def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
+            return None
+        base = self.config.get("base_image", "sci-hpc-base")
+        use_gpu = self.config.get("use_gpu", False) or "sci-hpc" in str(base)
+        deploy_file = "Dockerfile.deploy" if use_gpu else "cpu/Dockerfile.deploy"
+        deploy_base = (
+            "nvidia/cuda:12.6.0-runtime-ubuntu24.04" if use_gpu else "ubuntu:24.04"
+        )
+        suffix = str(getattr(self, "_build_suffix", ""))
+        content = self._read_dockerfile(
+            deploy_file,
+            {"BUILD_IMAGE": self.build_image_name(), "DEPLOY_BASE": deploy_base},
+        )
         return content, suffix
 
-    # ------------------------------------------------------------------
-    # Configuration
-    # ------------------------------------------------------------------
+    def _configure(self, **kwargs: Any) -> None:
+        """Validate the selected WarpX profile and prepare owned output."""
 
-    def _configure(self, **kwargs):
-        """
-        Configure WarpX.
-
-        Calls super()._configure() which updates self.config and (when
-        deploy_mode == 'container') triggers build_phase / build_deploy_phase.
-
-        In default mode, also creates the output directory and locates the
-        warpx binary on the system PATH.
-        """
         super()._configure(**kwargs)
+        self._validate_configuration()
+        if self.config.get("deploy_mode") == "default":
+            self.warpx_bin = self._discover_executable(self._deployment_environment())
+            self._ensure_output_dir()
 
-        if self.config.get('deploy_mode') == 'default':
-            Mkdir(self.config['out'],
-                  PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
-            # Find warpx binary (various naming conventions)
-            for name in ['warpx.3d.MPI.CUDA.SP', 'warpx', 'warpx.3d']:
-                if shutil.which(name):
-                    self.warpx_bin = name
-                    break
-            if not self.warpx_bin:
-                self.warpx_bin = 'warpx.3d.MPI.CUDA.SP'
+    def _validate_configuration(self) -> None:
+        """Reject ambiguous inputs and invalid MPI or override settings."""
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
-
-    def start(self):
-        """
-        Launch WarpX.
-
-        Branches on deploy_mode: uses MpiExecInfo with container engine for
-        container mode, MpiExecInfo with hostfile for default mode.
-        """
-        if self.config.get('deploy_mode') == 'container':
-            outdir = self.config.get('out', '/tmp/warpx_out')
-            Mkdir(outdir).run()
-
-            nprocs = self.config.get('nprocs', 2)
-
-            if self.config.get('inputs'):
-                inputs_arg = self.config['inputs']
-            else:
-                example = self.config.get('example', 'laser_acceleration')
-                inputs_arg = (
-                    f'/opt/warpx/Examples/Physics_applications/{example}/inputs_base_3d'
+        for name in ("nprocs", "ppn"):
+            value = self.config.get(name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        inputs = self.config.get("inputs")
+        bundle = self.config.get("input_bundle")
+        if inputs not in (None, "") and bundle not in (None, ""):
+            raise ValueError("inputs and input_bundle cannot be combined")
+        for name, value in (("inputs", inputs), ("input_bundle", bundle)):
+            if value not in (None, "") and not isinstance(value, str):
+                raise TypeError(f"{name} must be a path string")
+        input_path = self.config.get("input_path")
+        if input_path not in (None, "") and not isinstance(input_path, str):
+            raise TypeError("input_path must be a relative path string")
+        if bundle in (None, "") and input_path not in (None, ""):
+            raise ValueError("input_path requires input_bundle")
+        if inputs in (None, "") and bundle in (None, ""):
+            if self.config.get("example") == "custom":
+                raise ValueError(
+                    "custom WarpX execution requires inputs or input_bundle"
                 )
+            self._validate_overrides()
+        elif self.config.get("override_input_parameters"):
+            self._validate_overrides()
 
-            base = self.config.get('base_image', 'sci-hpc-base')
-            use_gpu = self.config.get('use_gpu', False) or 'sci-hpc' in base
-            # WarpX binary name embeds feature flags (MPI/CUDA/SP/PSP/OPMD/EB/QED).
-            # Dockerfile.deploy creates a stable symlink at this path; mpiexec
-            # doesn't invoke a shell per rank, so a glob wouldn't expand here.
-            warpx_bin = '/opt/warpx/build/bin/warpx.3d'
-            diag_args = [
-                'diagnostics.diags_names=diag1',
-                'diag1.diag_type=Full',
-                f'diag1.file_prefix={outdir}/diag1',
-                f'diag1.intervals={self.config["plot_int"]}',
-            ]
-            inner = ' '.join([
-                warpx_bin,
-                inputs_arg,
-                f'max_step={self.config["max_step"]}',
-                f'amr.n_cell={self.config["n_cell"]}',
-                *diag_args,
-            ])
-            Exec(inner, MpiExecInfo(
-                nprocs=nprocs,
-                ppn=self.config.get('ppn'),
-                hostfile=self.hostfile,
-                port=self.ssh_port,
-                container=self._container_engine,
-                container_image=self.deploy_image_name(),
-                shared_dir=self.shared_dir,
-                private_dir=self.private_dir,
-                gpu=use_gpu,
-                env=self.mod_env,
-            )).run()
+    def _validate_overrides(self) -> None:
+        """Validate command-line overrides without interpreting scientific input."""
+
+        max_step = self.config.get("max_step")
+        if isinstance(max_step, bool) or not isinstance(max_step, int) or max_step <= 0:
+            raise ValueError("max_step must be a positive integer")
+        plot_int = self.config.get("plot_int")
+        if (
+            isinstance(plot_int, bool)
+            or not isinstance(plot_int, int)
+            or plot_int == 0
+            or plot_int < -1
+        ):
+            raise ValueError("plot_int must be -1 or a positive integer")
+        n_cell = self.config.get("n_cell")
+        if not isinstance(n_cell, str):
+            raise TypeError("n_cell must contain three positive integers")
+        try:
+            cells = tuple(int(value) for value in n_cell.split())
+        except ValueError as exc:
+            raise ValueError("n_cell must contain three positive integers") from exc
+        if len(cells) != 3 or any(value <= 0 for value in cells):
+            raise ValueError("n_cell must contain three positive integers")
+
+    @staticmethod
+    def _discover_executable(environment: dict[str, str]) -> str | None:
+        """Return the first supported WarpX program name available through PATH."""
+
+        for candidate in _EXECUTABLE_CANDIDATES:
+            if shutil.which(candidate, path=environment.get("PATH")) is not None:
+                return candidate
+        return None
+
+    def _output_dir(self) -> Path:
+        """Return the normalized package-owned output root."""
+
+        return self.resolve_shared_path(
+            self.config.get("out"), field="out", default="run"
+        )
+
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        """Return local or parallel-SSH execution according to the hostfile."""
+
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
+
+    def _ensure_output_dir(self) -> None:
+        """Create the exact output root on every participating host."""
+
+        output_dir = str(self._output_dir())
+        result = Mkdir(output_dir, self._node_exec_info(env=self.env)).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to create WarpX output directory {output_dir}: {failures}"
+            )
+
+    @staticmethod
+    def _resolve_bundle_input(
+        bundle: MaterializedInputBundle, requested: object
+    ) -> Path:
+        """Resolve one manifest-declared WarpX input without path inference."""
+
+        if requested in (None, ""):
+            return bundle.entrypoint
+        if not isinstance(requested, str) or "\\" in requested:
+            raise ValueError("input_path must be a confined manifest path")
+        relative = PurePosixPath(requested)
+        if relative.is_absolute() or any(
+            part in {"", ".", ".."} for part in relative.parts
+        ):
+            raise ValueError("input_path must be a confined manifest path")
+        declared = {item.path for item in bundle.manifest.files}
+        normalized = relative.as_posix()
+        if normalized not in declared:
+            raise ValueError("input_path is not declared by the input bundle")
+        selected = bundle.root / relative
+        if selected.is_symlink() or not selected.is_file():
+            raise ValueError("input_path is not a verified regular file")
+        return selected
+
+    def _stage_single_input(self, configured: str, output_dir: Path) -> Path:
+        """Copy one bounded regular input into package-owned storage."""
+
+        source = Path(
+            os.path.abspath(os.path.expandvars(os.path.expanduser(configured)))
+        )
+        try:
+            status = source.lstat()
+        except OSError as exc:
+            raise ValueError("inputs is not a readable regular file") from exc
+        if (
+            source.is_symlink()
+            or not source.is_file()
+            or status.st_size <= 0
+            or status.st_size > _MAX_INPUT_BYTES
+        ):
+            raise ValueError("inputs is not a bounded regular file")
+        destination = output_dir / source.name
+        if destination.exists() or destination.is_symlink():
+            raise ValueError("WarpX staged input already exists")
+        shutil.copyfile(source, destination)
+        os.chmod(destination, 0o600)
+        return destination
+
+    def _prepare_input(self) -> tuple[Path, Path, bool]:
+        """Materialize the selected input and return input, cwd, and caller flag."""
+
+        self._validate_configuration()
+        self._ensure_output_dir()
+        output_dir = self._output_dir()
+        configured_bundle = self.config.get("input_bundle")
+        if configured_bundle not in (None, ""):
+            assert isinstance(configured_bundle, str)
+            if self.shared_dir is None:
+                raise RuntimeError("WarpX input bundles require package shared storage")
+            bundle = extract_input_bundle(
+                configured_bundle, Path(self.shared_dir) / "input-bundles"
+            )
+            selected = self._resolve_bundle_input(bundle, self.config.get("input_path"))
+            relative = selected.relative_to(bundle.root)
+            stage_input_bundle(bundle, output_dir)
+            staged = output_dir / relative
+            return staged, staged.parent, True
+
+        configured_input = self.config.get("inputs")
+        if configured_input not in (None, ""):
+            assert isinstance(configured_input, str)
+            staged = self._stage_single_input(configured_input, output_dir)
+            return staged, output_dir, True
+
+        example = str(self.config.get("example") or "laser_acceleration")
+        example_dir = Path("/opt/warpx/Examples/Physics_applications") / example
+        return example_dir / "inputs_base_3d", example_dir, False
+
+    def _runtime_arguments(self, *, caller_input: bool) -> list[str]:
+        """Return output-only or explicitly authorized scientific overrides."""
+
+        if caller_input and not self.config.get("override_input_parameters"):
+            return []
+        output_dir = self._output_dir()
+        return [
+            f"max_step={self.config['max_step']}",
+            f"amr.n_cell={self.config['n_cell']}",
+            f"amr.plot_file={output_dir / 'plt'}",
+            f"amr.plot_int={self.config['plot_int']}",
+        ]
+
+    def start(self) -> None:
+        """Launch WarpX and fail the pipeline on any rank failure."""
+
+        input_path, cwd, caller_input = self._prepare_input()
+        if self.config.get("deploy_mode") == "container":
+            executable = "/opt/warpx/build/bin/warpx.3d"
+            exec_kwargs: dict[str, Any] = {
+                "port": self.ssh_port,
+                "container": self._container_engine,
+                "container_image": self.deploy_image_name(),
+                "shared_dir": self.shared_dir,
+                "private_dir": self.private_dir,
+                "gpu": self.config.get("use_gpu", False),
+            }
         else:
-            if self.config['inputs']:
-                inputs_arg = self.config['inputs']
-                cwd = os.path.dirname(self.config['inputs'])
-            elif self.config['example'] != 'custom':
-                example_dir = (
-                    f'/opt/warpx/Examples/Physics_applications/{self.config["example"]}'
-                )
-                inputs_arg = 'inputs_base_3d'
-                cwd = example_dir
-            else:
-                raise ValueError("Either 'inputs' or 'example' must be specified")
+            executable = self.warpx_bin or self._discover_executable(self.mod_env)
+            if executable is None:
+                raise RuntimeError("WarpX executable is unavailable through PATH")
+            exec_kwargs = {}
+        command = " ".join(
+            (
+                shlex.quote(executable),
+                shlex.quote(str(input_path)),
+                *(
+                    shlex.quote(value)
+                    for value in self._runtime_arguments(caller_input=caller_input)
+                ),
+            )
+        )
+        result = Exec(
+            command,
+            MpiExecInfo(
+                nprocs=self.config["nprocs"],
+                ppn=self.config["ppn"],
+                hostfile=self.hostfile,
+                env=self.mod_env,
+                cwd=str(cwd),
+                line_callback=self.runtime_line_callback(),
+                **exec_kwargs,
+            ),
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"WarpX execution failed: {failures}")
 
-            cmd = [
-                self.warpx_bin,
-                inputs_arg,
-                f'max_step={self.config["max_step"]}',
-                f'amr.n_cell={self.config["n_cell"]}',
-                f'amr.plot_file={self.config["out"]}/plt',
-                f'amr.plot_int={self.config["plot_int"]}',
-            ]
+    def stop(self) -> None:
+        """Do nothing because WarpX runs to process completion."""
 
-            Exec(' '.join(cmd),
-                 MpiExecInfo(nprocs=self.config['nprocs'],
-                             ppn=self.config['ppn'],
-                             hostfile=self.hostfile,
-                             env=self.mod_env,
-                             cwd=cwd)).run()
+    def clean(self) -> None:
+        """Remove only the exact configured WarpX output directory."""
 
-    def stop(self):
-        """Stop WarpX (no-op — WarpX runs to completion)."""
-        pass
-
-    def clean(self):
-        """Remove WarpX output directory."""
-        Rm(self.config['out'] + '*',
-           PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+        output_dir = self._output_dir()
+        if output_dir == Path(output_dir.anchor):
+            raise ValueError("refusing to clean a filesystem root as WarpX output")
+        result = Rm(
+            str(output_dir),
+            self._node_exec_info(env=self.env),
+            recursive=True,
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"Failed to clean WarpX output {output_dir}: {failures}")

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Jarvis-CD is a unified platform for deploying scientific applications, storage s
 
 - [Package Deployment Contracts](package-deployment.md) - Versioned execution, runtime resolution, configuration, and readiness metadata
 - [Package Input Bundles](input-bundles.md) - Digest-verified multi-file application inputs and mutable run staging
+- [WarpX Package](warpx.md) - Execution-owned inputs, runtime controls, and output artifacts
 - [Pipeline Configuration](pipelines.md) — Full YAML format, install managers (container/spack), environment management, multi-node, devcontainers
 - [Package Development Guide](package_dev_guide.md) — Create new packages, Dockerfile templates, container and spack support
 - [Pipeline Tests](pipeline_tests.md) — Automated testing with grid search and parameter sweeps

--- a/docs/warpx.md
+++ b/docs/warpx.md
@@ -1,0 +1,77 @@
+# WarpX Package
+
+`builtin.warpx` launches one three-dimensional WarpX particle-in-cell simulation under
+JARVIS-owned MPI execution. The package supports an installed example, one caller-supplied
+input file, or one selected member of a digest-verified package input bundle.
+
+## Input profiles
+
+| Profile | Settings | Behavior |
+|---|---|---|
+| Installed example | `example` | Runs the selected example from the installed WarpX tree and applies the configured bounds. |
+| Single input | `inputs` | Copies the regular input file into the package output root and launches it there. |
+| Input bundle | `input_bundle`, optional `input_path` | Verifies and stages every manifest member, then launches the selected member. An empty `input_path` selects the manifest entrypoint. |
+
+`inputs` and `input_bundle` are mutually exclusive. `input_path` is accepted only with an
+input bundle, must be a confined relative path, and must name a manifest-declared regular
+file. The special `custom` example requires one of the two caller-input forms.
+
+By default, JARVIS does not replace scientific values in caller inputs. Set
+`override_input_parameters=true` to apply `max_step`, `n_cell`, `plot_int`, and the
+package-owned plotfile prefix as WarpX command-line overrides. Installed examples always
+use those bounds.
+
+## Settings
+
+| Setting | Default | Meaning |
+|---|---:|---|
+| `nprocs` | `2` | MPI process count. |
+| `ppn` | `2` | MPI processes per node. |
+| `inputs` | empty | Single caller-supplied WarpX input file. |
+| `input_bundle` | empty | `jarvis.package-input-bundle.v1` archive. |
+| `input_path` | empty | Selected manifest member, or the entrypoint when empty. |
+| `example` | `laser_acceleration` | Installed example used without caller input. |
+| `override_input_parameters` | `false` | Authorize command-line overrides for caller input. |
+| `max_step` | `50` | Step bound for examples or authorized overrides. |
+| `n_cell` | `64 64 128` | Three positive base-grid dimensions. |
+| `out` | `run` | Output root; relative paths resolve below package shared storage. |
+| `plot_int` | `10` | Plot interval; `-1` disables plots. |
+| `use_gpu` | `false` | Select the CUDA container build and launch profile. |
+| `cuda_arch` | `80` | CUDA architecture used by the container build. |
+| `base_image` | `sci-hpc-base` | Base image used by package-owned container builds. |
+
+The native profile resolves a supported WarpX executable through the activated pipeline
+`PATH`. Its deployment contract advertises a provider-neutral `warpx` Spack query. Sites or
+callers may constrain the actual installation through ordinary JARVIS environment and
+installation configuration.
+
+## Outputs and completion
+
+The default `out=run` resolves to a dedicated directory below the execution package's
+durable shared directory. Relative
+diagnostic paths in supplied WarpX inputs therefore remain execution-owned. A nonzero exit
+from any MPI rank fails the package.
+
+At process completion, the package performs a bounded walk without following links. It
+reports the owned WarpX result tree plus high-confidence plotfile, checkpoint, ADIOS2, HDF5,
+JSON, CSV, and text diagnostics. Exact staged input files are excluded from the output
+manifest. A nonzero process exit or a discovery-bound truncation marks reported products
+incomplete.
+
+## Example bundle pipeline
+
+```yaml
+name: plasma-study
+pkgs:
+  - pkg_type: builtin.warpx
+    pkg_name: density_high
+    input_bundle: /data/langmuir-cases.tar
+    input_path: density-high/inputs
+    nprocs: 4
+    ppn: 4
+    out: run
+```
+
+Multiple package instances can select different manifest members without introducing a
+study-specific WarpX package. Downstream analysis remains a separate application or
+pipeline step.

--- a/test/unit/core/test_warpx_artifacts.py
+++ b/test/unit/core/test_warpx_artifacts.py
@@ -1,0 +1,138 @@
+"""Tests for builtin WarpX generated-artifact semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import (
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "warpx"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def test_finalization_reports_bounded_plotfiles_and_diagnostics(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Exact staged inputs are excluded while native products remain visible."""
+
+    (tmp_path / "density-low").mkdir()
+    (tmp_path / "density-low" / "inputs").write_text("input\n", encoding="utf-8")
+    diagnostic = tmp_path / "density-low" / "electron_energy.txt"
+    diagnostic.write_text("40 1e-13 0.0 1.0\n", encoding="utf-8")
+    plotfile = tmp_path / "density-low" / "plt00040"
+    plotfile.mkdir()
+    (plotfile / "Header").write_text("WarpX\n", encoding="utf-8")
+    (tmp_path / "density-low" / "unclassified.bin").write_bytes(b"result")
+
+    module = _module()
+    adapter = module.WarpxArtifactAdapter(
+        module.PurePosixPath("/scratch/warpx"),
+        frozenset({module.PurePosixPath("density-low/inputs")}),
+    )
+    monkeypatch.setattr(adapter, "_local_output_path", lambda: tmp_path)
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert adapter.finalize_artifacts_for_exit(0) == []
+    collection = observations[0]
+    assert collection.logical_name == "warpx-results"
+    assert collection.role is ArtifactRole.OUTPUT
+    assert collection.structure is ArtifactStructure.COLLECTION
+    assert collection.state is ArtifactState.FINALIZED
+    names = collection.metadata["member_names"]
+    assert "density-low/inputs" not in names
+    assert "density-low/electron_energy.txt" in names
+    assert "density-low/unclassified.bin" in names
+    concrete = {item.logical_name: item for item in observations[1:]}
+    histogram = concrete["warpx-density-low-electron_energy.txt"]
+    assert histogram.structure is ArtifactStructure.FILE
+    assert histogram.checksum is not None
+    assert concrete["warpx-density-low-plt00040"].format == "amrex-plotfile"
+    assert "warpx-density-low-unclassified.bin" not in concrete
+
+
+def test_nonzero_exit_marks_discovered_outputs_incomplete(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Filesystem presence cannot turn a failed WarpX run into success."""
+
+    (tmp_path / "electron_energy.txt").write_text("partial\n", encoding="utf-8")
+    module = _module()
+    adapter = module.WarpxArtifactAdapter(module.PurePosixPath("/scratch/warpx"))
+    monkeypatch.setattr(adapter, "_local_output_path", lambda: tmp_path)
+
+    observations = adapter.finalize_artifacts_for_exit(17)
+
+    assert observations
+    assert {item.state for item in observations} == {ArtifactState.INCOMPLETE}
+
+
+def test_discovery_bound_cannot_claim_complete_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A truncated output walk is visibly incomplete."""
+
+    for index in range(3):
+        (tmp_path / f"diag-{index}.txt").write_text(str(index), encoding="utf-8")
+    module = _module()
+    adapter = module.WarpxArtifactAdapter(module.PurePosixPath("/scratch/warpx"))
+    monkeypatch.setattr(adapter, "_local_output_path", lambda: tmp_path)
+    monkeypatch.setattr(module, "_MAX_DISCOVERED_ENTRIES", 2)
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert observations[0].state is ArtifactState.INCOMPLETE
+    assert observations[0].metadata["discovery_truncated"] is True
+
+
+def test_factory_scopes_relative_output_to_package_shared_root() -> None:
+    """Artifact discovery receives the same execution-owned output as launch."""
+
+    module = _module()
+
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.warpx",
+            "out": ".",
+            "shared_dir": "/execution/shared/warpx",
+            "runtime_cwd": "/execution/runtime",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.output_dir.as_posix() == "/execution/shared/warpx"
+    assert module.adapter_from_package({"pkg_type": "builtin.lammps"}) is None
+
+
+def test_container_private_output_is_not_claimed() -> None:
+    """A host cannot report artifacts from an unmounted container path."""
+
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.warpx",
+            "out": "/tmp/warpx",
+            "effective_deploy_mode": "container",
+            "shared_dir": "/execution/shared",
+            "private_dir": "/execution/private",
+            "runtime_cwd": "/execution/runtime",
+        }
+    )
+
+    assert adapter is None

--- a/test/unit/core/test_warpx_package_runtime.py
+++ b/test/unit/core/test_warpx_package_runtime.py
@@ -1,0 +1,306 @@
+"""Runtime-contract tests for the builtin JARVIS WarpX package."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import shlex
+import tarfile
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+)
+from jarvis_cd.shell import LocalExecInfo
+from jarvis_cd.util.hostfile import Hostfile
+
+
+def _load_warpx_package() -> ModuleType:
+    """Load the builtin package without changing repository imports."""
+
+    path = (
+        Path(__file__).resolve().parents[3] / "builtin" / "builtin" / "warpx" / "pkg.py"
+    )
+    spec = spec_from_file_location("test_warpx_runtime_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load WarpX package from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+warpx_package = _load_warpx_package()
+
+
+class _CapturedExec:
+    """Capture one launch and expose a configurable process result."""
+
+    commands: list[str] = []
+    infos: list[Any] = []
+    return_code = 0
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": self.return_code}
+        self.commands.append(command)
+        self.infos.append(exec_info)
+
+    def run(self) -> _CapturedExec:
+        """Return the captured result."""
+
+        return self
+
+
+class _CapturedMkdir:
+    """Create a local test output directory and report success."""
+
+    def __init__(self, path: str, exec_info: Any) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedMkdir:
+        """Materialize the test directory."""
+
+        Path(self.path).mkdir(parents=True, exist_ok=True)
+        return self
+
+
+class _CapturedRm:
+    """Capture exact cleanup authority."""
+
+    calls: list[tuple[str, bool]] = []
+
+    def __init__(self, path: str, exec_info: Any, *, recursive: bool = False) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.recursive = recursive
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedRm:
+        """Record the cleanup without deleting test files."""
+
+        self.calls.append((self.path, self.recursive))
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _capture_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep all unit tests free of process and remote-host side effects."""
+
+    _CapturedExec.commands = []
+    _CapturedExec.infos = []
+    _CapturedExec.return_code = 0
+    _CapturedRm.calls = []
+    monkeypatch.setattr(warpx_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(warpx_package, "Mkdir", _CapturedMkdir)
+    monkeypatch.setattr(warpx_package, "Rm", _CapturedRm)
+
+
+def _package(tmp_path: Path, config: dict[str, Any]) -> Any:
+    package = object.__new__(warpx_package.Warpx)
+    package.config = config
+    package.shared_dir = tmp_path / "shared"
+    package.private_dir = tmp_path / "private"
+    package.env = {}
+    package.mod_env = {"PATH": "/runtime/bin"}
+    package.warpx_bin = "warpx.3d.MPI.NOACC.DP.PDP"
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: Hostfile(find_ips=False))
+    package.runtime_line_callback = lambda: None
+    return package
+
+
+def _write_bundle(destination: Path) -> Path:
+    files = {
+        "density-low/inputs": b"max_step = 40\n",
+        "density-high/inputs": b"max_step = 40\nmy_constants.n0 = 4.e24\n",
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "density-low/inputs",
+        "files": [
+            {
+                "path": name,
+                "role": "warpx_input",
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, payload in files.items()
+        ],
+    }
+    manifest_bytes = json.dumps(manifest, sort_keys=True).encode()
+    with tarfile.open(destination, mode="w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(manifest_bytes)
+        archive.addfile(info, io.BytesIO(manifest_bytes))
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def _base_config(**overrides: Any) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "deploy_mode": "default",
+        "example": "custom",
+        "input_bundle": "",
+        "input_path": "",
+        "inputs": "",
+        "max_step": 50,
+        "n_cell": "64 64 128",
+        "nprocs": 4,
+        "out": "run",
+        "override_input_parameters": False,
+        "plot_int": 10,
+        "ppn": 4,
+        "use_gpu": False,
+    }
+    config.update(overrides)
+    return config
+
+
+def test_agent_contract_exposes_owned_single_and_bundle_inputs() -> None:
+    """Agents see staged input profiles without benchmark-specific settings."""
+
+    package = object.__new__(warpx_package.Warpx)
+    package.config = _base_config(example="laser_acceleration")
+    package.env = {}
+    package.mod_env = {}
+    menu = {item["name"]: item for item in package._configure_menu()}
+
+    assert menu["out"]["default"] == "run"
+    assert menu["inputs"]["input_binding"]["kind"] == "local_file"
+    assert menu["input_bundle"]["input_binding"]["kind"] == "local_file"
+    assert menu["override_input_parameters"]["default"] is False
+    contract = package._deployment_contract().to_dict()
+    assert {profile["name"] for profile in contract["execution_profiles"]} == {
+        "input_bundle",
+        "input_file",
+        "installed_example",
+    }
+
+
+def test_bundle_selects_one_manifest_input_and_preserves_scientific_values(
+    tmp_path: Path,
+) -> None:
+    """Two package instances can select different files from one exact bundle."""
+
+    bundle = _write_bundle(tmp_path / "warpx.tar")
+    package = _package(
+        tmp_path,
+        _base_config(input_bundle=str(bundle), input_path="density-high/inputs"),
+    )
+
+    package.start()
+
+    staged = tmp_path / "shared" / "run" / "density-high" / "inputs"
+    assert staged.read_bytes().endswith(b"my_constants.n0 = 4.e24\n")
+    command = _CapturedExec.commands[-1]
+    assert shlex.quote(str(staged.resolve())) in command
+    assert "max_step=" not in command
+    assert "amr.n_cell=" not in command
+    assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
+
+
+def test_single_input_is_copied_to_owned_output_before_launch(tmp_path: Path) -> None:
+    """An input binding never makes WarpX write beside the caller's source."""
+
+    source = tmp_path / "caller" / "inputs"
+    source.parent.mkdir()
+    source.write_text("max_step = 7\n", encoding="utf-8")
+    package = _package(tmp_path, _base_config(inputs=str(source)))
+
+    package.start()
+
+    staged = tmp_path / "shared" / "run" / "inputs"
+    assert staged.read_bytes() == source.read_bytes()
+    assert shlex.quote(str(staged.resolve())) in _CapturedExec.commands[-1]
+    assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
+
+
+def test_explicit_override_is_required_to_change_caller_input(tmp_path: Path) -> None:
+    """Package defaults do not silently replace supplied scientific settings."""
+
+    source = tmp_path / "inputs"
+    source.write_text("max_step = 7\n", encoding="utf-8")
+    package = _package(
+        tmp_path,
+        _base_config(
+            inputs=str(source),
+            max_step=12,
+            n_cell="8 8 16",
+            override_input_parameters=True,
+            plot_int=-1,
+        ),
+    )
+
+    package.start()
+
+    command = _CapturedExec.commands[-1]
+    assert "max_step=12" in command
+    assert "amr.n_cell=8 8 16" in command
+    assert "amr.plot_int=-1" in command
+
+
+def test_ambiguous_or_undeclared_inputs_fail_before_launch(tmp_path: Path) -> None:
+    """Input selection is explicit, closed, and free of path traversal."""
+
+    bundle = _write_bundle(tmp_path / "warpx.tar")
+    source = tmp_path / "inputs"
+    source.write_text("max_step = 1\n", encoding="utf-8")
+    package = _package(
+        tmp_path,
+        _base_config(inputs=str(source), input_bundle=str(bundle)),
+    )
+    with pytest.raises(ValueError, match="cannot be combined"):
+        package.start()
+
+    package.config = _base_config(
+        input_bundle=str(bundle), input_path="../density-high/inputs"
+    )
+    with pytest.raises(ValueError, match="confined manifest path"):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
+def test_process_failure_is_not_silently_accepted(tmp_path: Path) -> None:
+    """Any failing WarpX rank fails the package lifecycle."""
+
+    source = tmp_path / "inputs"
+    source.write_text("max_step = 1\n", encoding="utf-8")
+    package = _package(tmp_path, _base_config(inputs=str(source)))
+    _CapturedExec.return_code = 9
+
+    with pytest.raises(RuntimeError, match="WarpX execution failed"):
+        package.start()
+
+
+def test_clean_uses_one_exact_recursive_output_without_wildcard(tmp_path: Path) -> None:
+    """Cleanup cannot erase prefix-matching sibling directories."""
+
+    package = _package(tmp_path, _base_config(out="results"))
+
+    package.clean()
+
+    assert _CapturedRm.calls == [
+        (str((tmp_path / "shared" / "results").resolve()), True)
+    ]
+    assert "*" not in _CapturedRm.calls[0][0]
+
+
+def test_default_hostfile_uses_local_output_lifecycle(tmp_path: Path) -> None:
+    """Local execution does not require SSH for output directory management."""
+
+    package = _package(tmp_path, _base_config(example="laser_acceleration"))
+
+    assert isinstance(package._node_exec_info(), LocalExecInfo)


### PR DESCRIPTION
## Summary

- add generic digest-verified multi-file and staged single-file input semantics to builtin.warpx
- keep caller scientific inputs unchanged unless command-line overrides are explicitly enabled
- move outputs into execution-owned package storage, propagate MPI failures, and publish bounded WarpX result artifacts
- document the full agent-facing WarpX contract

## Verification

- uv run ruff check --fix builtin/builtin/warpx test/unit/core/test_warpx_package_runtime.py test/unit/core/test_warpx_artifacts.py
- uv run ruff format builtin/builtin/warpx test/unit/core/test_warpx_package_runtime.py test/unit/core/test_warpx_artifacts.py
- uv run pyright builtin/builtin/warpx/pkg.py builtin/builtin/warpx/artifacts.py test/unit/core/test_warpx_package_runtime.py test/unit/core/test_warpx_artifacts.py
- uv run pytest -q test/unit/core/test_warpx_package_runtime.py test/unit/core/test_warpx_artifacts.py test/unit/core/test_container_baremetal.py test/unit/core/test_container_docker_cluster.py test/unit/core/test_input_bundle.py (80 passed)

Ares qualification is pending. This PR is intentionally stacked and draft.