### PR TITLE
feat: harden BioBB native workflow

### DIFF
--- a/builtin/builtin/biobb_wf_md_setup/README.md
+++ b/builtin/builtin/biobb_wf_md_setup/README.md
@@ -18,7 +18,7 @@ fails. A successful process exit is the authoritative completion signal.
 Native execution requires:
 
 - `python3` with `biobb-model` and `biobb-gromacs` importable; and
-- `gmx` available through `PATH`.
+- `gmx` or the MPI-build name `gmx_mpi` available through `PATH`.
 
 The deployment descriptor reports these as separate runtime requirements. It
 also provides provider-neutral hints for Python distributions and a `gromacs`

--- a/builtin/builtin/biobb_wf_md_setup/README.md
+++ b/builtin/builtin/biobb_wf_md_setup/README.md
@@ -1,66 +1,87 @@
-# biobb_wf_md_setup
+# BioBB molecular-dynamics setup
 
-BioExcel Building Blocks 5-stage MD setup pipeline (fix side chain →
-pdb2gmx → editconf → solvate → solvate top). The native workflow runs
-GROMACS through `biobb_*` Python wrappers; container mode is wired via
-`/opt/run_batch.sh` inside the SIF.
+`builtin.biobb_wf_md_setup` prepares one caller-supplied PDB structure with
+BioExcel Building Blocks and GROMACS. The native profile performs five real
+stages:
 
-## Native workflow parameters (`_configure_menu`)
+1. copy the immutable caller input into package-owned storage;
+2. repair missing side chains with `biobb_model`;
+3. construct coordinates and topology with `pdb2gmx`;
+4. center the solute and construct the selected periodic box with `editconf`;
+5. solvate the system and update its topology with `solvate`.
 
-These parameters live in pkg.py / the pipeline YAML and tune what the
-GROMACS pipeline actually does:
+The package fails if any BioBB block, product check, or semantic output parser
+fails. A successful process exit is the authoritative completion signal.
 
-| Parameter | Default | Effect on I/O | Effect on compute |
-|---|---|---|---|
-| `pdb_file` | `/opt/biobb-bench/1AKI.pdb` | bigger PDB → bigger .gro / topology writes (~linear in atom count) | bigger PDB → more GROMACS work (super-linear) |
-| `replicates` | `1` | loops the 5-stage pipeline N times under `rep_NNN/` — I/O scales **linearly** in N | compute scales linearly in N too |
-| `nprocs` / `ppn` | `1` / `1` | unused in container mode (GROMACS is launched single-threaded by the wrapper) | unused in container mode |
-| `out` | `/tmp/biobb_out` | controls where the final per-rep tree gets staged via `cp -r`; sub-directory on NFS dominates the write traffic in container mode | n/a |
+## Native runtime
 
-**Compute-dominated stages**: `fix_side_chain` (~50%), `editconf`
-(~10%), `solvate` (~30%). `pdb2gmx` is mostly I/O on small PDBs.
+Native execution requires:
 
-## I/O-only benchmark mode (bind-mount override)
+- `python3` with `biobb-model` and `biobb-gromacs` importable; and
+- `gmx` available through `PATH`.
 
-For benchmarking storage rather than GROMACS, bind-mount
-`biobb_io_only.sh` over `/opt/run_batch.sh` in the YAML:
+The deployment descriptor reports these as separate runtime requirements. It
+also provides provider-neutral hints for Python distributions and a `gromacs`
+Spack spec. No container is required for the native profile.
+
+The scientific configuration is:
+
+| Parameter | Meaning | Default |
+|---|---|---|
+| `pdb_file` | Required caller-owned regular PDB input | none |
+| `out` | Package-owned result directory | `run` |
+| `force_field` | GROMACS force field passed to `pdb2gmx` | `amber99sb-ildn` |
+| `water_type` | Water model passed to `pdb2gmx` | `tip3p` |
+| `box_type` | `cubic`, `triclinic`, `dodecahedron`, or `octahedron` | `cubic` |
+| `distance_to_molecule` | Solute-to-box clearance in nanometers | `1.0` |
+| `ignore_input_hydrogens` | Reconstruct input hydrogens | `true` |
+| `merge_chains` | Merge input chains into one molecule | `false` |
+
+Example package configuration:
 
 ```yaml
-container_binds:
-  - ${HOME}/jarvis-bench-scripts/biobb_io_only.sh:/opt/run_batch.sh
-  - ${HOME}/jarvis-runs:${HOME}/jarvis-runs
-env:
-  BIOBB_FIX_MB:  "32"    # fix_side_chain stage size
-  BIOBB_P2G_MB:  "128"   # pdb2gmx .gro size
-  BIOBB_EDIT_MB: "128"   # editconf .gro size
-  BIOBB_SOLV_MB: "700"   # solvate .gro size (the heavy one)
-  BIOBB_TOP_MB:  "16"    # both topology .zip files
+- pkg_type: builtin.biobb_wf_md_setup
+  pkg_name: lysozyme_dodecahedron
+  pdb_file: /shared/inputs/1aki.pdb
+  out: run
+  force_field: amber99sb-ildn
+  water_type: tip3p
+  box_type: dodecahedron
+  distance_to_molecule: 1.0
+  ignore_input_hydrogens: true
+  merge_chains: false
 ```
 
-The proxy script writes `/dev/urandom` blocks at the configured sizes
-into the same `rep_NNN-<hostname>/` layout the real workflow uses, so
-storage backends see the same file count + naming.
+JARVIS copies `pdb_file` to `out/input.pdb` before execution. Existing files,
+links, empty files, non-PDB inputs, and inputs larger than 32 MiB fail locally
+before a scientific process starts.
 
-### Per-replicate budget = FIX + P2G + EDIT + SOLV + 2 × TOP
+## Outputs
 
-Default = 32 + 128 + 128 + 700 + 16 + 16 = **1020 MiB/rep**.
+The native workflow produces these exact files beneath `out`:
 
-## Tuning matrix (I/O-only mode)
+| File | Meaning |
+|---|---|
+| `biobb-result.json` | Closed result, parameters, stage states, metrics, and product hashes |
+| `fixed.pdb` | Side-chain-repaired structure |
+| `processed.gro` | Coordinates produced by `pdb2gmx` |
+| `processed_topology.zip` | Initial GROMACS topology bundle |
+| `boxed.gro` | Centered solute in the selected periodic box |
+| `solvated.gro` | Solvated coordinates |
+| `solvated_topology.zip` | Solvated topology bundle |
 
-| Goal | Knob | Rule of thumb |
-|---|---|---|
-| **More I/O per rep** | bump `BIOBB_SOLV_MB` (largest single stage) | 2× → ~1.6× total/rep |
-| **More I/O total** | bump `replicates` | linear |
-| **Smaller files** | drop the per-stage MB knobs, bump `replicates` | shifts toward open/close overhead |
-| **Shorter wall** | drop `replicates` (each rep is one full dd-pass through the budget) | linear |
-| **Bypass compute** | use the bind-mount mode above | wall ≈ I/O bytes ÷ NFS bw |
+The result uses schema `jarvis.biobb-md-setup-result.v1`. It records the input
+hash, scientific parameters, per-stage outcome, coordinate atom counts, box
+volume, topology molecule counts, solvent count, and the size and SHA-256 hash
+of every declared product. The artifact adapter checks those paths, sizes, and
+hashes before finalizing them. A nonzero process or driver result leaves every
+available product explicitly incomplete.
 
-## Measured calibration (ares, 4-node SLURM, NFS-backed overlay)
+## Legacy container benchmarking
 
-I/O-only mode, `replicates: 20`, default per-stage MB:
-
-- **Wall**: 225 s (3.8 min)
-- **I/O written**: 20 GiB (20 × 1020 MiB) → ≥20 GB target ✓
-- **Effective write rate**: ~92 MB/s (single-host NFS stream)
-
-YAML lives at `builtin/pipelines/ares/biobb_wf_md_setup_apptainer_test.yaml`.
+The prior container and Apptainer batch modes remain available for existing
+storage experiments. Their replication, parallel scratch, OpenMP, MD extension,
+and base-image controls are deliberately hidden from generic agent catalogs:
+they describe a synthetic container benchmark, not the ordinary scientific
+cell above. Native qualification and agent-facing use do not build or require
+Docker images.

