### PR TITLE
fix: isolate interceptor runtime environments

### DIFF
--- a/builtin/builtin/darshan/pkg.py
+++ b/builtin/builtin/darshan/pkg.py
@@ -2,23 +2,27 @@
 This module provides classes and methods to inject the Darshan interceptor.
 Darshan is ....
 """
+
+import os
+from typing import Any, cast
+
 from jarvis_cd.core.pkg import Interceptor
 from jarvis_cd.shell import PsshExecInfo
 from jarvis_cd.shell.process import Mkdir
-import os
 
 
 class Darshan(Interceptor):
     """
     This class provides methods to inject the Darshan interceptor.
     """
-    def _init(self):
+
+    def _init(self) -> None:
         """
         Initialize paths
         """
         pass
 
-    def _configure_menu(self):
+    def _configure_menu(self) -> list[dict[str, Any]]:
         """
         Create a CLI menu for the configurator method.
         For thorough documentation of these parameters, view:
@@ -28,26 +32,26 @@ class Darshan(Interceptor):
         """
         return [
             {
-                'name': 'log_dir',
-                'msg': 'Where darshan should place data',
-                'type': str,
-                'default': f'{os.getenv("HOME")}/darshan_logs',
+                "name": "log_dir",
+                "msg": "Where darshan should place data",
+                "type": str,
+                "default": f"{os.getenv('HOME')}/darshan_logs",
             },
             {
-                'name': 'job_id',
-                'msg': 'A semantic ID for the job to identify log files',
-                'type': str,
-                'default': 'myjob',
+                "name": "job_id",
+                "msg": "A semantic ID for the job to identify log files",
+                "type": str,
+                "default": "myjob",
             },
             {
-                'name': 'darshan_lib_container',
-                'msg': 'Path to libdarshan.so inside the container (container mode only)',
-                'type': str,
-                'default': '/opt/darshan/lib/libdarshan.so',
+                "name": "darshan_lib_container",
+                "msg": "Path to libdarshan.so inside the container (container mode only)",
+                "type": str,
+                "default": "/opt/darshan/lib/libdarshan.so",
             },
         ]
 
-    def _configure(self, **kwargs):
+    def _configure(self, **kwargs: Any) -> None:
         """
         Converts the Jarvis configuration to application-specific configuration.
         E.g., OrangeFS produces an orangefs.xml file.
