### PR TITLE
feat: harden WfCommons workflow cells

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,5 @@ include builtin/builtin/paraview/artifacts.py
 include builtin/builtin/paraview/service.py
 include builtin/builtin/paraview/service_http.py
 include builtin/builtin/paraview/service_supervisor.py
+include builtin/builtin/wfcommons/artifacts.py
+include wfcommons-schema.json

--- a/builtin/builtin/wfcommons/README.md
+++ b/builtin/builtin/wfcommons/README.md
@@ -1,69 +1,91 @@
 # WfCommons
 
-Generate a synthetic scientific workflow from a [WfCommons](https://wfcommons.org/)
-recipe, translate it into a runnable [WfBench](https://github.com/wfcommons/wfbench)
-benchmark, and execute the tasks locally in topological order.
+`builtin.wfcommons` generates and executes one bounded synthetic workflow cell
+using WfCommons and WfBench. Multiple package aliases compose a parameter grid;
+the package does not hide a benchmark-specific matrix inside one step.
 
-## What it runs
+JARVIS owns the process lifecycle, output root, pinned WfFormat schema, and
+artifact finalization. The scheduled workload never installs Python packages or
+downloads a schema. Operators prepare a WfCommons 1.4 runtime before execution,
+while agents select only scientific and workload dimensions.
 
-1. **Generate** — picks the named recipe (`montage`, `genome`, `cycles`, `blast`,
-   `bwa`, `srasearch`, `epigenomics`, `seismology`, `soykb`) and instantiates a
-   `WorkflowGenerator` with `num_tasks` tasks. Writes the WfFormat JSON to
-   `<out>/workflow.json`.
-2. **Translate** — uses `WfBenchTranslator` to produce an executable benchmark
-   workflow under `<out>/bench/` (per-task `wfbench` commands + I/O stubs).
-3. **Execute** — walks the DAG in topological order with a thread pool of
-   `max_workers` workers, shelling out to each task's `wfbench` command.
+## Configuration menu
 
-## Config
+| Key | Default | Responsibility |
+| --- | ---: | --- |
+| `recipe` | `montage` | WfCommons scientific workflow family. |
+| `num_tasks` | `100` | Requested generated task count. Recipe generators may produce a nearby realizable count, which the result records separately. |
+| `data_footprint_mb` | `0` | Total workflow data footprint in MB. Zero retains recipe defaults. |
+| `seed` | `424200` | Deterministic workflow topology seed. Reuse a seed to compare footprints at fixed topology. |
+| `cpu_work` | `1` | Positive WfBench CPU work units. Zero is rejected because WfBench would not exercise its intended I/O path. |
+| `percent_cpu` | `1.0` | Fraction of WfBench work threads assigned to CPU work. |
+| `drop_page_cache` | `false` | Enables WfBench's per-file `POSIX_FADV_DONTNEED` behavior. It does not claim a privileged system-wide cold cache. |
+| `clio_prefix` | `false` | Prefixes manifest-declared data paths with `clio::` for an explicitly attached storage interceptor. |
+| `out` | `run` | Package-owned result directory under the JARVIS shared root. |
+| `timeout_seconds` | `3600` | Hard cell timeout, bounded to one day. |
+| `nprocs`, `ppn` | `1`, `1` | The workflow driver is single-process. Generated tasks are controlled by WfBench. |
+| `runtime_python` | empty | Hidden operator setting. Empty uses `WFCOMMONS_PYTHON`, then the JARVIS Python executable. |
 
-| Key | Default | Notes |
-| --- | --- | --- |
-| `recipe` | `montage` | One of the 9 wfcommons recipes. |
-| `num_tasks` | `100` | Workflow size. |
-| `cpu_work` | `100` | CPU work units per `wfbench` task. |
-| `data_footprint` | `100M` | Data size per task; passed to translator. |
-| `max_workers` | `4` | Concurrency for the local task pool. |
-| `out` | `$HOME/wfcommons_out` | Output directory (json + bench/ + logs/). |
-| `keep_outputs` | `false` | Retain bulky `bench/data/` after the run. |
-| `venv` | `$HOME/.jarvis-wfcommons-venv` | Bare-metal venv path (default mode only). |
+## Runtime contract
 
-## Deployment modes
+Native execution requires Bash and a prepared Python runtime whose imported
+`wfcommons.__version__` is exactly `1.4`. The package's deployment description
+probes that contract. Configuration never creates a venv, upgrades pip, or
+installs from the network.
 
-- **`base_deploy_mode: container`** — builds a python venv with `wfcommons[bench]`
-  inside the build container and ships it via the deploy image.
-- **`base_deploy_mode: default`** — creates a venv at `venv:` on the local host
-  and `pip install`s wfcommons there (idempotent).
+The optional container build creates that runtime before workload execution,
+pins WfCommons 1.4, and verifies the WfFormat schema against repository digest
+`716e7b625a37a144674afbf8e6a008c21bbd0fd467ccbb7be39deab9fb8f6aab`.
+The built image digest is the deployable runtime identity.
 
-## Example
+## Results and artifacts
+
+Every successful step closes these package-owned artifacts:
+
+- `wfcommons-result.json`, schema `jarvis.wfcommons-result.v1`;
+- the generated WfFormat workflow manifest;
+- the WfBench workflow log;
+- a sorted Python distribution lock from the prepared runtime;
+- the exact staged WfFormat schema.
+
+The result binds the requested and observed task counts, MB footprint, seed,
+elapsed time, DAG edge count, topology hash, runtime versions, return code, and
+SHA-256 digest of every member. Nonzero execution leaves present products
+`incomplete`; it never finalizes them as successful outputs.
+
+## Four-cell example
+
+The following shape compares two task counts and two footprints without a
+benchmark-specific adapter:
 
 ```yaml
-name: wfcommons_container_test
-base_deploy_mode: container
-container_engine: docker
-container_base: ubuntu:24.04
-
+name: wfcommons_epigenomics_grid
 pkgs:
   - pkg_type: builtin.wfcommons
-    pkg_name: wfcommons_container
-    recipe: montage
-    num_tasks: 25
-    cpu_work: 100
-    data_footprint: 100M
-    out: /tmp/wfcommons_out
+    pkg_name: tasks_100_data_8
+    recipe: epigenomics
+    num_tasks: 100
+    data_footprint_mb: 8
+    seed: 424300
+  - pkg_type: builtin.wfcommons
+    pkg_name: tasks_100_data_32
+    recipe: epigenomics
+    num_tasks: 100
+    data_footprint_mb: 32
+    seed: 424300
+  - pkg_type: builtin.wfcommons
+    pkg_name: tasks_500_data_8
+    recipe: epigenomics
+    num_tasks: 500
+    data_footprint_mb: 8
+    seed: 424700
+  - pkg_type: builtin.wfcommons
+    pkg_name: tasks_500_data_32
+    recipe: epigenomics
+    num_tasks: 500
+    data_footprint_mb: 32
+    seed: 424700
 ```
 
-Run with:
-
-```
-jarvis ppl load yaml builtin/pipelines/examples/wfcommons_container_test.yaml
-jarvis ppl run
-```
-
-## Notes
-
-- The runner is single-process; task-level parallelism is governed by
-  `max_workers`, not by MPI. Set `nprocs: 1`, `ppn: 1`.
-- The WfBench tasks fabricate CPU + I/O load; they don't carry the actual
-  scientific kernel of (say) Montage. Use it for scheduler / storage / system
-  benchmarking, not for science.
+WfBench fabricates the CPU and I/O behavior of a workflow family; it does not
+execute the scientific kernels represented by recipe task names.

--- a/builtin/builtin/wfcommons/artifacts.py
+++ b/builtin/builtin/wfcommons/artifacts.py
@@ -1,0 +1,292 @@
+"""Generated-artifact semantics for the builtin WfCommons package."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+)
+
+RESULT_SCHEMA = "jarvis.wfcommons-result.v1"
+RESULT_NAME = "wfcommons-result.json"
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA-256 digest of one bounded artifact."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(slots=True)
+class WfcommonsArtifactAdapter:
+    """Report a closed workflow cell and its exact provenance members."""
+
+    output_dir: PurePosixPath
+    _local_root: Path | None = None
+    _finalized: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for authoritative process completion before reporting files."""
+
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Finalize products for a successful legacy completion callback."""
+
+        return self._finalize(return_code=0)
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Finalize products using the authoritative driver exit status."""
+
+        return self._finalize(return_code=return_code)
+
+    def reset_artifacts(self) -> None:
+        """Permit discovery after an execution stream is replaced."""
+
+        self._finalized = False
+
+    def _result(self) -> tuple[Path, dict[str, Any]]:
+        """Load and minimally validate the package-owned result document."""
+
+        root = self._local_output_path().resolve(strict=True)
+        if root.is_symlink() or not root.is_dir():
+            raise RuntimeError("WfCommons output root is not a real directory")
+        path = root / RESULT_NAME
+        if path.is_symlink() or not path.is_file() or path.stat().st_size > 1024 * 1024:
+            raise RuntimeError("WfCommons result is missing, unsafe, or oversized")
+        try:
+            document = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError("WfCommons result is not valid JSON") from exc
+        if (
+            not isinstance(document, dict)
+            or document.get("schema_version") != RESULT_SCHEMA
+        ):
+            raise RuntimeError("WfCommons result has the wrong schema")
+        return path, document
+
+    def _member(
+        self,
+        document: dict[str, Any],
+        *,
+        path_field: str,
+        hash_field: str,
+        maximum_bytes: int,
+    ) -> tuple[Path, PurePosixPath]:
+        """Resolve and digest-check one result-declared artifact member."""
+
+        relative = document.get(path_field)
+        expected = document.get(hash_field)
+        if (
+            not isinstance(relative, str)
+            or not relative
+            or not isinstance(expected, str)
+            or len(expected) != 64
+        ):
+            raise RuntimeError(f"WfCommons result omitted {path_field}")
+        candidate = Path(relative)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise RuntimeError(
+                f"WfCommons artifact escaped its output root: {relative}"
+            )
+        root = self._local_output_path().resolve(strict=True)
+        path = (root / candidate).resolve(strict=False)
+        if not path.is_relative_to(root):
+            raise RuntimeError(
+                f"WfCommons artifact escaped its output root: {relative}"
+            )
+        if path.is_symlink() or not path.is_file():
+            raise RuntimeError(f"WfCommons artifact is missing or unsafe: {relative}")
+        size = path.stat().st_size
+        if size <= 0 or size > maximum_bytes:
+            raise RuntimeError(
+                f"WfCommons artifact is outside its size bound: {relative}"
+            )
+        if _sha256(path) != expected:
+            raise RuntimeError(f"WfCommons artifact hash differs: {relative}")
+        return path, PurePosixPath(relative)
+
+    def _local_output_path(self) -> Path:
+        """Project the declared cluster directory into this host filesystem."""
+
+        if self._local_root is not None:
+            return self._local_root
+        return Path(self.output_dir.as_posix())
+
+    def _observation(
+        self,
+        path: Path,
+        cluster_path: PurePosixPath,
+        *,
+        logical_name: str,
+        kind: str,
+        role: ArtifactRole,
+        format_name: str,
+        media_type: str,
+        state: ArtifactState,
+        metadata: dict[str, Any],
+    ) -> ArtifactObservation:
+        """Create one exact file observation."""
+
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=role,
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(cluster_path),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=path.stat().st_size,
+            checksum=f"sha256:{_sha256(path)}",
+            message="Closed WfCommons workflow-cell product",
+            metadata=metadata,
+        )
+
+    def _finalize(self, *, return_code: int) -> list[ArtifactObservation]:
+        """Validate and report the exact result-declared files once."""
+
+        if self._finalized:
+            return []
+        self._finalized = True
+        result_path, document = self._result()
+        declared_return_code = document.get("return_code")
+        if not isinstance(declared_return_code, int) or isinstance(
+            declared_return_code, bool
+        ):
+            raise RuntimeError("WfCommons result omitted its process return code")
+        state = (
+            ArtifactState.FINALIZED
+            if return_code == 0 and declared_return_code == 0
+            else ArtifactState.INCOMPLETE
+        )
+        workflow, workflow_relative = self._member(
+            document,
+            path_field="workflow_manifest",
+            hash_field="workflow_sha256",
+            maximum_bytes=64 * 1024 * 1024,
+        )
+        log, log_relative = self._member(
+            document,
+            path_field="workflow_log",
+            hash_field="workflow_log_sha256",
+            maximum_bytes=64 * 1024 * 1024,
+        )
+        lock, lock_relative = self._member(
+            document,
+            path_field="dependency_lock",
+            hash_field="dependency_lock_sha256",
+            maximum_bytes=4 * 1024 * 1024,
+        )
+        schema, schema_relative = self._member(
+            document,
+            path_field="schema_file",
+            hash_field="schema_sha256",
+            maximum_bytes=1024 * 1024,
+        )
+        metadata = {
+            "application": "wfcommons",
+            "data_footprint_mb": document.get("data_footprint_mb"),
+            "observed_task_count": document.get("observed_task_count"),
+            "recipe": document.get("recipe"),
+            "requested_task_count": document.get("requested_task_count"),
+            "seed": document.get("seed"),
+            "topology_sha256": document.get("topology_sha256"),
+        }
+        return [
+            self._observation(
+                result_path,
+                self.output_dir / RESULT_NAME,
+                logical_name="wfcommons-result",
+                kind="scientific_result",
+                role=ArtifactRole.OUTPUT,
+                format_name=RESULT_SCHEMA,
+                media_type="application/json",
+                state=state,
+                metadata=metadata,
+            ),
+            self._observation(
+                workflow,
+                self.output_dir / workflow_relative,
+                logical_name="wfcommons-workflow",
+                kind="workflow_manifest",
+                role=ArtifactRole.OUTPUT,
+                format_name="wfcommons-wfformat-json",
+                media_type="application/json",
+                state=state,
+                metadata=metadata,
+            ),
+            self._observation(
+                log,
+                self.output_dir / log_relative,
+                logical_name="wfcommons-workflow-log",
+                kind="log",
+                role=ArtifactRole.LOG,
+                format_name="text-log",
+                media_type="text/plain",
+                state=state,
+                metadata=metadata,
+            ),
+            self._observation(
+                lock,
+                self.output_dir / lock_relative,
+                logical_name="wfcommons-dependency-lock",
+                kind="provenance",
+                role=ArtifactRole.PROVENANCE,
+                format_name="python-distributions",
+                media_type="text/plain",
+                state=state,
+                metadata=metadata,
+            ),
+            self._observation(
+                schema,
+                self.output_dir / schema_relative,
+                logical_name="wfcommons-schema",
+                kind="configuration",
+                role=ArtifactRole.PROVENANCE,
+                format_name="wfformat-json-schema",
+                media_type="application/schema+json",
+                state=state,
+                metadata=metadata,
+            ),
+        ]
+
+
+def adapter_from_package(package: dict[str, Any]) -> WfcommonsArtifactAdapter | None:
+    """Create artifact semantics only for builtin WfCommons."""
+
+    if package.get("pkg_type") != "builtin.wfcommons":
+        return None
+    configured = package.get("out")
+    if not isinstance(configured, str) or not configured:
+        raise ValueError("WfCommons artifact provider requires its output directory")
+    output_dir = PurePosixPath(configured)
+    if not output_dir.is_absolute() or not configured.startswith("/"):
+        raise ValueError("WfCommons artifact output must be an absolute cluster path")
+    shared = package.get("shared_dir")
+    if isinstance(shared, str) and shared:
+        shared_root = PurePosixPath(shared)
+        if not output_dir.is_relative_to(shared_root):
+            raise ValueError("WfCommons output directory escaped its shared root")
+    return WfcommonsArtifactAdapter(output_dir)
+
+
+__all__ = ["WfcommonsArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/wfcommons/build.sh
+++ b/builtin/builtin/wfcommons/build.sh
@@ -29,8 +29,9 @@ printf "StrictHostKeyChecking no\nUserKnownHostsFile /dev/null\n" >> /etc/ssh/ss
 python3 -m venv /opt/wfcommons-env
 /opt/wfcommons-env/bin/pip install --no-cache-dir --upgrade pip wheel setuptools
 
-# Install the wfcommons python library.
-/opt/wfcommons-env/bin/pip install --no-cache-dir wfcommons
+# Install the package-owned WfCommons version. The resulting image digest and
+# runtime dependency lock bind the resolved dependency environment.
+/opt/wfcommons-env/bin/pip install --no-cache-dir 'wfcommons==1.4'
 
 # wfcommons 1.4's wheel build doesn't reliably ship `bin/wfbench` or
 # `bin/cpu-benchmark` (setup.py's scripts= + dynamic data_files don't
@@ -39,7 +40,7 @@ python3 -m venv /opt/wfcommons-env
 # g++, then drop both into the venv's bin/.
 mkdir -p /opt/wfcommons-src
 /opt/wfcommons-env/bin/pip download --no-cache-dir --no-deps \
-    --no-binary=:all: --dest /opt/wfcommons-src wfcommons
+    --no-binary=:all: --dest /opt/wfcommons-src 'wfcommons==1.4'
 tar -xzf /opt/wfcommons-src/wfcommons-*.tar.gz -C /opt/wfcommons-src
 WFC_SRC=$(ls -d /opt/wfcommons-src/wfcommons-*/ | head -1)
 make -C "${WFC_SRC%/}"
@@ -76,3 +77,12 @@ PY
 mkdir -p /opt/wfcommons-driver
 cp run_wfbench.py /opt/wfcommons-driver/run_wfbench.py
 chmod +x /opt/wfcommons-driver/run_wfbench.py
+
+# WfCommons otherwise downloads the latest WfFormat schema during execution.
+# Fetch at image-build time only and fail closed unless the pinned bytes match.
+curl -fsSL \
+    https://raw.githubusercontent.com/wfcommons/wfformat/master/wfcommons-schema.json \
+    -o /opt/wfcommons-driver/wfcommons-schema.json
+printf '%s  %s\n' \
+    '716e7b625a37a144674afbf8e6a008c21bbd0fd467ccbb7be39deab9fb8f6aab' \
+    /opt/wfcommons-driver/wfcommons-schema.json | sha256sum --check --strict

--- a/builtin/builtin/wfcommons/pkg.py
+++ b/builtin/builtin/wfcommons/pkg.py
@@ -1,267 +1,480 @@
-"""
-WfCommons (https://wfcommons.org/) jarvis package.
+"""Generate and execute one bounded WfCommons/WfBench workflow cell."""
 
-Generates a synthetic scientific workflow from a wfcommons recipe
-(Montage, Genome, Cycles, etc.), translates it into a runnable WfBench
-benchmark workflow, and executes the resulting tasks locally in
-topological order via a thread pool.
+from __future__ import annotations
 
-Supports both bare-metal (default) and container deployment modes.
-"""
+import os
+import shlex
+import shutil
+import sys
+import sysconfig
+from pathlib import Path
+from typing import Any
+
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
-from jarvis_cd.shell.process import Mkdir, Rm
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo
+from jarvis_cd.shell.process import Rm
 
-
-RECIPES = [
-    'montage', 'genome', 'cycles', 'blast', 'bwa',
-    'srasearch', 'epigenomics', 'seismology', 'soykb', 'rnaseq',
-]
+RECIPES = (
+    "montage",
+    "genome",
+    "cycles",
+    "blast",
+    "bwa",
+    "srasearch",
+    "epigenomics",
+    "seismology",
+    "soykb",
+    "rnaseq",
+)
+_EXPECTED_WFCOMMONS_VERSION = "1.4"
+_MAX_TASKS = 100_000
+_MAX_DATA_FOOTPRINT_MB = 1_000_000
+_MAX_TIMEOUT_SECONDS = 86_400
 
 
 class Wfcommons(Application):
+    """Run one deterministic synthetic workflow study cell.
+
+    JARVIS owns runtime selection, the pinned WfFormat schema, the output
+    directory, process completion, and artifact reporting. A prepared runtime
+    must already contain the expected WfCommons version. Runtime installation
+    is intentionally outside scheduled scientific execution.
     """
-    Wfcommons workflow benchmark runner.
 
-    Generates a WfFormat workflow from a recipe, translates it with
-    WfBench, and executes the tasks. The translator is invoked locally
-    on a single node; task parallelism is controlled by `max_workers`.
-    """
+    def _init(self) -> None:
+        """Initialize the package without mutable global runtime state."""
 
-    def _init(self):
-        pass
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        """Describe one scientific workflow cell and its execution bounds."""
 
-    def _configure_menu(self):
         return [
             {
-                'name': 'recipe',
-                'msg': 'WfCommons recipe to generate',
-                'type': str,
-                'choices': RECIPES,
-                'default': 'montage',
+                "name": "recipe",
+                "msg": "Synthetic scientific workflow recipe",
+                "type": str,
+                "choices": list(RECIPES),
+                "default": "montage",
             },
             {
-                'name': 'num_tasks',
-                'msg': 'Number of tasks in the generated workflow',
-                'type': int,
-                'default': 100,
+                "name": "num_tasks",
+                "msg": "Requested number of generated workflow tasks",
+                "type": int,
+                "default": 100,
             },
             {
-                'name': 'cpu_work',
-                'msg': ('CPU work units per wfbench task. MUST be > 0; '
-                        'wfbench gates io_alternate on cpu-benchmark progress '
-                        'updates, so cpu_work=0 silently disables ALL '
-                        'reads/writes. Use 1 for minimal CPU + maximal I/O.'),
-                'type': int,
-                'default': 1,
+                "name": "data_footprint_mb",
+                "msg": "Total generated workflow data footprint in MB; 0 uses recipe defaults",
+                "type": int,
+                "default": 0,
             },
             {
-                'name': 'data_footprint',
-                'msg': 'Per-file data size (e.g. 100M, 1G); 0 = recipe defaults',
-                'type': str,
-                'default': '0',
+                "name": "seed",
+                "msg": "Random seed controlling generated workflow topology",
+                "type": int,
+                "default": 424_200,
             },
             {
-                'name': 'percent_cpu',
-                'msg': ('CPU vs memory thread split for the cpu-benchmark '
-                        'process (cpu_threads = 10*percent_cpu, '
-                        'mem_threads = 10 - cpu_threads). Does NOT directly '
-                        'affect I/O volume. mem_threads spawn stress-ng — '
-                        'NOT installed on every system. Default 1.0 (all '
-                        'cpu, no mem threads) so the I/O path runs cleanly '
-                        'on systems without stress-ng.'),
-                'type': float,
-                'default': 1.0,
+                "name": "cpu_work",
+                "msg": "Positive WfBench CPU work units per task",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'drop_page_cache',
-                'msg': ('After each read/write, call '
-                        'posix_fadvise(POSIX_FADV_DONTNEED) so the kernel '
-                        'drops the file from the page cache. Writes also '
-                        'fsync first so dirty pages become drop-eligible. '
-                        'Makes NFS-vs-CTE comparisons apples-to-apples: '
-                        'the CTE adapter has no client-side cache, so '
-                        'letting NFS warm-cache the workflow data '
-                        'biases the comparison. Toggling this sets '
-                        'WFBENCH_DROP_CACHE=1 in the wfbench env.'),
-                'type': bool,
-                'default': False,
+                "name": "percent_cpu",
+                "msg": "Fraction of WfBench work threads assigned to CPU work",
+                "type": float,
+                "default": 1.0,
             },
             {
-                'name': 'out',
-                'msg': 'Output directory (receives bench/ + bench/bash/)',
-                'type': str,
-                'default': '${HOME}/wfcommons_out',
+                "name": "drop_page_cache",
+                "msg": "Request per-file POSIX_FADV_DONTNEED behavior in WfBench",
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'clio_prefix',
-                'msg': 'Rewrite wfbench task paths to begin with "clio::" '
-                       '(opts every read/write into WRP CTE POSIX '
-                       'interception when libwrp_cte_posix.so is LD_PRELOADed)',
-                'type': bool,
-                'default': False,
+                "name": "clio_prefix",
+                "msg": "Prefix translated workflow data paths with clio::",
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'venv',
-                'msg': 'Path to a wfcommons venv (bare-metal mode only)',
-                'type': str,
-                'default': '${HOME}/.jarvis-wfcommons-venv',
+                "name": "out",
+                "msg": "Package-owned output directory relative to the shared root",
+                "type": str,
+                "default": "run",
             },
             {
-                'name': 'nprocs',
-                'msg': 'MPI ranks (driver runs single-process; tasks use max_workers)',
-                'type': int,
-                'default': 1,
+                "name": "timeout_seconds",
+                "msg": "Maximum elapsed time for this workflow cell",
+                "type": int,
+                "default": 3600,
             },
             {
-                'name': 'ppn',
-                'msg': 'MPI processes per node',
-                'type': int,
-                'default': 1,
+                "name": "nprocs",
+                "msg": "Scheduler process count; WfCommons cell execution is single-process",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'base_image',
-                'msg': 'Base image for the build container',
-                'type': str,
-                'default': 'ubuntu:24.04',
+                "name": "ppn",
+                "msg": "Scheduler processes per node; must be one",
+                "type": int,
+                "default": 1,
+            },
+            {
+                "name": "runtime_python",
+                "msg": "Operator-owned Python executable containing WfCommons 1.4",
+                "type": str,
+                "default": "",
+                "agent_visible": False,
+            },
+            {
+                "name": "base_image",
+                "msg": "Base image for an operator-built container runtime",
+                "type": str,
+                "default": "ubuntu:24.04",
+                "agent_visible": False,
             },
         ]
 
-    # ------------------------------------------------------------------
-    # Container build hooks
-    # ------------------------------------------------------------------
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe the prepared runtime and successful-exit contract."""
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+        completed = ReadinessContract(
+            mechanism="process_exit", condition="successful_exit"
+        )
+        if self.config.get("deploy_mode") == "container":
+            wfcommons_status = RuntimeStatus("unknown", "container_runtime_not_probed")
+            bash_status = RuntimeStatus("unknown", "container_runtime_not_probed")
+            wfcommons_capabilities: tuple[str, ...] = ()
+            bash_capabilities: tuple[str, ...] = ()
+        else:
+            environment = self._deployment_environment()
+            python = self._runtime_python()
+            expected = self._expected_version()
+            version_probe = probe_program(
+                python,
+                environment=environment,
+                arguments=(
+                    "-c",
+                    (
+                        "import wfcommons; import sys; "
+                        f"sys.exit(0 if getattr(wfcommons, '__version__', '') == {expected!r} else 3)"
+                    ),
+                ),
+            )
+            bash_probe = probe_program(
+                "bash", environment=environment, arguments=("--version",)
+            )
+            wfcommons_status = version_probe.status
+            bash_status = bash_probe.status
+            wfcommons_capabilities = (
+                ("synthetic_workflow_generation", "wfbench_execution", "wfformat")
+                if wfcommons_status.usable is True
+                else ()
+            )
+            bash_capabilities = (
+                ("bash_workflow_execution",) if bash_status.usable is True else ()
+            )
+        runtime = RuntimeRequirement(
+            requirement_id="wfcommons_runtime",
+            description=(
+                f"Prepared Python runtime containing WfCommons {_EXPECTED_WFCOMMONS_VERSION}"
+            ),
+            required_capabilities=(
+                "synthetic_workflow_generation",
+                "wfbench_execution",
+                "wfformat",
+            ),
+            available_capabilities=wfcommons_capabilities,
+            status=wfcommons_status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="path", query_kind="program", query_value="python3"
+                ),
+            ),
+        )
+        bash = RuntimeRequirement(
+            requirement_id="bash",
+            description="Bash runtime used by the generated WfBench workflow",
+            required_capabilities=("bash_workflow_execution",),
+            available_capabilities=bash_capabilities,
+            status=bash_status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="path", query_kind="program", query_value="bash"
+                ),
+            ),
+        )
+        return PackageDeploymentContract(
+            package="builtin.wfcommons",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="synthetic_workflow_cell",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("recipe", "is_not_empty"),),
+                    runtime_requirements=("bash", "wfcommons_runtime"),
+                    readiness=completed,
+                    description=(
+                        "Generate and execute one deterministic WfBench workflow cell."
+                    ),
+                ),
+            ),
+            runtime_requirements=(bash, runtime),
+        )
+
+    def _build_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Build an operator-owned container runtime when requested."""
+
+        if self.config.get("deploy_mode") != "container":
             return None
-        content = self._read_build_script('build.sh', {
-            'BASE_IMAGE': self.config.get('base_image', 'ubuntu:24.04'),
-        })
-        return content, 'py311'
+        content = self._read_build_script(
+            "build.sh", {"BASE_IMAGE": self.config.get("base_image", "ubuntu:24.04")}
+        )
+        return content, "py311"
 
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Create the deploy image containing the prepared runtime."""
+
+        if self.config.get("deploy_mode") != "container":
             return None
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': 'ubuntu:24.04',
-        })
-        return content, 'py311'
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {
+                "BUILD_IMAGE": self.build_image_name(),
+                "DEPLOY_BASE": "ubuntu:24.04",
+            },
+        )
+        return content, "py311"
 