--- a/builtin/builtin/biobb_wf_md_setup/artifacts.py
+++ b/builtin/builtin/biobb_wf_md_setup/artifacts.py
@@ -1,0 +1,368 @@
+"""Generated-artifact semantics for the builtin BioBB MD-setup package."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import posixpath
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+)
+
+RESULT_SCHEMA = "jarvis.biobb-md-setup-result.v1"
+RESULT_NAME = "biobb-result.json"
+_MAX_RESULT_BYTES = 1024 * 1024
+_MAX_PRODUCT_BYTES = 512 * 1024 * 1024
+_PRODUCTS = {
+    "fixed.pdb": (
+        "biobb-fixed-structure",
+        "molecular_structure",
+        "pdb",
+        "chemical/x-pdb",
+    ),
+    "processed.gro": (
+        "biobb-processed-coordinates",
+        "molecular_structure",
+        "gromacs-gro",
+        "chemical/x-gro",
+    ),
+    "processed_topology.zip": (
+        "biobb-processed-topology",
+        "scientific_dataset",
+        "gromacs-topology-zip",
+        "application/zip",
+    ),
+    "boxed.gro": (
+        "biobb-boxed-coordinates",
+        "molecular_structure",
+        "gromacs-gro",
+        "chemical/x-gro",
+    ),
+    "solvated.gro": (
+        "biobb-solvated-coordinates",
+        "molecular_structure",
+        "gromacs-gro",
+        "chemical/x-gro",
+    ),
+    "solvated_topology.zip": (
+        "biobb-solvated-topology",
+        "scientific_dataset",
+        "gromacs-topology-zip",
+        "application/zip",
+    ),
+}
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA-256 digest of one bounded file."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(slots=True)
+class BiobbMdSetupArtifactAdapter:
+    """Report one closed BioBB result and its exact declared products."""
+
+    output_dir: PurePosixPath
+    _local_root: Path | None = None
+    _finalized: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for authoritative process completion before reporting files."""
+
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Finalize products for a successful legacy completion callback."""
+
+        return self._finalize(return_code=0)
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Finalize products using the authoritative driver exit status."""
+
+        return self._finalize(return_code=return_code)
+
+    def reset_artifacts(self) -> None:
+        """Permit discovery after an execution stream is replaced."""
+
+        self._finalized = False
+
+    def _local_output_path(self) -> Path:
+        """Project the declared cluster directory into this host filesystem."""
+
+        if self._local_root is not None:
+            return self._local_root
+        return Path(self.output_dir.as_posix())
+
+    def _result(self) -> tuple[Path, dict[str, Any]]:
+        """Load and validate the bounded package-owned result document."""
+
+        raw_root = self._local_output_path()
+        if raw_root.is_symlink():
+            raise RuntimeError("BioBB output root is not a real directory")
+        try:
+            root = raw_root.resolve(strict=True)
+        except OSError as exc:
+            raise RuntimeError("BioBB output root is unavailable") from exc
+        if root.is_symlink() or not root.is_dir():
+            raise RuntimeError("BioBB output root is not a real directory")
+        path = root / RESULT_NAME
+        if (
+            path.is_symlink()
+            or not path.is_file()
+            or path.stat().st_size <= 0
+            or path.stat().st_size > _MAX_RESULT_BYTES
+        ):
+            raise RuntimeError("BioBB result is missing, unsafe, or oversized")
+        try:
+            document = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError("BioBB result is not valid JSON") from exc
+        if (
+            not isinstance(document, dict)
+            or document.get("schema_version") != RESULT_SCHEMA
+            or document.get("status") not in {"completed", "failed"}
+        ):
+            raise RuntimeError("BioBB result has the wrong schema")
+        return path, document
+
+    def _members(
+        self, document: dict[str, Any]
+    ) -> list[tuple[Path, PurePosixPath, tuple[str, str, str, str]]]:
+        """Resolve and digest-check every exact result-declared product."""
+
+        values = document.get("artifacts")
+        if not isinstance(values, list) or len(values) > len(_PRODUCTS):
+            raise RuntimeError("BioBB result has an invalid artifact list")
+        root = self._local_output_path().resolve(strict=True)
+        members: list[tuple[Path, PurePosixPath, tuple[str, str, str, str]]] = []
+        seen: set[str] = set()
+        for item in values:
+            if not isinstance(item, dict):
+                raise RuntimeError("BioBB result has an invalid artifact member")
+            relative = item.get("path")
+            expected_format = item.get("format")
+            expected_size = item.get("size_bytes")
+            expected_hash = item.get("sha256")
+            if not isinstance(relative, str):
+                raise RuntimeError("BioBB result declared an unknown artifact")
+            candidate = Path(relative)
+            if candidate.is_absolute() or ".." in candidate.parts:
+                raise RuntimeError(
+                    f"BioBB artifact escaped its output root: {relative}"
+                )
+            if relative not in _PRODUCTS:
+                raise RuntimeError("BioBB result declared an unknown artifact")
+            if relative in seen:
+                raise RuntimeError("BioBB result declared a duplicate artifact")
+            seen.add(relative)
+            identity = _PRODUCTS[relative]
+            if expected_format != identity[2]:
+                raise RuntimeError("BioBB artifact format differs from its contract")
+            unresolved = root / candidate
+            if unresolved.is_symlink():
+                raise RuntimeError(f"BioBB artifact is missing or unsafe: {relative}")
+            path = unresolved.resolve(strict=False)
+            if not path.is_relative_to(root):
+                raise RuntimeError(
+                    f"BioBB artifact escaped its output root: {relative}"
+                )
+            if path.is_symlink() or not path.is_file():
+                raise RuntimeError(f"BioBB artifact is missing or unsafe: {relative}")
+            size = path.stat().st_size
+            if (
+                isinstance(expected_size, bool)
+                or not isinstance(expected_size, int)
+                or expected_size != size
+                or not 0 < size <= _MAX_PRODUCT_BYTES
+            ):
+                raise RuntimeError(f"BioBB artifact size differs: {relative}")
+            if (
+                not isinstance(expected_hash, str)
+                or len(expected_hash) != 64
+                or _sha256(path) != expected_hash
+            ):
+                raise RuntimeError(f"BioBB artifact hash differs: {relative}")
+            members.append((path, PurePosixPath(relative), identity))
+        if document.get("status") == "completed" and seen != set(_PRODUCTS):
+            raise RuntimeError("completed BioBB result omitted required products")
+        return members
+
+    @staticmethod
+    def _metadata(document: dict[str, Any]) -> dict[str, Any]:
+        """Project bounded scientific values into each artifact observation."""
+
+        parameters = document.get("parameters")
+        metrics = document.get("metrics")
+        if not isinstance(parameters, dict) or not isinstance(metrics, dict):
+            raise RuntimeError("BioBB result omitted parameters or metrics")
+        return {
+            "application": "biobb_wf_md_setup",
+            "box_type": parameters.get("box_type"),
+            "distance_to_molecule": parameters.get("distance_to_molecule"),
+            "force_field": parameters.get("force_field"),
+            "water_type": parameters.get("water_type"),
+            "boxed_volume_nm3": metrics.get("boxed_volume_nm3"),
+            "solvated_atom_count": metrics.get("solvated_atom_count"),
+            "solvent_molecule_count": metrics.get("solvent_molecule_count"),
+        }
+
+    def _observation(
+        self,
+        path: Path,
+        cluster_path: PurePosixPath,
+        *,
+        logical_name: str,
+        kind: str,
+        format_name: str,
+        media_type: str,
+        state: ArtifactState,
+        metadata: dict[str, Any],
+    ) -> ArtifactObservation:
+        """Create one exact file observation."""
+
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(cluster_path),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=path.stat().st_size,
+            checksum=f"sha256:{_sha256(path)}",
+            message="Closed BioBB molecular-dynamics setup product",
+            metadata=metadata,
+        )
+
+    def _finalize(self, *, return_code: int) -> list[ArtifactObservation]:
+        """Validate and report the exact result-declared files once."""
+
+        if self._finalized:
+            return []
+        self._finalized = True
+        result_path, document = self._result()
+        declared_return_code = document.get("return_code")
+        if isinstance(declared_return_code, bool) or not isinstance(
+            declared_return_code, int
+        ):
+            raise RuntimeError("BioBB result omitted its process return code")
+        members = self._members(document)
+        state = (
+            ArtifactState.FINALIZED
+            if return_code == 0
+            and declared_return_code == 0
+            and document["status"] == "completed"
+            else ArtifactState.INCOMPLETE
+        )
+        metadata = self._metadata(document)
+        observations = [
+            self._observation(
+                result_path,
+                self.output_dir / RESULT_NAME,
+                logical_name="biobb-md-setup-result",
+                kind="scientific_result",
+                format_name=RESULT_SCHEMA,
+                media_type="application/json",
+                state=state,
+                metadata=metadata,
+            )
+        ]
+        observations.extend(
+            self._observation(
+                path,
+                self.output_dir / relative,
+                logical_name=identity[0],
+                kind=identity[1],
+                format_name=identity[2],
+                media_type=identity[3],
+                state=state,
+                metadata=metadata,
+            )
+            for path, relative, identity in members
+        )
+        return observations
+
+
+def adapter_from_package(package: dict[str, Any]) -> BiobbMdSetupArtifactAdapter | None:
+    """Create artifact semantics only for builtin BioBB MD setup."""
+
+    if package.get("pkg_type") != "builtin.biobb_wf_md_setup":
+        return None
+    output_dir = _configured_output_dir(
+        package.get("out"),
+        shared_dir=package.get("shared_dir"),
+        runtime_cwd=package.get("runtime_cwd"),
+    )
+    deploy_mode = str(package.get("effective_deploy_mode") or "default").casefold()
+    if deploy_mode == "container":
+        roots = tuple(
+            root
+            for root in (
+                _optional_absolute_path(package.get("shared_dir")),
+                _optional_absolute_path(package.get("private_dir")),
+            )
+            if root is not None
+        )
+        if not any(output_dir.is_relative_to(root) for root in roots):
+            return None
+    return BiobbMdSetupArtifactAdapter(output_dir)
+
+
+def _configured_output_dir(
+    value: object,
+    *,
+    shared_dir: object,
+    runtime_cwd: object,
+) -> PurePosixPath:
+    """Resolve the normalized absolute output directory used by the package."""
+
+    raw = "run" if value in (None, "") else value
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("BioBB artifacts require a printable output path")
+    path = PurePosixPath(raw)
+    if not path.is_absolute():
+        base = _optional_absolute_path(shared_dir)
+        if base is None:
+            base = _optional_absolute_path(runtime_cwd)
+        if base is None:
+            raise ValueError(
+                "relative BioBB artifact output requires shared_dir or runtime_cwd"
+            )
+        path = base / path
+    normalized = PurePosixPath(posixpath.normpath(path.as_posix()))
+    if not normalized.is_absolute() or ".." in normalized.parts:
+        raise ValueError("BioBB artifacts require a normalized absolute output path")
+    return normalized
+
+
+def _optional_absolute_path(value: object) -> PurePosixPath | None:
+    """Return a normalized absolute POSIX path when one is available."""
+
+    if not isinstance(value, str) or not value:
+        return None
+    path = PurePosixPath(value)
+    if not path.is_absolute() or ".." in path.parts:
+        return None
+    return path
+
+
+__all__ = ["BiobbMdSetupArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/biobb_wf_md_setup/pkg.py
+++ b/builtin/builtin/biobb_wf_md_setup/pkg.py
@@ -1,180 +1,511 @@
-"""
-This module provides classes and methods to launch the biobb_wf_md_setup
-application.  BioExcel Building Blocks MD setup pipeline: fetch PDB,
-fix side chains, topology, box, solvation via GROMACS.
-"""
+"""Launch the BioBB five-stage molecular-dynamics setup workflow."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+from pathlib import Path
+from typing import Any
+
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, LocalExecInfo, PsshExecInfo
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    probe_program,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
+
+_MAX_PDB_BYTES = 32 * 1024 * 1024
+_NATIVE_INPUT_NAME = "input.pdb"
+_FORCE_FIELDS = frozenset(
+    {
+        "amber03",
+        "amber94",
+        "amber96",
+        "amber99",
+        "amber99sb",
+        "amber99sb-ildn",
+        "amberGS",
+        "charmm27",
+        "gromos43a1",
+        "gromos43a2",
+        "gromos45a3",
+        "gromos53a5",
+        "gromos53a6",
+        "gromos54a7",
+        "oplsaa",
+    }
+)
+_WATER_TYPES = frozenset({"spc", "spce", "tip3p", "tip4p", "tip5p", "tips3p"})
+_BOX_TYPES = frozenset({"cubic", "triclinic", "dodecahedron", "octahedron"})
 
 
 class BiobbWfMdSetup(Application):
-    """
-    BiobbWfMdSetup class supporting both default (bare-metal) and container
-    deployment.
+    """Prepare one caller-supplied molecular structure with BioBB and GROMACS.
 
-    Set deploy_mode='container' to build and run the biobb MD setup pipeline
-    inside a Docker/Podman/Apptainer container with GROMACS 2026.
-    Set deploy_mode='default' to use a system-installed environment.
+    Native mode copies an immutable PDB into package-owned storage and runs the
+    package-owned five-stage driver. Legacy container benchmarking remains
+    available but is not exposed as an agent-facing scientific profile.
     """
 
-    def _init(self):
-        pass
+    def _init(self) -> None:
+        self.python_bin: str | None = None
 
-    def _configure_menu(self):
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
             {
-                'name': 'nprocs',
-                'msg': 'Number of MPI processes',
-                'type': int,
-                'default': 1,
+                "name": "nprocs",
+                "msg": "Legacy process count; native MD setup is serial",
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
             },
             {
-                'name': 'ppn',
-                'msg': 'Processes per node',
-                'type': int,
-                'default': 1,
+                "name": "ppn",
+                "msg": "Legacy processes per node; native MD setup is serial",
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
             },
             {
-                'name': 'pdb_file',
-                'msg': 'Path to input PDB file',
-                'type': str,
-                'default': '/opt/biobb-bench/1AKI.pdb',
+                "name": "pdb_file",
+                "msg": (
+                    "Caller-supplied PDB structure. JARVIS copies it into the "
+                    "execution-owned output directory before launch."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                'name': 'out',
-                'msg': 'Output directory for results',
-                'type': str,
-                'default': '/tmp/biobb_out',
+                "name": "out",
+                "msg": (
+                    "Output directory. Relative paths resolve under the JARVIS "
+                    "package shared directory."
+                ),
+                "type": str,
+                "default": "run",
             },
             {
-                'name': 'replicates',
-                'msg': ('Number of times to run the MD-setup pipeline '
-                        'back-to-back inside the same container exec. '
-                        'Used to scale I/O for benchmarking when the '
-                        'bundled lysozyme PDB is too small to dominate '
-                        'wall time on its own.'),
-                'type': int,
-                'default': 1,
+                "name": "force_field",
+                "msg": "GROMACS force field used to construct the topology",
+                "type": str,
+                "default": "amber99sb-ildn",
             },
             {
-                'name': 'parallel_scratch_root',
-                'msg': ('Root dir for per-rep BIOBB_SCRATCH_DIR when '
-                        'parallel_reps > 1. Each rep gets '
-                        '`<root>/biobb-scratch-<rep>`. Default /dev/shm '
-                        '(node-local tmpfs). Point at a FUSE mount '
-                        'to route every GROMACS/biobb intermediate '
-                        'through that adapter.'),
-                'type': str,
-                'default': '/dev/shm',
+                "name": "water_type",
+                "msg": "GROMACS water model used by pdb2gmx and solvation",
+                "type": str,
+                "default": "tip3p",
             },
             {
-                'name': 'parallel_reps',
-                'msg': ('Per-host replicate concurrency. When > 1, the '
-                        'replicates loop fans across hosts via '
-                        'PsshExecInfo and each host runs this many in '
-                        'parallel using `wait -n` batching. Default 1 '
-                        'preserves the original host[0]-only sequential '
-                        'loop.'),
-                'type': int,
-                'default': 1,
+                "name": "box_type",
+                "msg": "Periodic simulation-box geometry",
+                "type": str,
+                "default": "cubic",
             },
             {
-                'name': 'omp_threads',
-                'msg': ('OMP_NUM_THREADS for each parallel replicate. '
-                        'Set to roughly cores_per_node / parallel_reps so '
-                        'concurrent GROMACS instances on the same host '
-                        'don\'t oversubscribe. 0 = leave unset (GROMACS '
-                        'auto-detects which over-grabs when run in '
-                        'parallel).'),
-                'type': int,
-                'default': 0,
+                "name": "distance_to_molecule",
+                "msg": "Minimum solute-to-box distance in nanometers",
+                "type": float,
+                "default": 1.0,
             },
             {
-                'name': 'md_steps',
-                'msg': ('Production MD step count for the biobb_md_extend '
-                        'post-step. Each step is 2 fs by default, so 5000 '
-                        'steps ≈ 10 ps simulated time. 0 = skip the MD '
-                        'extension entirely (legacy setup-only behavior).'),
-                'type': int,
-                'default': 0,
+                "name": "ignore_input_hydrogens",
+                "msg": "Regenerate hydrogens while constructing the topology",
+                "type": bool,
+                "default": True,
             },
             {
-                'name': 'md_nstxout',
-                'msg': ('XTC frame stride for the production MD '
-                        '(`nstxout-compressed` in the .mdp). Lower = more '
-                        'frames written = more I/O without changing '
-                        'compute. The per-rep trajectory file size is '
-                        'roughly md_steps / md_nstxout * frame_size.'),
-                'type': int,
-                'default': 100,
+                "name": "merge_chains",
+                "msg": "Merge all input chains into one molecule definition",
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'md_extend_script',
-                'msg': ('In-container path to the md-extend helper '
-                        'script. Bind the host script at this path via '
-                        '`container_binds` (e.g. '
-                        '${HOME}/jarvis-bench-scripts/biobb_md_extend.sh:'
-                        '/opt/biobb_md_extend.sh) and set md_steps > 0 '
-                        'to enable.'),
-                'type': str,
-                'default': '/opt/biobb_md_extend.sh',
+                "name": "replicates",
+                "msg": (
+                    "Number of times to run the MD-setup pipeline "
+                    "back-to-back inside the same container exec. "
+                    "Used to scale I/O for benchmarking when the "
+                    "bundled lysozyme PDB is too small to dominate "
+                    "wall time on its own."
+                ),
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
             },
             {
-                'name': 'base_image',
-                'msg': 'Base Docker image for build container',
-                'type': str,
-                'default': 'sci-hpc-base',
+                "name": "parallel_scratch_root",
+                "msg": (
+                    "Root dir for per-rep BIOBB_SCRATCH_DIR when "
+                    "parallel_reps > 1. Each rep gets "
+                    "`<root>/biobb-scratch-<rep>`. Default /dev/shm "
+                    "(node-local tmpfs). Point at a FUSE mount "
+                    "to route every GROMACS/biobb intermediate "
+                    "through that adapter."
+                ),
+                "type": str,
+                "default": "/dev/shm",
+                "agent_visible": False,
+            },
+            {
+                "name": "parallel_reps",
+                "msg": (
+                    "Per-host replicate concurrency. When > 1, the "
+                    "replicates loop fans across hosts via "
+                    "PsshExecInfo and each host runs this many in "
+                    "parallel using `wait -n` batching. Default 1 "
+                    "preserves the original host[0]-only sequential "
+                    "loop."
+                ),
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
+            },
+            {
+                "name": "omp_threads",
+                "msg": (
+                    "OMP_NUM_THREADS for each parallel replicate. "
+                    "Set to roughly cores_per_node / parallel_reps so "
+                    "concurrent GROMACS instances on the same host "
+                    "don't oversubscribe. 0 = leave unset (GROMACS "
+                    "auto-detects which over-grabs when run in "
+                    "parallel)."
+                ),
+                "type": int,
+                "default": 0,
+                "agent_visible": False,
+            },
+            {
+                "name": "md_steps",
+                "msg": (
+                    "Production MD step count for the biobb_md_extend "
+                    "post-step. Each step is 2 fs by default, so 5000 "
+                    "steps ≈ 10 ps simulated time. 0 = skip the MD "
+                    "extension entirely (legacy setup-only behavior)."
+                ),
+                "type": int,
+                "default": 0,
+                "agent_visible": False,
+            },
+            {
+                "name": "md_nstxout",
+                "msg": (
+                    "XTC frame stride for the production MD "
+                    "(`nstxout-compressed` in the .mdp). Lower = more "
+                    "frames written = more I/O without changing "
+                    "compute. The per-rep trajectory file size is "
+                    "roughly md_steps / md_nstxout * frame_size."
+                ),
+                "type": int,
+                "default": 100,
+                "agent_visible": False,
+            },
+            {
+                "name": "md_extend_script",
+                "msg": (
+                    "In-container path to the md-extend helper "
+                    "script. Bind the host script at this path via "
+                    "`container_binds` (e.g. "
+                    "${HOME}/jarvis-bench-scripts/biobb_md_extend.sh:"
+                    "/opt/biobb_md_extend.sh) and set md_steps > 0 "
+                    "to enable."
+                ),
+                "type": str,
+                "default": "/opt/biobb_md_extend.sh",
+                "agent_visible": False,
+            },
+            {
+                "name": "base_image",
+                "msg": "Base Docker image for build container",
+                "type": str,
+                "default": "sci-hpc-base",
+                "agent_visible": False,
             },
         ]
+
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe the native BioBB and GROMACS runtime requirements."""
+
+        environment = self._deployment_environment()
+        biobb_probe = probe_program(
+            "python3",
+            environment=environment,
+            arguments=("-c", "import biobb_gromacs, biobb_model"),
+            timeout_seconds=10,
+        )
+        gromacs_probe = probe_program(
+            "gmx",
+            environment=environment,
+            arguments=("--version",),
+            timeout_seconds=10,
+        )
+        requirements = (
+            RuntimeRequirement(
+                requirement_id="biobb_python",
+                description="Python runtime with BioBB model and GROMACS blocks",
+                required_capabilities=("biobb_md_setup",),
+                available_capabilities=(
+                    ("biobb_md_setup",) if biobb_probe.status.usable is True else ()
+                ),
+                status=biobb_probe.status,
+                provider_resolutions=(
+                    ProviderResolution("python", "distribution", "biobb-gromacs"),
+                    ProviderResolution("python", "distribution", "biobb-model"),
+                ),
+            ),
+            RuntimeRequirement(
+                requirement_id="gromacs",
+                description="GROMACS command-line runtime available through PATH",
+                required_capabilities=("molecular_dynamics_preparation",),
+                available_capabilities=(
+                    ("molecular_dynamics_preparation",)
+                    if gromacs_probe.status.usable is True
+                    else ()
+                ),
+                status=gromacs_probe.status,
+                provider_resolutions=(ProviderResolution("spack", "spec", "gromacs"),),
+            ),
+        )
+        return PackageDeploymentContract(
+            package="builtin.biobb_wf_md_setup",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="native_md_setup",
+                    execution_kind="batch",
+                    when=(
+                        ConfigurationCondition("deploy_mode", "equals", "default"),
+                        ConfigurationCondition("pdb_file", "is_not_empty"),
+                    ),
+                    runtime_requirements=("biobb_python", "gromacs"),
+                    readiness=ReadinessContract(
+                        mechanism="process_exit", condition="successful_exit"
+                    ),
+                    description=(
+                        "Prepare one caller-supplied PDB through side-chain repair, "
+                        "topology generation, box construction, and solvation."
+                    ),
+                ),
+            ),
+            runtime_requirements=requirements,
+        )
 
     # ------------------------------------------------------------------
     # Container Dockerfile generators
     # ------------------------------------------------------------------
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _build_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
             return None
-        content = self._read_build_script('build.sh', {
-            'BASE_IMAGE': self.config.get('base_image', 'sci-hpc-base'),
-        })
-        return content, 'gromacs2026'
+        content = self._read_build_script(
+            "build.sh",
+            {
+                "BASE_IMAGE": self.config.get("base_image", "sci-hpc-base"),
+            },
+        )
+        return content, "gromacs2026"
 
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
             return None
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': 'ubuntu:24.04',
-        })
-        return content, 'gromacs2026'
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {
+                "BUILD_IMAGE": self.build_image_name(),
+                "DEPLOY_BASE": "ubuntu:24.04",
+            },
+        )
+        return content, "gromacs2026"
 
     # ------------------------------------------------------------------
     # Configuration
     # ------------------------------------------------------------------
 
-    def _configure(self, **kwargs):
-        """
-        Configure biobb_wf_md_setup.
+    def _configure(self, **kwargs: Any) -> None:
+        """Validate native settings and prepare package-owned output storage."""
 
-        Calls super()._configure() which updates self.config and (when
-        deploy_mode == 'container') triggers build_phase / build_deploy_phase.
-
-        In default mode, also creates the output directory on all nodes.
-        """
         super()._configure(**kwargs)
+        if self.config.get("deploy_mode") == "default":
+            self._validate_native_configuration()
+            self.python_bin = self._discover_python(self._deployment_environment())
+            self._ensure_output_dir()
 
-        if self.config.get('deploy_mode') == 'default':
-            if self.config['out']:
-                Mkdir(self.config['out'],
-                      PsshExecInfo(hostfile=self.hostfile,
-                                   env=self.env)).run()
+    @staticmethod
+    def _discover_python(environment: dict[str, str]) -> str | None:
+        """Return a Python command from the activated package environment."""
+
+        for candidate in ("python3", "python"):
+            if shutil.which(candidate, path=environment.get("PATH")) is not None:
+                return candidate
+        return None
+
+    def _output_dir(self) -> Path:
+        """Return the normalized package-owned output root."""
+
+        return self.resolve_shared_path(
+            self.config.get("out"), field="out", default="run"
+        )
+
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        """Return local or parallel-SSH execution according to the hostfile."""
+
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
+
+    def _ensure_output_dir(self) -> None:
+        """Create the exact output root on every participating host."""
+
+        output_dir = str(self._output_dir())
+        result = Mkdir(output_dir, self._node_exec_info(env=self.env)).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to create BioBB output directory {output_dir}: {failures}"
+            )
+
+    def _validate_native_configuration(self) -> None:
+        """Reject missing input and unsupported scientific settings locally."""
+
+        pdb_file = self.config.get("pdb_file")
+        if not isinstance(pdb_file, str) or not pdb_file:
+            raise ValueError("native BioBB MD setup requires pdb_file")
+        for name, supported in (
+            ("force_field", _FORCE_FIELDS),
+            ("water_type", _WATER_TYPES),
+            ("box_type", _BOX_TYPES),
+        ):
+            value = self.config.get(name)
+            if not isinstance(value, str) or value not in supported:
+                raise ValueError(f"unsupported {name}: {value!r}")
+        distance = self.config.get("distance_to_molecule")
+        if (
+            isinstance(distance, bool)
+            or not isinstance(distance, (int, float))
+            or not 0 < float(distance) <= 10
+        ):
+            raise ValueError(
+                "distance_to_molecule must be greater than 0 and at most 10"
+            )
+        for name in ("ignore_input_hydrogens", "merge_chains"):
+            if not isinstance(self.config.get(name), bool):
+                raise ValueError(f"{name} must be a boolean")
+
+    def _stage_native_input(self) -> Path:
+        """Copy one bounded caller PDB into execution-owned storage."""
+
+        self._validate_native_configuration()
+        self._ensure_output_dir()
+        configured = self.config.get("pdb_file")
+        if not isinstance(configured, str):
+            raise ValueError("native BioBB MD setup requires pdb_file")
+        source = Path(
+            os.path.abspath(os.path.expandvars(os.path.expanduser(configured)))
+        )
+        try:
+            status = source.lstat()
+        except OSError as exc:
+            raise ValueError("pdb_file is not a readable bounded regular PDB") from exc
+        if (
+            source.is_symlink()
+            or not source.is_file()
+            or source.suffix.casefold() != ".pdb"
+            or status.st_size <= 0
+            or status.st_size > _MAX_PDB_BYTES
+        ):
+            raise ValueError("pdb_file is not a bounded regular PDB")
+        destination = self._output_dir() / _NATIVE_INPUT_NAME
+        if destination.exists() or destination.is_symlink():
+            raise ValueError("BioBB staged input already exists")
+        shutil.copyfile(source, destination, follow_symlinks=False)
+        os.chmod(destination, 0o600)
+        return destination
+
+    def _start_native(self) -> None:
+        """Execute the package-owned BioBB workflow and propagate failure."""
+
+        staged = self._stage_native_input()
+        python_bin = self.python_bin or self._discover_python(self.mod_env)
+        if python_bin is None:
+            raise RuntimeError("BioBB Python runtime is unavailable through PATH")
+        script = Path(__file__).with_name("run_md_setup.py").resolve()
+        force_field = self.config.get("force_field")
+        water_type = self.config.get("water_type")
+        box_type = self.config.get("box_type")
+        distance = self.config.get("distance_to_molecule")
+        if (
+            not isinstance(force_field, str)
+            or not isinstance(water_type, str)
+            or not isinstance(box_type, str)
+            or isinstance(distance, bool)
+            or not isinstance(distance, (int, float))
+        ):
+            raise RuntimeError("validated BioBB scientific configuration was lost")
+        args = [
+            python_bin,
+            str(script),
+            str(staged),
+            str(staged.parent),
+            "--force-field",
+            force_field,
+            "--water-type",
+            water_type,
+            "--box-type",
+            box_type,
+            "--distance-to-molecule",
+            str(float(distance)),
+            "--gmx",
+            "gmx",
+        ]
+        if self.config.get("ignore_input_hydrogens") is True:
+            args.append("--ignore-input-hydrogens")
+        if self.config.get("merge_chains") is True:
+            args.append("--merge-chains")
+        command = " ".join(shlex.quote(argument) for argument in args)
+        result = Exec(
+            command,
+            LocalExecInfo(
+                env=self.mod_env,
+                cwd=str(staged.parent),
+                line_callback=self.runtime_line_callback(),
+            ),
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"BioBB MD setup failed: {failures}")
+
+    def _legacy_integer(self, name: str, default: int) -> int:
+        """Read one legacy container integer without permissive coercion."""
+
+        value = self.config.get(name, default)
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"{name} must be an integer")
+        return value
+
+    def _legacy_string(self, name: str, default: str) -> str:
+        """Read one legacy container string without implicit serialization."""
+
+        value = self.config.get(name, default)
+        if not isinstance(value, str):
+            raise ValueError(f"{name} must be a string")
+        return value
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
-    def start(self):
+    def start(self) -> None:
         """
         Launch biobb_wf_md_setup.
 
@@ -190,12 +521,12 @@ class BiobbWfMdSetup(Application):
         pdb_file config point at either a single PDB or a directory of
         PDBs.
         """
-        if self.config.get('deploy_mode') == 'container':
-            replicates = max(int(self.config.get('replicates', 1) or 1), 1)
-            parallel = max(int(self.config.get('parallel_reps', 1) or 1), 1)
-            omp = int(self.config.get('omp_threads', 0) or 0)
-            pdb_in = self.config['pdb_file']
-            out_root = self.config['out']
+        if self.config.get("deploy_mode") == "container":
+            replicates = max(self._legacy_integer("replicates", 1), 1)
+            parallel = max(self._legacy_integer("parallel_reps", 1), 1)
+            omp = self._legacy_integer("omp_threads", 0)
+            pdb_in = self._legacy_string("pdb_file", "")
+            out_root = self._legacy_string("out", "run")
 
             if parallel <= 1:
                 # Original single-host sequential path. Preserved for
@@ -208,17 +539,20 @@ class BiobbWfMdSetup(Application):
                         f"set -e; "
                         f"for i in $(seq 1 {replicates}); do "
                         f"  rep=$(printf 'rep_%03d' \"$i\"); "
-                        f"  echo \"=== biobb replicate $rep ($i/{replicates}) ===\"; "
+                        f'  echo "=== biobb replicate $rep ($i/{replicates}) ==="; '
                         f"  /opt/run_batch.sh '{pdb_in}' '{out_root}/'$rep || exit 1; "
                         f"done"
                     )
-                Exec(cmd, LocalExecInfo(
-                    container=self._container_engine,
-                    container_image=self.deploy_image_name(),
-                    shared_dir=self.shared_dir,
-                    private_dir=self.private_dir,
-                    env=self.mod_env,
-                )).run()
+                Exec(
+                    cmd,
+                    LocalExecInfo(
+                        container=self._container_engine,
+                        container_image=self.deploy_image_name(),
+                        shared_dir=self.shared_dir,
+                        private_dir=self.private_dir,
+                        env=self.mod_env,
+                    ),
+                ).run()
                 return
 
             # parallel_reps > 1: fan replicates across every host in the
@@ -237,31 +571,27 @@ class BiobbWfMdSetup(Application):
             # fail with "File exists / Invalid argument".
             nhosts = max(len(self.hostfile.hosts), 1) if self.hostfile else 1
             local_reps = (replicates + nhosts - 1) // nhosts  # ceil
-            scratch_root = (self.config.get('parallel_scratch_root')
-                            or '/dev/shm').rstrip('/')
-            omp_export = (
-                f"export OMP_NUM_THREADS={omp}; " if omp > 0 else ""
-            )
+            scratch_root = self._legacy_string(
+                "parallel_scratch_root", "/dev/shm"
+            ).rstrip("/")
+            omp_export = f"export OMP_NUM_THREADS={omp}; " if omp > 0 else ""
             # MD extension: when md_steps > 0, chain the in-container
             # helper script after /opt/run_batch.sh in each rep. Adds
             # an EM + production-NVT pass on top of the setup-only biobb
             # pipeline so the workflow generates real trajectory data
             # decoupled from compute step count via nstxout-compressed.
-            md_steps = int(self.config.get('md_steps', 0) or 0)
-            md_nstxout = int(self.config.get('md_nstxout', 100) or 100)
-            md_extend_script = self.config.get('md_extend_script') or \
-                '/opt/biobb_md_extend.sh'
+            md_steps = self._legacy_integer("md_steps", 0)
+            md_nstxout = self._legacy_integer("md_nstxout", 100)
+            md_extend_script = self._legacy_string(
+                "md_extend_script", "/opt/biobb_md_extend.sh"
+            )
             md_export = ""
             md_chain = ""
             if md_steps > 0:
                 md_export = (
-                    f"export MD_STEPS={md_steps}; "
-                    f"export MD_NSTXOUT={md_nstxout}; "
+                    f"export MD_STEPS={md_steps}; export MD_NSTXOUT={md_nstxout}; "
                 )
-                md_chain = (
-                    f"      && {md_extend_script} "
-                    f"\"$BIOBB_SCRATCH_DIR\" \"$out\" "
-                )
+                md_chain = f'      && {md_extend_script} "$BIOBB_SCRATCH_DIR" "$out" '
             # Build command. Bash $$, $!, ${{}}, ${{#PIDS[@]}}, ${{PIDS[@]:1}}
             # all need doubled braces / escape so f-string passes them
             # through untouched.
@@ -275,48 +605,55 @@ class BiobbWfMdSetup(Application):
                 f"PDB='{pdb_in}'; "
                 f"OUT='{out_root}'; "
                 f"H=$(hostname -s); "
-                f"echo \"[biobb-parallel] host=$H reps=$LOCAL parallel=$PAR omp=${{OMP_NUM_THREADS:-default}} md_steps=${{MD_STEPS:-0}} md_nstxout=${{MD_NSTXOUT:-0}}\"; "
+                f'echo "[biobb-parallel] host=$H reps=$LOCAL parallel=$PAR omp=${{OMP_NUM_THREADS:-default}} md_steps=${{MD_STEPS:-0}} md_nstxout=${{MD_NSTXOUT:-0}}"; '
                 f"PIDS=(); "
                 f"for i in $(seq 1 $LOCAL); do "
                 f"  ( "
-                f"    rep=$(printf 'rep_%03d-%s' \"$i\" \"$H\"); "
-                f"    out=\"$OUT/$rep\"; "
-                f"    export BIOBB_SCRATCH_DIR=\"{scratch_root}/biobb-scratch-$rep\"; "
-                f"    /opt/run_batch.sh \"$PDB\" \"$out\" "
+                f'    rep=$(printf \'rep_%03d-%s\' "$i" "$H"); '
+                f'    out="$OUT/$rep"; '
+                f'    export BIOBB_SCRATCH_DIR="{scratch_root}/biobb-scratch-$rep"; '
+                f'    /opt/run_batch.sh "$PDB" "$out" '
                 f"{md_chain}"
-                f"      && echo \"[biobb-parallel] host=$H $rep DONE\" "
-                f"      || {{ echo \"[biobb-parallel] host=$H $rep FAILED\" >&2; exit 1; }} "
+                f'      && echo "[biobb-parallel] host=$H $rep DONE" '
+                f'      || {{ echo "[biobb-parallel] host=$H $rep FAILED" >&2; exit 1; }} '
                 f"  ) & "
                 f"  PIDS+=($!); "
-                f"  if [ \"${{#PIDS[@]}}\" -ge $PAR ]; then "
+                f'  if [ "${{#PIDS[@]}}" -ge $PAR ]; then '
                 f"    wait -n; "
-                f"    PIDS=(\"${{PIDS[@]:1}}\"); "
+                f'    PIDS=("${{PIDS[@]:1}}"); '
                 f"  fi; "
                 f"done; "
                 f"wait"
             )
-            Exec(cmd, PsshExecInfo(
-                hostfile=self.hostfile,
-                container=self._container_engine,
-                container_image=self.deploy_image_name(),
-                shared_dir=self.shared_dir,
-                private_dir=self.private_dir,
-                env=self.mod_env,
-            )).run()
+            Exec(
+                cmd,
+                PsshExecInfo(
+                    hostfile=self.hostfile,
+                    container=self._container_engine,
+                    container_image=self.deploy_image_name(),
+                    shared_dir=self.shared_dir,
+                    private_dir=self.private_dir,
+                    env=self.mod_env,
+                ),
+            ).run()
         else:
-            cmd = ' '.join([
-                'python3', '/opt/run_md_setup.py',
-                self.config['pdb_file'],
-                self.config['out'],
-            ])
-            Exec(cmd, LocalExecInfo(env=self.mod_env)).run()
+            self._start_native()
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop biobb_wf_md_setup (no-op -- runs to completion)."""
         pass
 
-    def clean(self):
-        """Remove biobb_wf_md_setup output directory."""
-        if self.config['out']:
-            Rm(self.config['out'] + '*',
-               PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+    def clean(self) -> None:
+        """Remove only the exact configured BioBB output directory."""
+
+        output_dir = self._output_dir()
+        if output_dir == Path(output_dir.anchor):
+            raise ValueError("refusing to clean a filesystem root as BioBB output")
+        result = Rm(
+            str(output_dir),
+            self._node_exec_info(env=self.env),
+            recursive=True,
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"Failed to clean BioBB output {output_dir}: {failures}")

--- a/builtin/builtin/biobb_wf_md_setup/pkg.py
+++ b/builtin/builtin/biobb_wf_md_setup/pkg.py
@@ -24,6 +24,7 @@ from jarvis_cd.shell.process import Mkdir, Rm
 
 _MAX_PDB_BYTES = 32 * 1024 * 1024
 _NATIVE_INPUT_NAME = "input.pdb"
+_GROMACS_EXECUTABLES = ("gmx", "gmx_mpi")
 _FORCE_FIELDS = frozenset(
     {
         "amber03",
@@ -57,6 +58,7 @@ class BiobbWfMdSetup(Application):
 
     def _init(self) -> None:
         self.python_bin: str | None = None
+        self.gmx_bin: str | None = None
 
     def _configure_menu(self) -> list[dict[str, Any]]:
         return [
@@ -238,14 +240,16 @@ class BiobbWfMdSetup(Application):
         """Describe the native BioBB and GROMACS runtime requirements."""
 
         environment = self._deployment_environment()
+        python_program = self._discover_python(environment) or "python3"
+        gromacs_program = self._discover_gromacs(environment) or "gmx"
         biobb_probe = probe_program(
-            "python3",
+            python_program,
             environment=environment,
             arguments=("-c", "import biobb_gromacs, biobb_model"),
             timeout_seconds=10,
         )
         gromacs_probe = probe_program(
-            "gmx",
+            gromacs_program,
             environment=environment,
             arguments=("--version",),
             timeout_seconds=10,
@@ -338,6 +342,7 @@ class BiobbWfMdSetup(Application):
         if self.config.get("deploy_mode") == "default":
             self._validate_native_configuration()
             self.python_bin = self._discover_python(self._deployment_environment())
+            self.gmx_bin = self._discover_gromacs(self._deployment_environment())
             self._ensure_output_dir()
 
     @staticmethod
@@ -345,6 +350,15 @@ class BiobbWfMdSetup(Application):
         """Return a Python command from the activated package environment."""
 
         for candidate in ("python3", "python"):
+            if shutil.which(candidate, path=environment.get("PATH")) is not None:
+                return candidate
+        return None
+
+    @staticmethod
+    def _discover_gromacs(environment: dict[str, str]) -> str | None:
+        """Return the first supported GROMACS executable available through PATH."""
+
+        for candidate in _GROMACS_EXECUTABLES:
             if shutil.which(candidate, path=environment.get("PATH")) is not None:
                 return candidate
         return None
@@ -439,6 +453,9 @@ class BiobbWfMdSetup(Application):
         python_bin = self.python_bin or self._discover_python(self.mod_env)
         if python_bin is None:
             raise RuntimeError("BioBB Python runtime is unavailable through PATH")
+        gmx_bin = self.gmx_bin or self._discover_gromacs(self.mod_env)
+        if gmx_bin is None:
+            raise RuntimeError("GROMACS runtime is unavailable through PATH")
         script = Path(__file__).with_name("run_md_setup.py").resolve()
         force_field = self.config.get("force_field")
         water_type = self.config.get("water_type")
@@ -466,7 +483,7 @@ class BiobbWfMdSetup(Application):
             "--distance-to-molecule",
             str(float(distance)),
             "--gmx",
-            "gmx",
+            gmx_bin,
         ]
         if self.config.get("ignore_input_hydrogens") is True:
             args.append("--ignore-input-hydrogens")

--- a/builtin/builtin/biobb_wf_md_setup/run_batch.sh
+++ b/builtin/builtin/biobb_wf_md_setup/run_batch.sh
@@ -74,7 +74,7 @@ else
     PASS=0; FAIL=0
     for p in "${PDBS[@]}"; do
         tag=$(basename "$p" .pdb)
-        if ls "$OUT_DIR/$tag/"*_solvate.gro >/dev/null 2>&1; then
+        if [ -s "$OUT_DIR/$tag/solvated.gro" ]; then
             PASS=$((PASS+1))
         else
             FAIL=$((FAIL+1))

--- a/builtin/builtin/biobb_wf_md_setup/run_md_setup.py
+++ b/builtin/builtin/biobb_wf_md_setup/run_md_setup.py
@@ -1,63 +1,415 @@
-#!/opt/biobb-env/bin/python
-"""Five-step MD setup for a single PDB. Exit 0 on full success."""
-import os, sys, shutil, time
-pdb_in = sys.argv[1]
-workdir = sys.argv[2]
-os.makedirs(workdir, exist_ok=True)
-os.chdir(workdir)
-code = os.path.splitext(os.path.basename(pdb_in))[0]
-t0 = time.time()
-results = {}
+#!/usr/bin/env python3
+"""Run and record one five-stage BioBB molecular-dynamics setup cell."""
 
-local = os.path.join(workdir, code + '.pdb')
-if not os.path.exists(local):
-    shutil.copy(pdb_in, local)
-results['1_stage'] = 'PASS'
+from __future__ import annotations
 
-from biobb_model.model.fix_side_chain import fix_side_chain
-from biobb_gromacs.gromacs.pdb2gmx   import pdb2gmx
-from biobb_gromacs.gromacs.editconf  import editconf
-from biobb_gromacs.gromacs.solvate   import solvate
+import argparse
+import hashlib
+import json
+import math
+import os
+import shutil
+import time
+import zipfile
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
 
-def ok(path):
-    return os.path.isfile(path) and os.path.getsize(path) > 0
+RESULT_SCHEMA = "jarvis.biobb-md-setup-result.v1"
+RESULT_NAME = "biobb-result.json"
 
-fixed = os.path.join(workdir, code + '_fixed.pdb')
-try:
-    fix_side_chain(input_pdb_path=local, output_pdb_path=fixed)
-    results['2_fix_side_chain'] = 'PASS' if ok(fixed) else 'FAIL'
-except Exception as e:
-    results['2_fix_side_chain'] = f'FAIL: {e}'
 
-gro  = os.path.join(workdir, code + '_pdb2gmx.gro')
-topz = os.path.join(workdir, code + '_pdb2gmx_top.zip')
-if results['2_fix_side_chain'] == 'PASS':
+@dataclass(frozen=True, slots=True)
+class RunConfiguration:
+    """Closed scientific configuration for one BioBB MD-setup execution."""
+
+    input_pdb: Path
+    output_dir: Path
+    force_field: str
+    water_type: str
+    box_type: str
+    distance_to_molecule: float
+    ignore_input_hydrogens: bool
+    merge_chains: bool
+    gmx: str
+
+
+@dataclass(frozen=True, slots=True)
+class BioBBFunctions:
+    """Loaded BioBB entrypoints used by the package-owned driver."""
+
+    fix_side_chain: Callable[..., Any]
+    pdb2gmx: Callable[..., Any]
+    editconf: Callable[..., Any]
+    solvate: Callable[..., Any]
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA-256 digest of one bounded file."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _require_file(path: Path, description: str) -> None:
+    """Require one nonempty regular, non-symlink stage product."""
+
+    if path.is_symlink() or not path.is_file() or path.stat().st_size <= 0:
+        raise RuntimeError(f"BioBB did not produce {description}: {path.name}")
+
+
+def _pdb_atom_count(path: Path) -> int:
+    """Count coordinate records in a PDB file."""
+
+    with path.open("r", encoding="utf-8", errors="replace") as stream:
+        return sum(line.startswith(("ATOM  ", "HETATM")) for line in stream)
+
+
+def _gro_metrics(path: Path) -> dict[str, Any]:
+    """Read the atom count and periodic-box volume from a GROMACS GRO file."""
+
+    lines = path.read_text(encoding="utf-8", errors="strict").splitlines()
+    if len(lines) < 3:
+        raise RuntimeError(f"GRO output is truncated: {path.name}")
     try:
-        pdb2gmx(input_pdb_path=fixed, output_gro_path=gro, output_top_zip_path=topz)
-        results['3_pdb2gmx'] = 'PASS' if ok(gro) else 'FAIL'
-    except Exception as e:
-        results['3_pdb2gmx'] = f'FAIL: {e}'
+        atom_count = int(lines[1].strip())
+        values = [float(value) for value in lines[-1].split()]
+    except ValueError as exc:
+        raise RuntimeError(f"GRO output is malformed: {path.name}") from exc
+    if atom_count <= 0 or len(lines) < atom_count + 3 or len(values) not in {3, 9}:
+        raise RuntimeError(f"GRO output is malformed: {path.name}")
+    if len(values) == 3:
+        volume = values[0] * values[1] * values[2]
+    else:
+        first = (values[0], values[3], values[4])
+        second = (values[5], values[1], values[6])
+        third = (values[7], values[8], values[2])
+        volume = abs(
+            first[0] * (second[1] * third[2] - second[2] * third[1])
+            - first[1] * (second[0] * third[2] - second[2] * third[0])
+            + first[2] * (second[0] * third[1] - second[1] * third[0])
+        )
+    if not math.isfinite(volume) or volume <= 0:
+        raise RuntimeError(f"GRO output has an invalid box: {path.name}")
+    return {
+        "atom_count": atom_count,
+        "box_values_nm": values,
+        "box_volume_nm3": volume,
+    }
 
-    if results.get('3_pdb2gmx') == 'PASS':
-        box = os.path.join(workdir, code + '_editconf.gro')
+
+def _topology_molecule_counts(path: Path) -> dict[str, int]:
+    """Read the closed ``[ molecules ]`` table from a topology ZIP archive."""
+
+    counts: dict[str, int] = {}
+    try:
+        with zipfile.ZipFile(path) as archive:
+            candidates = sorted(
+                name
+                for name in archive.namelist()
+                if not name.endswith("/") and name.casefold().endswith(".top")
+            )
+            if not candidates:
+                raise RuntimeError("topology archive has no .top member")
+            text = archive.read(candidates[0]).decode("utf-8", errors="strict")
+    except (OSError, UnicodeError, zipfile.BadZipFile, KeyError) as exc:
+        raise RuntimeError(f"cannot read topology archive: {path.name}") from exc
+    in_molecules = False
+    for raw_line in text.splitlines():
+        line = raw_line.split(";", maxsplit=1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_molecules = line[1:-1].strip().casefold() == "molecules"
+            continue
+        if not in_molecules:
+            continue
+        fields = line.split()
+        if len(fields) < 2:
+            continue
         try:
-            editconf(input_gro_path=gro, output_gro_path=box,
-                     properties={'box_type': 'cubic', 'distance_to_molecule': 1.0})
-            results['4_editconf'] = 'PASS' if ok(box) else 'FAIL'
-        except Exception as e:
-            results['4_editconf'] = f'FAIL: {e}'
+            count = int(fields[-1])
+        except ValueError as exc:
+            raise RuntimeError("topology molecules table is malformed") from exc
+        if count < 0:
+            raise RuntimeError("topology molecule count cannot be negative")
+        name = fields[0]
+        counts[name] = counts.get(name, 0) + count
+    if not counts:
+        raise RuntimeError("topology archive has no molecule counts")
+    return counts
 
-        if results.get('4_editconf') == 'PASS':
-            sol    = os.path.join(workdir, code + '_solvate.gro')
-            soltop = os.path.join(workdir, code + '_solvate_top.zip')
-            try:
-                solvate(input_solute_gro_path=box, output_gro_path=sol,
-                        input_top_zip_path=topz, output_top_zip_path=soltop)
-                results['5_solvate'] = 'PASS' if ok(sol) else 'FAIL'
-            except Exception as e:
-                results['5_solvate'] = f'FAIL: {e}'
 
-print(f"\n=== {code} results ({time.time()-t0:.1f}s) ===")
-for k, v in results.items():
-    print(f"  {k}: {v}")
-sys.exit(0 if all(v == 'PASS' for v in results.values()) else 1)
+def _load_functions() -> BioBBFunctions:
+    """Import BioBB lazily so package inspection needs no scientific runtime."""
+
+    from biobb_gromacs.gromacs.editconf import (  # pyright: ignore[reportMissingImports]
+        editconf,
+    )
+    from biobb_gromacs.gromacs.pdb2gmx import (  # pyright: ignore[reportMissingImports]
+        pdb2gmx,
+    )
+    from biobb_gromacs.gromacs.solvate import (  # pyright: ignore[reportMissingImports]
+        solvate,
+    )
+    from biobb_model.model.fix_side_chain import (  # pyright: ignore[reportMissingImports]
+        fix_side_chain,
+    )
+
+    return BioBBFunctions(fix_side_chain, pdb2gmx, editconf, solvate)
+
+
+def _invoke(name: str, function: Callable[..., Any], **kwargs: Any) -> dict[str, Any]:
+    """Execute one BioBB block and return a closed successful stage record."""
+
+    started = time.monotonic()
+    return_code = function(**kwargs)
+    if isinstance(return_code, int) and not isinstance(return_code, bool):
+        if return_code != 0:
+            raise RuntimeError(f"BioBB stage {name} returned {return_code}")
+    return {
+        "name": name,
+        "status": "completed",
+        "elapsed_seconds": round(time.monotonic() - started, 6),
+    }
+
+
+def _artifact(root: Path, path: Path, *, format_name: str) -> dict[str, Any]:
+    """Describe one exact output relative to the owned result root."""
+
+    resolved_root = root.resolve(strict=True)
+    resolved = path.resolve(strict=True)
+    if path.is_symlink() or not resolved.is_relative_to(resolved_root):
+        raise RuntimeError(f"BioBB output escaped its owned root: {path}")
+    size = resolved.stat().st_size
+    if not resolved.is_file() or size <= 0:
+        raise RuntimeError(f"BioBB output is missing: {path.name}")
+    return {
+        "path": resolved.relative_to(resolved_root).as_posix(),
+        "format": format_name,
+        "size_bytes": size,
+        "sha256": _sha256(resolved),
+    }
+
+
+def run(
+    config: RunConfiguration,
+    *,
+    functions: BioBBFunctions | None = None,
+) -> int:
+    """Execute the BioBB workflow and write a machine-readable result document."""
+
+    root = config.output_dir.resolve(strict=True)
+    input_path = config.input_pdb.resolve(strict=True)
+    if (
+        config.input_pdb.is_symlink()
+        or not input_path.is_file()
+        or not input_path.is_relative_to(root)
+    ):
+        raise ValueError("input PDB must be a regular file in the output directory")
+    loaded = functions or _load_functions()
+    fixed = root / "fixed.pdb"
+    processed = root / "processed.gro"
+    processed_topology = root / "processed_topology.zip"
+    boxed = root / "boxed.gro"
+    solvated = root / "solvated.gro"
+    solvated_topology = root / "solvated_topology.zip"
+    stages: list[dict[str, Any]] = [
+        {"name": "stage_input", "status": "completed", "elapsed_seconds": 0.0}
+    ]
+    output_specs: list[tuple[Path, str]] = []
+    status = "completed"
+    error: dict[str, str] | None = None
+    started = time.monotonic()
+    try:
+        stages.append(
+            _invoke(
+                "fix_side_chain",
+                loaded.fix_side_chain,
+                input_pdb_path=str(input_path),
+                output_pdb_path=str(fixed),
+            )
+        )
+        _require_file(fixed, "side-chain-repaired PDB")
+        output_specs.append((fixed, "pdb"))
+        stages.append(
+            _invoke(
+                "pdb2gmx",
+                loaded.pdb2gmx,
+                input_pdb_path=str(fixed),
+                output_gro_path=str(processed),
+                output_top_zip_path=str(processed_topology),
+                properties={
+                    "force_field": config.force_field,
+                    "water_type": config.water_type,
+                    "ignh": config.ignore_input_hydrogens,
+                    "merge": config.merge_chains,
+                    "gmx_path": config.gmx,
+                },
+            )
+        )
+        _require_file(processed, "pdb2gmx coordinates")
+        _require_file(processed_topology, "pdb2gmx topology")
+        output_specs.extend(
+            ((processed, "gromacs-gro"), (processed_topology, "gromacs-topology-zip"))
+        )
+        stages.append(
+            _invoke(
+                "editconf",
+                loaded.editconf,
+                input_gro_path=str(processed),
+                output_gro_path=str(boxed),
+                properties={
+                    "box_type": config.box_type,
+                    "distance_to_molecule": config.distance_to_molecule,
+                    "center_molecule": True,
+                    "gmx_path": config.gmx,
+                },
+            )
+        )
+        _require_file(boxed, "boxed coordinates")
+        output_specs.append((boxed, "gromacs-gro"))
+        stages.append(
+            _invoke(
+                "solvate",
+                loaded.solvate,
+                input_solute_gro_path=str(boxed),
+                output_gro_path=str(solvated),
+                input_top_zip_path=str(processed_topology),
+                output_top_zip_path=str(solvated_topology),
+                properties={"gmx_path": config.gmx},
+            )
+        )
+        _require_file(solvated, "solvated coordinates")
+        _require_file(solvated_topology, "solvated topology")
+        output_specs.extend(
+            ((solvated, "gromacs-gro"), (solvated_topology, "gromacs-topology-zip"))
+        )
+    except Exception as exc:
+        status = "failed"
+        error = {"type": type(exc).__name__, "message": str(exc)[:2048]}
+        stages.append(
+            {
+                "name": "workflow",
+                "status": "failed",
+                "elapsed_seconds": round(time.monotonic() - started, 6),
+                "error": error,
+            }
+        )
+
+    metrics: dict[str, Any] = {"input_pdb_atom_count": _pdb_atom_count(input_path)}
+    if status == "completed":
+        try:
+            boxed_metrics = _gro_metrics(boxed)
+            solvated_metrics = _gro_metrics(solvated)
+            molecule_counts = _topology_molecule_counts(solvated_topology)
+            metrics.update(
+                {
+                    "boxed_atom_count": boxed_metrics["atom_count"],
+                    "boxed_volume_nm3": boxed_metrics["box_volume_nm3"],
+                    "solvated_atom_count": solvated_metrics["atom_count"],
+                    "solvated_volume_nm3": solvated_metrics["box_volume_nm3"],
+                    "molecule_counts": molecule_counts,
+                    "solvent_molecule_count": molecule_counts.get(
+                        "SOL", molecule_counts.get("WAT")
+                    ),
+                }
+            )
+        except Exception as exc:
+            status = "failed"
+            error = {"type": type(exc).__name__, "message": str(exc)[:2048]}
+            stages.append(
+                {
+                    "name": "validate_outputs",
+                    "status": "failed",
+                    "elapsed_seconds": round(time.monotonic() - started, 6),
+                    "error": error,
+                }
+            )
+    artifacts = [
+        _artifact(root, path, format_name=format_name)
+        for path, format_name in output_specs
+        if path.exists() and not path.is_symlink() and path.is_file()
+    ]
+    result: dict[str, Any] = {
+        "schema_version": RESULT_SCHEMA,
+        "status": status,
+        "return_code": 0 if status == "completed" else 1,
+        "elapsed_seconds": round(time.monotonic() - started, 6),
+        "parameters": {
+            "force_field": config.force_field,
+            "water_type": config.water_type,
+            "box_type": config.box_type,
+            "distance_to_molecule": config.distance_to_molecule,
+            "ignore_input_hydrogens": config.ignore_input_hydrogens,
+            "merge_chains": config.merge_chains,
+        },
+        "input": {
+            "path": input_path.relative_to(root).as_posix(),
+            "size_bytes": input_path.stat().st_size,
+            "sha256": _sha256(input_path),
+        },
+        "stages": stages,
+        "metrics": metrics,
+        "artifacts": artifacts,
+    }
+    if error is not None:
+        result["error"] = error
+    (root / RESULT_NAME).write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return int(result["return_code"])
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> RunConfiguration:
+    """Parse one closed command-line execution request."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_pdb", type=Path)
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--force-field", default="amber99sb-ildn")
+    parser.add_argument("--water-type", default="tip3p")
+    parser.add_argument("--box-type", default="cubic")
+    parser.add_argument("--distance-to-molecule", default=1.0, type=float)
+    parser.add_argument("--ignore-input-hydrogens", action="store_true")
+    parser.add_argument("--merge-chains", action="store_true")
+    parser.add_argument("--gmx", default="gmx")
+    args = parser.parse_args(argv)
+    return RunConfiguration(
+        input_pdb=args.input_pdb,
+        output_dir=args.output_dir,
+        force_field=args.force_field,
+        water_type=args.water_type,
+        box_type=args.box_type,
+        distance_to_molecule=args.distance_to_molecule,
+        ignore_input_hydrogens=args.ignore_input_hydrogens,
+        merge_chains=args.merge_chains,
+        gmx=args.gmx,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run one command-line BioBB MD-setup cell."""
+
+    config = _parse_args(argv)
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    root = config.output_dir.resolve(strict=True)
+    source = config.input_pdb.resolve(strict=True)
+    if not source.is_relative_to(root):
+        if config.input_pdb.is_symlink() or not source.is_file():
+            raise ValueError("input PDB must be a regular file")
+        staged = root / "input.pdb"
+        if staged.exists() or staged.is_symlink():
+            raise ValueError("staged input already exists")
+        shutil.copyfile(source, staged, follow_symlinks=False)
+        os.chmod(staged, 0o600)
+        config = replace(config, input_pdb=staged, output_dir=root)
+    return run(config)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builtin/builtin/biobb_wf_md_setup/run_md_setup.py
+++ b/builtin/builtin/biobb_wf_md_setup/run_md_setup.py
@@ -248,7 +248,7 @@ def run(
                     "water_type": config.water_type,
                     "ignh": config.ignore_input_hydrogens,
                     "merge": config.merge_chains,
-                    "gmx_path": config.gmx,
+                    "binary_path": config.gmx,
                 },
             )
         )
@@ -267,7 +267,7 @@ def run(
                     "box_type": config.box_type,
                     "distance_to_molecule": config.distance_to_molecule,
                     "center_molecule": True,
-                    "gmx_path": config.gmx,
+                    "binary_path": config.gmx,
                 },
             )
         )
@@ -281,7 +281,7 @@ def run(
                 output_gro_path=str(solvated),
                 input_top_zip_path=str(processed_topology),
                 output_top_zip_path=str(solvated_topology),
-                properties={"gmx_path": config.gmx},
+                properties={"binary_path": config.gmx},
             )
         )
         _require_file(solvated, "solvated coordinates")

--- a/test/unit/core/test_biobb_wf_md_setup_artifacts.py
+++ b/test/unit/core/test_biobb_wf_md_setup_artifacts.py
@@ -1,0 +1,178 @@
+"""Generated-artifact tests for the builtin BioBB MD-setup package."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import ArtifactRole, ArtifactState, load_artifacts_module
+
+
+def _load_artifacts() -> ModuleType:
+    """Load BioBB artifact semantics directly from the builtin package."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "biobb_wf_md_setup"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _closed_result(root: Path, *, status: str = "completed") -> None:
+    products = [
+        ("fixed.pdb", "pdb"),
+        ("processed.gro", "gromacs-gro"),
+        ("processed_topology.zip", "gromacs-topology-zip"),
+        ("boxed.gro", "gromacs-gro"),
+        ("solvated.gro", "gromacs-gro"),
+        ("solvated_topology.zip", "gromacs-topology-zip"),
+    ]
+    artifacts = []
+    for name, format_name in products:
+        path = root / name
+        path.write_bytes(f"product:{name}\n".encode())
+        artifacts.append(
+            {
+                "path": name,
+                "format": format_name,
+                "size_bytes": path.stat().st_size,
+                "sha256": _sha(path),
+            }
+        )
+    result = {
+        "schema_version": "jarvis.biobb-md-setup-result.v1",
+        "status": status,
+        "return_code": 0 if status == "completed" else 1,
+        "parameters": {
+            "force_field": "amber99sb-ildn",
+            "water_type": "tip3p",
+            "box_type": "cubic",
+            "distance_to_molecule": 1.0,
+            "ignore_input_hydrogens": True,
+            "merge_chains": False,
+        },
+        "input": {"path": "input.pdb", "size_bytes": 5, "sha256": "0" * 64},
+        "stages": [{"name": "solvate", "status": status}],
+        "metrics": {
+            "boxed_volume_nm3": 24.0,
+            "solvated_atom_count": 8,
+            "solvent_molecule_count": 2,
+        },
+        "artifacts": artifacts,
+    }
+    (root / "biobb-result.json").write_text(json.dumps(result), encoding="utf-8")
+
+
+def test_success_reports_result_and_all_exact_products(tmp_path: Path) -> None:
+    """A closed successful cell exposes hashes and semantic metrics."""
+
+    _closed_result(tmp_path)
+    module = _load_artifacts()
+    adapter = module.BiobbMdSetupArtifactAdapter(
+        module.PurePosixPath("/execution/shared/biobb"), tmp_path
+    )
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert [item.logical_name for item in observations] == [
+        "biobb-md-setup-result",
+        "biobb-fixed-structure",
+        "biobb-processed-coordinates",
+        "biobb-processed-topology",
+        "biobb-boxed-coordinates",
+        "biobb-solvated-coordinates",
+        "biobb-solvated-topology",
+    ]
+    assert all(item.state is ArtifactState.FINALIZED for item in observations)
+    assert observations[0].role is ArtifactRole.OUTPUT
+    assert observations[0].metadata["solvent_molecule_count"] == 2
+    assert adapter.finalize_artifacts_for_exit(0) == []
+
+
+def test_nonzero_process_or_failed_document_never_finalizes(tmp_path: Path) -> None:
+    """Filesystem presence cannot conceal process or driver failure."""
+
+    _closed_result(tmp_path, status="failed")
+    module = _load_artifacts()
+    adapter = module.BiobbMdSetupArtifactAdapter(
+        module.PurePosixPath("/execution/shared/biobb"), tmp_path
+    )
+
+    observations = adapter.finalize_artifacts_for_exit(7)
+
+    assert observations
+    assert all(item.state is ArtifactState.INCOMPLETE for item in observations)
+
+
+def test_declared_product_hash_and_root_confinement_are_enforced(
+    tmp_path: Path,
+) -> None:
+    """A result cannot redirect artifact ownership or silently change a file."""
+
+    _closed_result(tmp_path)
+    module = _load_artifacts()
+    document = json.loads((tmp_path / "biobb-result.json").read_text())
+    document["artifacts"][0]["sha256"] = "f" * 64
+    (tmp_path / "biobb-result.json").write_text(json.dumps(document))
+    adapter = module.BiobbMdSetupArtifactAdapter(
+        module.PurePosixPath("/execution/shared/biobb"), tmp_path
+    )
+    with pytest.raises(RuntimeError, match="hash differs"):
+        adapter.finalize_artifacts_for_exit(0)
+
+    _closed_result(tmp_path)
+    document = json.loads((tmp_path / "biobb-result.json").read_text())
+    document["artifacts"][0]["path"] = "../outside.pdb"
+    (tmp_path / "biobb-result.json").write_text(json.dumps(document))
+    adapter = module.BiobbMdSetupArtifactAdapter(
+        module.PurePosixPath("/execution/shared/biobb"), tmp_path
+    )
+    with pytest.raises(RuntimeError, match="escaped"):
+        adapter.finalize_artifacts_for_exit(0)
+
+
+def test_factory_resolves_relative_output_and_ignores_unrelated_packages() -> None:
+    """Artifact discovery uses the same package-owned root as native launch."""
+
+    module = _load_artifacts()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.biobb_wf_md_setup",
+            "out": "run",
+            "shared_dir": "/execution/shared/biobb",
+            "runtime_cwd": "/execution/runtime",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.output_dir.as_posix() == "/execution/shared/biobb/run"
+    assert module.adapter_from_package({"pkg_type": "builtin.ior"}) is None
+
+
+def test_container_private_output_is_not_claimed() -> None:
+    """A host cannot report artifacts from an unmounted container path."""
+
+    module = _load_artifacts()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.biobb_wf_md_setup",
+            "out": "/tmp/biobb",
+            "effective_deploy_mode": "container",
+            "shared_dir": "/execution/shared",
+            "private_dir": "/execution/private",
+            "runtime_cwd": "/execution/runtime",
+        }
+    )
+
+    assert adapter is None

