### PR TITLE
feat: harden Xcompact3D inputs and artifacts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,4 +8,5 @@ include builtin/builtin/paraview/service.py
 include builtin/builtin/paraview/service_http.py
 include builtin/builtin/paraview/service_supervisor.py
 include builtin/builtin/wfcommons/artifacts.py
+include builtin/builtin/xcompact3d/artifacts.py
 include wfcommons-schema.json

--- a/builtin/builtin/xcompact3d/artifacts.py
+++ b/builtin/builtin/xcompact3d/artifacts.py
@@ -1,0 +1,413 @@
+"""Generated-artifact semantics for the builtin Xcompact3D package."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import posixpath
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+from jarvis_cd.artifacts.schema import JsonValue
+from jarvis_cd.input_bundle import extract_input_bundle
+
+_MAX_DISCOVERED_ENTRIES = 4096
+_MAX_REPORTED_MEMBERS = 256
+_MAX_CHECKSUM_BYTES = 64 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class _DiscoveredEntry:
+    """One safe output member below the package-owned result root."""
+
+    relative_path: PurePosixPath
+    is_file: bool
+    is_directory: bool
+    size_bytes: int | None
+
+
+@dataclass
+class Xcompact3dArtifactAdapter:
+    """Discover bounded Xcompact3D logs, checkpoints, fields, and statistics."""
+
+    output_dir: PurePosixPath
+    input_paths: frozenset[PurePosixPath] = frozenset()
+    _finalized: bool = False
+    _collection_artifact_id: str = field(default_factory=new_artifact_id)
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for process completion before inspecting mutable outputs."""
+
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Report outputs after a successful process completion."""
+
+        return self._finalize(return_code=0)
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Report outputs with the authoritative process completion state."""
+
+        return self._finalize(return_code=return_code)
+
+    def reset_artifacts(self) -> None:
+        """Permit discovery after an execution stream is replaced."""
+
+        self._finalized = False
+
+    def _finalize(self, *, return_code: int) -> list[ArtifactObservation]:
+        if self._finalized:
+            return []
+        self._finalized = True
+        entries, truncated = self._discover_entries()
+        outputs = self._output_entries(entries)
+        if not outputs and not truncated:
+            return []
+        state = (
+            ArtifactState.FINALIZED
+            if return_code == 0 and not truncated
+            else ArtifactState.INCOMPLETE
+        )
+        observations = [
+            self._collection_observation(outputs, state=state, truncated=truncated)
+        ]
+        observations.extend(
+            self._member_observation(entry, entries=outputs, state=state)
+            for entry in outputs
+            if self._is_concrete_product(entry)
+        )
+        return observations
+
+    def _discover_entries(self) -> tuple[list[_DiscoveredEntry], bool]:
+        """Walk the owned output tree without following links and with a bound."""
+
+        root = self._local_output_path()
+        if not root.exists():
+            return [], False
+        if root.is_symlink() or not root.is_dir():
+            raise RuntimeError(
+                f"Xcompact3D output root is not a real directory: {root}"
+            )
+        discovered: list[_DiscoveredEntry] = []
+        truncated = False
+        try:
+            for current, directory_names, file_names in os.walk(
+                root, topdown=True, followlinks=False
+            ):
+                current_path = Path(current)
+                safe_directories: list[str] = []
+                for name in sorted(directory_names):
+                    path = current_path / name
+                    if path.is_symlink():
+                        continue
+                    if len(discovered) >= _MAX_DISCOVERED_ENTRIES:
+                        truncated = True
+                        break
+                    discovered.append(
+                        _DiscoveredEntry(
+                            PurePosixPath(path.relative_to(root).as_posix()),
+                            False,
+                            True,
+                            None,
+                        )
+                    )
+                    safe_directories.append(name)
+                directory_names[:] = [] if truncated else safe_directories
+                if truncated:
+                    break
+                for name in sorted(file_names):
+                    path = current_path / name
+                    if path.is_symlink() or not path.is_file():
+                        continue
+                    if len(discovered) >= _MAX_DISCOVERED_ENTRIES:
+                        truncated = True
+                        break
+                    discovered.append(
+                        _DiscoveredEntry(
+                            PurePosixPath(path.relative_to(root).as_posix()),
+                            True,
+                            False,
+                            path.stat().st_size,
+                        )
+                    )
+                if truncated:
+                    break
+        except OSError as exc:
+            raise RuntimeError(
+                f"cannot inspect Xcompact3D output directory {root}: {exc}"
+            ) from exc
+        return discovered, truncated
+
+    def _local_output_path(self) -> Path:
+        """Project the declared cluster path into the current host filesystem."""
+
+        return Path(self.output_dir.as_posix())
+
+    def _output_entries(
+        self, entries: list[_DiscoveredEntry]
+    ) -> list[_DiscoveredEntry]:
+        """Exclude exact inputs and directories that contain only staged inputs."""
+
+        files = [
+            entry
+            for entry in entries
+            if entry.is_file and entry.relative_path not in self.input_paths
+        ]
+        retained_paths = {entry.relative_path for entry in files}
+        directories = [
+            entry
+            for entry in entries
+            if entry.is_directory
+            and any(
+                candidate != entry.relative_path
+                and candidate.is_relative_to(entry.relative_path)
+                for candidate in retained_paths
+            )
+        ]
+        selected = {entry.relative_path: entry for entry in files}
+        selected.update({entry.relative_path: entry for entry in directories})
+        return [selected[path] for path in sorted(selected)]
+
+    @staticmethod
+    def _is_concrete_product(entry: _DiscoveredEntry) -> bool:
+        """Recognize stable, high-confidence Xcompact3D products."""
+
+        name = entry.relative_path.name.casefold()
+        if entry.is_directory:
+            return name in {"data", "statistics"} or name.endswith(".bp")
+        return name in {"checkpoint", "restart.info", "xcompact3d.log"}
+
+    def _collection_observation(
+        self,
+        outputs: list[_DiscoveredEntry],
+        *,
+        state: ArtifactState,
+        truncated: bool,
+    ) -> ArtifactObservation:
+        """Describe the bounded package-owned result tree."""
+
+        names: list[JsonValue] = [
+            entry.relative_path.as_posix() for entry in outputs[:_MAX_REPORTED_MEMBERS]
+        ]
+        size_bytes = sum(entry.size_bytes or 0 for entry in outputs if entry.is_file)
+        return ArtifactObservation(
+            artifact_id=self._collection_artifact_id,
+            logical_name="xcompact3d-results",
+            kind="scientific_dataset",
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(self.output_dir),
+            format="xcompact3d-output-tree",
+            size_bytes=size_bytes,
+            message=(
+                "Xcompact3D output discovery reached its safety bound"
+                if truncated
+                else "Xcompact3D output tree finalized"
+            ),
+            metadata={
+                "application": "xcompact3d",
+                "completion_signal": "process_exit",
+                "discovery_truncated": truncated,
+                "member_count_observed": len(outputs),
+                "member_names": names,
+                "member_names_truncated": len(outputs) > len(names),
+            },
+        )
+
+    def _member_observation(
+        self,
+        entry: _DiscoveredEntry,
+        *,
+        entries: list[_DiscoveredEntry],
+        state: ArtifactState,
+    ) -> ArtifactObservation:
+        """Describe one solver log, checkpoint, field, or statistics product."""
+
+        name = entry.relative_path.name.casefold()
+        logical_name, kind, format_name, media_type = _product_identity(name)
+        size_bytes = entry.size_bytes
+        if entry.is_directory:
+            size_bytes = sum(
+                item.size_bytes or 0
+                for item in entries
+                if item.is_file
+                and item.relative_path.is_relative_to(entry.relative_path)
+            )
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=ArtifactRole.OUTPUT,
+            structure=(
+                ArtifactStructure.FILE
+                if entry.is_file
+                else ArtifactStructure.COLLECTION
+            ),
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(
+                self.output_dir / entry.relative_path
+            ),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=size_bytes,
+            checksum=self._checksum(entry),
+            message="Xcompact3D product finalized",
+            metadata={"application": "xcompact3d"},
+        )
+
+    def _checksum(self, entry: _DiscoveredEntry) -> str | None:
+        """Hash bounded files while avoiding unbounded finalization work."""
+
+        if (
+            not entry.is_file
+            or entry.size_bytes is None
+            or entry.size_bytes > _MAX_CHECKSUM_BYTES
+        ):
+            return None
+        path = self._local_output_path() / entry.relative_path
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                digest.update(chunk)
+        return f"sha256:{digest.hexdigest()}"
+
+
+def adapter_from_package(package: dict[str, Any]) -> Xcompact3dArtifactAdapter | None:
+    """Create artifact semantics for the builtin Xcompact3D package."""
+
+    if package.get("pkg_type") != "builtin.xcompact3d":
+        return None
+    output_dir = _configured_output_dir(
+        package.get("out"),
+        shared_dir=package.get("shared_dir"),
+        runtime_cwd=package.get("runtime_cwd"),
+    )
+    deploy_mode = str(package.get("effective_deploy_mode") or "default").casefold()
+    if deploy_mode == "container":
+        roots = tuple(
+            root
+            for root in (
+                _optional_absolute_path(package.get("shared_dir")),
+                _optional_absolute_path(package.get("private_dir")),
+            )
+            if root is not None
+        )
+        if not any(output_dir.is_relative_to(root) for root in roots):
+            return None
+    input_paths: set[PurePosixPath] = set()
+    input_bundle = package.get("input_bundle")
+    if isinstance(input_bundle, str) and input_bundle:
+        shared_dir = _optional_absolute_path(package.get("shared_dir"))
+        if shared_dir is None:
+            raise ValueError("Xcompact3D input-bundle artifacts require shared_dir")
+        materialized = extract_input_bundle(
+            input_bundle, Path(shared_dir.as_posix()) / "input-bundles"
+        )
+        input_paths.update(
+            PurePosixPath(item.path) for item in materialized.manifest.files
+        )
+    configured_input = package.get("inputs")
+    if isinstance(configured_input, str) and configured_input:
+        input_paths.add(PurePosixPath(Path(configured_input).name))
+    return Xcompact3dArtifactAdapter(output_dir, frozenset(input_paths))
+
+
+def _configured_output_dir(
+    value: object,
+    *,
+    shared_dir: object,
+    runtime_cwd: object,
+) -> PurePosixPath:
+    """Resolve the normalized absolute output directory used by the package."""
+
+    raw = "run" if value in (None, "") else value
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("Xcompact3D artifacts require a printable output path")
+    path = PurePosixPath(raw)
+    if not path.is_absolute():
+        base = _optional_absolute_path(shared_dir)
+        if base is None:
+            base = _optional_absolute_path(runtime_cwd)
+        if base is None:
+            raise ValueError(
+                "relative Xcompact3D artifact output requires shared_dir or runtime_cwd"
+            )
+        path = base / path
+    normalized = PurePosixPath(posixpath.normpath(path.as_posix()))
+    if not normalized.is_absolute() or ".." in normalized.parts:
+        raise ValueError(
+            "Xcompact3D artifacts require a normalized absolute output path"
+        )
+    return normalized
+
+
+def _optional_absolute_path(value: object) -> PurePosixPath | None:
+    """Return a normalized absolute POSIX path when one is available."""
+
+    if not isinstance(value, str) or not value:
+        return None
+    path = PurePosixPath(value)
+    if not path.is_absolute() or ".." in path.parts:
+        return None
+    return path
+
+
+def _product_identity(name: str) -> tuple[str, str, str, str | None]:
+    """Return the stable artifact identity for a recognized product name."""
+
+    if name == "xcompact3d.log":
+        return (
+            "xcompact3d-log",
+            "scientific_log",
+            "xcompact3d-runtime-log",
+            "text/plain",
+        )
+    if name == "checkpoint":
+        return (
+            "xcompact3d-checkpoint",
+            "checkpoint",
+            "xcompact3d-checkpoint",
+            "application/octet-stream",
+        )
+    if name == "restart.info":
+        return (
+            "xcompact3d-restart-info",
+            "checkpoint_metadata",
+            "xcompact3d-restart-info",
+            "text/plain",
+        )
+    if name == "data":
+        return (
+            "xcompact3d-data",
+            "scientific_dataset",
+            "xcompact3d-field-output",
+            "application/x-xcompact3d-fields",
+        )
+    if name == "statistics":
+        return (
+            "xcompact3d-statistics",
+            "scientific_dataset",
+            "xcompact3d-statistics",
+            "application/x-xcompact3d-statistics",
+        )
+    return (
+        "xcompact3d-adios2",
+        "scientific_dataset",
+        "adios2-bp",
+        "application/x-adios2",
+    )