-    # ------------------------------------------------------------------
-    # Configure
-    # ------------------------------------------------------------------
+    def _configure(self, **kwargs: Any) -> None:
+        """Persist a valid cell without installing software or touching outputs."""
 
-    def _configure(self, **kwargs):
         super()._configure(**kwargs)
-
-        if self.config['recipe'] not in RECIPES:
-            raise ValueError(
-                f"recipe '{self.config['recipe']}' not in {RECIPES}"
-            )
-
-        # wfbench main() guards the cpu-benchmark spawn behind
-        # `if args.cpu_work:` (wfbench script line 443). When that block
-        # is skipped, nothing feeds the cpu_queue that io_alternate
-        # blocks on, so the io subprocess hangs until wfbench main kills
-        # it on shutdown — no reads, no writes, just process spawn
-        # overhead. Coerce cpu_work to a minimum of 1 so this path is
-        # always taken.
-        if int(self.config.get('cpu_work', 0)) <= 0:
-            self.log(
-                "cpu_work was 0; coercing to 1 so wfbench actually "
-                "performs I/O (cpu_work=0 silently disables it)"
-            )
-            self.config['cpu_work'] = 1
-
-        # Propagate the drop-page-cache toggle to the wfbench subprocess
-        # (wfbench reads WFBENCH_DROP_CACHE in _drop_page_cache helper).
-        if self.config.get('drop_page_cache', False):
-            self.setenv('WFBENCH_DROP_CACHE', '1')
-
-        if self.config.get('deploy_mode') == 'default':
-            # Output dir on every node so MPI/PSSH topo-execution works.
-            Mkdir(self.config['out'],
-                  PsshExecInfo(hostfile=self.hostfile,
-                               env=self.env)).run()
-            # Bare-metal venv with wfcommons. Idempotent — if the venv
-            # exists and imports wfcommons, skip the (slow) pip install.
-            venv = self.config['venv']
-            ensure = (
-                f"python3 -c 'import sys; sys.exit(0)' && "
-                f"if [ ! -x '{venv}/bin/python3' ]; then "
-                f"  python3 -m venv '{venv}'; "
-                f"fi && "
-                f"'{venv}/bin/pip' install --quiet --upgrade pip && "
-                f"'{venv}/bin/python3' -c 'import wfcommons' 2>/dev/null || "
-                f"'{venv}/bin/pip' install --quiet 'wfcommons[bench]'"
-            )
-            Exec(ensure, LocalExecInfo(env=self.env)).run()
-            self.setenv('WFCOMMONS_PYTHON', f"{venv}/bin/python3")
-
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
+        self._validate_configuration()
 
     @staticmethod