--- a/test/unit/core/test_biobb_wf_md_setup_driver.py
+++ b/test/unit/core/test_biobb_wf_md_setup_driver.py
@@ -1,0 +1,234 @@
+"""Tests for the package-owned BioBB MD-setup driver."""
+
+from __future__ import annotations
+
+import json
+import sys
+import zipfile
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+
+def _load_driver() -> ModuleType:
+    """Load the standalone driver without requiring BioBB at test time."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "biobb_wf_md_setup"
+        / "run_md_setup.py"
+    )
+    name = "test_biobb_md_setup_driver_module"
+    spec = spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load BioBB driver from {path}")
+    module = module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+driver = _load_driver()
+
+
+def _gro(path: Path, atom_count: int, box: str = "2.0 3.0 4.0") -> None:
+    lines = ["generated", str(atom_count)]
+    lines.extend(
+        f"    1SOL     OW{index:5d}   0.000   0.000   0.000"
+        for index in range(1, atom_count + 1)
+    )
+    lines.append(box)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _topology(path: Path, *, solvent: int) -> None:
+    with zipfile.ZipFile(path, mode="w") as archive:
+        archive.writestr(
+            "topol.top",
+            f"[ system ]\nProtein\n\n[ molecules ]\nProtein 1\nSOL {solvent}\n",
+        )
+
+
+def _functions(calls: dict[str, dict[str, Any]]) -> Any:
+    def fix_side_chain(**kwargs: Any) -> int:
+        calls["fix_side_chain"] = kwargs
+        Path(kwargs["output_pdb_path"]).write_text(
+            Path(kwargs["input_pdb_path"]).read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        return 0
+
+    def pdb2gmx(**kwargs: Any) -> int:
+        calls["pdb2gmx"] = kwargs
+        _gro(Path(kwargs["output_gro_path"]), 2)
+        _topology(Path(kwargs["output_top_zip_path"]), solvent=0)
+        return 0
+
+    def editconf(**kwargs: Any) -> int:
+        calls["editconf"] = kwargs
+        _gro(Path(kwargs["output_gro_path"]), 2)
+        return 0
+
+    def solvate(**kwargs: Any) -> int:
+        calls["solvate"] = kwargs
+        _gro(Path(kwargs["output_gro_path"]), 8)
+        _topology(Path(kwargs["output_top_zip_path"]), solvent=2)
+        return 0
+
+    return driver.BioBBFunctions(fix_side_chain, pdb2gmx, editconf, solvate)
+
+
+def _config(root: Path) -> Any:
+    input_path = root / "input.pdb"
+    input_path.write_text(
+        "ATOM      1  N   ALA A   1\nHETATM    2  O   HOH A   2\nEND\n",
+        encoding="utf-8",
+    )
+    return driver.RunConfiguration(
+        input_pdb=input_path,
+        output_dir=root,
+        force_field="charmm27",
+        water_type="spce",
+        box_type="dodecahedron",
+        distance_to_molecule=1.25,
+        ignore_input_hydrogens=True,
+        merge_chains=False,
+        gmx="gmx",
+    )
+
+
+def test_successful_driver_records_semantics_metrics_and_exact_outputs(
+    tmp_path: Path,
+) -> None:
+    """A real five-stage cell closes with scientific values and file hashes."""
+
+    calls: dict[str, dict[str, Any]] = {}
+
+    return_code = driver.run(_config(tmp_path), functions=_functions(calls))
+
+    assert return_code == 0
+    result = json.loads((tmp_path / driver.RESULT_NAME).read_text(encoding="utf-8"))
+    assert result["schema_version"] == driver.RESULT_SCHEMA
+    assert result["status"] == "completed"
+    assert result["parameters"] == {
+        "box_type": "dodecahedron",
+        "distance_to_molecule": 1.25,
+        "force_field": "charmm27",
+        "ignore_input_hydrogens": True,
+        "merge_chains": False,
+        "water_type": "spce",
+    }
+    assert result["metrics"]["input_pdb_atom_count"] == 2
+    assert result["metrics"]["boxed_volume_nm3"] == pytest.approx(24.0)
+    assert result["metrics"]["solvent_molecule_count"] == 2
+    assert [stage["name"] for stage in result["stages"]] == [
+        "stage_input",
+        "fix_side_chain",
+        "pdb2gmx",
+        "editconf",
+        "solvate",
+    ]
+    assert len(result["artifacts"]) == 6
+    assert all(len(item["sha256"]) == 64 for item in result["artifacts"])
+    assert calls["pdb2gmx"]["properties"] == {
+        "force_field": "charmm27",
+        "water_type": "spce",
+        "ignh": True,
+        "merge": False,
+        "gmx_path": "gmx",
+    }
+    assert calls["editconf"]["properties"]["box_type"] == "dodecahedron"
+
+
+def test_failed_stage_writes_a_nonzero_closed_partial_result(tmp_path: Path) -> None:
+    """A BioBB exception remains inspectable without becoming a successful run."""
+
+    calls: dict[str, dict[str, Any]] = {}
+    functions = _functions(calls)
+
+    def fail_pdb2gmx(**kwargs: Any) -> int:
+        del kwargs
+        return 9
+
+    failed = driver.BioBBFunctions(
+        functions.fix_side_chain,
+        fail_pdb2gmx,
+        functions.editconf,
+        functions.solvate,
+    )
+
+    return_code = driver.run(_config(tmp_path), functions=failed)
+
+    assert return_code == 1
+    result = json.loads((tmp_path / driver.RESULT_NAME).read_text(encoding="utf-8"))
+    assert result["status"] == "failed"
+    assert result["return_code"] == 1
+    assert result["error"]["type"] == "RuntimeError"
+    assert [item["path"] for item in result["artifacts"]] == ["fixed.pdb"]
+
+
+def test_malformed_scientific_output_is_a_recorded_failure(tmp_path: Path) -> None:
+    """A nominal block return cannot bypass semantic output validation."""
+
+    calls: dict[str, dict[str, Any]] = {}
+    functions = _functions(calls)
+
+    def malformed_solvate(**kwargs: Any) -> int:
+        Path(kwargs["output_gro_path"]).write_text("not a GRO\n", encoding="utf-8")
+        _topology(Path(kwargs["output_top_zip_path"]), solvent=2)
+        return 0
+
+    malformed = driver.BioBBFunctions(
+        functions.fix_side_chain,
+        functions.pdb2gmx,
+        functions.editconf,
+        malformed_solvate,
+    )
+
+    return_code = driver.run(_config(tmp_path), functions=malformed)
+
+    assert return_code == 1
+    result = json.loads((tmp_path / driver.RESULT_NAME).read_text(encoding="utf-8"))
+    assert result["status"] == "failed"
+    assert result["stages"][-1]["name"] == "validate_outputs"
+    assert result["error"]["message"].startswith("GRO output is truncated")
+
+
+def test_gro_parser_handles_triclinic_box_vectors(tmp_path: Path) -> None:
+    """Nine-value GROMACS boxes use the documented vector ordering."""
+
+    path = tmp_path / "triclinic.gro"
+    _gro(path, 1, "2.0 3.0 4.0 0.0 0.0 0.5 0.0 0.0 0.25")
+
+    metrics = driver._gro_metrics(path)
+
+    assert metrics["atom_count"] == 1
+    assert metrics["box_volume_nm3"] == pytest.approx(24.0)
+
+
+def test_input_must_be_inside_the_package_owned_output(tmp_path: Path) -> None:
+    """The driver cannot claim or mutate a caller-owned source path."""
+
+    root = tmp_path / "out"
+    root.mkdir()
+    outside = tmp_path / "outside.pdb"
+    outside.write_text("ATOM\n", encoding="utf-8")
+    config = driver.RunConfiguration(
+        input_pdb=outside,
+        output_dir=root,
+        force_field="amber99sb-ildn",
+        water_type="tip3p",
+        box_type="cubic",
+        distance_to_molecule=1.0,
+        ignore_input_hydrogens=True,
+        merge_chains=False,
+        gmx="gmx",
+    )
+
+    with pytest.raises(ValueError, match="output directory"):
+        driver.run(config, functions=_functions({}))

--- a/test/unit/core/test_biobb_wf_md_setup_driver.py
+++ b/test/unit/core/test_biobb_wf_md_setup_driver.py
@@ -98,7 +98,7 @@ def _config(root: Path) -> Any:
         distance_to_molecule=1.25,
         ignore_input_hydrogens=True,
         merge_chains=False,
-        gmx="gmx",
+        gmx="gmx_mpi",
     )
 
 
@@ -140,8 +140,10 @@ def test_successful_driver_records_semantics_metrics_and_exact_outputs(
         "water_type": "spce",
         "ignh": True,
         "merge": False,
-        "gmx_path": "gmx",
+        "binary_path": "gmx_mpi",
     }
+    assert calls["editconf"]["properties"]["binary_path"] == "gmx_mpi"
+    assert calls["solvate"]["properties"]["binary_path"] == "gmx_mpi"
     assert calls["editconf"]["properties"]["box_type"] == "dodecahedron"
 
 

--- a/test/unit/core/test_biobb_wf_md_setup_package_runtime.py
+++ b/test/unit/core/test_biobb_wf_md_setup_package_runtime.py
@@ -128,6 +128,7 @@ def _package(tmp_path: Path, config: dict[str, Any]) -> Any:
     package.env = {}
     package.mod_env = {"PATH": "/runtime/bin"}
     package.python_bin = "python3"
+    package.gmx_bin = "gmx_mpi"
     package.pipeline = SimpleNamespace(get_hostfile=lambda: Hostfile(find_ips=False))
     package.runtime_line_callback = lambda: None
     return package
@@ -214,8 +215,30 @@ def test_native_run_copies_input_and_launches_package_owned_driver(
     assert "--water-type spce" in command
     assert "--box-type dodecahedron" in command
     assert "--distance-to-molecule 1.25" in command
+    assert "--gmx gmx_mpi" in command
     assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
     assert isinstance(_CapturedExec.infos[-1], LocalExecInfo)
+
+
+def test_gromacs_discovery_supports_mpi_named_spack_builds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid ``gmx_mpi`` installation satisfies the GROMACS runtime."""
+
+    monkeypatch.setattr(
+        biobb_package.shutil,
+        "which",
+        lambda program, *, path: (
+            "/spack/gromacs/bin/gmx_mpi"
+            if program == "gmx_mpi" and path == "/spack/bin"
+            else None
+        ),
+    )
+
+    assert (
+        biobb_package.BiobbWfMdSetup._discover_gromacs({"PATH": "/spack/bin"})
+        == "gmx_mpi"
+    )
 
 
 def test_native_run_rejects_missing_unsafe_or_colliding_input(tmp_path: Path) -> None:

--- a/test/unit/core/test_biobb_wf_md_setup_package_runtime.py
+++ b/test/unit/core/test_biobb_wf_md_setup_package_runtime.py
@@ -1,0 +1,294 @@
+"""Runtime-contract tests for the builtin BioBB MD-setup package."""
+
+from __future__ import annotations
+
+import shlex
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.deployment import ProgramProbeResult, RuntimeStatus
+from jarvis_cd.shell import LocalExecInfo
+from jarvis_cd.util.hostfile import Hostfile
+
+
+def _load_package() -> ModuleType:
+    """Load the builtin package without changing repository imports."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "biobb_wf_md_setup"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_biobb_md_setup_runtime_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load BioBB package from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+biobb_package = _load_package()
+
+
+class _CapturedExec:
+    """Capture launches and expose a configurable process result."""
+
+    commands: list[str] = []
+    infos: list[Any] = []
+    return_code = 0
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": self.return_code}
+        self.commands.append(command)
+        self.infos.append(exec_info)
+
+    def run(self) -> _CapturedExec:
+        """Return the captured result."""
+
+        return self
+
+
+class _CapturedMkdir:
+    """Create the requested test directory."""
+
+    def __init__(self, path: str, exec_info: Any) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedMkdir:
+        """Materialize the directory and report success."""
+
+        Path(self.path).mkdir(parents=True, exist_ok=True)
+        return self
+
+
+class _CapturedRm:
+    """Capture exact cleanup authority without deleting files."""
+
+    calls: list[tuple[str, bool]] = []
+
+    def __init__(self, path: str, exec_info: Any, *, recursive: bool = False) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.recursive = recursive
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedRm:
+        """Record the requested cleanup."""
+
+        self.calls.append((self.path, self.recursive))
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _capture_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep package tests free of process and remote-host side effects."""
+
+    _CapturedExec.commands = []
+    _CapturedExec.infos = []
+    _CapturedExec.return_code = 0
+    _CapturedRm.calls = []
+    monkeypatch.setattr(biobb_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(biobb_package, "Mkdir", _CapturedMkdir)
+    monkeypatch.setattr(biobb_package, "Rm", _CapturedRm)
+
+
+def _base_config(**overrides: Any) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "deploy_mode": "default",
+        "pdb_file": "",
+        "out": "run",
+        "force_field": "amber99sb-ildn",
+        "water_type": "tip3p",
+        "box_type": "cubic",
+        "distance_to_molecule": 1.0,
+        "ignore_input_hydrogens": True,
+        "merge_chains": False,
+        "nprocs": 1,
+        "ppn": 1,
+    }
+    config.update(overrides)
+    return config
+
+
+def _package(tmp_path: Path, config: dict[str, Any]) -> Any:
+    package = object.__new__(biobb_package.BiobbWfMdSetup)
+    package.config = config
+    package.shared_dir = tmp_path / "shared"
+    package.private_dir = tmp_path / "private"
+    package.env = {}
+    package.mod_env = {"PATH": "/runtime/bin"}
+    package.python_bin = "python3"
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: Hostfile(find_ips=False))
+    package.runtime_line_callback = lambda: None
+    return package
+
+
+def test_agent_contract_exposes_real_scientific_inputs_and_hides_benchmark_knobs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agents see the scientific cell instead of container benchmark controls."""
+
+    monkeypatch.setattr(
+        biobb_package,
+        "probe_program",
+        lambda *_args, **_kwargs: ProgramProbeResult(
+            RuntimeStatus("ready", "runtime_probe_succeeded")
+        ),
+    )
+    package = object.__new__(biobb_package.BiobbWfMdSetup)
+    package.config = _base_config()
+    package.env = {}
+    package.mod_env = {}
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    contract = package._deployment_contract().to_dict()
+
+    assert menu["pdb_file"]["default"] == ""
+    assert menu["pdb_file"]["input_binding"] == {
+        "schema_version": "jarvis.configuration-input-binding.v1",
+        "kind": "local_file",
+        "structure": "regular_file",
+    }
+    assert menu["out"]["default"] == "run"
+    assert menu["force_field"]["default"] == "amber99sb-ildn"
+    assert menu["box_type"]["default"] == "cubic"
+    assert all(
+        menu[name]["agent_visible"] is False
+        for name in {
+            "replicates",
+            "parallel_scratch_root",
+            "parallel_reps",
+            "omp_threads",
+            "md_steps",
+            "md_nstxout",
+            "md_extend_script",
+            "base_image",
+        }
+    )
+    assert [profile["name"] for profile in contract["execution_profiles"]] == [
+        "native_md_setup"
+    ]
+    assert {item["id"] for item in contract["runtime_requirements"]} == {
+        "biobb_python",
+        "gromacs",
+    }
+
+
+def test_native_run_copies_input_and_launches_package_owned_driver(
+    tmp_path: Path,
+) -> None:
+    """The caller PDB is immutable and all generated files share one owned root."""
+
+    source = tmp_path / "caller" / "protein with space.pdb"
+    source.parent.mkdir()
+    source.write_text("ATOM      1  N   ALA A   1\nEND\n", encoding="utf-8")
+    package = _package(
+        tmp_path,
+        _base_config(
+            pdb_file=str(source),
+            force_field="charmm27",
+            water_type="spce",
+            box_type="dodecahedron",
+            distance_to_molecule=1.25,
+        ),
+    )
+
+    package.start()
+
+    staged = tmp_path / "shared" / "run" / "input.pdb"
+    assert staged.read_bytes() == source.read_bytes()
+    command = _CapturedExec.commands[-1]
+    assert shlex.quote(str(staged.resolve())) in command
+    assert "run_md_setup.py" in command
+    assert "--force-field charmm27" in command
+    assert "--water-type spce" in command
+    assert "--box-type dodecahedron" in command
+    assert "--distance-to-molecule 1.25" in command
+    assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
+    assert isinstance(_CapturedExec.infos[-1], LocalExecInfo)
+
+
+def test_native_run_rejects_missing_unsafe_or_colliding_input(tmp_path: Path) -> None:
+    """Malformed input and staged-name collisions fail before process launch."""
+
+    package = _package(tmp_path, _base_config())
+    with pytest.raises(ValueError, match="requires pdb_file"):
+        package.start()
+
+    empty = tmp_path / "empty.pdb"
+    empty.touch()
+    package.config = _base_config(pdb_file=str(empty))
+    with pytest.raises(ValueError, match="bounded regular PDB"):
+        package.start()
+
+    source = tmp_path / "protein.pdb"
+    source.write_text("ATOM\n", encoding="utf-8")
+    collision = tmp_path / "shared" / "run" / "input.pdb"
+    collision.parent.mkdir(parents=True, exist_ok=True)
+    collision.write_text("unrelated\n", encoding="utf-8")
+    package.config = _base_config(pdb_file=str(source))
+    with pytest.raises(ValueError, match="staged input already exists"):
+        package.start()
+
+    assert collision.read_text(encoding="utf-8") == "unrelated\n"
+    assert _CapturedExec.commands == []
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"force_field": "unknown"}, "force_field"),
+        ({"water_type": "unknown"}, "water_type"),
+        ({"box_type": "sphere"}, "box_type"),
+        ({"distance_to_molecule": 0.0}, "distance_to_molecule"),
+        ({"distance_to_molecule": 10.1}, "distance_to_molecule"),
+    ],
+)
+def test_native_scientific_parameters_are_closed_and_bounded(
+    tmp_path: Path, overrides: dict[str, Any], message: str
+) -> None:
+    """The package rejects unsupported scientific configurations locally."""
+
+    source = tmp_path / "protein.pdb"
+    source.write_text("ATOM\n", encoding="utf-8")
+    package = _package(tmp_path, _base_config(pdb_file=str(source), **overrides))
+
+    with pytest.raises(ValueError, match=message):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
+def test_native_process_failure_fails_the_package_lifecycle(tmp_path: Path) -> None:
+    """A failed BioBB stage cannot be represented as a successful pipeline."""
+
+    source = tmp_path / "protein.pdb"
+    source.write_text("ATOM\n", encoding="utf-8")
+    package = _package(tmp_path, _base_config(pdb_file=str(source)))
+    _CapturedExec.return_code = 7
+
+    with pytest.raises(RuntimeError, match="BioBB MD setup failed"):
+        package.start()
+
+
+def test_clean_uses_one_exact_recursive_output_without_wildcard(tmp_path: Path) -> None:
+    """Cleanup cannot erase prefix-matching sibling directories."""
+
+    package = _package(tmp_path, _base_config(out="results"))
+
+    package.clean()
+
+    assert _CapturedRm.calls == [
+        (str((tmp_path / "shared" / "results").resolve()), True)
+    ]
+    assert "*" not in _CapturedRm.calls[0][0]


### PR DESCRIPTION
## Purpose

Makes `builtin.biobb_wf_md_setup` a reusable native JARVIS application for one caller-supplied biomolecular structure. This is package functionality, not benchmark-specific study logic.

## Changes

- binds one PDB configuration input into execution-owned storage with size, structure, and digest checks
- resolves an operator-prepared BioBB Python runtime and either `gmx` or `gmx_mpi`
- exposes force field, water model, box geometry, solute distance, hydrogen, and chain semantics while hiding legacy benchmark controls from agents
- executes the real five-stage BioBB workflow and propagates stage failures
- passes the resolved GROMACS executable through BioBB's supported `binary_path` property
- finalizes a closed result plus fixed, processed, boxed, solvated, and topology artifacts with bounded scientific metadata

## Root cause fixed

The first Ares candidate used the unsupported BioBB property `gmx_path`. BioBB therefore attempted the literal `gmx` command even though the resolved Ares executable is `gmx_mpi`. The corrected driver passes `binary_path` to every GROMACS block.

## Validation

- Ruff check passed
- Ruff format check passed
- Pyright passed with zero errors and warnings
- 21 focused BioBB package, driver, and artifact tests passed
- direct FastMCP Ares execution `jarvis_67ddaf5a47b546748a05c4b91a91e981`, Slurm job `22645`, completed with return code 0 at commit `f83342ab17cbf246957ad99b028baeb4a8f53930`
- two ordinary package instances prepared the exact same public 1UBQ input as cubic and dodecahedral systems using BioBB 5.2.1 and GROMACS 2024.3
- independent retained evidence verified all 30 native files and closed coordinate/topology arithmetic

## Stacking

This draft is stacked on `feat/xcompact3d-input-artifacts`; review only the three commits in this branch.