--- a/builtin/builtin/xcompact3d/artifacts.py
+++ b/builtin/builtin/xcompact3d/artifacts.py
@@ -24,6 +24,7 @@ from jarvis_cd.input_bundle import extract_input_bundle
 _MAX_DISCOVERED_ENTRIES = 4096
 _MAX_REPORTED_MEMBERS = 256
 _MAX_CHECKSUM_BYTES = 64 * 1024 * 1024
+_RUNTIME_INPUT_NAME = "jarvis-input.i3d"
 
 
 @dataclass(frozen=True, slots=True)
@@ -321,9 +322,19 @@ def adapter_from_package(package: dict[str, Any]) -> Xcompact3dArtifactAdapter |
         input_paths.update(
             PurePosixPath(item.path) for item in materialized.manifest.files
         )
+        requested = package.get("input_path")
+        selected = (
+            PurePosixPath(requested)
+            if isinstance(requested, str) and requested
+            else PurePosixPath(
+                materialized.entrypoint.relative_to(materialized.root).as_posix()
+            )
+        )
+        input_paths.add(selected.parent / _RUNTIME_INPUT_NAME)
     configured_input = package.get("inputs")
     if isinstance(configured_input, str) and configured_input:
         input_paths.add(PurePosixPath(Path(configured_input).name))