-    def _data_bytes(s):
-        """Parse '100M', '1G', '500k', or a plain integer to bytes."""
-        if s is None:
-            return 0
-        s = str(s).strip()
-        if not s:
-            return 0
-        units = {'k': 1024, 'm': 1024**2, 'g': 1024**3, 't': 1024**4}
-        suffix = s[-1].lower()
-        if suffix in units:
-            return int(float(s[:-1]) * units[suffix])
-        return int(s)
+    def _require_int(value: object, name: str, *, minimum: int, maximum: int) -> int:
+        """Return one bounded integer or fail without coercion."""
 
-    def _driver_args(self):
-        cfg = self.config
-        args = [
-            f"--recipe {cfg['recipe']}",
-            f"--num-tasks {cfg['num_tasks']}",
-            f"--cpu-work {cfg['cpu_work']}",
-            f"--data {self._data_bytes(cfg['data_footprint'])}",
-            f"--percent-cpu {cfg['percent_cpu']}",
-            f"--out '{cfg['out']}'",
-        ]
-        if cfg.get('clio_prefix'):
-            args.append('--clio-prefix')
-        return ' '.join(args)
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or value < minimum
+            or value > maximum
+        ):
+            raise ValueError(f"{name} must be an integer from {minimum} to {maximum}")
+        return value
 