@@ -55,22 +59,44 @@ class Darshan(Interceptor):
         :param kwargs: Configuration parameters for this pkg.
         :return: None
         """
-        self.env['DARSHAN_LOG_DIR'] = self.config['log_dir']
-        self.env['PBS_JOBID'] = self.config['job_id']
-        if self.config['deploy_mode'] == 'container':
-            self.config['DARSHAN_LIB'] = self.config['darshan_lib_container']
+        config = cast(dict[str, Any], self.config)
+        log_dir = config.get("log_dir")
+        job_id = config.get("job_id")
+        deploy_mode = config.get("deploy_mode")
+        if not isinstance(log_dir, str) or not log_dir:
+            raise ValueError("Darshan log_dir must be a non-empty string")
+        if not isinstance(job_id, str) or not job_id:
+            raise ValueError("Darshan job_id must be a non-empty string")
+        if deploy_mode == "container":
+            library = config.get("darshan_lib_container")
+            if not isinstance(library, str) or not library:
+                raise ValueError(
+                    "Darshan container library path must be a non-empty string"
+                )
         else:
-            self.config['DARSHAN_LIB'] = self.find_library('darshan')
-            if self.config['DARSHAN_LIB'] is None:
-                raise Exception('Could not find darshan')
-            print(f'Found libdarshan.so at {self.config["DARSHAN_LIB"]}')
-        Mkdir(self.env['DARSHAN_LOG_DIR'],
-              PsshExecInfo(hostfile=self.hostfile)).run()
+            library = self.find_library("darshan")
+            if library is None:
+                raise RuntimeError("Could not find darshan")
+            print(f"Found libdarshan.so at {library}")
+        config["DARSHAN_LIB"] = library
+        self.env["DARSHAN_LOG_DIR"] = log_dir
+        self.env["PBS_JOBID"] = job_id
+        Mkdir(log_dir, PsshExecInfo(hostfile=self.hostfile)).run()
 
-    def modify_env(self):
+    def modify_env(self) -> None:
         """
         Modify the jarvis environment.
 
         :return: None
         """
-        self.prepend_env('LD_PRELOAD', self.config['DARSHAN_LIB'])
+        config = cast(dict[str, Any], self.config)
+        log_dir = config.get("log_dir")
+        job_id = config.get("job_id")
+        library = config.get("DARSHAN_LIB")
+        if not all(isinstance(value, str) and value for value in (log_dir, job_id)):
+            raise ValueError("Darshan runtime configuration is incomplete")
+        if not isinstance(library, str) or not library:
+            raise ValueError("Darshan library was not resolved during configuration")
+        self.setenv("DARSHAN_LOG_DIR", cast(str, log_dir))
+        self.setenv("PBS_JOBID", cast(str, job_id))
+        self.prepend_env("LD_PRELOAD", library)

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -825,6 +825,10 @@ Interceptor aliases share the pipeline package namespace. JARVIS verifies that
 every referenced alias exists and derives from `Interceptor` before saving or
 starting the pipeline. Removing an interceptor that is still referenced fails
 instead of silently running the target package without interception.
+Interceptor configuration does not enter the pipeline-wide environment: each
+instance applies its runtime variables only to the packages that name its alias.
+Consequently, the two Darshan instances above retain distinct log directories
+and job identifiers even when both target packages run in one pipeline.
 The common `interceptors` setting is included in agent-visible package metadata
 for applications and services, while interceptor packages hide it because
 nested interception is invalid.

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -3212,13 +3212,16 @@ class Pipeline:
         print("Reconfiguring pipeline packages with existing configurations...")
         self.configure_all_packages()
 
-    def _configure_package_instance(self, pkg_def: Dict[str, Any], pkg_type_label: str):
+    def _configure_package_instance(
+        self, pkg_def: Dict[str, Any], pkg_type_label: str
+    ) -> None:
         """
         Configure a single package or interceptor instance.
 
         :param pkg_def: Package definition dictionary
         :param pkg_type_label: Label for logging ("package" or "interceptor")
         """
+        from jarvis_cd.core.pkg import Interceptor
         from jarvis_cd.util.logger import logger
 
         try:
@@ -3236,8 +3239,12 @@ class Pipeline:
                 else:
                     pkg_def["config"] = pkg_instance.config.copy()
 
-                # Update the package environment in the pipeline's env
-                self.env.update(pkg_instance.env)
+                # Interceptor runtime mutations belong only to explicitly linked
+                # packages. Configuration may prepare resources using an
+                # interceptor-local environment, but must not leak that state into
+                # every later package through the pipeline-wide environment.
+                if not isinstance(pkg_instance, Interceptor):
+                    self.env.update(pkg_instance.env)
 
             # Print END message
             logger.success(f"[{pkg_def['pkg_type']}] [CONFIGURE] END")

--- a/test/unit/core/test_pipeline_coverage.py
+++ b/test/unit/core/test_pipeline_coverage.py
@@ -369,6 +369,68 @@ class TestPipelineCoverage(unittest.TestCase):
         self.assertNotIn("LD_PRELOAD", plain.mod_env)
         self.assertEqual(observed.mod_env["LD_PRELOAD"], "/tmp/libmonitor.so")
 
+    def test_configured_interceptor_environments_remain_package_local(self) -> None:
+        """Two configured Darshan aliases retain independent runtime settings."""
+        pipeline = self._make_pipeline("interceptor_runtime_isolation")
+        pipeline.append(
+            "builtin.darshan",
+            package_alias="darshan_ior",
+            config_args=[
+                "log_dir=/tmp/ior_logs",
+                "job_id=ior",
+            ],
+        )
+        pipeline.append(
+            "builtin.darshan",
+            package_alias="darshan_clio",
+            config_args=[
+                "log_dir=/tmp/clio_logs",
+                "job_id=clio",
+            ],
+        )
+        pipeline.append(
+            "builtin.echo",
+            package_alias="ior",
+            config_args=['interceptors=["darshan_ior"]'],
+        )
+        pipeline.append(
+            "builtin.echo",
+            package_alias="clio",
+            config_args=['interceptors=["darshan_clio"]'],
+        )
+        pipeline.append("builtin.echo", package_alias="plain")
+
+        pipeline.interceptors["darshan_ior"]["config"]["deploy_mode"] = "container"
+        pipeline.interceptors["darshan_clio"]["config"]["deploy_mode"] = "container"
+
+        with patch("builtin.darshan.pkg.Mkdir.run"):
+            pipeline._configure_package_instance(
+                pipeline.interceptors["darshan_ior"], "interceptor"
+            )
+            pipeline._configure_package_instance(
+                pipeline.interceptors["darshan_clio"], "interceptor"
+            )
+
+        self.assertNotIn("DARSHAN_LOG_DIR", pipeline.env)
+        self.assertNotIn("PBS_JOBID", pipeline.env)
+
+        ior = pipeline._load_package_instance(pipeline.packages[0], pipeline.env)
+        clio = pipeline._load_package_instance(pipeline.packages[1], pipeline.env)
+        plain = pipeline._load_package_instance(pipeline.packages[2], pipeline.env)
+        pipeline._apply_interceptors_to_package(ior, pipeline.packages[0])
+        pipeline._apply_interceptors_to_package(clio, pipeline.packages[1])
+        pipeline._apply_interceptors_to_package(plain, pipeline.packages[2])
+
+        self.assertEqual(ior.env["DARSHAN_LOG_DIR"], "/tmp/ior_logs")
+        self.assertEqual(ior.env["PBS_JOBID"], "ior")
+        self.assertEqual(ior.mod_env["LD_PRELOAD"], "/opt/darshan/lib/libdarshan.so")
+        self.assertEqual(clio.env["DARSHAN_LOG_DIR"], "/tmp/clio_logs")
+        self.assertEqual(clio.env["PBS_JOBID"], "clio")
+        self.assertEqual(clio.mod_env["LD_PRELOAD"], "/opt/darshan/lib/libdarshan.so")
+        self.assertNotIn("DARSHAN_LOG_DIR", plain.env)
+        self.assertNotIn("PBS_JOBID", plain.env)
+        self.assertNotIn("LD_PRELOAD", plain.mod_env)
+
     def test_append_rejects_cross_kind_alias_collision(self):
         """Package and interceptor IDs share one pipeline namespace."""
         pipeline = self._make_pipeline("append_interceptor_collision")


### PR DESCRIPTION
## Summary

- preserve explicit named interceptor-to-package links while keeping interceptor configuration out of the pipeline-wide environment
- apply Darshan log directory, job identity, and preload library only to packages that reference the selected Darshan alias
- document and test two independently configured Darshan instances targeting separate applications

## Root cause

Interceptor definitions were correctly represented as named graph nodes, but configuration merged each interceptor environment into the pipeline environment. Configuring a second Darshan instance could therefore overwrite runtime variables inherited by every package, including unlinked packages.

## Validation

- `uv run --no-sync --no-cache pytest -q test/unit/core/test_pipeline_coverage.py test/unit/core/test_pkg_methods.py test/unit/core/test_spack_install.py test/unit/core/test_container_baremetal.py test/unit/core/test_route_pkg.py` (136 passed)
- `uv run --no-sync --no-cache pyright builtin/builtin/darshan/pkg.py`
- scoped Ruff check and format