+        input_paths.add(PurePosixPath(_RUNTIME_INPUT_NAME))
     return Xcompact3dArtifactAdapter(output_dir, frozenset(input_paths))
 
 

--- a/builtin/builtin/xcompact3d/pkg.py
+++ b/builtin/builtin/xcompact3d/pkg.py
@@ -30,6 +30,7 @@ from jarvis_cd.shell.process import Mkdir, Rm
 
 _EXECUTABLE_CANDIDATES = ("xcompact3d", "incompact3d")
 _MAX_INPUT_BYTES = 64 * 1024 * 1024
+_RUNTIME_INPUT_NAME = "jarvis-input.i3d"
 
 
 class Xcompact3d(Application):
@@ -337,12 +338,25 @@ class Xcompact3d(Application):
             relative = selected.relative_to(bundle.root)
             stage_input_bundle(bundle, output_dir)
             staged = output_dir / relative
-            return staged, staged.parent
+            return self._stage_runtime_input(staged), staged.parent
 
         configured_input = self.config.get("inputs")
         assert isinstance(configured_input, str) and configured_input
         staged = self._stage_single_input(configured_input, output_dir)
-        return staged, output_dir
+        return self._stage_runtime_input(staged), output_dir
+
+    @staticmethod
+    def _stage_runtime_input(selected: Path) -> Path:
+        """Copy the selected input to a short, reserved solver argument."""
+
+        launch_input = selected.parent / _RUNTIME_INPUT_NAME
+        if launch_input == selected:
+            return selected
+        if launch_input.exists() or launch_input.is_symlink():
+            raise ValueError("Xcompact3D runtime input alias already exists")
+        shutil.copyfile(selected, launch_input, follow_symlinks=False)
+        os.chmod(launch_input, 0o600)
+        return launch_input
 
     def start(self) -> None:
         """Launch Xcompact3D and fail the pipeline on any rank failure."""
@@ -363,10 +377,11 @@ class Xcompact3d(Application):
                 raise RuntimeError("Xcompact3D executable is unavailable through PATH")
             exec_kwargs = {}
         log_path = cwd / "xcompact3d.log"