-    def start(self):
-        if self.config.get('deploy_mode') == 'container':
-            cmd = (
-                '/opt/wfcommons-env/bin/python3 '
-                '/opt/wfcommons-driver/run_wfbench.py '
-                + self._driver_args()
+    def _validate_configuration(self) -> None:
+        """Reject ambiguous, unsafe, or unsupported study settings."""
+
+        recipe = self.config.get("recipe")
+        if recipe not in RECIPES:
+            raise ValueError(f"recipe must be one of: {', '.join(RECIPES)}")
+        self._require_int(
+            self.config.get("num_tasks"), "num_tasks", minimum=1, maximum=_MAX_TASKS
+        )
+        self._require_int(
+            self.config.get("data_footprint_mb"),
+            "data_footprint_mb",
+            minimum=0,
+            maximum=_MAX_DATA_FOOTPRINT_MB,
+        )
+        self._require_int(
+            self.config.get("cpu_work"), "cpu_work", minimum=1, maximum=1_000_000
+        )
+        self._require_int(self.config.get("seed"), "seed", minimum=0, maximum=2**32 - 1)
+        self._require_int(
+            self.config.get("timeout_seconds"),
+            "timeout_seconds",
+            minimum=1,
+            maximum=_MAX_TIMEOUT_SECONDS,
+        )
+        percent_cpu = self.config.get("percent_cpu")
+        if (
+            isinstance(percent_cpu, bool)
+            or not isinstance(percent_cpu, (int, float))
+            or not 0 < float(percent_cpu) <= 1
+        ):
+            raise ValueError("percent_cpu must be greater than 0 and at most 1")
+        if self.config.get("nprocs") != 1 or self.config.get("ppn") != 1:
+            raise ValueError(
+                "WfCommons workflow cells require single-process execution"
             )
-            Exec(cmd, LocalExecInfo(
-                env=self.mod_env,
+        runtime_python = self.config.get("runtime_python", "")
+        if not isinstance(runtime_python, str):
+            raise ValueError("runtime_python must be a path string")
+        out = self.config.get("out")
+        if not isinstance(out, str) or not out.strip():
+            raise ValueError("out must be a non-empty path")
+
+    def _expected_version(self) -> str:
+        """Return the package-owned WfCommons version pin."""
+
+        return _EXPECTED_WFCOMMONS_VERSION
+
+    def _runtime_python(self) -> str:
+        """Resolve the operator-prepared Python executable."""
+
+        if self.config.get("deploy_mode") == "container":
+            return "/opt/wfcommons-env/bin/python3"
+        configured = self.config.get("runtime_python")
+        if isinstance(configured, str) and configured:
+            return os.path.expandvars(os.path.expanduser(configured))
+        environment = getattr(self, "mod_env", {})
+        from_environment = environment.get("WFCOMMONS_PYTHON")
+        if from_environment:
+            return from_environment
+        return sys.executable
+
+    def _output_dir(self) -> Path:
+        """Return the package-owned output directory."""
+
+        return self.resolve_shared_path(
+            self.config.get("out"), field="out", default="run"
+        )
+
+    def _schema_source(self) -> Path:
+        """Return the repository-pinned WfFormat schema."""
+
+        package_dir = self._package_dir()
+        package_copy = package_dir / "wfcommons-schema.json"
+        if package_copy.is_file() and not package_copy.is_symlink():
+            return package_copy
+        repository_copy = package_dir.parents[2] / "wfcommons-schema.json"
+        if repository_copy.is_file() and not repository_copy.is_symlink():
+            return repository_copy
+        installed_copy = Path(sysconfig.get_path("data")) / "wfcommons-schema.json"
+        if installed_copy.is_file() and not installed_copy.is_symlink():
+            return installed_copy
+        raise RuntimeError("Pinned WfFormat schema is missing from the package")
+
+    def _package_dir(self) -> Path:
+        """Return the configured package directory as an absolute path."""
+
+        package_dir = self.pkg_dir
+        if not isinstance(package_dir, str) or not package_dir:
+            raise RuntimeError("WfCommons package directory is unavailable")
+        return Path(package_dir).resolve()
+
+    @staticmethod
+    def _failures(result: Any) -> dict[str, int]:
+        """Return all nonzero host exits from one JARVIS shell result."""
+
+        return {host: code for host, code in result.exit_code.items() if code != 0}
+
+    def _driver_arguments(self, *, schema_path: Path) -> list[str]:
+        """Return one shell-safe driver argument vector."""
+
+        arguments = [
+            "--recipe",
+            str(self.config["recipe"]),
+            "--num-tasks",
+            str(self.config["num_tasks"]),
+            "--cpu-work",
+            str(self.config["cpu_work"]),
+            "--data-footprint-mb",
+            str(self.config["data_footprint_mb"]),
+            "--percent-cpu",
+            str(self.config["percent_cpu"]),
+            "--seed",
+            str(self.config["seed"]),
+            "--schema-file",
+            str(schema_path),
+            "--expected-wfcommons-version",
+            self._expected_version(),
+            "--out",
+            str(self._output_dir()),
+        ]
+        if self.config.get("clio_prefix"):
+            arguments.append("--clio-prefix")
+        return arguments
+
+    def start(self) -> None:
+        """Generate and execute one cell and fail on any process error."""
+
+        self._validate_configuration()
+        output_dir = self._output_dir()
+        if output_dir.exists():
+            raise ValueError(f"WfCommons output already exists: {output_dir}")
+        output_dir.mkdir(parents=True, mode=0o700)
+        schema_source = self._schema_source()
+        schema_path = output_dir / "wfcommons-schema.json"
+        shutil.copyfile(schema_source, schema_path, follow_symlinks=False)
+        os.chmod(schema_path, 0o400)
+        self.config["out"] = str(output_dir)  # pyright: ignore[reportArgumentType]
+
+        if self.config.get("deploy_mode") == "container":
+            driver = "/opt/wfcommons-driver/run_wfbench.py"
+            info = LocalExecInfo(
+                env=dict(self.mod_env),
+                cwd=str(output_dir),
+                timeout=self.config["timeout_seconds"],
+                line_callback=self.runtime_line_callback(),
                 container=self._container_engine,
                 container_image=self.deploy_image_name(),
                 shared_dir=self.shared_dir,
                 private_dir=self.private_dir,
-            )).run()
-        else:
-            driver = f"{self.pkg_dir}/run_wfbench.py"
-            cmd = (
-                f"{self.config['venv']}/bin/python3 {driver} "
-                + self._driver_args()
             )
-            Exec(cmd, LocalExecInfo(env=self.mod_env)).run()
+        else:
+            driver = str(self._package_dir() / "run_wfbench.py")
+            environment = dict(self.mod_env)
+            if self.config.get("drop_page_cache"):
+                environment["WFBENCH_DROP_CACHE"] = "1"
+            info = LocalExecInfo(
+                env=environment,
+                cwd=str(output_dir),
+                timeout=self.config["timeout_seconds"],
+                line_callback=self.runtime_line_callback(),
+            )
+        command = " ".join(
+            shlex.quote(value)
+            for value in (
+                self._runtime_python(),
+                driver,
+                *self._driver_arguments(schema_path=schema_path),
+            )
+        )
+        result = Exec(command, info).run()
+        failures = self._failures(result)
+        if failures:
+            rendered = ", ".join(f"{host}={code}" for host, code in failures.items())
+            raise RuntimeError(f"WfCommons execution failed: {rendered}")
 
-    def stop(self):
-        pass
+    def stop(self) -> None:
+        """Do nothing because the workflow cell runs to process completion."""
 
-    def clean(self):
-        if self.config.get('out'):
-            Rm(self.config['out'],
-               PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+    def clean(self) -> None:
+        """Remove only the exact package-owned output directory."""
 
-    def _get_stat(self, stat_dict):
-        stat_dict[f'{self.pkg_id}.recipe'] = self.config['recipe']
-        stat_dict[f'{self.pkg_id}.num_tasks'] = self.config['num_tasks']
-        stat_dict[f'{self.pkg_id}.runtime'] = self.start_time
+        output_dir = self._output_dir()
+        if output_dir == Path(output_dir.anchor):
+            raise ValueError("refusing to clean a filesystem root as WfCommons output")
+        result = Rm(str(output_dir), LocalExecInfo(env=self.env), recursive=True).run()
+        failures = self._failures(result)
+        if failures:
+            raise RuntimeError(
+                f"Failed to clean WfCommons output {output_dir}: {failures}"
+            )
+
+    def _get_stat(self, stat_dict: dict[str, Any]) -> None:
+        """Expose the requested workflow cell in JARVIS statistics."""
+
+        stat_dict[f"{self.pkg_id}.recipe"] = self.config["recipe"]
+        stat_dict[f"{self.pkg_id}.num_tasks"] = self.config["num_tasks"]
+        stat_dict[f"{self.pkg_id}.data_footprint_mb"] = self.config["data_footprint_mb"]
+        stat_dict[f"{self.pkg_id}.runtime"] = getattr(self, "start_time", None)
+
+
+__all__ = ["RECIPES", "Wfcommons"]

--- a/builtin/builtin/wfcommons/pkg.py
+++ b/builtin/builtin/wfcommons/pkg.py
@@ -159,8 +159,14 @@ class Wfcommons(Application):
             wfcommons_capabilities: tuple[str, ...] = ()
             bash_capabilities: tuple[str, ...] = ()
         else:
-            environment = self._deployment_environment()
-            python = self._runtime_python()
+            environment = dict(self._deployment_environment())
+            python_path = Path(self._runtime_python())
+            python = python_path.name
+            if python_path.is_absolute():
+                existing_path = environment.get("PATH", "")
+                environment["PATH"] = os.pathsep.join(
+                    value for value in (str(python_path.parent), existing_path) if value
+                )
             expected = self._expected_version()
             version_probe = probe_program(
                 python,

--- a/builtin/builtin/wfcommons/run_wfbench.py
+++ b/builtin/builtin/wfcommons/run_wfbench.py
@@ -1,38 +1,25 @@
 #!/usr/bin/env python3
-"""
-Driver: generate a wfcommons recipe-based benchmark workflow, translate
-it into a self-contained bash workflow, and execute it.
+"""Generate, translate, execute, and close one WfCommons workflow cell."""
 
-Uses the real wfcommons 1.x API:
+from __future__ import annotations
 
-    WorkflowBenchmark(recipe=<RecipeCls>, num_tasks=N)
-        .create_benchmark(save_dir, cpu_work=..., data=...)   -> path to JSON
-    BashTranslator(workflow=<json_path>).translate(output_folder=...)
-        -> writes run_workflow.sh + bin/{wfbench,cpu-benchmark} + data/
-
-The translator's `bin/wfbench` script picks up its shebang from the
-`wfbench` interpreter on PATH at translation time. Run this driver
-under the same venv that has wfcommons installed so that shebang
-resolves to a python that exists inside this environment.
-"""
 import argparse
+import hashlib
+import importlib.metadata
 import json
 import os
+import random
 import re
-import shutil
 import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
-# Block-buffered stdout hides failures: when the driver fails mid-run,
-# the tail of stderr (Traceback) lands in the log immediately while the
-# trailing stdout prints arrive only when the interpreter exits, which
-# scrambles the apparent ordering. Force line-buffering up front.
-sys.stdout.reconfigure(line_buffering=True)
-sys.stderr.reconfigure(line_buffering=True)
-
-
+RESULT_SCHEMA = "jarvis.wfcommons-result.v1"
+RESULT_NAME = "wfcommons-result.json"
+DEPENDENCY_LOCK_NAME = "dependency-lock.txt"
+WORKFLOW_LOG_NAME = "workflow.log"
 RECIPE_IMPORTS = {
     "montage": "MontageRecipe",
     "genome": "GenomeRecipe",
@@ -47,162 +34,289 @@ RECIPE_IMPORTS = {
 }
 
 
-def load_recipe(name: str):
-    import wfcommons
-    attr = RECIPE_IMPORTS.get(name.lower())
-    if not attr or not hasattr(wfcommons, attr):
-        raise RuntimeError(
-            f"unknown recipe '{name}'. choices: {sorted(RECIPE_IMPORTS)}"
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest of one regular file."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _relative_file(run_root: Path, path: Path, *, label: str) -> str:
+    """Return a confined relative path for one closed result member."""
+
+    root = run_root.resolve(strict=True)
+    resolved = path.resolve(strict=True)
+    if (
+        resolved.is_symlink()
+        or not resolved.is_file()
+        or not resolved.is_relative_to(root)
+    ):
+        raise ValueError(f"{label} is not a confined regular file")
+    return resolved.relative_to(root).as_posix()
+
+
+def workflow_identity(path: Path) -> tuple[int, int, str]:
+    """Return observed tasks, directed edges, and a topology-only hash."""
+
+    raw = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    try:
+        tasks = raw["workflow"]["specification"]["tasks"]
+    except (KeyError, TypeError) as exc:
+        raise ValueError("WfCommons workflow omitted specification tasks") from exc
+    if not isinstance(tasks, list) or not tasks:
+        raise ValueError("WfCommons workflow tasks must be a non-empty list")
+    topology: list[dict[str, Any]] = []
+    edge_count = 0
+    for task in tasks:
+        if not isinstance(task, dict):
+            raise ValueError("WfCommons workflow task is malformed")
+        task_id = task.get("id", task.get("name"))
+        parents = task.get("parents", [])
+        children = task.get("children", [])
+        if (
+            not isinstance(task_id, str)
+            or not task_id
+            or not isinstance(parents, list)
+            or not isinstance(children, list)
+        ):
+            raise ValueError("WfCommons workflow topology is malformed")
+        normalized_parents = sorted(str(value) for value in parents)
+        normalized_children = sorted(str(value) for value in children)
+        edge_count += len(normalized_children)
+        topology.append(
+            {
+                "children": normalized_children,
+                "id": task_id,
+                "parents": normalized_parents,
+            }
         )
-    return getattr(wfcommons, attr)
+    topology.sort(key=lambda item: item["id"])
+    encoded = json.dumps(topology, sort_keys=True, separators=(",", ":")).encode()
+    return len(tasks), edge_count, hashlib.sha256(encoded).hexdigest()
 
 
-def main():
-    p = argparse.ArgumentParser()
-    p.add_argument("--recipe", required=True)
-    p.add_argument("--num-tasks", type=int, required=True)
-    p.add_argument("--cpu-work", type=int, default=100,
-                   help="cpu_work units passed to wfbench tasks")
-    p.add_argument("--data", type=int, default=0,
-                   help="total workflow data footprint in bytes "
-                        "(0 = recipe defaults). Converted to MB internally "
-                        "before being passed to WorkflowBenchmark.create_benchmark, "
-                        "whose `data` arg is documented as 'Total workflow data "
-                        "footprint (in MB)'.")
-    p.add_argument("--percent-cpu", type=float, default=0.6)
-    p.add_argument("--out", type=str, required=True,
-                   help="output dir; receives bench/ and bench/bash/")
-    p.add_argument("--clio-prefix", action="store_true",
-                   help="rewrite every input/output path the translated "
-                        "run_workflow.sh hands to wfbench so it begins "
-                        "with 'clio::'. The WRP CTE POSIX adapter, when "
-                        "LD_PRELOAD'd, only intercepts paths with that "
-                        "prefix; this flag is the opt-in for actually "
-                        "routing wfbench's data I/O through CTE.")
-    args = p.parse_args()
+def write_dependency_lock(destination: Path) -> None:
+    """Write a deterministic snapshot of the prepared Python environment."""
 
-    from wfcommons.wfbench import WorkflowBenchmark, BashTranslator
-
-    out_dir = Path(args.out).resolve()
-    out_dir.mkdir(parents=True, exist_ok=True)
-    bench_dir = out_dir / "bench"
-    bench_dir.mkdir(parents=True, exist_ok=True)
-
-    recipe_cls = load_recipe(args.recipe)
-    # wfcommons.WorkflowBenchmark.create_benchmark expects `data` in MB
-    # (its docstring: "Total workflow data footprint (in MB)"). The
-    # driver accepts bytes for consistency with the pkg.py SizeType
-    # parsing of values like "20G"; convert here.
-    data_mb = (args.data + (1024 * 1024) - 1) // (1024 * 1024) if args.data else 0
-    print(f"[wfbench] recipe={args.recipe} num_tasks={args.num_tasks} "
-          f"cpu_work={args.cpu_work} data={args.data}B (={data_mb} MB)",
-          flush=True)
-
-    bm = WorkflowBenchmark(recipe=recipe_cls, num_tasks=args.num_tasks)
-    create_kwargs = dict(
-        save_dir=bench_dir,
-        cpu_work=args.cpu_work,
-        percent_cpu=args.percent_cpu,
+    packages = sorted(
+        {
+            f"{distribution.metadata['Name']}=={distribution.version}"
+            for distribution in importlib.metadata.distributions()
+            if distribution.metadata.get("Name")
+        },
+        key=str.casefold,
     )
-    if data_mb > 0:
-        create_kwargs["data"] = data_mb
-    json_path = bm.create_benchmark(**create_kwargs)
-    print(f"[wfbench] generated benchmark JSON: {json_path}", flush=True)
+    temporary = destination.with_suffix(destination.suffix + ".tmp")
+    temporary.write_text("\n".join(packages) + "\n", encoding="utf-8")
+    os.replace(temporary, destination)
 
-    bash_dir = bench_dir / "bash"
-    # BashTranslator.translate calls Path.mkdir(parents=True) without
-    # exist_ok, so a leftover bash/ from a prior failed run will fail
-    # the whole pipeline. Clean it up before translating.
-    #
-    # ignore_errors: on NFS, files still held open by a prior wfbench
-    # worker become .nfs* "silly-rename" placeholders that can't be
-    # unlinked until the holder closes them. shutil.rmtree raises on
-    # those, but the directory will be empty enough for the translator
-    # once normal entries are gone — fall back to renaming any
-    # leftover dir out of the way.
-    if bash_dir.exists():
-        print(f"[wfbench] removing stale {bash_dir}", flush=True)
-        shutil.rmtree(bash_dir, ignore_errors=True)
-        if bash_dir.exists():
-            stash = bash_dir.with_name(
-                bash_dir.name + ".stale." + str(int(time.time())))
-            print(f"[wfbench] couldn't fully remove (NFS .nfs* locks?); "
-                  f"renaming to {stash}", flush=True)
-            bash_dir.rename(stash)
 
-    print(f"[wfbench] translating to bash workflow under {bash_dir}", flush=True)
-    BashTranslator(workflow=json_path).translate(output_folder=bash_dir)
+def build_result_document(
+    *,
+    run_root: Path,
+    recipe: str,
+    requested_task_count: int,
+    data_footprint_mb: int,
+    seed: int,
+    elapsed_seconds: float,
+    return_code: int,
+    workflow_path: Path,
+    workflow_log: Path,
+    dependency_lock: Path,
+    schema_path: Path,
+    wfcommons_version: str,
+    python_version: str,
+) -> dict[str, object]:
+    """Build one closed, generic WfCommons result document."""
 
-    runner = bash_dir / "run_workflow.sh"
-    if not runner.exists():
-        raise RuntimeError(f"translator did not produce {runner}")
+    observed_tasks, edge_count, topology_sha256 = workflow_identity(workflow_path)
+    return {
+        "schema_version": RESULT_SCHEMA,
+        "recipe": recipe,
+        "requested_task_count": requested_task_count,
+        "observed_task_count": observed_tasks,
+        "data_footprint_mb": data_footprint_mb,
+        "seed": seed,
+        "elapsed_seconds": elapsed_seconds,
+        "return_code": return_code,
+        "dag_edge_count": edge_count,
+        "topology_sha256": topology_sha256,
+        "workflow_manifest": _relative_file(
+            run_root, workflow_path, label="workflow manifest"
+        ),
+        "workflow_sha256": sha256_file(workflow_path),
+        "workflow_log": _relative_file(run_root, workflow_log, label="workflow log"),
+        "workflow_log_sha256": sha256_file(workflow_log),
+        "dependency_lock": _relative_file(
+            run_root, dependency_lock, label="dependency lock"
+        ),
+        "dependency_lock_sha256": sha256_file(dependency_lock),
+        "schema_file": _relative_file(run_root, schema_path, label="WfFormat schema"),
+        "schema_sha256": sha256_file(schema_path),
+        "wfcommons_version": wfcommons_version,
+        "python_version": python_version,
+    }
 
-    if args.clio_prefix:
-        # Discover the set of paths the workflow actually uses (so we
-        # don't hardcode 'data/'): collect every path the WfFormat JSON
-        # mentions under task `files`, then rewrite each occurrence in
-        # run_workflow.sh's JSON-encoded --input-files / --output-files
-        # args. Sort by length descending so a path that's a prefix of
-        # another doesn't shadow it (e.g. "data/foo" before "data/foo_2").
-        with json_path.open() as fh:
-            workflow_doc = json.load(fh)
-        tasks = (workflow_doc.get("workflow", {}).get("specification", {})
-                              .get("tasks") or
-                 workflow_doc.get("workflow", {}).get("tasks") or
-                 workflow_doc.get("tasks") or [])
-        paths = set()
-        for t in tasks:
-            for f in t.get("inputFiles", []) or t.get("input_files", []) or []:
-                if isinstance(f, dict) and "name" in f:
-                    paths.add(f["name"])
-                elif isinstance(f, str):
-                    paths.add(f)
-            for f in t.get("outputFiles", []) or t.get("output_files", []) or []:
-                if isinstance(f, dict) and "name" in f:
-                    paths.add(f["name"])
-                elif isinstance(f, str):
-                    paths.add(f)
-        # BashTranslator stages all files under bash/data/; the strings
-        # baked into run_workflow.sh are JSON-encoded with that prefix.
-        candidates = sorted(
-            {f"data/{p}" for p in paths} | paths,
-            key=len, reverse=True,
+
+def write_result(destination: Path, document: dict[str, object]) -> None:
+    """Atomically publish one completed result document."""
+
+    temporary = destination.with_suffix(destination.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    os.replace(temporary, destination)
+
+
+def load_recipe(name: str) -> type[Any]:
+    """Resolve one explicitly supported WfCommons recipe class."""
+
+    import wfcommons  # pyright: ignore[reportMissingImports]
+
+    attribute = RECIPE_IMPORTS.get(name.casefold())
+    if attribute is None or not hasattr(wfcommons, attribute):
+        raise RuntimeError(
+            f"unknown recipe {name!r}; choices: {sorted(RECIPE_IMPORTS)}"
         )
-        with runner.open() as fh:
-            text = fh.read()
-        rewritten = 0
-        for raw in candidates:
-            # Paths appear inside escaped JSON: '...\"data/foo\"...'.
-            # Match the literal escaped-quote + path + escaped-quote and
-            # prepend 'clio::' once.
-            pattern = re.compile(r'(\\")' + re.escape(raw) + r'(\\")')
-            text, n = pattern.subn(r'\1clio::' + raw + r'\2', text)
-            rewritten += n
-        with runner.open("w") as fh:
-            fh.write(text)
-        print(f"[wfbench] clio-prefix: rewrote {rewritten} path "
-              f"occurrences in {runner}", flush=True)
+    return getattr(wfcommons, attribute)
 
-    # The translator's bin/wfbench is copied from the python interpreter
-    # that ran the translator. When we run inside an apptainer SIF, its
-    # absolute shebang naturally points at /opt/wfcommons-env/bin/python3,
-    # which exists. Sanity check.
-    wfbench_bin = bash_dir / "bin" / "wfbench"
-    if wfbench_bin.exists():
-        with wfbench_bin.open() as fh:
-            shebang = fh.readline().rstrip()
-        print(f"[wfbench] bin/wfbench shebang: {shebang}", flush=True)
 
-    print(f"[wfbench] executing {runner}", flush=True)
-    rc = subprocess.run(
-        ["bash", "run_workflow.sh"],
-        cwd=str(bash_dir),
-    ).returncode
-    if rc != 0:
-        print(f"[wfbench] run_workflow.sh exited with rc={rc}", file=sys.stderr)
-        sys.exit(rc)
-    print(f"[wfbench] OK", flush=True)
+def _rewrite_clio_paths(workflow_path: Path, runner: Path) -> int:
+    """Prefix only manifest-declared workflow data paths with ``clio::``."""
+
+    workflow = json.loads(workflow_path.read_text(encoding="utf-8", errors="strict"))
+    tasks = workflow["workflow"]["specification"]["tasks"]
+    paths: set[str] = set()
+    for task in tasks:
+        for key in ("inputFiles", "input_files", "outputFiles", "output_files"):
+            for value in task.get(key, []) or []:
+                if isinstance(value, dict) and isinstance(value.get("name"), str):
+                    paths.add(value["name"])
+                elif isinstance(value, str):
+                    paths.add(value)
+    candidates = sorted(
+        {f"data/{path}" for path in paths} | paths, key=len, reverse=True
+    )
+    text = runner.read_text(encoding="utf-8", errors="strict")
+    rewritten = 0
+    for raw in candidates:
+        pattern = re.compile(r'(\\")' + re.escape(raw) + r'(\\")')
+        text, count = pattern.subn(r"\1clio::" + raw + r"\2", text)
+        rewritten += count
+    runner.write_text(text, encoding="utf-8")
+    return rewritten
+
+
+def _parse_arguments() -> argparse.Namespace:
+    """Parse the bounded one-cell driver interface."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--recipe", choices=sorted(RECIPE_IMPORTS), required=True)
+    parser.add_argument("--num-tasks", type=int, required=True)
+    parser.add_argument("--cpu-work", type=int, required=True)
+    parser.add_argument("--data-footprint-mb", type=int, required=True)
+    parser.add_argument("--percent-cpu", type=float, required=True)
+    parser.add_argument("--seed", type=int, required=True)
+    parser.add_argument("--schema-file", type=Path, required=True)
+    parser.add_argument("--expected-wfcommons-version", required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--clio-prefix", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Execute one workflow cell and return its workflow process status."""
+
+    arguments = _parse_arguments()
+    run_root = arguments.out.resolve(strict=True)
+    schema_path = arguments.schema_file.resolve(strict=True)
+    if schema_path.parent != run_root or schema_path.name != "wfcommons-schema.json":
+        raise ValueError("schema file must be the JARVIS-staged output member")
+
+    import numpy as np  # pyright: ignore[reportMissingImports]
+    import wfcommons  # pyright: ignore[reportMissingImports]
+    from wfcommons.wfbench import (  # pyright: ignore[reportMissingImports]
+        BashTranslator,
+        WorkflowBenchmark,
+    )
+
+    version = str(getattr(wfcommons, "__version__", ""))
+    if version != arguments.expected_wfcommons_version:
+        raise RuntimeError(
+            f"WfCommons version differs: expected {arguments.expected_wfcommons_version}, got {version or 'unknown'}"
+        )
+    random.seed(arguments.seed)
+    np.random.seed(arguments.seed)
+    write_dependency_lock(run_root / DEPENDENCY_LOCK_NAME)
+
+    benchmark_root = run_root / "benchmark"
+    recipe = load_recipe(arguments.recipe)
+    generator = WorkflowBenchmark(recipe=recipe, num_tasks=arguments.num_tasks)
+    create_arguments: dict[str, object] = {
+        "save_dir": benchmark_root,
+        "cpu_work": arguments.cpu_work,
+        "percent_cpu": arguments.percent_cpu,
+    }
+    if arguments.data_footprint_mb > 0:
+        create_arguments["data"] = arguments.data_footprint_mb
+    workflow_path = Path(generator.create_benchmark(**create_arguments)).resolve(
+        strict=True
+    )
+    bash_root = run_root / "bash"
+    if bash_root.exists():
+        raise ValueError("WfCommons translator output already exists")
+    BashTranslator(workflow=workflow_path).translate(output_folder=bash_root)
+    runner = bash_root / "run_workflow.sh"
+    if runner.is_symlink() or not runner.is_file():
+        raise RuntimeError("WfCommons translator omitted run_workflow.sh")
+    if arguments.clio_prefix:
+        rewritten = _rewrite_clio_paths(workflow_path, runner)
+        print(f"[wfcommons] clio-prefixed path occurrences={rewritten}", flush=True)
+
+    environment = dict(os.environ)
+    environment["PATH"] = f"{Path(sys.executable).parent}:{environment.get('PATH', '')}"
+    log_path = run_root / WORKFLOW_LOG_NAME
+    started = time.perf_counter()
+    with log_path.open("wb") as log:
+        completed = subprocess.run(
+            ["bash", runner.name],
+            cwd=bash_root,
+            env=environment,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+    elapsed = time.perf_counter() - started
+    document = build_result_document(
+        run_root=run_root,
+        recipe=arguments.recipe,
+        requested_task_count=arguments.num_tasks,
+        data_footprint_mb=arguments.data_footprint_mb,
+        seed=arguments.seed,
+        elapsed_seconds=elapsed,
+        return_code=completed.returncode,
+        workflow_path=workflow_path,
+        workflow_log=log_path,
+        dependency_lock=run_root / DEPENDENCY_LOCK_NAME,
+        schema_path=schema_path,
+        wfcommons_version=version,
+        python_version=sys.version.split()[0],
+    )
+    write_result(run_root / RESULT_NAME, document)
+    print(
+        "WFCOMMONS_RESULT "
+        f"schema={RESULT_SCHEMA} recipe={arguments.recipe} "
+        f"requested_tasks={arguments.num_tasks} "
+        f"observed_tasks={document['observed_task_count']} "
+        f"footprint_mb={arguments.data_footprint_mb} "
+        f"elapsed_s={elapsed:.9g} return_code={completed.returncode}",
+        flush=True,
+    )
+    return completed.returncode
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ jarvis_cd = ["*.yaml", "*.yml"]
 "*" = ["*.py", "*.yaml", "*.yml", "*.md", "*.txt", "*.conf", "*.xml", "*.param", "*.f", "*.input", "*.png", "*.sh"]
 builtin = ["pipelines/**/*.yaml", "pipelines/**/*.yml"]
 
+[tool.setuptools.data-files]
+"." = ["wfcommons-schema.json"]
+
 [project.scripts]
 jarvis = "jarvis_cd.core.cli:main"
 

--- a/test/unit/core/test_wfcommons_artifacts.py
+++ b/test/unit/core/test_wfcommons_artifacts.py
@@ -1,0 +1,127 @@
+"""Generated-artifact tests for the builtin WfCommons package."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from pathlib import PurePosixPath
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import load_artifacts_module
+
+
+def _load_artifacts() -> ModuleType:
+    """Load WfCommons artifact semantics directly from the builtin package."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "wfcommons"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _closed_run(root: Path, *, return_code: int = 0) -> None:
+    workflow = root / "workflow.json"
+    log = root / "workflow.log"
+    lock = root / "dependency-lock.txt"
+    schema = root / "wfcommons-schema.json"
+    workflow.write_text('{"workflow": {}}\n', encoding="utf-8")
+    log.write_text("complete\n", encoding="utf-8")
+    lock.write_text("wfcommons==1.4\n", encoding="utf-8")
+    schema.write_text("{}\n", encoding="utf-8")
+    result = {
+        "schema_version": "jarvis.wfcommons-result.v1",
+        "recipe": "epigenomics",
+        "requested_task_count": 100,
+        "observed_task_count": 97,
+        "data_footprint_mb": 8,
+        "seed": 424300,
+        "elapsed_seconds": 1.2,
+        "return_code": return_code,
+        "workflow_manifest": workflow.name,
+        "workflow_sha256": _sha(workflow),
+        "workflow_log": log.name,
+        "workflow_log_sha256": _sha(log),
+        "dependency_lock": lock.name,
+        "dependency_lock_sha256": _sha(lock),
+        "schema_file": schema.name,
+        "schema_sha256": _sha(schema),
+    }
+    (root / "wfcommons-result.json").write_text(json.dumps(result), encoding="utf-8")
+
+
+def test_finalized_run_reports_result_workflow_log_and_provenance(
+    tmp_path: Path,
+) -> None:
+    """A successful cell exposes all closed products with exact hashes."""
+
+    module = _load_artifacts()
+    _closed_run(tmp_path)
+    adapter = module.adapter_from_package(
+        {"pkg_type": "builtin.wfcommons", "out": "/execution/shared/wfcommons"}
+    )
+    assert adapter is not None
+    adapter._local_root = tmp_path
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert [item.logical_name for item in observations] == [
+        "wfcommons-result",
+        "wfcommons-workflow",
+        "wfcommons-workflow-log",
+        "wfcommons-dependency-lock",
+        "wfcommons-schema",
+    ]
+    assert all(item.state.value == "finalized" for item in observations)
+    assert all(
+        item.checksum and item.checksum.startswith("sha256:") for item in observations
+    )
+    assert adapter.finalize_artifacts_for_exit(0) == []
+
+
+def test_failed_process_never_finalizes_outputs(tmp_path: Path) -> None:
+    """A nonzero driver result leaves available products explicitly incomplete."""
+
+    module = _load_artifacts()
+    _closed_run(tmp_path, return_code=9)
+    adapter = module.WfcommonsArtifactAdapter(
+        PurePosixPath("/execution/shared/wfcommons"), tmp_path
+    )
+
+    observations = adapter.finalize_artifacts_for_exit(9)
+
+    assert observations
+    assert all(item.state.value == "incomplete" for item in observations)
+
+
+def test_result_cannot_escape_the_owned_output_root(tmp_path: Path) -> None:
+    """Artifact paths from the result document are confined to the output root."""
+
+    module = _load_artifacts()
+    _closed_run(tmp_path)
+    result = json.loads((tmp_path / "wfcommons-result.json").read_text())
+    result["workflow_manifest"] = "../outside.json"
+    (tmp_path / "wfcommons-result.json").write_text(json.dumps(result))
+
+    adapter = module.WfcommonsArtifactAdapter(
+        PurePosixPath("/execution/shared/wfcommons"), tmp_path
+    )
+    with pytest.raises(RuntimeError, match="escaped"):
+        adapter.finalize_artifacts_for_exit(0)
+
+
+def test_unrelated_package_has_no_wfcommons_artifact_adapter() -> None:
+    """Artifact semantics remain package-specific."""
+
+    module = _load_artifacts()
+    assert module.adapter_from_package({"pkg_type": "builtin.ior"}) is None

--- a/test/unit/core/test_wfcommons_driver.py
+++ b/test/unit/core/test_wfcommons_driver.py
@@ -1,0 +1,103 @@
+"""Pure result-contract tests for the WfCommons driver."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_driver() -> ModuleType:
+    """Load the driver as a module without executing its CLI."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "wfcommons"
+        / "run_wfbench.py"
+    )
+    spec = spec_from_file_location("test_builtin_wfcommons_driver", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load the WfCommons driver from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+driver = _load_driver()
+
+
+def _manifest(path: Path) -> None:
+    document = {
+        "workflow": {
+            "specification": {
+                "tasks": [
+                    {"id": "a", "parents": [], "children": ["b"]},
+                    {"id": "b", "parents": ["a"], "children": []},
+                ]
+            }
+        }
+    }
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+
+def test_workflow_identity_is_stable_and_counts_edges(tmp_path: Path) -> None:
+    """Topology identity excludes file sizes and other footprint-only values."""
+
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    _manifest(first)
+    raw = json.loads(first.read_text(encoding="utf-8"))
+    raw["workflow"]["specification"]["files"] = [
+        {"id": "data", "sizeInBytes": 99_000_000}
+    ]
+    second.write_text(json.dumps(raw), encoding="utf-8")
+
+    assert driver.workflow_identity(first) == driver.workflow_identity(second)
+    assert driver.workflow_identity(first)[:2] == (2, 1)
+
+
+def test_result_document_binds_runtime_schema_and_closed_outputs(
+    tmp_path: Path,
+) -> None:
+    """The generic result records exact inputs and successful process completion."""
+
+    manifest = tmp_path / "workflow.json"
+    log = tmp_path / "workflow.log"
+    lock = tmp_path / "dependency-lock.txt"
+    schema = tmp_path / "wfcommons-schema.json"
+    _manifest(manifest)
+    log.write_text("ok\n", encoding="utf-8")
+    lock.write_text("wfcommons==1.4\n", encoding="utf-8")
+    schema.write_text("{}\n", encoding="utf-8")
+
+    result = driver.build_result_document(
+        run_root=tmp_path,
+        recipe="epigenomics",
+        requested_task_count=100,
+        data_footprint_mb=8,
+        seed=424300,
+        elapsed_seconds=1.25,
+        return_code=0,
+        workflow_path=manifest,
+        workflow_log=log,
+        dependency_lock=lock,
+        schema_path=schema,
+        wfcommons_version="1.4",
+        python_version="3.12.8",
+    )
+
+    assert result["schema_version"] == "jarvis.wfcommons-result.v1"
+    assert result["observed_task_count"] == 2
+    assert result["dag_edge_count"] == 1
+    assert result["return_code"] == 0
+    assert (
+        result["workflow_sha256"] == hashlib.sha256(manifest.read_bytes()).hexdigest()
+    )
+    assert result["schema_sha256"] == hashlib.sha256(schema.read_bytes()).hexdigest()
+    assert result["workflow_manifest"] == "workflow.json"
+    assert result["workflow_log"] == "workflow.log"
+    assert result["dependency_lock"] == "dependency-lock.txt"

--- a/test/unit/core/test_wfcommons_package.py
+++ b/test/unit/core/test_wfcommons_package.py
@@ -120,12 +120,18 @@ def test_agent_contract_exposes_one_reproducible_study_cell(
     """Agents configure science dimensions while operators own the runtime path."""
 
     package = _package(Path("."))
+    probes: list[tuple[str, dict[str, str]]] = []
+
+    def probe(program: str, **kwargs: Any) -> SimpleNamespace:
+        probes.append((program, kwargs["environment"]))
+        return SimpleNamespace(
+            status=wfcommons_package.RuntimeStatus("ready", "runtime_probe_succeeded")
+        )
+
     monkeypatch.setattr(
         wfcommons_package,
         "probe_program",
-        lambda *args, **kwargs: SimpleNamespace(
-            status=wfcommons_package.RuntimeStatus("ready", "runtime_probe_succeeded")
-        ),
+        probe,
     )
 
     menu = {item["name"]: item for item in package._configure_menu()}
@@ -134,6 +140,8 @@ def test_agent_contract_exposes_one_reproducible_study_cell(
     assert menu["runtime_python"]["agent_visible"] is False
     assert "venv" not in menu
     contract = package._deployment_contract().to_dict()
+    assert probes[0][0] == "python3"
+    assert probes[0][1]["PATH"].split(wfcommons_package.os.pathsep)[0] == "/runtime/bin"
     assert contract["package"] == "builtin.wfcommons"
     assert contract["execution_profiles"] == [
         {

--- a/test/unit/core/test_wfcommons_package.py
+++ b/test/unit/core/test_wfcommons_package.py
@@ -1,0 +1,213 @@
+"""Runtime-contract tests for the builtin WfCommons package."""
+
+from __future__ import annotations
+
+import shlex
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def _load_package() -> ModuleType:
+    """Load builtin WfCommons without relying on repository registration."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "wfcommons"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_builtin_wfcommons", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load the WfCommons package from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+wfcommons_package = _load_package()
+
+
+class _CapturedExec:
+    """Capture exact package commands and expose configurable process results."""
+
+    commands: list[str] = []
+    infos: list[Any] = []
+    return_code = 0
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": self.return_code}
+        self.commands.append(command)
+        self.infos.append(exec_info)
+
+    def run(self) -> _CapturedExec:
+        """Return the captured result."""
+
+        return self
+
+
+class _CapturedRm:
+    """Capture package-owned cleanup without deleting test files."""
+
+    calls: list[tuple[str, bool]] = []
+
+    def __init__(self, path: str, exec_info: Any, *, recursive: bool = False) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.recursive = recursive
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedRm:
+        """Record the cleanup request."""
+
+        self.calls.append((self.path, self.recursive))
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _capture_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep package tests free of external process side effects."""
+
+    _CapturedExec.commands = []
+    _CapturedExec.infos = []
+    _CapturedExec.return_code = 0
+    _CapturedRm.calls = []
+    monkeypatch.setattr(wfcommons_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(wfcommons_package, "Rm", _CapturedRm)
+
+
+def _package(tmp_path: Path, **updates: object) -> Any:
+    """Build a minimally configured WfCommons package instance."""
+
+    package = object.__new__(wfcommons_package.Wfcommons)
+    package.shared_dir = str(tmp_path / "shared")
+    package.private_dir = str(tmp_path / "private")
+    package.pkg_dir = str(
+        Path(__file__).resolve().parents[3] / "builtin" / "builtin" / "wfcommons"
+    )
+    package.env = {"PATH": "/runtime/bin"}
+    package.mod_env = dict(package.env)
+    package.config = {
+        "clio_prefix": False,
+        "cpu_work": 1,
+        "data_footprint_mb": 8,
+        "deploy_mode": "default",
+        "drop_page_cache": False,
+        "nprocs": 1,
+        "out": "run",
+        "percent_cpu": 1.0,
+        "ppn": 1,
+        "recipe": "epigenomics",
+        "runtime_python": "/runtime/bin/python3",
+        "seed": 424300,
+        "timeout_seconds": 3600,
+        "num_tasks": 100,
+    }
+    package.config.update(updates)
+    package.runtime_line_callback = lambda: None
+    return package
+
+
+def test_agent_contract_exposes_one_reproducible_study_cell(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agents configure science dimensions while operators own the runtime path."""
+
+    package = _package(Path("."))
+    monkeypatch.setattr(
+        wfcommons_package,
+        "probe_program",
+        lambda *args, **kwargs: SimpleNamespace(
+            status=wfcommons_package.RuntimeStatus("ready", "runtime_probe_succeeded")
+        ),
+    )
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    assert menu["data_footprint_mb"]["type"] is int
+    assert menu["seed"]["type"] is int
+    assert menu["runtime_python"]["agent_visible"] is False
+    assert "venv" not in menu
+    contract = package._deployment_contract().to_dict()
+    assert contract["package"] == "builtin.wfcommons"
+    assert contract["execution_profiles"] == [
+        {
+            "name": "synthetic_workflow_cell",
+            "execution_kind": "batch",
+            "when": [{"parameter": "recipe", "operator": "is_not_empty"}],
+            "runtime_requirements": ["bash", "wfcommons_runtime"],
+            "readiness": {
+                "mechanism": "process_exit",
+                "condition": "successful_exit",
+            },
+            "description": "Generate and execute one deterministic WfBench workflow cell.",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        ({"num_tasks": 0}, "num_tasks"),
+        ({"data_footprint_mb": -1}, "data_footprint_mb"),
+        ({"cpu_work": 0}, "cpu_work"),
+        ({"percent_cpu": 1.1}, "percent_cpu"),
+        ({"seed": -1}, "seed"),
+        ({"nprocs": 2}, "single-process"),
+    ],
+)
+def test_invalid_study_dimensions_fail_closed(
+    tmp_path: Path, updates: dict[str, object], message: str
+) -> None:
+    """Invalid scientific and execution settings are rejected, never coerced."""
+
+    package = _package(tmp_path, **updates)
+
+    with pytest.raises(ValueError, match=message):
+        package._validate_configuration()
+
+
+def test_start_stages_pinned_schema_and_builds_one_cell_command(tmp_path: Path) -> None:
+    """One package instance owns one result directory and one study cell."""
+
+    package = _package(tmp_path)
+
+    package.start()
+
+    output = tmp_path / "shared" / "run"
+    schema = output / "wfcommons-schema.json"
+    assert schema.read_bytes() == package._schema_source().read_bytes()
+    assert package.config["out"] == str(output.resolve())
+    command = _CapturedExec.commands[-1]
+    assert command.startswith(shlex.quote("/runtime/bin/python3"))
+    assert "--recipe epigenomics" in command
+    assert "--num-tasks 100" in command
+    assert "--data-footprint-mb 8" in command
+    assert "--seed 424300" in command
+    assert shlex.quote(str(schema.resolve())) in command
+    assert _CapturedExec.infos[-1].cwd == str(output.resolve())
+    assert _CapturedExec.infos[-1].timeout == 3600
+
+
+def test_start_propagates_driver_failure(tmp_path: Path) -> None:
+    """A failed WfBench cell makes the JARVIS package fail."""
+
+    package = _package(tmp_path)
+    _CapturedExec.return_code = 17
+
+    with pytest.raises(RuntimeError, match="WfCommons execution failed.*17"):
+        package.start()
+
+
+def test_clean_targets_only_the_normalized_package_output(tmp_path: Path) -> None:
+    """Cleanup authority cannot expand beyond the package-owned output."""
+
+    package = _package(tmp_path)
+    package.clean()
+
+    assert _CapturedRm.calls == [(str((tmp_path / "shared" / "run").resolve()), True)]


### PR DESCRIPTION
## Summary
- replace scheduled runtime installation with a prepared, version-probed WfCommons 1.4 contract
- model one deterministic WfBench cell per ordinary package instance
- stage the pinned WfFormat schema and finalize result, workflow, log, dependency, and schema artifacts
- document composition of task-count and data-footprint grids

## Validation
- 16 focused WfCommons tests passed
- 82 adjacent deployment, artifact, and pipeline tests passed
- changed-file Ruff and Pyright passed
- built wheel contains the artifact adapter and pinned schema
- broad local pytest exceeded a 3 minute time budget without emitting a failure; CI remains authoritative for the complete suite

Stacked on the WarpX package slice so each reusable scientific-package improvement remains independently reviewable.