+        input_argument = input_path.name
         command = " ".join(
             (
                 shlex.quote(executable),
-                shlex.quote(str(input_path)),
+                shlex.quote(input_argument),
                 ">",
                 shlex.quote(str(log_path)),
                 "2>&1",

--- a/builtin/builtin/xcompact3d/pkg.py
+++ b/builtin/builtin/xcompact3d/pkg.py
@@ -1,144 +1,409 @@
-"""
-This module provides classes and methods to launch the Xcompact3d application.
-Xcompact3d (Incompact3d) is a high-order finite-difference flow solver for
-DNS and LES of incompressible turbulent flows.
-"""
+"""Launch native or containerized Xcompact3D simulations."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+from pathlib import Path, PurePosixPath
+from typing import Any
+
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo, LocalExecInfo
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
+
+_EXECUTABLE_CANDIDATES = ("xcompact3d", "incompact3d")
+_MAX_INPUT_BYTES = 64 * 1024 * 1024
 
 
 class Xcompact3d(Application):
+    """Run one caller-defined Xcompact3D simulation.
+
+    JARVIS copies a single input or a digest-verified multi-file input bundle
+    into package-owned storage, launches the selected input under MPI, records
+    the solver stream in that workspace, and exposes typed output artifacts.
+    Scientific study composition remains a pipeline or benchmark concern.
     """
-    Xcompact3d container package supporting both default (bare-metal) and
-    container deployment.
 
-    Set deploy_mode='container' to build and run Xcompact3d inside a
-    Docker/Podman/Apptainer container with ADIOS2 and 2DECOMP&FFT.
-    Set deploy_mode='default' to use a system-installed xcompact3d via MPI.
-    """
+    def _init(self) -> None:
+        self.xcompact3d_bin: str | None = None
 
-    def _init(self):
-        pass
-
-    def _configure_menu(self):
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
             {
-                'name': 'nprocs',
-                'msg': 'Number of MPI processes',
-                'type': int,
-                'default': 4,
+                "name": "nprocs",
+                "msg": "Number of MPI processes",
+                "type": int,
+                "default": 4,
             },
             {
-                'name': 'ppn',
-                'msg': 'Processes per node',
-                'type': int,
-                'default': 4,
+                "name": "ppn",
+                "msg": "MPI processes per node",
+                "type": int,
+                "default": 4,
             },
             {
-                'name': 'case',
-                'msg': 'Xcompact3d test case (e.g., TGV, Channel-Flow)',
-                'type': str,
-                'default': 'TGV',
+                "name": "inputs",
+                "msg": (
+                    "Single Xcompact3D .i3d input file. JARVIS copies it into "
+                    "the execution-owned output directory before launch."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                'name': 'out',
-                'msg': 'Output directory for results',
-                'type': str,
-                'default': '/tmp/xcompact3d_out',
+                "name": "input_bundle",
+                "msg": (
+                    "Digest-verified multi-file JARVIS package input bundle. "
+                    "All manifest files are staged into the execution-owned "
+                    "output directory."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                'name': 'base_image',
-                'msg': 'Base Docker image for build container',
-                'type': str,
-                'default': 'ubuntu:24.04',
+                "name": "input_path",
+                "msg": (
+                    "Relative manifest member to execute from input_bundle; "
+                    "empty selects the manifest entrypoint"
+                ),
+                "type": str,
+                "default": "",
+            },
+            {
+                "name": "out",
+                "msg": (
+                    "Output directory. Relative paths resolve under the JARVIS "
+                    "package shared directory."
+                ),
+                "type": str,
+                "default": "run",
+            },
+            {
+                "name": "base_image",
+                "msg": "Base image for a package-owned container build",
+                "type": str,
+                "default": "ubuntu:24.04",
             },
         ]
 
-    # ------------------------------------------------------------------
-    # Container Dockerfile generators
-    # ------------------------------------------------------------------
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe Xcompact3D runtime, input, and completion semantics."""
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
-            return None
-        base = self.config.get('base_image', 'ubuntu:24.04')
-        content = self._read_build_script('build.sh', {
-            'BASE_IMAGE': base,
-        })
-        return content, 'adios2'
-
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
-            return None
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': 'ubuntu:24.04',
-        })
-        return content, 'adios2'
-
-    # ------------------------------------------------------------------
-    # Configuration
-    # ------------------------------------------------------------------
-
-    def _configure(self, **kwargs):
-        """
-        Configure Xcompact3d.
-
-        Calls super()._configure() which updates self.config and (when
-        deploy_mode == 'container') triggers build_phase / build_deploy_phase.
-
-        In default mode, also creates the output directory on all nodes.
-        """
-        super()._configure(**kwargs)
-
-        if self.config.get('deploy_mode') == 'default':
-            if self.config['out']:
-                Mkdir(self.config['out'],
-                      PsshExecInfo(hostfile=self.hostfile,
-                                   env=self.env)).run()
-
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
-
-    def start(self):
-        """
-        Launch Xcompact3d.
-
-        In container mode, runs xcompact3d via MPI inside the deploy
-        container. In default mode, runs xcompact3d from PATH.
-        """
-        if self.config.get('deploy_mode') == 'container':
-            cmd = 'xcompact3d'
-
-            Exec(cmd, MpiExecInfo(
-                nprocs=self.config['nprocs'],
-                ppn=self.config['ppn'],
-                hostfile=self.hostfile,
-                port=self.ssh_port,
-                container=self._container_engine,
-                container_image=self.deploy_image_name(),
-                shared_dir=self.shared_dir,
-                private_dir=self.private_dir,
-                env=self.mod_env,
-            )).run()
+        if self.config.get("deploy_mode") == "container":
+            status = RuntimeStatus("unknown", "container_runtime_not_probed")
+            capabilities: tuple[str, ...] = ()
         else:
-            cmd = 'xcompact3d'
-            Exec(cmd, MpiExecInfo(
-                nprocs=self.config['nprocs'],
-                ppn=self.config['ppn'],
+            program = self._discover_executable(self._deployment_environment())
+            if program is None:
+                status = RuntimeStatus("unavailable", "software_not_found")
+                capabilities = ()
+            else:
+                probe = probe_program(
+                    program,
+                    environment=self._deployment_environment(),
+                    arguments=("--version",),
+                    accepted_return_codes=(0, 1, 2),
+                    timeout_seconds=5,
+                )
+                status = probe.status
+                capabilities = (
+                    ("mpi_execution", "incompressible_flow", "xcompact3d")
+                    if status.usable is True
+                    else ()
+                )
+        runtime = RuntimeRequirement(
+            requirement_id="xcompact3d",
+            description="MPI-enabled Xcompact3D runtime available through PATH",
+            required_capabilities=(
+                "mpi_execution",
+                "incompressible_flow",
+                "xcompact3d",
+            ),
+            available_capabilities=capabilities,
+            status=status,
+        )
+        completed = ReadinessContract(
+            mechanism="process_exit", condition="successful_exit"
+        )
+        return PackageDeploymentContract(
+            package="builtin.xcompact3d",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="input_file",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("inputs", "is_not_empty"),),
+                    runtime_requirements=("xcompact3d",),
+                    readiness=completed,
+                    description=(
+                        "Run one caller-supplied Xcompact3D input copied into an "
+                        "execution-owned working directory."
+                    ),
+                ),
+                ExecutionProfile(
+                    name="input_bundle",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    runtime_requirements=("xcompact3d",),
+                    readiness=completed,
+                    description=(
+                        "Run one selected input from a digest-verified multi-file "
+                        "bundle in an execution-owned working directory."
+                    ),
+                ),
+            ),
+            runtime_requirements=(runtime,),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    requires=(ConfigurationCondition("input_path", "is_empty"),),
+                    description="input_path is valid only with input_bundle.",
+                ),
+            ),
+        )
+
+    def _build_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
+            return None
+        base = self.config.get("base_image", "ubuntu:24.04")
+        content = self._read_build_script("build.sh", {"BASE_IMAGE": base})
+        return content, "adios2"
+
+    def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
+            return None
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {
+                "BUILD_IMAGE": self.build_image_name(),
+                "DEPLOY_BASE": "ubuntu:24.04",
+            },
+        )
+        return content, "adios2"
+
+    def _configure(self, **kwargs: Any) -> None:
+        """Validate the selected input profile and prepare owned output."""
+
+        super()._configure(**kwargs)
+        self._validate_configuration()
+        if self.config.get("deploy_mode") == "default":
+            self.xcompact3d_bin = self._discover_executable(
+                self._deployment_environment()
+            )
+            self._ensure_output_dir()
+
+    def _validate_configuration(self) -> None:
+        """Reject absent, ambiguous, or malformed input and MPI settings."""
+
+        for name in ("nprocs", "ppn"):
+            value = self.config.get(name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        inputs = self.config.get("inputs")
+        bundle = self.config.get("input_bundle")
+        if inputs not in (None, "") and bundle not in (None, ""):
+            raise ValueError("inputs and input_bundle cannot be combined")
+        for name, value in (("inputs", inputs), ("input_bundle", bundle)):
+            if value not in (None, "") and not isinstance(value, str):
+                raise TypeError(f"{name} must be a path string")
+        if inputs in (None, "") and bundle in (None, ""):
+            raise ValueError("Xcompact3D requires inputs or input_bundle")
+        input_path = self.config.get("input_path")
+        if input_path not in (None, "") and not isinstance(input_path, str):
+            raise TypeError("input_path must be a relative path string")
+        if bundle in (None, "") and input_path not in (None, ""):
+            raise ValueError("input_path requires input_bundle")
+
+    @staticmethod
+    def _discover_executable(environment: dict[str, str]) -> str | None:
+        """Return the first supported executable available through PATH."""
+
+        for candidate in _EXECUTABLE_CANDIDATES:
+            if shutil.which(candidate, path=environment.get("PATH")) is not None:
+                return candidate
+        return None
+
+    def _output_dir(self) -> Path:
+        """Return the normalized package-owned output root."""
+
+        return self.resolve_shared_path(
+            self.config.get("out"), field="out", default="run"
+        )
+
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        """Return local or parallel-SSH execution according to the hostfile."""
+
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
+
+    def _ensure_output_dir(self) -> None:
+        """Create the exact output root on every participating host."""
+
+        output_dir = str(self._output_dir())
+        result = Mkdir(output_dir, self._node_exec_info(env=self.env)).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to create Xcompact3D output directory {output_dir}: {failures}"
+            )
+
+    @staticmethod
+    def _resolve_bundle_input(
+        bundle: MaterializedInputBundle, requested: object
+    ) -> Path:
+        """Resolve one manifest-declared input without path inference."""
+
+        if requested in (None, ""):
+            return bundle.entrypoint
+        if not isinstance(requested, str) or "\\" in requested:
+            raise ValueError("input_path must be a confined manifest path")
+        relative = PurePosixPath(requested)
+        if relative.is_absolute() or any(
+            part in {"", ".", ".."} for part in relative.parts
+        ):
+            raise ValueError("input_path must be a confined manifest path")
+        declared = {item.path for item in bundle.manifest.files}
+        normalized = relative.as_posix()
+        if normalized not in declared:
+            raise ValueError("input_path is not declared by the input bundle")
+        selected = bundle.root / relative
+        if selected.is_symlink() or not selected.is_file():
+            raise ValueError("input_path is not a verified regular file")
+        return selected
+
+    def _stage_single_input(self, configured: str, output_dir: Path) -> Path:
+        """Copy one bounded regular input into package-owned storage."""
+
+        source = Path(
+            os.path.abspath(os.path.expandvars(os.path.expanduser(configured)))
+        )
+        try:
+            status = source.lstat()
+        except OSError as exc:
+            raise ValueError("inputs is not a readable regular file") from exc
+        if (
+            source.is_symlink()
+            or not source.is_file()
+            or status.st_size <= 0
+            or status.st_size > _MAX_INPUT_BYTES
+        ):
+            raise ValueError("inputs is not a bounded regular file")
+        destination = output_dir / source.name
+        if destination.exists() or destination.is_symlink():
+            raise ValueError("Xcompact3D staged input already exists")
+        shutil.copyfile(source, destination)
+        os.chmod(destination, 0o600)
+        return destination
+
+    def _prepare_input(self) -> tuple[Path, Path]:
+        """Materialize the selected input and return its path and working directory."""
+
+        self._validate_configuration()
+        self._ensure_output_dir()
+        output_dir = self._output_dir()
+        configured_bundle = self.config.get("input_bundle")
+        if configured_bundle not in (None, ""):
+            assert isinstance(configured_bundle, str)
+            if self.shared_dir is None:
+                raise RuntimeError("Xcompact3D input bundles require shared storage")
+            bundle = extract_input_bundle(
+                configured_bundle, Path(self.shared_dir) / "input-bundles"
+            )
+            selected = self._resolve_bundle_input(bundle, self.config.get("input_path"))
+            relative = selected.relative_to(bundle.root)
+            stage_input_bundle(bundle, output_dir)
+            staged = output_dir / relative
+            return staged, staged.parent
+
+        configured_input = self.config.get("inputs")
+        assert isinstance(configured_input, str) and configured_input
+        staged = self._stage_single_input(configured_input, output_dir)
+        return staged, output_dir
+
+    def start(self) -> None:
+        """Launch Xcompact3D and fail the pipeline on any rank failure."""
+
+        input_path, cwd = self._prepare_input()
+        if self.config.get("deploy_mode") == "container":
+            executable = "xcompact3d"
+            exec_kwargs: dict[str, Any] = {
+                "port": self.ssh_port,
+                "container": self._container_engine,
+                "container_image": self.deploy_image_name(),
+                "shared_dir": self.shared_dir,
+                "private_dir": self.private_dir,
+            }
+        else:
+            executable = self.xcompact3d_bin or self._discover_executable(self.mod_env)
+            if executable is None:
+                raise RuntimeError("Xcompact3D executable is unavailable through PATH")
+            exec_kwargs = {}
+        log_path = cwd / "xcompact3d.log"
+        command = " ".join(
+            (
+                shlex.quote(executable),
+                shlex.quote(str(input_path)),
+                ">",
+                shlex.quote(str(log_path)),
+                "2>&1",
+            )
+        )
+        result = Exec(
+            command,
+            MpiExecInfo(
+                nprocs=self.config["nprocs"],
+                ppn=self.config["ppn"],
                 hostfile=self.hostfile,
                 env=self.mod_env,
-                cwd=self.config.get('out'),
-            )).run()
+                cwd=str(cwd),
+                line_callback=self.runtime_line_callback(),
+                **exec_kwargs,
+            ),
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"Xcompact3D execution failed: {failures}")
 
-    def stop(self):
-        """Stop Xcompact3d (no-op -- runs to completion)."""
-        pass
+    def stop(self) -> None:
+        """Do nothing because Xcompact3D runs to process completion."""
 
-    def clean(self):
-        """Remove Xcompact3d output directory."""
-        if self.config['out']:
-            Rm(self.config['out'] + '*',
-               PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+    def clean(self) -> None:
+        """Remove only the exact configured Xcompact3D output directory."""
+
+        output_dir = self._output_dir()
+        if output_dir == Path(output_dir.anchor):
+            raise ValueError("refusing to clean a filesystem root as Xcompact3D output")
+        result = Rm(
+            str(output_dir),
+            self._node_exec_info(env=self.env),
+            recursive=True,
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to clean Xcompact3D output {output_dir}: {failures}"
+            )

--- a/builtin/pipelines/examples/xcompact3d_container_test.yaml
+++ b/builtin/pipelines/examples/xcompact3d_container_test.yaml
@@ -21,5 +21,9 @@ pkgs:
     pkg_name: xcompact3d_container
     nprocs: 2
     ppn: 2
-    case: TGV
-    out: /tmp/xcompact3d_out
+    # Replace this path with a jarvis.package-input-bundle.v1 archive that is
+    # visible to JARVIS. The bundle should include the selected .i3d file and
+    # support resources such as adios2_config.xml.
+    input_bundle: /path/to/xcompact3d-inputs.tar
+    input_path: channel/input_test_x.i3d
+    out: run

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Jarvis-CD is a unified platform for deploying scientific applications, storage s
 - [Package Deployment Contracts](package-deployment.md) - Versioned execution, runtime resolution, configuration, and readiness metadata
 - [Package Input Bundles](input-bundles.md) - Digest-verified multi-file application inputs and mutable run staging
 - [WarpX Package](warpx.md) - Execution-owned inputs, runtime controls, and output artifacts
+- [Xcompact3D Package](xcompact3d.md) - Verified multi-file inputs, MPI execution, and output artifacts
 - [Pipeline Configuration](pipelines.md) — Full YAML format, install managers (container/spack), environment management, multi-node, devcontainers
 - [Package Development Guide](package_dev_guide.md) — Create new packages, Dockerfile templates, container and spack support
 - [Pipeline Tests](pipeline_tests.md) — Automated testing with grid search and parameter sweeps

--- a/docs/xcompact3d.md
+++ b/docs/xcompact3d.md
@@ -1,0 +1,71 @@
+# Xcompact3D Package
+
+`builtin.xcompact3d` launches one caller-defined incompressible-flow simulation under
+JARVIS-owned MPI execution. It deliberately does not encode a particular scientific study,
+axis comparison, or benchmark. Multiple package instances can select distinct inputs and a
+separate analysis step can compare their outputs.
+
+## Input profiles
+
+| Profile | Settings | Behavior |
+|---|---|---|
+| Single input | `inputs` | Copies one bounded regular `.i3d` file into package-owned storage and launches it there. |
+| Input bundle | `input_bundle`, optional `input_path` | Verifies and stages every manifest member, then launches the selected member. An empty `input_path` selects the manifest entrypoint. |
+
+`inputs` and `input_bundle` are mutually exclusive, and one is required. `input_path` is
+accepted only with an input bundle. It must be a confined relative path that exactly names a
+manifest member. A bundle is the appropriate profile when an input depends on files such as
+`adios2_config.xml`, geometry, restart data, or other solver resources.
+
+## Settings
+
+| Setting | Default | Meaning |
+|---|---:|---|
+| `nprocs` | `4` | MPI process count. |
+| `ppn` | `4` | MPI processes per node. |
+| `inputs` | empty | Single caller-supplied Xcompact3D input file. |
+| `input_bundle` | empty | `jarvis.package-input-bundle.v1` archive. |
+| `input_path` | empty | Selected manifest member, or the entrypoint when empty. |
+| `out` | `run` | Output root; relative paths resolve below package shared storage. |
+| `base_image` | `ubuntu:24.04` | Base image for the optional package-owned container build. |
+
+The native profile resolves `xcompact3d` or `incompact3d` from the pipeline environment.
+Runtime installation remains an operator or installation-manager responsibility; an agent
+does not provide executable paths.
+
+## Outputs and completion
+
+The selected input and all support files are copied into an execution-owned working tree.
+The solver stream is written to `xcompact3d.log` beside the selected input. A nonzero result
+from any MPI rank fails the package.
+
+At process completion, the package performs a bounded output walk without following links.
+It reports the complete owned result tree and stable high-confidence products for the solver
+log, checkpoint, restart metadata, field-data collection, statistics collection, and ADIOS2
+BP collections. Exact staged inputs are excluded. A nonzero process exit or bounded-walk
+truncation marks discovered products incomplete.
+
+## Multi-input example
+
+```yaml
+name: channel-orientation-study
+pkgs:
+  - pkg_type: builtin.xcompact3d
+    pkg_name: channel_x
+    input_bundle: /data/channel-cases.tar
+    input_path: channel/input_test_x.i3d
+    nprocs: 4
+    ppn: 4
+    out: channel-x
+  - pkg_type: builtin.xcompact3d
+    pkg_name: channel_z
+    input_bundle: /data/channel-cases.tar
+    input_path: channel/input_test_z.i3d
+    nprocs: 4
+    ppn: 4
+    out: channel-z
+```
+
+This pipeline runs two ordinary application instances. Any scientific comparison belongs in
+an explicit downstream package or in the caller's validation layer rather than in the
+Xcompact3D launcher.

--- a/test/unit/core/test_xcompact3d_artifacts.py
+++ b/test/unit/core/test_xcompact3d_artifacts.py
@@ -1,0 +1,151 @@
+"""Tests for builtin Xcompact3D generated-artifact semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import (
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "xcompact3d"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def _write_products(root: Path) -> None:
+    (root / "channel").mkdir(parents=True)
+    (root / "channel" / "input.i3d").write_text("input\n", encoding="utf-8")
+    (root / "channel" / "adios2_config.xml").write_text("<xml/>\n", encoding="utf-8")
+    (root / "channel" / "xcompact3d.log").write_text(
+        "UT 6.666662e-1 -4.6e-7\n", encoding="utf-8"
+    )
+    (root / "channel" / "checkpoint").write_bytes(b"checkpoint")
+    (root / "channel" / "restart.info").write_text("100\n", encoding="utf-8")
+    (root / "channel" / "data").mkdir()
+    (root / "channel" / "data" / "snapshot-1.xdmf").write_text(
+        "<Xdmf/>\n", encoding="utf-8"
+    )
+    (root / "channel" / "statistics").mkdir()
+    (root / "channel" / "statistics" / "umean.dat100").write_bytes(b"stats")
+
+
+def test_finalization_reports_owned_results_and_excludes_staged_inputs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Scientific outputs are visible without reclassifying exact inputs."""
+
+    _write_products(tmp_path)
+    module = _module()
+    adapter = module.Xcompact3dArtifactAdapter(
+        module.PurePosixPath("/scratch/xcompact3d"),
+        frozenset(
+            {
+                module.PurePosixPath("channel/input.i3d"),
+                module.PurePosixPath("channel/adios2_config.xml"),
+            }
+        ),
+    )
+    monkeypatch.setattr(adapter, "_local_output_path", lambda: tmp_path)
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert adapter.finalize_artifacts_for_exit(0) == []
+    collection = observations[0]
+    assert collection.logical_name == "xcompact3d-results"
+    assert collection.role is ArtifactRole.OUTPUT
+    assert collection.structure is ArtifactStructure.COLLECTION
+    assert collection.state is ArtifactState.FINALIZED
+    assert "channel/input.i3d" not in collection.metadata["member_names"]
+    names = {item.logical_name: item for item in observations[1:]}
+    assert names["xcompact3d-log"].format == "xcompact3d-runtime-log"
+    assert names["xcompact3d-checkpoint"].checksum is not None
+    assert names["xcompact3d-data"].structure is ArtifactStructure.COLLECTION
+    assert names["xcompact3d-statistics"].structure is ArtifactStructure.COLLECTION
+
+
+def test_nonzero_exit_marks_discovered_outputs_incomplete(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Filesystem presence cannot turn a failed solver run into success."""
+
+    _write_products(tmp_path)
+    module = _module()
+    adapter = module.Xcompact3dArtifactAdapter(
+        module.PurePosixPath("/scratch/xcompact3d")
+    )
+    monkeypatch.setattr(adapter, "_local_output_path", lambda: tmp_path)
+
+    observations = adapter.finalize_artifacts_for_exit(17)
+
+    assert observations
+    assert {item.state for item in observations} == {ArtifactState.INCOMPLETE}
+
+
+def test_discovery_bound_cannot_claim_complete_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A truncated output walk is visibly incomplete."""
+
+    _write_products(tmp_path)
+    module = _module()
+    adapter = module.Xcompact3dArtifactAdapter(
+        module.PurePosixPath("/scratch/xcompact3d")
+    )
+    monkeypatch.setattr(adapter, "_local_output_path", lambda: tmp_path)
+    monkeypatch.setattr(module, "_MAX_DISCOVERED_ENTRIES", 2)
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert observations[0].state is ArtifactState.INCOMPLETE
+    assert observations[0].metadata["discovery_truncated"] is True
+
+
+def test_factory_scopes_relative_output_to_package_shared_root() -> None:
+    """Artifact discovery receives the same execution-owned root as launch."""
+
+    module = _module()
+
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.xcompact3d",
+            "out": "run",
+            "shared_dir": "/execution/shared/xcompact3d",
+            "runtime_cwd": "/execution/runtime",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.output_dir.as_posix() == "/execution/shared/xcompact3d/run"
+    assert module.adapter_from_package({"pkg_type": "builtin.lammps"}) is None
+
+
+def test_container_private_output_is_not_claimed() -> None:
+    """A host cannot report artifacts from an unmounted container path."""
+
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.xcompact3d",
+            "out": "/tmp/xcompact3d",
+            "effective_deploy_mode": "container",
+            "shared_dir": "/execution/shared",
+            "private_dir": "/execution/private",
+            "runtime_cwd": "/execution/runtime",
+        }
+    )
+
+    assert adapter is None

--- a/test/unit/core/test_xcompact3d_artifacts.py
+++ b/test/unit/core/test_xcompact3d_artifacts.py
@@ -29,6 +29,7 @@ def _module() -> ModuleType:
 def _write_products(root: Path) -> None:
     (root / "channel").mkdir(parents=True)
     (root / "channel" / "input.i3d").write_text("input\n", encoding="utf-8")
+    (root / "channel" / "jarvis-input.i3d").write_text("input\n", encoding="utf-8")
     (root / "channel" / "adios2_config.xml").write_text("<xml/>\n", encoding="utf-8")
     (root / "channel" / "xcompact3d.log").write_text(
         "UT 6.666662e-1 -4.6e-7\n", encoding="utf-8"
@@ -56,6 +57,7 @@ def test_finalization_reports_owned_results_and_excludes_staged_inputs(
             {
                 module.PurePosixPath("channel/input.i3d"),
                 module.PurePosixPath("channel/adios2_config.xml"),
+                module.PurePosixPath("channel/jarvis-input.i3d"),
             }
         ),
     )
@@ -70,6 +72,7 @@ def test_finalization_reports_owned_results_and_excludes_staged_inputs(
     assert collection.structure is ArtifactStructure.COLLECTION
     assert collection.state is ArtifactState.FINALIZED
     assert "channel/input.i3d" not in collection.metadata["member_names"]
+    assert "channel/jarvis-input.i3d" not in collection.metadata["member_names"]
     names = {item.logical_name: item for item in observations[1:]}
     assert names["xcompact3d-log"].format == "xcompact3d-runtime-log"
     assert names["xcompact3d-checkpoint"].checksum is not None

--- a/test/unit/core/test_xcompact3d_package_runtime.py
+++ b/test/unit/core/test_xcompact3d_package_runtime.py
@@ -199,9 +199,12 @@ def test_bundle_selects_one_manifest_input_without_modifying_it(tmp_path: Path) 
     package.start()
 
     staged = tmp_path / "shared" / "run" / "channel" / "input_test_z.i3d"
+    launch_input = staged.parent / "jarvis-input.i3d"
     assert staged.read_bytes().endswith(b"idir_stream=3\n/End\n")
+    assert launch_input.read_bytes() == staged.read_bytes()
     command = _CapturedExec.commands[-1]
-    assert shlex.quote(str(staged.resolve())) in command
+    assert command.startswith("xcompact3d jarvis-input.i3d ")
+    assert shlex.quote(str(staged.resolve())) not in command
     assert str((staged.parent / "xcompact3d.log").resolve()) in command
     assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
 
@@ -217,9 +220,33 @@ def test_single_input_is_copied_to_owned_output_before_launch(tmp_path: Path) ->
     package.start()
 
     staged = tmp_path / "shared" / "run" / "input.i3d"
+    launch_input = staged.parent / "jarvis-input.i3d"
     assert staged.read_bytes() == source.read_bytes()
-    assert shlex.quote(str(staged.resolve())) in _CapturedExec.commands[-1]
+    assert launch_input.read_bytes() == staged.read_bytes()
+    assert _CapturedExec.commands[-1].startswith("xcompact3d jarvis-input.i3d ")
+    assert shlex.quote(str(staged.resolve())) not in _CapturedExec.commands[-1]
     assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
+
+
+def test_reserved_runtime_input_name_cannot_replace_a_bundle_member(
+    tmp_path: Path,
+) -> None:
+    """A bundle cannot make the short runtime alias overwrite another input."""
+
+    bundle = _write_bundle(tmp_path / "channel.tar")
+    package = _package(
+        tmp_path,
+        _base_config(input_bundle=str(bundle), input_path="channel/input_test_z.i3d"),
+    )
+    collision = tmp_path / "shared" / "run" / "channel" / "jarvis-input.i3d"
+    collision.parent.mkdir(parents=True)
+    collision.write_text("unrelated\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="runtime input alias already exists"):
+        package.start()
+
+    assert collision.read_text(encoding="utf-8") == "unrelated\n"
+    assert _CapturedExec.commands == []
 
 
 def test_ambiguous_or_undeclared_inputs_fail_before_launch(tmp_path: Path) -> None:

--- a/test/unit/core/test_xcompact3d_package_runtime.py
+++ b/test/unit/core/test_xcompact3d_package_runtime.py
@@ -1,0 +1,281 @@
+"""Runtime-contract tests for the builtin JARVIS Xcompact3D package."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import shlex
+import tarfile
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+)
+from jarvis_cd.shell import LocalExecInfo
+from jarvis_cd.util.hostfile import Hostfile
+
+
+def _load_package() -> ModuleType:
+    """Load the builtin package without changing repository imports."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "xcompact3d"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_xcompact3d_runtime_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load Xcompact3D package from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+xcompact3d_package = _load_package()
+
+
+class _CapturedExec:
+    """Capture one launch and expose a configurable process result."""
+
+    commands: list[str] = []
+    infos: list[Any] = []
+    return_code = 0
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": self.return_code}
+        self.commands.append(command)
+        self.infos.append(exec_info)
+
+    def run(self) -> _CapturedExec:
+        """Return the captured result."""
+
+        return self
+
+
+class _CapturedMkdir:
+    """Create a local test output directory and report success."""
+
+    def __init__(self, path: str, exec_info: Any) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedMkdir:
+        """Materialize the test directory."""
+
+        Path(self.path).mkdir(parents=True, exist_ok=True)
+        return self
+
+
+class _CapturedRm:
+    """Capture exact cleanup authority."""
+
+    calls: list[tuple[str, bool]] = []
+
+    def __init__(self, path: str, exec_info: Any, *, recursive: bool = False) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.recursive = recursive
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedRm:
+        """Record cleanup without deleting test files."""
+
+        self.calls.append((self.path, self.recursive))
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _capture_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep package tests free of process and remote-host side effects."""
+
+    _CapturedExec.commands = []
+    _CapturedExec.infos = []
+    _CapturedExec.return_code = 0
+    _CapturedRm.calls = []
+    monkeypatch.setattr(xcompact3d_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(xcompact3d_package, "Mkdir", _CapturedMkdir)
+    monkeypatch.setattr(xcompact3d_package, "Rm", _CapturedRm)
+
+
+def _package(tmp_path: Path, config: dict[str, Any]) -> Any:
+    package = object.__new__(xcompact3d_package.Xcompact3d)
+    package.config = config
+    package.shared_dir = tmp_path / "shared"
+    package.private_dir = tmp_path / "private"
+    package.env = {}
+    package.mod_env = {"PATH": "/runtime/bin"}
+    package.xcompact3d_bin = "xcompact3d"
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: Hostfile(find_ips=False))
+    package.runtime_line_callback = lambda: None
+    return package
+
+
+def _write_bundle(destination: Path) -> Path:
+    files = {
+        "channel/input_test_x.i3d": b"&BasicParam\n idir_stream=1\n/End\n",
+        "channel/input_test_z.i3d": b"&BasicParam\n idir_stream=3\n/End\n",
+        "channel/adios2_config.xml": b"<adios-config/>\n",
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "channel/input_test_x.i3d",
+        "files": [
+            {
+                "path": name,
+                "role": "xcompact3d_input" if name.endswith(".i3d") else "support",
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, payload in files.items()
+        ],
+    }
+    manifest_bytes = json.dumps(manifest, sort_keys=True).encode()
+    with tarfile.open(destination, mode="w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(manifest_bytes)
+        archive.addfile(info, io.BytesIO(manifest_bytes))
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def _base_config(**overrides: Any) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "deploy_mode": "default",
+        "input_bundle": "",
+        "input_path": "",
+        "inputs": "",
+        "nprocs": 4,
+        "out": "run",
+        "ppn": 4,
+    }
+    config.update(overrides)
+    return config
+
+
+def test_agent_contract_exposes_generic_single_and_bundle_inputs() -> None:
+    """Agents see ordinary Xcompact3D inputs, not benchmark-specific axes."""
+
+    package = object.__new__(xcompact3d_package.Xcompact3d)
+    package.config = _base_config()
+    package.env = {}
+    package.mod_env = {}
+    menu = {item["name"]: item for item in package._configure_menu()}
+
+    assert menu["out"]["default"] == "run"
+    assert menu["inputs"]["input_binding"]["kind"] == "local_file"
+    assert menu["input_bundle"]["input_binding"]["kind"] == "local_file"
+    assert "axis" not in menu
+    contract = package._deployment_contract().to_dict()
+    assert {profile["name"] for profile in contract["execution_profiles"]} == {
+        "input_bundle",
+        "input_file",
+    }
+
+
+def test_bundle_selects_one_manifest_input_without_modifying_it(tmp_path: Path) -> None:
+    """Independent package instances can select distinct files from one bundle."""
+
+    bundle = _write_bundle(tmp_path / "channel.tar")
+    package = _package(
+        tmp_path,
+        _base_config(input_bundle=str(bundle), input_path="channel/input_test_z.i3d"),
+    )
+
+    package.start()
+
+    staged = tmp_path / "shared" / "run" / "channel" / "input_test_z.i3d"
+    assert staged.read_bytes().endswith(b"idir_stream=3\n/End\n")
+    command = _CapturedExec.commands[-1]
+    assert shlex.quote(str(staged.resolve())) in command
+    assert str((staged.parent / "xcompact3d.log").resolve()) in command
+    assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
+
+
+def test_single_input_is_copied_to_owned_output_before_launch(tmp_path: Path) -> None:
+    """A caller input is never executed in its source directory."""
+
+    source = tmp_path / "caller" / "input.i3d"
+    source.parent.mkdir()
+    source.write_text("&BasicParam\n idir_stream=1\n/End\n", encoding="utf-8")
+    package = _package(tmp_path, _base_config(inputs=str(source)))
+
+    package.start()
+
+    staged = tmp_path / "shared" / "run" / "input.i3d"
+    assert staged.read_bytes() == source.read_bytes()
+    assert shlex.quote(str(staged.resolve())) in _CapturedExec.commands[-1]
+    assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
+
+
+def test_ambiguous_or_undeclared_inputs_fail_before_launch(tmp_path: Path) -> None:
+    """Input selection is explicit and rejects traversal or ambiguity."""
+
+    bundle = _write_bundle(tmp_path / "channel.tar")
+    source = tmp_path / "input.i3d"
+    source.write_text("&BasicParam\n/End\n", encoding="utf-8")
+    package = _package(
+        tmp_path,
+        _base_config(inputs=str(source), input_bundle=str(bundle)),
+    )
+    with pytest.raises(ValueError, match="cannot be combined"):
+        package.start()
+
+    package.config = _base_config(
+        input_bundle=str(bundle), input_path="../channel/input_test_z.i3d"
+    )
+    with pytest.raises(ValueError, match="confined manifest path"):
+        package.start()
+
+    package.config = _base_config()
+    with pytest.raises(ValueError, match="requires inputs or input_bundle"):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
+def test_process_failure_is_not_silently_accepted(tmp_path: Path) -> None:
+    """Any failing Xcompact3D rank fails the package lifecycle."""
+
+    source = tmp_path / "input.i3d"
+    source.write_text("&BasicParam\n/End\n", encoding="utf-8")
+    package = _package(tmp_path, _base_config(inputs=str(source)))
+    _CapturedExec.return_code = 9
+
+    with pytest.raises(RuntimeError, match="Xcompact3D execution failed"):
+        package.start()
+
+
+def test_clean_uses_one_exact_recursive_output_without_wildcard(tmp_path: Path) -> None:
+    """Cleanup cannot erase prefix-matching sibling directories."""
+
+    package = _package(tmp_path, _base_config(out="results"))
+
+    package.clean()
+
+    assert _CapturedRm.calls == [
+        (str((tmp_path / "shared" / "results").resolve()), True)
+    ]
+    assert "*" not in _CapturedRm.calls[0][0]
+
+
+def test_default_hostfile_uses_local_output_lifecycle(tmp_path: Path) -> None:
+    """Local output preparation does not require SSH."""
+
+    package = _package(tmp_path, _base_config())
+
+    assert isinstance(package._node_exec_info(), LocalExecInfo)


### PR DESCRIPTION
## Summary

- replace the unused case label with single-file and digest-verified multi-file input profiles
- run one ordinary Xcompact3D input per package instance with exact output ownership and failure propagation
- report bounded solver logs, checkpoints, field data, and statistics as typed artifacts
- document the agent-facing package contract and multi-instance study composition

## Local verification

- uv run --no-sync --no-cache ruff check builtin/builtin/xcompact3d test/unit/core/test_xcompact3d_package_runtime.py test/unit/core/test_xcompact3d_artifacts.py
- uv run --no-sync --no-cache ruff format --check builtin/builtin/xcompact3d test/unit/core/test_xcompact3d_package_runtime.py test/unit/core/test_xcompact3d_artifacts.py
- uv run --no-sync --no-cache pyright builtin/builtin/xcompact3d test/unit/core/test_xcompact3d_package_runtime.py test/unit/core/test_xcompact3d_artifacts.py
- focused and shared contract suite: 50 passed, zero skipped
- wheel build includes both pkg.py and rtifacts.py

Ares qualification evidence will be added after exercising this exact commit through the JARVIS MCP surface.