### PR TITLE
feat: harden Gadget2 scientific inputs

### DIFF
--- a/builtin/builtin/gadget2/README.md
+++ b/builtin/builtin/gadget2/README.md
@@ -1,48 +1,79 @@
-GADGET is a freely available code for cosmological N-body/SPH simulations on massively parallel computers with distributed memory. GADGET uses an explicit communication model that is implemented with the standardized MPI communication interface. The code can be run on essentially all supercomputer systems presently in use, including clusters of workstations or individual PCs.
+# Gadget2
 
-GADGET computes gravitational forces with a hierarchical tree algorithm (optionally in combination with a particle-mesh scheme for long-range gravitational forces) and represents fluids by means of smoothed particle hydrodynamics (SPH). The code can be used for studies of isolated systems, or for simulations that include the cosmological expansion of space, both with or without periodic boundary conditions. In all these types of simulations, GADGET follows the evolution of a self-gravitating collisionless N-body system, and allows gas dynamics to be optionally included. Both the force computation and the time stepping of GADGET are fully adaptive, with a dynamic range which is, in principle, unlimited.
+The JARVIS Gadget2 package runs distributed-memory N-body and SPH simulations.
+The agent-facing profile accepts a complete, digest-verified JARVIS input bundle
+instead of selecting one of the repository's stock demonstrations. This lets a
+caller supply a scientific parameter file, initial conditions, and any related
+support files without giving the package authority over arbitrary host paths.
 
-https://wwwmpa.mpa-garching.mpg.de/gadget/
+The Gadget2 project is documented at
+<https://wwwmpa.mpa-garching.mpg.de/gadget/>.
 
-# Installation
+## Native runtime
 
-```bash
-spack install hdf5@1.14.1 gsl@2.1 fftw@2
-scspkg create gadget2
-cd $(scspkg pkg src gadget2)
-git clone https://github.com/lukemartinlogan/gadget2.git
-export GADGET2_PATH=$(scspkg pkg src gadget2)/gadget2
-export FFTW_PATH=$(spack find --format "{PREFIX}" fftw@2)
+Provide an MPI-enabled `Gadget2` or `gadget2` executable through `PATH`. The
+runtime must be built with the FFTW 2, GSL, MPI, and optional HDF5 dependencies
+required by its selected compile-time options. JARVIS probes the executable and
+reports the runtime readiness through the package deployment contract.
+
+The benchmark and scientific profile do not install software or select an
+arbitrary source repository at runtime. Site operators prepare and pin the
+runtime independently.
+
+## Scientific input bundle
+
+The `input_bundle` must be a JARVIS input-bundle archive. Its manifest declares
+every file, its SHA-256 digest, size, role, and one entrypoint. The entrypoint is
+normally a `.param` file. `parameter_path` can select another declared `.param`
+member, but cannot name an undeclared or escaping path.
+
+For example, a bundle can contain:
+
+```text
+jarvis-input-manifest.json
+galaxy/
+  galaxy.param
+  ICs/
+    galaxy_littleendian.dat
 ```
 
-# Create environment
+The parameter file can use paths relative to its own directory, such as:
 
-```bash
-spack load hdf5@1.14.1 gsl@2.1 fftw@2
-jarvis env build gadget2 +GADGET2_PATH +FFTW_PATH
+```text
+InitCondFile  ICs/galaxy_littleendian.dat
+OutputDir     output/
+EnergyFile   energy.txt
+InfoFile     info.txt
+SnapshotFileBase snapshot
 ```
 
-# Gassphere Pipeline
+JARVIS verifies the archive, extracts it into package-owned storage, copies the
+verified tree into the configured output root, and runs Gadget2 from the
+parameter file's directory. The caller-owned archive is never modified.
+
+## Pipeline example
 
 ```bash
-jarvis pipeline create gassphere
-jarvis pipeline env copy gadget2
-jarvis pipeline append gadget2
-jarvis pkg configure gadget2 \
-test_case=gadget2 \
-out=${HOME}/gadget2
-jarvis pipeline run
+jarvis ppl create galaxy-study
+jarvis ppl append builtin.gadget2 galaxy \
+  input_bundle=/data/inputs/galaxy-study.tar \
+  parameter_path=galaxy/galaxy.param \
+  out=galaxy-run \
+  nprocs=8 \
+  ppn=4
+jarvis ppl run
 ```
 
-# NGenIC Pipeline
+Relative `out` paths resolve beneath the package shared directory. The package
+reports the bounded result tree, energy and runtime tables, snapshot sets, and
+restart sets through JARVIS artifact semantics. A zero process exit is not
+sufficient for finalization: required energy, information, and snapshot products
+must also exist.
 
-```bash
-jarvis pipeline create gassphere
-jarvis pipeline env copy gadget2
-jarvis pipeline append gadget2
-jarvis pkg configure gadget2 \
-test_case=gassphere-ngen \
-out=${HOME}/gadget2 \
-ic=hello
-jarvis pipeline run
-```
+## Retained stock profile
+
+Existing pipelines that configure `gadget2_path`, `test_case`, and `output`
+continue to use the historical stock-case profile. Those controls remain hidden
+from agent-facing metadata so a generated scientific study cannot silently fall
+back to the default `gassphere` example. New scientific workflows should use an
+input bundle.

--- a/builtin/builtin/gadget2/artifacts.py
+++ b/builtin/builtin/gadget2/artifacts.py
@@ -1,0 +1,399 @@
+"""Generated-artifact semantics for the builtin Gadget2 package."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import posixpath
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+from jarvis_cd.artifacts.schema import JsonValue
+from jarvis_cd.input_bundle import extract_input_bundle
+
+_MAX_DISCOVERED_FILES = 4096
+_MAX_REPORTED_MEMBERS = 512
+_MAX_CHECKSUM_BYTES = 256 * 1024 * 1024
+_LOG_PRODUCTS = {
+    "energy.txt": (
+        "gadget2-energy",
+        "scientific_dataset",
+        "gadget2-energy-table",
+        "text/plain",
+    ),
+    "info.txt": (
+        "gadget2-info",
+        "scientific_log",
+        "gadget2-timestep-log",
+        "text/plain",
+    ),
+    "cpu.txt": (
+        "gadget2-cpu",
+        "performance_log",
+        "gadget2-cpu-log",
+        "text/plain",
+    ),
+    "timings.txt": (
+        "gadget2-timings",
+        "performance_log",
+        "gadget2-timing-log",
+        "text/plain",
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _OutputFile:
+    """One safe regular file below the package-owned result root."""
+
+    relative_path: PurePosixPath
+    size_bytes: int
+
+
+@dataclass
+class Gadget2ArtifactAdapter:
+    """Discover bounded Gadget2 logs, snapshots, and restart state."""
+
+    output_dir: PurePosixPath
+    input_paths: frozenset[PurePosixPath] = frozenset()
+    _local_root: Path | None = None
+    _finalized: bool = False
+    _collection_artifact_id: str = field(default_factory=new_artifact_id)
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for authoritative process completion before inspecting outputs."""
+
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Finalize outputs for a successful legacy completion callback."""
+
+        return self._finalize(return_code=0)
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Finalize outputs with the authoritative process completion state."""
+
+        return self._finalize(return_code=return_code)
+
+    def reset_artifacts(self) -> None:
+        """Permit discovery after an execution stream is replaced."""
+
+        self._finalized = False
+
+    def _local_output_path(self) -> Path:
+        """Project the declared cluster directory into this host filesystem."""
+
+        if self._local_root is not None:
+            return self._local_root
+        return Path(self.output_dir.as_posix())
+
+    def _discover_files(self) -> tuple[list[_OutputFile], bool]:
+        """Walk the owned output tree without following links and with a bound."""
+
+        root = self._local_output_path()
+        if not root.exists():
+            return [], False
+        if root.is_symlink() or not root.is_dir():
+            raise RuntimeError(f"Gadget2 output root is not a real directory: {root}")
+        files: list[_OutputFile] = []
+        truncated = False
+        try:
+            for current, directory_names, file_names in os.walk(
+                root, topdown=True, followlinks=False
+            ):
+                current_path = Path(current)
+                directory_names[:] = [
+                    name
+                    for name in sorted(directory_names)
+                    if not (current_path / name).is_symlink()
+                ]
+                for name in sorted(file_names):
+                    path = current_path / name
+                    if path.is_symlink() or not path.is_file():
+                        continue
+                    relative = PurePosixPath(path.relative_to(root).as_posix())
+                    if relative in self.input_paths:
+                        continue
+                    if len(files) >= _MAX_DISCOVERED_FILES:
+                        truncated = True
+                        break
+                    files.append(_OutputFile(relative, path.stat().st_size))
+                if truncated:
+                    break
+        except OSError as exc:
+            raise RuntimeError(
+                f"cannot inspect Gadget2 output directory {root}: {exc}"
+            ) from exc
+        return files, truncated
+
+    def _finalize(self, *, return_code: int) -> list[ArtifactObservation]:
+        if self._finalized:
+            return []
+        self._finalized = True
+        files, truncated = self._discover_files()
+        if not files and not truncated:
+            return []
+        by_basename: dict[str, list[_OutputFile]] = {}
+        for item in files:
+            by_basename.setdefault(item.relative_path.name.casefold(), []).append(item)
+        snapshots = [
+            item
+            for item in files
+            if item.relative_path.name.casefold().startswith("snapshot_")
+        ]
+        restarts = [
+            item
+            for item in files
+            if item.relative_path.name.casefold().startswith("restart.")
+        ]
+        missing = [
+            name
+            for name in ("energy.txt", "info.txt")
+            if len(by_basename.get(name, ())) != 1
+        ]
+        if not snapshots:
+            missing.append("snapshot")
+        valid = return_code == 0 and not truncated and not missing
+        state = ArtifactState.FINALIZED if valid else ArtifactState.INCOMPLETE
+        if missing:
+            message = "Gadget2 result is missing required products: " + ", ".join(
+                missing
+            )
+        elif truncated:
+            message = "Gadget2 output discovery reached its safety bound"
+        elif return_code != 0:
+            message = f"Gadget2 process exited with status {return_code}"
+        else:
+            message = "Gadget2 result tree finalized"
+        observations = [
+            self._collection_observation(files, state=state, message=message)
+        ]
+        for basename, identity in _LOG_PRODUCTS.items():
+            matches = by_basename.get(basename, ())
+            if len(matches) == 1:
+                observations.append(
+                    self._file_observation(matches[0], identity=identity, state=state)
+                )
+        if snapshots:
+            observations.append(
+                self._set_observation(
+                    snapshots,
+                    logical_name="gadget2-snapshots",
+                    kind="scientific_dataset",
+                    format_name="gadget2-snapshot-set",
+                    media_type="application/x-gadget2-snapshot",
+                    state=state,
+                )
+            )
+        if restarts:
+            observations.append(
+                self._set_observation(
+                    restarts,
+                    logical_name="gadget2-restarts",
+                    kind="checkpoint",
+                    format_name="gadget2-restart-set",
+                    media_type="application/x-gadget2-restart",
+                    state=state,
+                )
+            )
+        return observations
+
+    def _collection_observation(
+        self,
+        files: list[_OutputFile],
+        *,
+        state: ArtifactState,
+        message: str,
+    ) -> ArtifactObservation:
+        """Describe the bounded package-owned result tree."""
+
+        names: list[JsonValue] = [
+            item.relative_path.as_posix() for item in files[:_MAX_REPORTED_MEMBERS]
+        ]
+        return ArtifactObservation(
+            artifact_id=self._collection_artifact_id,
+            logical_name="gadget2-results",
+            kind="scientific_dataset",
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(self.output_dir),
+            format="gadget2-output-tree",
+            size_bytes=sum(item.size_bytes for item in files),
+            message=message,
+            metadata={
+                "application": "gadget2",
+                "completion_signal": "process_exit",
+                "member_count_observed": len(files),
+                "member_names": names,
+                "member_names_truncated": len(files) > len(names),
+            },
+        )
+
+    def _file_observation(
+        self,
+        item: _OutputFile,
+        *,
+        identity: tuple[str, str, str, str],
+        state: ArtifactState,
+    ) -> ArtifactObservation:
+        """Describe one exact Gadget2 log or table."""
+
+        logical_name, kind, format_name, media_type = identity
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(
+                self.output_dir / item.relative_path
+            ),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=item.size_bytes,
+            checksum=self._checksum(item),
+            message="Gadget2 product finalized",
+            metadata={"application": "gadget2"},
+        )
+
+    def _set_observation(
+        self,
+        items: list[_OutputFile],
+        *,
+        logical_name: str,
+        kind: str,
+        format_name: str,
+        media_type: str,
+        state: ArtifactState,
+    ) -> ArtifactObservation:
+        """Describe one bounded set of snapshots or per-rank restart files."""
+
+        paths: list[JsonValue] = [
+            item.relative_path.as_posix() for item in items[:_MAX_REPORTED_MEMBERS]
+        ]
+        parents = {item.relative_path.parent for item in items}
+        location = self.output_dir
+        if len(parents) == 1:
+            location /= next(iter(parents))
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(location),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=sum(item.size_bytes for item in items),
+            message="Gadget2 product set finalized",
+            metadata={
+                "application": "gadget2",
+                "member_count": len(items),
+                "member_names": paths,
+                "member_names_truncated": len(items) > len(paths),
+            },
+        )
+
+    def _checksum(self, item: _OutputFile) -> str | None:
+        """Hash one bounded output file."""
+
+        if item.size_bytes > _MAX_CHECKSUM_BYTES:
+            return None
+        path = self._local_output_path() / item.relative_path
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                digest.update(chunk)
+        return f"sha256:{digest.hexdigest()}"
+
+
+def adapter_from_package(package: dict[str, Any]) -> Gadget2ArtifactAdapter | None:
+    """Create artifact semantics for the builtin Gadget2 package."""
+
+    if package.get("pkg_type") != "builtin.gadget2":
+        return None
+    input_bundle = package.get("input_bundle")
+    if not isinstance(input_bundle, str) or not input_bundle:
+        return None
+    output_dir = _configured_output_dir(
+        package.get("out"),
+        shared_dir=package.get("shared_dir"),
+        runtime_cwd=package.get("runtime_cwd"),
+    )
+    deploy_mode = str(package.get("effective_deploy_mode") or "default").casefold()
+    if deploy_mode == "container":
+        roots = tuple(
+            root
+            for root in (
+                _optional_absolute_path(package.get("shared_dir")),
+                _optional_absolute_path(package.get("private_dir")),
+            )
+            if root is not None
+        )
+        if not any(output_dir.is_relative_to(root) for root in roots):
+            return None
+    shared_dir = _optional_absolute_path(package.get("shared_dir"))
+    if shared_dir is None:
+        raise ValueError("Gadget2 input-bundle artifacts require shared_dir")
+    materialized = extract_input_bundle(
+        input_bundle, Path(shared_dir.as_posix()) / "input-bundles"
+    )
+    input_paths = frozenset(
+        PurePosixPath(item.path) for item in materialized.manifest.files
+    )
+    return Gadget2ArtifactAdapter(output_dir, input_paths)
+
+
+def _configured_output_dir(
+    value: object,
+    *,
+    shared_dir: object,
+    runtime_cwd: object,
+) -> PurePosixPath:
+    """Resolve the normalized absolute output directory used by the package."""
+
+    raw = "run" if value in (None, "") else value
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("Gadget2 artifacts require a printable output path")
+    path = PurePosixPath(raw)
+    if not path.is_absolute():
+        base = _optional_absolute_path(shared_dir)
+        if base is None:
+            base = _optional_absolute_path(runtime_cwd)
+        if base is None:
+            raise ValueError(
+                "relative Gadget2 artifact output requires shared_dir or runtime_cwd"
+            )
+        path = base / path
+    normalized = PurePosixPath(posixpath.normpath(path.as_posix()))
+    if not normalized.is_absolute() or ".." in normalized.parts:
+        raise ValueError("Gadget2 artifacts require a normalized absolute output path")
+    return normalized
+
+
+def _optional_absolute_path(value: object) -> PurePosixPath | None:
+    """Return a normalized absolute POSIX path when one is available."""
+
+    if not isinstance(value, str) or not value:
+        return None
+    path = PurePosixPath(value)
+    if not path.is_absolute() or ".." in path.parts:
+        return None
+    return path

--- a/builtin/builtin/gadget2/artifacts.py
+++ b/builtin/builtin/gadget2/artifacts.py
@@ -9,6 +9,10 @@ from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from .output_contract import (
+    Gadget2OutputContract,
+    parse_gadget2_output_contract,
+)
 from jarvis_cd.artifacts import (
     ArtifactLocation,
     ArtifactObservation,
@@ -25,25 +29,25 @@ _MAX_DISCOVERED_FILES = 4096
 _MAX_REPORTED_MEMBERS = 512
 _MAX_CHECKSUM_BYTES = 256 * 1024 * 1024
 _LOG_PRODUCTS = {
-    "energy.txt": (
+    "energy_file": (
         "gadget2-energy",
         "scientific_dataset",
         "gadget2-energy-table",
         "text/plain",
     ),
-    "info.txt": (
+    "info_file": (
         "gadget2-info",
         "scientific_log",
         "gadget2-timestep-log",
         "text/plain",
     ),
-    "cpu.txt": (
+    "cpu_file": (
         "gadget2-cpu",
         "performance_log",
         "gadget2-cpu-log",
         "text/plain",
     ),
-    "timings.txt": (
+    "timings_file": (
         "gadget2-timings",
         "performance_log",
         "gadget2-timing-log",
@@ -66,6 +70,7 @@ class Gadget2ArtifactAdapter:
 
     output_dir: PurePosixPath
     input_paths: frozenset[PurePosixPath] = frozenset()
+    declared_outputs: Gadget2OutputContract | None = None
     _local_root: Path | None = None
     _finalized: bool = False
     _collection_artifact_id: str = field(default_factory=new_artifact_id)
@@ -146,26 +151,33 @@ class Gadget2ArtifactAdapter:
         files, truncated = self._discover_files()
         if not files and not truncated:
             return []
-        by_basename: dict[str, list[_OutputFile]] = {}
-        for item in files:
-            by_basename.setdefault(item.relative_path.name.casefold(), []).append(item)
+        declared = self.declared_outputs
+        if declared is None:
+            raise RuntimeError("Gadget2 artifact discovery requires declared outputs")
+        by_path = {item.relative_path: item for item in files}
+        snapshot_base = declared.snapshot_file_base
         snapshots = [
             item
             for item in files
-            if item.relative_path.name.casefold().startswith("snapshot_")
+            if item.relative_path.parent == snapshot_base.parent
+            and item.relative_path.name.startswith(f"{snapshot_base.name}_")
         ]
         restarts = [
             item
             for item in files
-            if item.relative_path.name.casefold().startswith("restart.")
+            if item.relative_path.parent == declared.output_dir
+            and item.relative_path.name.casefold().startswith("restart.")
         ]
-        missing = [
-            name
-            for name in ("energy.txt", "info.txt")
-            if len(by_basename.get(name, ())) != 1
-        ]
-        if not snapshots:
-            missing.append("snapshot")
+        missing: list[str] = []
+        for label, path in (
+            ("EnergyFile", declared.energy_file),
+            ("InfoFile", declared.info_file),
+        ):
+            product = by_path.get(path)
+            if product is None or product.size_bytes <= 0:
+                missing.append(label)
+        if not any(snapshot.size_bytes > 0 for snapshot in snapshots):
+            missing.append("SnapshotFileBase")
         valid = return_code == 0 and not truncated and not missing
         state = ArtifactState.FINALIZED if valid else ArtifactState.INCOMPLETE
         if missing:
@@ -181,11 +193,15 @@ class Gadget2ArtifactAdapter:
         observations = [
             self._collection_observation(files, state=state, message=message)
         ]
-        for basename, identity in _LOG_PRODUCTS.items():
-            matches = by_basename.get(basename, ())
-            if len(matches) == 1:
+        for field_name, identity in _LOG_PRODUCTS.items():
+            declared_path = getattr(declared, field_name)
+            if declared_path is not None and declared_path in by_path:
                 observations.append(
-                    self._file_observation(matches[0], identity=identity, state=state)
+                    self._file_observation(
+                        by_path[declared_path],
+                        identity=identity,
+                        state=state,
+                    )
                 )
         if snapshots:
             observations.append(
@@ -355,10 +371,45 @@ def adapter_from_package(package: dict[str, Any]) -> Gadget2ArtifactAdapter | No
     materialized = extract_input_bundle(
         input_bundle, Path(shared_dir.as_posix()) / "input-bundles"
     )
+    parameter_path = _selected_parameter_path(
+        package.get("parameter_path"),
+        entrypoint=materialized.manifest.entrypoint,
+        declared=frozenset(item.path for item in materialized.manifest.files),
+    )
+    parameter = materialized.root / parameter_path
+    try:
+        parameter_text = parameter.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise ValueError("Gadget2 parameter file must be readable UTF-8 text") from exc
+    declared_outputs = parse_gadget2_output_contract(
+        parameter_text,
+        parameter_path=parameter_path,
+    )
     input_paths = frozenset(
         PurePosixPath(item.path) for item in materialized.manifest.files
     )
-    return Gadget2ArtifactAdapter(output_dir, input_paths)
+    return Gadget2ArtifactAdapter(output_dir, input_paths, declared_outputs)
+
+
+def _selected_parameter_path(
+    value: object,
+    *,
+    entrypoint: str,
+    declared: frozenset[str],
+) -> PurePosixPath:
+    """Resolve the package-selected parameter within the bundle manifest."""
+
+    raw = entrypoint if value in (None, "") else value
+    if not isinstance(raw, str) or not raw or "\\" in raw:
+        raise ValueError("Gadget2 parameter_path must be a manifest path")
+    path = PurePosixPath(raw)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError("Gadget2 parameter_path must be a confined manifest path")
+    if path.as_posix() not in declared:
+        raise ValueError("Gadget2 parameter_path is not declared by the input bundle")
+    if path.suffix.casefold() != ".param":
+        raise ValueError("Gadget2 parameter_path must end in .param")
+    return path
 
 
 def _configured_output_dir(

--- a/builtin/builtin/gadget2/output_contract.py
+++ b/builtin/builtin/gadget2/output_contract.py
@@ -1,0 +1,129 @@
+"""Parse confined output declarations from Gadget2 parameter files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+_REQUIRED_FIELDS = (
+    "OutputDir",
+    "EnergyFile",
+    "InfoFile",
+    "SnapshotFileBase",
+)
+_OPTIONAL_FIELDS = ("CpuFile", "TimingsFile")
+
+
+@dataclass(frozen=True, slots=True)
+class Gadget2OutputContract:
+    """Output paths declared by one Gadget2 parameter file.
+
+    Every path is relative to the root into which the input bundle is staged.
+    """
+
+    output_dir: PurePosixPath
+    energy_file: PurePosixPath
+    info_file: PurePosixPath
+    snapshot_file_base: PurePosixPath
+    cpu_file: PurePosixPath | None = None
+    timings_file: PurePosixPath | None = None
+
+
+def parse_gadget2_output_contract(
+    text: str,
+    *,
+    parameter_path: PurePosixPath,
+) -> Gadget2OutputContract:
+    """Return the exact confined outputs declared by a parameter file.
+
+    :param text: UTF-8 decoded Gadget2 parameter contents.
+    :param parameter_path: Parameter path relative to the staged bundle root.
+    :raises ValueError: If a required declaration is absent, duplicated, or unsafe.
+    """
+
+    parameter_path = _confined_path(parameter_path.as_posix(), field="parameter_path")
+    values: dict[str, list[str]] = {
+        name: [] for name in (*_REQUIRED_FIELDS, *_OPTIONAL_FIELDS)
+    }
+    for raw_line in text.splitlines():
+        statement = raw_line.partition("%")[0].partition(";")[0].strip()
+        if not statement:
+            continue
+        tokens = statement.split()
+        field = tokens[0]
+        if field not in values:
+            continue
+        if len(tokens) != 2:
+            raise ValueError(f"Gadget2 {field} must contain one path token")
+        values[field].append(tokens[1])
+
+    for field in _REQUIRED_FIELDS:
+        if len(values[field]) != 1:
+            raise ValueError(
+                f"Gadget2 parameter file must declare {field} exactly once"
+            )
+    for field in _OPTIONAL_FIELDS:
+        if len(values[field]) > 1:
+            raise ValueError(f"Gadget2 parameter file may declare {field} at most once")
+
+    parameter_dir = parameter_path.parent
+    output_dir = _join_confined(
+        parameter_dir,
+        values["OutputDir"][0],
+        field="OutputDir",
+    )
+
+    def product(field: str) -> PurePosixPath:
+        return _join_confined(output_dir, values[field][0], field=field)
+
+    def optional_product(field: str) -> PurePosixPath | None:
+        if not values[field]:
+            return None
+        return _join_confined(output_dir, values[field][0], field=field)
+
+    return Gadget2OutputContract(
+        output_dir=output_dir,
+        energy_file=product("EnergyFile"),
+        info_file=product("InfoFile"),
+        snapshot_file_base=product("SnapshotFileBase"),
+        cpu_file=optional_product("CpuFile"),
+        timings_file=optional_product("TimingsFile"),
+    )
+
+
+def _join_confined(
+    base: PurePosixPath,
+    value: str,
+    *,
+    field: str,
+) -> PurePosixPath:
+    """Join one untrusted relative token below a previously confined base."""
+
+    relative = _confined_path(value, field=field)
+    joined = base / relative
+    try:
+        joined.relative_to(base)
+    except ValueError as exc:
+        raise ValueError(f"Gadget2 {field} escapes its declared output root") from exc
+    return joined
+
+
+def _confined_path(value: str, *, field: str) -> PurePosixPath:
+    """Parse one bounded printable relative POSIX path."""
+
+    if (
+        not value
+        or len(value) > 1024
+        or "\\" in value
+        or any(ord(character) < 32 for character in value)
+    ):
+        raise ValueError(f"Gadget2 {field} must use a confined POSIX path")
+    path = PurePosixPath(value)
+    if (
+        not path.parts
+        or path.is_absolute()
+        or ".." in path.parts
+        or (path.parts and ":" in path.parts[0])
+    ):
+        raise ValueError(f"Gadget2 {field} must use a confined POSIX path")
+    return path

--- a/builtin/builtin/gadget2/pkg.py
+++ b/builtin/builtin/gadget2/pkg.py
@@ -8,6 +8,10 @@ import shutil
 from pathlib import Path, PurePosixPath
 from typing import Any, cast
 
+from .output_contract import (
+    Gadget2OutputContract,
+    parse_gadget2_output_contract,
+)
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.deployment import (
     ConfigurationCondition,
@@ -195,7 +199,8 @@ class Gadget2(Application):
                     when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
                     runtime_requirements=("gadget2",),
                     readiness=ReadinessContract(
-                        mechanism="process_exit", condition="successful_exit"
+                        mechanism="process_exit",
+                        condition="successful_exit_with_required_products",
                     ),
                     description=(
                         "Run one caller-supplied Gadget2 parameter and "
@@ -339,7 +344,7 @@ class Gadget2(Application):
             raise ValueError("selected Gadget2 parameter_path is not a regular file")
         return selected
 
-    def _prepare_native_input(self) -> Path:
+    def _prepare_native_input(self) -> tuple[Path, Gadget2OutputContract]:
         """Verify and copy one complete simulation bundle into owned storage."""
 
         self._validate_native_configuration()
@@ -359,49 +364,32 @@ class Gadget2(Application):
         staged = self._output_dir() / relative
         if staged.is_symlink() or not staged.is_file():
             raise RuntimeError("staged Gadget2 parameter file is unavailable")
-        self._prepare_native_output_directory(staged)
-        return staged
+        contract = self._prepare_native_output_directory(staged, relative=relative)
+        self._assert_native_outputs_absent(contract)
+        return staged, contract
 
-    @staticmethod
-    def _prepare_native_output_directory(parameter: Path) -> Path:
+    def _prepare_native_output_directory(
+        self,
+        parameter: Path,
+        *,
+        relative: Path,
+    ) -> Gadget2OutputContract:
         """Create the parameter-declared output directory inside owned storage."""
 
         try:
-            lines = parameter.read_text(encoding="utf-8").splitlines()
+            text = parameter.read_text(encoding="utf-8")
         except (OSError, UnicodeError) as exc:
             raise ValueError(
                 "Gadget2 parameter file must be readable UTF-8 text"
             ) from exc
-        values: list[str] = []
-        for raw_line in lines:
-            statement = raw_line.partition("%")[0].partition(";")[0].strip()
-            if not statement:
-                continue
-            tokens = statement.split()
-            if tokens[0] != "OutputDir":
-                continue
-            if len(tokens) != 2:
-                raise ValueError("Gadget2 OutputDir must contain one path token")
-            values.append(tokens[1])
-        if len(values) != 1:
-            raise ValueError(
-                "Gadget2 parameter file must declare OutputDir exactly once"
-            )
-
-        raw_output = values[0]
-        if "\\" in raw_output:
-            raise ValueError("Gadget2 OutputDir must use a confined POSIX path")
-        relative = PurePosixPath(raw_output)
-        if (
-            relative.is_absolute()
-            or ".." in relative.parts
-            or (relative.parts and ":" in relative.parts[0])
-        ):
-            raise ValueError("Gadget2 OutputDir must use a confined POSIX path")
-        lexical_target = parameter.parent.joinpath(*relative.parts)
+        contract = parse_gadget2_output_contract(
+            text,
+            parameter_path=PurePosixPath(relative.as_posix()),
+        )
+        lexical_target = self._output_dir().joinpath(*contract.output_dir.parts)
         if lexical_target.is_symlink():
             raise ValueError("Gadget2 OutputDir cannot be a symbolic link")
-        root = parameter.parent.resolve()
+        root = self._output_dir().resolve()
         target = lexical_target.resolve(strict=False)
         try:
             target.relative_to(root)
@@ -413,12 +401,83 @@ class Gadget2(Application):
             raise RuntimeError("could not create Gadget2 OutputDir") from exc
         if target.is_symlink() or not target.is_dir():
             raise ValueError("Gadget2 OutputDir must resolve to a directory")
-        return target
+        return contract
+
+    def _contract_path(self, relative: PurePosixPath) -> Path:
+        """Resolve one parsed output path below the package-owned run root."""
+
+        root = self._output_dir().resolve()
+        lexical = self._output_dir().joinpath(*relative.parts)
+        resolved = lexical.resolve(strict=False)
+        try:
+            resolved.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(
+                "Gadget2 output path escapes staged input storage"
+            ) from exc
+        return lexical
+
+    def _snapshot_products(
+        self,
+        contract: Gadget2OutputContract,
+    ) -> list[Path]:
+        """Return bounded regular snapshots matching the declared file base."""
+
+        base = self._contract_path(contract.snapshot_file_base)
+        parent = base.parent
+        if parent.is_symlink() or not parent.is_dir():
+            return []
+        products: list[Path] = []
+        for candidate in parent.glob(f"{base.name}_*"):
+            if candidate.is_symlink() or not candidate.is_file():
+                continue
+            products.append(candidate)
+            if len(products) >= 4096:
+                break
+        return products
+
+    def _assert_native_outputs_absent(
+        self,
+        contract: Gadget2OutputContract,
+    ) -> None:
+        """Prevent staged or stale files from satisfying completion checks."""
+
+        for relative in (contract.energy_file, contract.info_file):
+            path = self._contract_path(relative)
+            if path.exists() or path.is_symlink():
+                raise ValueError(
+                    "Gadget2 required outputs must not exist before execution"
+                )
+        if self._snapshot_products(contract):
+            raise ValueError("Gadget2 snapshots must not exist before execution")
+
+    def _validate_native_completion(
+        self,
+        contract: Gadget2OutputContract,
+    ) -> None:
+        """Require non-empty scientific products after a successful process exit."""
+
+        missing: list[str] = []
+        for label, relative in (
+            ("EnergyFile", contract.energy_file),
+            ("InfoFile", contract.info_file),
+        ):
+            path = self._contract_path(relative)
+            if path.is_symlink() or not path.is_file() or path.stat().st_size <= 0:
+                missing.append(label)
+        snapshots = self._snapshot_products(contract)
+        if not any(snapshot.stat().st_size > 0 for snapshot in snapshots):
+            missing.append("SnapshotFileBase")
+        if missing:
+            raise RuntimeError(
+                "Gadget2 exited without required non-empty products: "
+                + ", ".join(missing)
+            )
 
     def _start_native(self) -> None:
         """Launch the staged scientific input and propagate every rank failure."""
 
-        parameter = self._prepare_native_input()
+        parameter, contract = self._prepare_native_input()
         executable = self.gadget2_bin or self._discover_executable(self.mod_env)
         if executable is None:
             raise RuntimeError("Gadget2 executable is unavailable through PATH")
@@ -437,6 +496,7 @@ class Gadget2(Application):
         failures = {host: code for host, code in result.exit_code.items() if code != 0}
         if failures:
             raise RuntimeError(f"Gadget2 execution failed: {failures}")
+        self._validate_native_completion(contract)
 
     def _configure_legacy(self) -> None:
         """Preserve the historical stock-case/container configuration."""

--- a/builtin/builtin/gadget2/pkg.py
+++ b/builtin/builtin/gadget2/pkg.py
@@ -1,186 +1,533 @@
-"""
-Gadget2 cosmological N-body/SPH simulation. Supports bare-metal and
-container deployments. Container mode builds FFTW 2.1.5 from source (Gadget2
-needs the single-precision, type-prefixed, MPI variant — FFTW3 in the Ubuntu
-archive is ABI-incompatible) and clones lukemartinlogan/gadget2 into
-/opt/gadget2 in build.sh.
-"""
+"""Launch native or containerized Gadget2 simulations."""
+
+from __future__ import annotations
+
 import os
+import shlex
+import shutil
+from pathlib import Path, PurePosixPath
+from typing import Any, cast
 
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo, MpiExecInfo, Mkdir
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ReadinessContract,
+    RuntimeRequirement,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
+from jarvis_cd.shell.process import Mkdir, Rm
 
-
-_TEST_CASES = ['gassphere']
-_GADGET2_PATH_CONTAINER = '/opt/gadget2'
-_BINARY_REL_PATH = 'build/bin/Gadget2'
+_LEGACY_TEST_CASES = (
+    "gassphere",
+    "galaxy",
+    "cluster",
+    "lcdm_gas",
+    "lcdm_gas-ngen",
+)
+_GADGET2_PATH_CONTAINER = "/opt/gadget2"
+_BINARY_REL_PATH = "build/bin/Gadget2"
+_EXECUTABLE_CANDIDATES = ("Gadget2", "gadget2")
 
 
 class Gadget2(Application):
-    """
-    Gadget2 driver.
+    """Run one caller-defined Gadget2 parameter and initial-condition bundle.
+
+    The native profile stages a digest-verified multi-file bundle into one
+    execution-owned directory and launches exactly one declared parameter file.
+    The historical stock-case/container profile remains available for existing
+    pipelines but is not advertised as an agent-facing scientific contract.
     """
 
-    def _configure_menu(self):
+    def _init(self) -> None:
+        self.gadget2_bin: str | None = None
+
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
-            {'name': 'gadget2_path',
-             'msg': ('Absolute path to the Gadget2 source tree (containing '
-                     'ICs/, Gadget2/, build/). In container mode this is '
-                     'baked into the image at /opt/gadget2 and this option '
-                     'is ignored.'),
-             'type': str, 'default': None},
-            {'name': 'test_case', 'msg': 'Predefined test case (paramfile basename)',
-             'type': str, 'default': 'gassphere', 'choices': _TEST_CASES},
-            {'name': 'output', 'msg': 'Output directory (None = under shared_dir)',
-             'type': str, 'default': None},
-            {'name': 'time_max', 'msg': 'Maximum simulation time (internal units)',
-             'type': float, 'default': 0.05},
-            {'name': 'buffer_size', 'msg': 'Communication buffer size in MB',
-             'type': float, 'default': 15},
-            {'name': 'part_alloc_factor',
-             'msg': 'Per-rank particle allocation factor (1.0 - 3.0)',
-             'type': float, 'default': 1.5},
-            {'name': 'tree_alloc_factor', 'msg': 'BH-tree allocation factor',
-             'type': float, 'default': 0.9},
-            {'name': 'nprocs', 'msg': 'Total number of MPI ranks',
-             'type': int, 'default': 2},
-            {'name': 'ppn', 'msg': 'Processes per node',
-             'type': int, 'default': 2},
-            {'name': 'exec_mode', 'msg': 'Multi-node mode: mpi or pssh',
-             'type': str, 'default': 'mpi', 'choices': ['mpi', 'pssh']},
+            {
+                "name": "input_bundle",
+                "msg": (
+                    "Digest-verified JARVIS input bundle containing one Gadget2 "
+                    "parameter file and every referenced initial-condition or "
+                    "support file. The bundle is copied into execution-owned "
+                    "storage before launch."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
+            },
+            {
+                "name": "parameter_path",
+                "msg": (
+                    "Relative manifest member to execute; empty selects the "
+                    "input-bundle entrypoint"
+                ),
+                "type": str,
+                "default": "",
+            },
+            {
+                "name": "out",
+                "msg": (
+                    "Output directory. Relative paths resolve under the JARVIS "
+                    "package shared directory."
+                ),
+                "type": str,
+                "default": "run",
+            },
+            {
+                "name": "nprocs",
+                "msg": "Total number of MPI ranks",
+                "type": int,
+                "default": 2,
+            },
+            {
+                "name": "ppn",
+                "msg": "MPI ranks per node",
+                "type": int,
+                "default": 2,
+            },
+            {
+                "name": "gadget2_path",
+                "msg": "Legacy source-tree path used by stock examples",
+                "type": str,
+                "default": None,
+                "agent_visible": False,
+            },
+            {
+                "name": "test_case",
+                "msg": "Legacy bundled Gadget2 stock-case template",
+                "type": str,
+                "default": "gassphere",
+                "choices": list(_LEGACY_TEST_CASES),
+                "agent_visible": False,
+            },
+            {
+                "name": "output",
+                "msg": "Legacy stock-case output directory",
+                "type": str,
+                "default": None,
+                "agent_visible": False,
+            },
+            {
+                "name": "time_max",
+                "msg": "Legacy stock-case maximum simulation time",
+                "type": float,
+                "default": 0.05,
+                "agent_visible": False,
+            },
+            {
+                "name": "buffer_size",
+                "msg": "Legacy stock-case communication buffer size in MB",
+                "type": float,
+                "default": 15.0,
+                "agent_visible": False,
+            },
+            {
+                "name": "part_alloc_factor",
+                "msg": "Legacy stock-case particle allocation factor",
+                "type": float,
+                "default": 1.5,
+                "agent_visible": False,
+            },
+            {
+                "name": "tree_alloc_factor",
+                "msg": "Legacy stock-case tree allocation factor",
+                "type": float,
+                "default": 0.9,
+                "agent_visible": False,
+            },
+            {
+                "name": "exec_mode",
+                "msg": "Legacy multi-node launch mode",
+                "type": str,
+                "default": "mpi",
+                "choices": ["mpi", "pssh"],
+                "agent_visible": False,
+            },
         ]
 
-    # ------------------------------------------------------------------
-    # Container build/deploy
-    # ------------------------------------------------------------------
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe native Gadget2 runtime, input, and completion semantics."""
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+        environment = self._deployment_environment()
+        program = self._discover_executable(environment)
+        probe = probe_program(
+            program or "Gadget2",
+            environment=environment,
+            accepted_return_codes=(0, 1),
+            timeout_seconds=5,
+        )
+        capabilities = (
+            ("gadget2", "mpi_execution", "particle_simulation")
+            if program is not None and probe.status.usable is True
+            else ()
+        )
+        runtime = RuntimeRequirement(
+            requirement_id="gadget2",
+            description="MPI-enabled Gadget2 runtime available through PATH",
+            required_capabilities=(
+                "gadget2",
+                "mpi_execution",
+                "particle_simulation",
+            ),
+            available_capabilities=capabilities,
+            status=probe.status,
+        )
+        return PackageDeploymentContract(
+            package="builtin.gadget2",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="input_bundle",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    runtime_requirements=("gadget2",),
+                    readiness=ReadinessContract(
+                        mechanism="process_exit", condition="successful_exit"
+                    ),
+                    description=(
+                        "Run one caller-supplied Gadget2 parameter and "
+                        "initial-condition bundle under MPI."
+                    ),
+                ),
+            ),
+            runtime_requirements=(runtime,),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    requires=(ConfigurationCondition("parameter_path", "is_empty"),),
+                    description="parameter_path is valid only with input_bundle.",
+                ),
+            ),
+        )
+
+    def _build_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Build the retained legacy container image when requested."""
+
+        if self.config.get("deploy_mode") != "container":
             return None
-        return self._read_build_script('build.sh', {}), 'default'
+        return self._read_build_script("build.sh", {}), "default"
 
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Create the retained legacy container deployment image."""
+
+        if self.config.get("deploy_mode") != "container":
             return None
-        base = getattr(self.pipeline, 'container_base', 'ubuntu:22.04')
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': base,
-        })
-        return content, ''
+        base = getattr(self.pipeline, "container_base", "ubuntu:22.04")
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {
+                "BUILD_IMAGE": self.build_image_name(),
+                "DEPLOY_BASE": base,
+            },
+        )
+        return content, ""
 
-    # ------------------------------------------------------------------
-    # Configuration
-    # ------------------------------------------------------------------
+    def _configure(self, **kwargs: Any) -> None:
+        """Validate the selected profile and prepare package-owned storage."""
 
-    def _configure(self, **kwargs):
         super()._configure(**kwargs)
+        if self._uses_native_bundle():
+            self._validate_native_configuration()
+            if self.config.get("deploy_mode") == "default":
+                self.gadget2_bin = self._discover_executable(
+                    self._deployment_environment()
+                )
+            self._ensure_output_dir()
+            return
+        self._configure_legacy()
 
-        if self.config.get('deploy_mode') == 'container':
+    def _uses_native_bundle(self) -> bool:
+        """Return whether the explicit scientific input profile is selected."""
+
+        return self.config.get("input_bundle") not in (None, "")
+
+    @staticmethod
+    def _discover_executable(environment: dict[str, str]) -> str | None:
+        """Return the first supported Gadget2 executable available through PATH."""
+
+        for candidate in _EXECUTABLE_CANDIDATES:
+            if shutil.which(candidate, path=environment.get("PATH")) is not None:
+                return candidate
+        return None
+
+    def _validate_native_configuration(self) -> None:
+        """Reject missing bundle, unsafe parameter selection, and invalid MPI sizes."""
+
+        bundle = self.config.get("input_bundle")
+        if not isinstance(bundle, str) or not bundle:
+            raise ValueError("native Gadget2 requires input_bundle")
+        parameter_path = self.config.get("parameter_path")
+        if parameter_path not in (None, "") and not isinstance(parameter_path, str):
+            raise TypeError("parameter_path must be a relative path string")
+        values: dict[str, int] = {}
+        for name in ("nprocs", "ppn"):
+            value = self.config.get(name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+            values[name] = value
+        if values["ppn"] > values["nprocs"]:
+            raise ValueError("ppn cannot exceed nprocs")
+        if self.config.get("deploy_mode") != "default":
+            raise ValueError("input_bundle requires native deploy_mode=default")
+
+    def _output_dir(self) -> Path:
+        """Return the normalized package-owned output root."""
+
+        if self._uses_native_bundle():
+            value = self.config.get("out")
+            return self.resolve_shared_path(value, field="out", default="run")
+        value = self.config.get("output")
+        if value in (None, "") and self.config.get("out") not in (None, "", "run"):
+            value = self.config.get("out")
+        return self.resolve_shared_path(value, field="output", default="gadget2_out")
+
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        """Return local or parallel-SSH execution according to the hostfile."""
+
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
+
+    def _ensure_output_dir(self) -> None:
+        """Create the exact output root on every participating host."""
+
+        output_dir = str(self._output_dir())
+        result = Mkdir(output_dir, self._node_exec_info(env=self.env)).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to create Gadget2 output directory {output_dir}: {failures}"
+            )
+
+    @staticmethod
+    def _resolve_bundle_parameter(
+        bundle: MaterializedInputBundle, requested: object
+    ) -> Path:
+        """Resolve one manifest-declared parameter file without path inference."""
+
+        if requested in (None, ""):
+            selected = bundle.entrypoint
+        else:
+            if not isinstance(requested, str) or "\\" in requested:
+                raise ValueError("parameter_path must be a confined manifest path")
+            relative = PurePosixPath(requested)
+            if relative.is_absolute() or any(
+                part in {"", ".", ".."} for part in relative.parts
+            ):
+                raise ValueError("parameter_path must be a confined manifest path")
+            declared = {item.path for item in bundle.manifest.files}
+            if relative.as_posix() not in declared:
+                raise ValueError("parameter_path is not declared by the input bundle")
+            selected = bundle.root / relative
+        if selected.suffix.casefold() != ".param":
+            raise ValueError("selected Gadget2 parameter_path must end in .param")
+        if selected.is_symlink() or not selected.is_file():
+            raise ValueError("selected Gadget2 parameter_path is not a regular file")
+        return selected
+
+    def _prepare_native_input(self) -> Path:
+        """Verify and copy one complete simulation bundle into owned storage."""
+
+        self._validate_native_configuration()
+        self._ensure_output_dir()
+        configured = self.config.get("input_bundle")
+        assert isinstance(configured, str) and configured
+        if self.shared_dir is None:
+            raise RuntimeError("Gadget2 input bundles require shared storage")
+        bundle = extract_input_bundle(
+            configured, Path(self.shared_dir) / "input-bundles"
+        )
+        selected = self._resolve_bundle_parameter(
+            bundle, self.config.get("parameter_path")
+        )
+        relative = selected.relative_to(bundle.root)
+        stage_input_bundle(bundle, self._output_dir())
+        staged = self._output_dir() / relative
+        if staged.is_symlink() or not staged.is_file():
+            raise RuntimeError("staged Gadget2 parameter file is unavailable")
+        return staged
+
+    def _start_native(self) -> None:
+        """Launch the staged scientific input and propagate every rank failure."""
+
+        parameter = self._prepare_native_input()
+        executable = self.gadget2_bin or self._discover_executable(self.mod_env)
+        if executable is None:
+            raise RuntimeError("Gadget2 executable is unavailable through PATH")
+        command = " ".join((shlex.quote(executable), shlex.quote(parameter.name)))
+        result = Exec(
+            command,
+            MpiExecInfo(
+                nprocs=self.config["nprocs"],
+                ppn=self.config["ppn"],
+                hostfile=self.hostfile,
+                env=self.mod_env,
+                cwd=str(parameter.parent),
+                line_callback=self.runtime_line_callback(),
+            ),
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"Gadget2 execution failed: {failures}")
+
+    def _configure_legacy(self) -> None:
+        """Preserve the historical stock-case/container configuration."""
+
+        config = cast(dict[str, Any], self.config)
+        if config.get("parameter_path") not in (None, ""):
+            raise ValueError("parameter_path requires input_bundle")
+        if config.get("deploy_mode") == "container":
             gadget2_path = _GADGET2_PATH_CONTAINER
         else:
-            gadget2_path = (
-                self.config.get('gadget2_path')
-                or self.env.get('GADGET2_PATH')
-                or os.environ.get('GADGET2_PATH')
+            configured_path = (
+                config.get("gadget2_path")
+                or self.env.get("GADGET2_PATH")
+                or os.environ.get("GADGET2_PATH")
             )
-            if not gadget2_path:
+            if not isinstance(configured_path, str) or not configured_path:
                 raise RuntimeError(
-                    "GADGET2_PATH is not set. Set gadget2_path or export "
-                    "GADGET2_PATH for bare-metal, or use deploy_mode=container."
+                    "GADGET2_PATH is not set. Set gadget2_path for the legacy "
+                    "stock profile or provide input_bundle for the native profile."
                 )
+            gadget2_path = configured_path
             if not os.path.isdir(gadget2_path):
                 raise RuntimeError(
                     f"gadget2_path does not exist on the local node: {gadget2_path}"
                 )
-        self.config['gadget2_path'] = gadget2_path
-        self.setenv('GADGET2_PATH', gadget2_path)
-
-        if self.config.get('output') is None:
-            self.config['output'] = f'{self.shared_dir}/gadget2_out'
-        Mkdir([self.config['output']], LocalExecInfo()).run()
-
-        test_case = self.config.get('test_case', 'gassphere')
-        paramfile_in = os.path.join(self.pkg_dir, 'paramfiles',
-                                    f'{test_case}.param')
-        paramfile_out = os.path.join(self.config['output'],
-                                     f'{test_case}.param')
-        # MaxSizeTimestep is hard-coded in the stock paramfile to 0.02; with
-        # TimeMax much smaller we'd never take a step. The template only
-        # exposes the params Jarvis users tend to tune.
-        self.copy_template_file(paramfile_in, paramfile_out, replacements={
-            'REPO_DIR': gadget2_path,
-            'OUTPUT_DIR': self.config['output'],
-            'TIME_MAX': self.config['time_max'],
-            'BUFFER_SIZE': self.config['buffer_size'],
-            'PART_ALLOC_FACTOR': self.config['part_alloc_factor'],
-            'TREE_ALLOC_FACTOR': self.config['tree_alloc_factor'],
-        })
-        self.config['paramfile'] = paramfile_out
-
+        config["gadget2_path"] = gadget2_path
+        self.setenv("GADGET2_PATH", gadget2_path)
+        self._ensure_output_dir()
+        test_case = config.get("test_case", "gassphere")
+        if not isinstance(test_case, str) or test_case not in _LEGACY_TEST_CASES:
+            raise ValueError(f"unsupported legacy Gadget2 test_case: {test_case!r}")
+        package_dir = self.pkg_dir
+        if not isinstance(package_dir, str) or not package_dir:
+            raise RuntimeError("Gadget2 package directory is unavailable")
+        parameter_input = os.path.join(package_dir, "paramfiles", f"{test_case}.param")
+        parameter_output = self._output_dir() / f"{test_case}.param"
+        self.copy_template_file(
+            parameter_input,
+            str(parameter_output),
+            replacements={
+                "REPO_DIR": gadget2_path,
+                "OUTPUT_DIR": str(self._output_dir()),
+                "TIME_MAX": config["time_max"],
+                "BUFFER_SIZE": config["buffer_size"],
+                "PART_ALLOC_FACTOR": config["part_alloc_factor"],
+                "TREE_ALLOC_FACTOR": config["tree_alloc_factor"],
+            },
+        )
+        config["paramfile"] = str(parameter_output)
         binary = os.path.join(gadget2_path, _BINARY_REL_PATH)
-        if self.config.get('deploy_mode') != 'container' and not os.path.exists(binary):
-            raise RuntimeError(
-                f"Gadget2 binary not found at {binary}. Build it first via "
-                f"`cmake -S {gadget2_path} -B {gadget2_path}/build && "
-                f"cmake --build {gadget2_path}/build`."
-            )
-        self.config['binary'] = binary
+        if config.get("deploy_mode") != "container" and not os.path.isfile(binary):
+            raise RuntimeError(f"Gadget2 binary not found at {binary}")
+        config["binary"] = binary
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
+    def _use_remote(self) -> bool:
+        """Return whether the configured hostfile names remote nodes."""
 
-    def _use_remote(self):
         return self.hostfile is not None and not self.hostfile.is_local()
 
-    def _container_kwargs(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _container_kwargs(self) -> dict[str, Any]:
+        """Return legacy container launch arguments when applicable."""
+
+        if self.config.get("deploy_mode") != "container":
             return {}
-        return dict(
-            container=self._container_engine,
-            container_image=self.deploy_image_name(),
-            shared_dir=self.shared_dir,
-            private_dir=self.private_dir,
-        )
+        return {
+            "container": self._container_engine,
+            "container_image": self.deploy_image_name(),
+            "shared_dir": self.shared_dir,
+            "private_dir": self.private_dir,
+        }
 
-    def _exec_info(self, cwd):
-        nprocs = self.config['nprocs']
-        ppn = self.config['ppn']
-        exec_mode = self.config.get('exec_mode', 'mpi')
-        kwargs = dict(env=self.mod_env, cwd=cwd, **self._container_kwargs())
+    def _legacy_exec_info(self, cwd: str) -> LocalExecInfo | MpiExecInfo | PsshExecInfo:
+        """Return the historical stock-case execution mode."""
 
-        if exec_mode == 'mpi':
-            hostfile = self.hostfile if self._use_remote() else None
+        kwargs: dict[str, Any] = {
+            "env": self.mod_env,
+            "cwd": cwd,
+            **self._container_kwargs(),
+        }
+        if self.config.get("exec_mode", "mpi") == "mpi":
             return MpiExecInfo(
-                nprocs=nprocs, ppn=ppn, hostfile=hostfile,
-                port=self.ssh_port, **kwargs,
+                nprocs=self.config["nprocs"],
+                ppn=self.config["ppn"],
+                hostfile=self.hostfile if self._use_remote() else None,
+                port=self.ssh_port,
+                **kwargs,
             )
-        if exec_mode == 'pssh' and self._use_remote():
+        if self._use_remote():
             return PsshExecInfo(hostfile=self.hostfile, **kwargs)
         return LocalExecInfo(**kwargs)
 
-    def start(self):
-        # Gadget2 reads / writes paths relative to cwd. Run from the output
-        # dir so EnergyFile / InfoFile / snapshots land alongside the
-        # paramfile. Gadget2's MAXLEN_FILENAME is 100 chars — passing the
-        # full absolute path (often >100 under /tmp/...) overflows an early
-        # strcpy on startup ("buffer overflow detected"). We cd into the
-        # output dir and pass just the basename to stay well under the cap.
-        # Also needs a bash -c wrapper: the container exec wrapper doesn't
-        # honor exec_info.cwd, and mpirun takes the first token as the
-        # executable — wrap in `bash -c '...'` so mpirun launches it per-rank.
-        cwd = self.config['output']
-        paramfile_base = os.path.basename(self.config['paramfile'])
-        inner = f'cd {cwd} && {self.config["binary"]} {paramfile_base}'
-        cmd = f"bash -c \"{inner}\""
-        Exec(cmd, self._exec_info(cwd)).run()
+    def _start_legacy(self) -> None:
+        """Run the retained stock-case profile."""
 
-    def stop(self):
-        pass
+        config = cast(dict[str, Any], self.config)
+        cwd = str(self._output_dir())
+        parameter_file = config.get("paramfile")
+        binary = config.get("binary")
+        if not isinstance(parameter_file, str) or not isinstance(binary, str):
+            raise RuntimeError("legacy Gadget2 launch configuration is incomplete")
+        parameter_name = os.path.basename(parameter_file)
+        inner = " ".join(
+            (
+                "cd",
+                shlex.quote(cwd),
+                "&&",
+                shlex.quote(binary),
+                shlex.quote(parameter_name),
+            )
+        )
+        command = f"bash -c {shlex.quote(inner)}"
+        result = Exec(command, self._legacy_exec_info(cwd)).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"Gadget2 execution failed: {failures}")
 
-    def clean(self):
-        pass
+    def start(self) -> None:
+        """Run the explicit native bundle or retained legacy stock profile."""
 
-    def _get_stat(self, stat_dict):
-        stat_dict[f'{self.pkg_id}.runtime'] = self.start_time
+        if self._uses_native_bundle():
+            self._start_native()
+        elif "paramfile" in self.config and "binary" in self.config:
+            self._start_legacy()
+        else:
+            self._validate_native_configuration()
+
+    def stop(self) -> None:
+        """Do nothing because Gadget2 runs to process completion."""
+
+    def clean(self) -> None:
+        """Remove only the exact configured Gadget2 output directory."""
+
+        output_dir = self._output_dir()
+        if output_dir == Path(output_dir.anchor):
+            raise ValueError("refusing to clean a filesystem root as Gadget2 output")
+        result = Rm(
+            str(output_dir),
+            self._node_exec_info(env=self.env),
+            recursive=True,
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to clean Gadget2 output {output_dir}: {failures}"
+            )
+
+    def _get_stat(self, stat_dict: dict[str, Any]) -> None:
+        """Report the package runtime through the legacy statistics surface."""
+
+        stat_dict[f"{self.pkg_id}.runtime"] = getattr(self, "start_time", None)

--- a/builtin/builtin/gadget2/pkg.py
+++ b/builtin/builtin/gadget2/pkg.py
@@ -102,6 +102,7 @@ class Gadget2(Application):
                 "msg": "Legacy source-tree path used by stock examples",
                 "type": str,
                 "default": None,
+                "required": False,
                 "agent_visible": False,
             },
             {
@@ -117,6 +118,7 @@ class Gadget2(Application):
                 "msg": "Legacy stock-case output directory",
                 "type": str,
                 "default": None,
+                "required": False,
                 "agent_visible": False,
             },
             {

--- a/builtin/builtin/gadget2/pkg.py
+++ b/builtin/builtin/gadget2/pkg.py
@@ -359,7 +359,61 @@ class Gadget2(Application):
         staged = self._output_dir() / relative
         if staged.is_symlink() or not staged.is_file():
             raise RuntimeError("staged Gadget2 parameter file is unavailable")
+        self._prepare_native_output_directory(staged)
         return staged
+
+    @staticmethod
+    def _prepare_native_output_directory(parameter: Path) -> Path:
+        """Create the parameter-declared output directory inside owned storage."""
+
+        try:
+            lines = parameter.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeError) as exc:
+            raise ValueError(
+                "Gadget2 parameter file must be readable UTF-8 text"
+            ) from exc
+        values: list[str] = []
+        for raw_line in lines:
+            statement = raw_line.partition("%")[0].partition(";")[0].strip()
+            if not statement:
+                continue
+            tokens = statement.split()
+            if tokens[0] != "OutputDir":
+                continue
+            if len(tokens) != 2:
+                raise ValueError("Gadget2 OutputDir must contain one path token")
+            values.append(tokens[1])
+        if len(values) != 1:
+            raise ValueError(
+                "Gadget2 parameter file must declare OutputDir exactly once"
+            )
+
+        raw_output = values[0]
+        if "\\" in raw_output:
+            raise ValueError("Gadget2 OutputDir must use a confined POSIX path")
+        relative = PurePosixPath(raw_output)
+        if (
+            relative.is_absolute()
+            or ".." in relative.parts
+            or (relative.parts and ":" in relative.parts[0])
+        ):
+            raise ValueError("Gadget2 OutputDir must use a confined POSIX path")
+        lexical_target = parameter.parent.joinpath(*relative.parts)
+        if lexical_target.is_symlink():
+            raise ValueError("Gadget2 OutputDir cannot be a symbolic link")
+        root = parameter.parent.resolve()
+        target = lexical_target.resolve(strict=False)
+        try:
+            target.relative_to(root)
+        except ValueError as exc:
+            raise ValueError("Gadget2 OutputDir escapes staged input storage") from exc
+        try:
+            target.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise RuntimeError("could not create Gadget2 OutputDir") from exc
+        if target.is_symlink() or not target.is_dir():
+            raise ValueError("Gadget2 OutputDir must resolve to a directory")
+        return target
 
     def _start_native(self) -> None:
         """Launch the staged scientific input and propagate every rank failure."""

--- a/builtin/builtin/gadget2/pkg.py
+++ b/builtin/builtin/gadget2/pkg.py
@@ -241,7 +241,7 @@ class Gadget2(Application):
         super()._configure(**kwargs)
         if self._uses_native_bundle():
             self._validate_native_configuration()
-            if self.config.get("deploy_mode") == "default":
+            if self.config.get("deploy_mode", "default") == "default":
                 self.gadget2_bin = self._discover_executable(
                     self._deployment_environment()
                 )
@@ -280,7 +280,7 @@ class Gadget2(Application):
             values[name] = value
         if values["ppn"] > values["nprocs"]:
             raise ValueError("ppn cannot exceed nprocs")
-        if self.config.get("deploy_mode") != "default":
+        if self.config.get("deploy_mode", "default") != "default":
             raise ValueError("input_bundle requires native deploy_mode=default")
 
     def _output_dir(self) -> Path:

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -4253,10 +4253,17 @@ class Pipeline:
                         name = menu_item.get("name")
                         default_value = menu_item.get("default")
 
-                        # If parameter has no default and is not provided in config, it's required
+                        # Preserve the historical ``default=None`` convention,
+                        # while allowing packages with conditional profiles to
+                        # declare that a nullable-looking legacy setting is not
+                        # unconditionally required. PkgArgParse already treats
+                        # the explicit ``required`` field as authoritative.
+                        required = menu_item.get("required")
+                        if required is None:
+                            required = default_value is None
                         if (
                             name
-                            and default_value is None
+                            and required is True
                             and (name not in config or config[name] is None)
                         ):
                             missing_required.append(name)

--- a/test/unit/core/test_gadget2_artifacts.py
+++ b/test/unit/core/test_gadget2_artifacts.py
@@ -1,0 +1,198 @@
+"""Artifact-contract tests for the builtin Gadget2 package."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+)
+
+
+def _load_artifacts() -> ModuleType:
+    """Load the package-local artifact module."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "gadget2"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def _write_bundle(destination: Path) -> Path:
+    files = {
+        "galaxy/galaxy.param": b"InitCondFile ICs/galaxy.dat\n",
+        "galaxy/ICs/galaxy.dat": b"initial-condition\x00\x01",
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "galaxy/galaxy.param",
+        "files": [
+            {
+                "path": name,
+                "role": "gadget2_input",
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, payload in files.items()
+        ],
+    }
+    encoded = json.dumps(manifest, sort_keys=True).encode()
+    with tarfile.open(destination, "w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(encoded)
+        archive.addfile(info, io.BytesIO(encoded))
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def _adapter(module: ModuleType, tmp_path: Path) -> Any:
+    adapter = module.Gadget2ArtifactAdapter(
+        module.PurePosixPath("/scratch/gadget2/run"),
+        frozenset(
+            {
+                module.PurePosixPath("galaxy/galaxy.param"),
+                module.PurePosixPath("galaxy/ICs/galaxy.dat"),
+            }
+        ),
+    )
+    adapter._local_root = tmp_path / "run"
+    return adapter
+
+
+def _write_products(root: Path) -> None:
+    (root / "galaxy" / "ICs").mkdir(parents=True)
+    (root / "galaxy" / "galaxy.param").write_text(
+        "InitCondFile ICs/galaxy.dat\n", encoding="utf-8"
+    )
+    (root / "galaxy" / "ICs" / "galaxy.dat").write_bytes(b"initial-condition\x00\x01")
+    products = root / "galaxy" / "output"
+    products.mkdir()
+    (products / "energy.txt").write_text(
+        "0 0 -10 4\n0.1 0 -9.99 3.99\n", encoding="utf-8"
+    )
+    (products / "info.txt").write_text("Begin Step 1\n", encoding="utf-8")
+    (products / "cpu.txt").write_text("Step 1\n", encoding="utf-8")
+    (products / "timings.txt").write_text("Step=1\n", encoding="utf-8")
+    (products / "snapshot_000").write_bytes(b"snapshot-zero")
+    (products / "snapshot_001").write_bytes(b"snapshot-one")
+    (products / "restart.0").write_bytes(b"rank-zero")
+    (products / "restart.1").write_bytes(b"rank-one")
+
+
+def test_success_finalizes_closed_logs_snapshots_and_restart_sets(
+    tmp_path: Path,
+) -> None:
+    """A successful run reports outputs but never republishes staged inputs."""
+
+    module = _load_artifacts()
+    adapter = _adapter(module, tmp_path)
+    _write_products(tmp_path / "run")
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    by_name = {item.logical_name: item for item in observations}
+    assert set(by_name) == {
+        "gadget2-results",
+        "gadget2-energy",
+        "gadget2-info",
+        "gadget2-cpu",
+        "gadget2-timings",
+        "gadget2-snapshots",
+        "gadget2-restarts",
+    }
+    assert all(item.state is ArtifactState.FINALIZED for item in observations)
+    assert by_name["gadget2-snapshots"].structure is ArtifactStructure.COLLECTION
+    assert by_name["gadget2-restarts"].structure is ArtifactStructure.COLLECTION
+    members = by_name["gadget2-results"].metadata["member_names"]
+    assert "galaxy/galaxy.param" not in members
+    assert "galaxy/ICs/galaxy.dat" not in members
+    assert "galaxy/output/energy.txt" in members
+    assert adapter.finalize_artifacts_for_exit(0) == []
+
+
+def test_missing_scientific_products_cannot_be_finalized(tmp_path: Path) -> None:
+    """Process exit alone is weaker than a Gadget2 result contract."""
+
+    module = _load_artifacts()
+    adapter = _adapter(module, tmp_path)
+    root = tmp_path / "run" / "galaxy" / "output"
+    root.mkdir(parents=True)
+    (root / "info.txt").write_text("started\n", encoding="utf-8")
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert observations
+    assert all(item.state is ArtifactState.INCOMPLETE for item in observations)
+    assert "missing" in observations[0].message.casefold()
+
+
+def test_nonzero_exit_marks_observed_products_incomplete(tmp_path: Path) -> None:
+    """Native files cannot conceal an authoritative process failure."""
+
+    module = _load_artifacts()
+    adapter = _adapter(module, tmp_path)
+    _write_products(tmp_path / "run")
+
+    observations = adapter.finalize_artifacts_for_exit(7)
+
+    assert observations
+    assert all(item.state is ArtifactState.INCOMPLETE for item in observations)
+
+
+def test_factory_resolves_relative_output_and_ignores_unrelated_packages(
+    tmp_path: Path,
+) -> None:
+    """Artifact authority remains exact to one package-owned output root."""
+
+    module = _load_artifacts()
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.gadget2",
+            "input_bundle": str(bundle),
+            "out": "run",
+            "shared_dir": "/execution/shared/gadget2",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.output_dir.as_posix() == "/execution/shared/gadget2/run"
+    assert module.adapter_from_package({"pkg_type": "builtin.ior"}) is None
+
+
+def test_container_private_output_is_not_claimed(tmp_path: Path) -> None:
+    """A host cannot report files that exist only in a private container path."""
+
+    module = _load_artifacts()
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.gadget2",
+            "input_bundle": str(bundle),
+            "out": "/tmp/gadget2",
+            "effective_deploy_mode": "container",
+            "shared_dir": "/execution/shared",
+            "private_dir": "/execution/private",
+        }
+    )
+
+    assert adapter is None

--- a/test/unit/core/test_gadget2_artifacts.py
+++ b/test/unit/core/test_gadget2_artifacts.py
@@ -36,7 +36,11 @@ def _load_artifacts() -> ModuleType:
 
 def _write_bundle(destination: Path) -> Path:
     files = {
-        "galaxy/galaxy.param": b"InitCondFile ICs/galaxy.dat\n",
+        "galaxy/galaxy.param": (
+            b"InitCondFile ICs/galaxy.dat\nOutputDir output/\n"
+            b"EnergyFile energy.txt\nInfoFile info.txt\nCpuFile cpu.txt\n"
+            b"TimingsFile timings.txt\nSnapshotFileBase snapshot\n"
+        ),
         "galaxy/ICs/galaxy.dat": b"initial-condition\x00\x01",
     }
     manifest = {
@@ -65,6 +69,14 @@ def _write_bundle(destination: Path) -> Path:
 
 
 def _adapter(module: ModuleType, tmp_path: Path) -> Any:
+    declared = module.parse_gadget2_output_contract(
+        (
+            "OutputDir output/\nEnergyFile energy.txt\nInfoFile info.txt\n"
+            "CpuFile cpu.txt\nTimingsFile timings.txt\n"
+            "SnapshotFileBase snapshot\n"
+        ),
+        parameter_path=module.PurePosixPath("galaxy/galaxy.param"),
+    )
     adapter = module.Gadget2ArtifactAdapter(
         module.PurePosixPath("/scratch/gadget2/run"),
         frozenset(
@@ -73,6 +85,7 @@ def _adapter(module: ModuleType, tmp_path: Path) -> Any:
                 module.PurePosixPath("galaxy/ICs/galaxy.dat"),
             }
         ),
+        declared,
     )
     adapter._local_root = tmp_path / "run"
     return adapter
@@ -81,7 +94,12 @@ def _adapter(module: ModuleType, tmp_path: Path) -> Any:
 def _write_products(root: Path) -> None:
     (root / "galaxy" / "ICs").mkdir(parents=True)
     (root / "galaxy" / "galaxy.param").write_text(
-        "InitCondFile ICs/galaxy.dat\n", encoding="utf-8"
+        (
+            "InitCondFile ICs/galaxy.dat\nOutputDir output/\n"
+            "EnergyFile energy.txt\nInfoFile info.txt\nCpuFile cpu.txt\n"
+            "TimingsFile timings.txt\nSnapshotFileBase snapshot\n"
+        ),
+        encoding="utf-8",
     )
     (root / "galaxy" / "ICs" / "galaxy.dat").write_bytes(b"initial-condition\x00\x01")
     products = root / "galaxy" / "output"
@@ -143,6 +161,57 @@ def test_missing_scientific_products_cannot_be_finalized(tmp_path: Path) -> None
     assert observations
     assert all(item.state is ArtifactState.INCOMPLETE for item in observations)
     assert "missing" in observations[0].message.casefold()
+
+
+def test_zero_byte_declared_products_cannot_be_finalized(tmp_path: Path) -> None:
+    """Names alone cannot turn an aborted zero-status run into valid artifacts."""
+
+    module = _load_artifacts()
+    adapter = _adapter(module, tmp_path)
+    root = tmp_path / "run" / "galaxy" / "output"
+    root.mkdir(parents=True)
+    (root / "energy.txt").write_bytes(b"")
+    (root / "info.txt").write_bytes(b"")
+    (root / "snapshot_000").write_bytes(b"")
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert observations
+    assert all(item.state is ArtifactState.INCOMPLETE for item in observations)
+
+
+def test_parameter_declared_names_drive_artifact_discovery(tmp_path: Path) -> None:
+    """Custom scientific filenames are discovered without stock-name guesses."""
+
+    module = _load_artifacts()
+    declared = module.parse_gadget2_output_contract(
+        (
+            "OutputDir products/\nEnergyFile conserved.dat\n"
+            "InfoFile progress.log\nSnapshotFileBase states/galaxy\n"
+        ),
+        parameter_path=module.PurePosixPath("galaxy/custom.param"),
+    )
+    adapter = module.Gadget2ArtifactAdapter(
+        module.PurePosixPath("/scratch/gadget2/run"),
+        frozenset(),
+        declared,
+    )
+    adapter._local_root = tmp_path / "run"
+    products = tmp_path / "run" / "galaxy" / "products"
+    (products / "states").mkdir(parents=True)
+    (products / "conserved.dat").write_text("0 -1\n", encoding="utf-8")
+    (products / "progress.log").write_text("Step 1\n", encoding="utf-8")
+    (products / "states" / "galaxy_000").write_bytes(b"snapshot")
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    by_name = {item.logical_name: item for item in observations}
+    assert all(item.state is ArtifactState.FINALIZED for item in observations)
+    assert by_name["gadget2-energy"].location.value.endswith("conserved.dat")
+    assert by_name["gadget2-info"].location.value.endswith("progress.log")
+    assert by_name["gadget2-snapshots"].metadata["member_names"] == [
+        "galaxy/products/states/galaxy_000"
+    ]
 
 
 def test_nonzero_exit_marks_observed_products_incomplete(tmp_path: Path) -> None:

--- a/test/unit/core/test_gadget2_package_runtime.py
+++ b/test/unit/core/test_gadget2_package_runtime.py
@@ -146,11 +146,15 @@ def _package(tmp_path: Path, config: dict[str, Any]) -> Any:
     return package
 
 
-def _write_bundle(destination: Path) -> Path:
+def _write_bundle(
+    destination: Path,
+    *,
+    parameter: bytes = (
+        b"InitCondFile ICs/galaxy.dat\nOutputDir output/\nEnergyFile energy.txt\n"
+    ),
+) -> Path:
     files = {
-        "galaxy/galaxy.param": (
-            b"InitCondFile ICs/galaxy.dat\nOutputDir output/\nEnergyFile energy.txt\n"
-        ),
+        "galaxy/galaxy.param": parameter,
         "galaxy/ICs/galaxy.dat": b"gadget2-initial-condition\x00\x01",
     }
     manifest = {
@@ -246,11 +250,43 @@ def test_bundle_is_verified_and_staged_before_native_launch(tmp_path: Path) -> N
     staged_ic = workdir / "ICs" / "galaxy.dat"
     assert staged_parameter.read_bytes().startswith(b"InitCondFile")
     assert staged_ic.read_bytes() == b"gadget2-initial-condition\x00\x01"
+    assert (workdir / "output").is_dir()
     assert bundle.read_bytes() == source_bytes
     command = _CapturedExec.commands[-1]
     assert command == "Gadget2 galaxy.param"
     assert _CapturedExec.infos[-1].cwd == str(workdir.resolve())
     assert isinstance(_CapturedExec.infos[-1], gadget2_package.MpiExecInfo)
+
+
+@pytest.mark.parametrize(
+    ("parameter", "message"),
+    [
+        (b"InitCondFile ICs/galaxy.dat\n", "declare OutputDir exactly once"),
+        (
+            b"OutputDir output/\nOutputDir other/\n",
+            "declare OutputDir exactly once",
+        ),
+        (b"OutputDir ../escape/\n", "confined POSIX path"),
+        (b"OutputDir /tmp/escape/\n", "confined POSIX path"),
+        (b"OutputDir C:/escape/\n", "confined POSIX path"),
+        (b"OutputDir output\\escape\n", "confined POSIX path"),
+        (b"OutputDir output path\n", "one path token"),
+    ],
+)
+def test_native_output_directory_is_single_and_confined(
+    tmp_path: Path,
+    parameter: bytes,
+    message: str,
+) -> None:
+    """A supplied parameter cannot direct Gadget2 outside staged storage."""
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar", parameter=parameter)
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+
+    with pytest.raises(ValueError, match=message):
+        package.start()
+
+    assert _CapturedExec.commands == []
 
 
 def test_parameter_override_must_name_a_declared_bundle_file(tmp_path: Path) -> None:

--- a/test/unit/core/test_gadget2_package_runtime.py
+++ b/test/unit/core/test_gadget2_package_runtime.py
@@ -1,0 +1,354 @@
+"""Runtime-contract tests for the builtin Gadget2 package."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import shlex
+import tarfile
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+)
+from jarvis_cd.shell import LocalExecInfo
+from jarvis_cd.util.hostfile import Hostfile
+
+
+def _load_package() -> ModuleType:
+    """Load the builtin package without changing repository imports."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "gadget2"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_gadget2_runtime_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load Gadget2 package from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gadget2_package = _load_package()
+
+
+class _CapturedExec:
+    """Capture launches and expose a configurable process result."""
+
+    commands: list[str] = []
+    infos: list[Any] = []
+    return_code = 0
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": self.return_code}
+        self.commands.append(command)
+        self.infos.append(exec_info)
+
+    def run(self) -> _CapturedExec:
+        """Return the captured result."""
+
+        return self
+
+
+class _CapturedMkdir:
+    """Create the requested test directory."""
+
+    def __init__(self, path: str, exec_info: Any) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedMkdir:
+        """Materialize the directory and report success."""
+
+        Path(self.path).mkdir(parents=True, exist_ok=True)
+        return self
+
+
+class _CapturedRm:
+    """Capture exact cleanup authority without deleting files."""
+
+    calls: list[tuple[str, bool]] = []
+
+    def __init__(self, path: str, exec_info: Any, *, recursive: bool = False) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.recursive = recursive
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedRm:
+        """Record the requested cleanup."""
+
+        self.calls.append((self.path, self.recursive))
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _capture_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep package tests free of process and remote-host side effects."""
+
+    _CapturedExec.commands = []
+    _CapturedExec.infos = []
+    _CapturedExec.return_code = 0
+    _CapturedRm.calls = []
+    monkeypatch.setattr(gadget2_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(gadget2_package, "Mkdir", _CapturedMkdir)
+    monkeypatch.setattr(gadget2_package, "Rm", _CapturedRm)
+
+
+def _base_config(**overrides: Any) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "deploy_mode": "default",
+        "input_bundle": "",
+        "parameter_path": "",
+        "out": "run",
+        "nprocs": 2,
+        "ppn": 2,
+        "exec_mode": "mpi",
+        "gadget2_path": None,
+        "test_case": "gassphere",
+        "output": None,
+        "time_max": 0.05,
+        "buffer_size": 15.0,
+        "part_alloc_factor": 1.5,
+        "tree_alloc_factor": 0.9,
+    }
+    config.update(overrides)
+    return config
+
+
+def _package(tmp_path: Path, config: dict[str, Any]) -> Any:
+    package = object.__new__(gadget2_package.Gadget2)
+    package.config = config
+    package.shared_dir = tmp_path / "shared"
+    package.private_dir = tmp_path / "private"
+    package.env = {}
+    package.mod_env = {"PATH": "/runtime/bin"}
+    package.gadget2_bin = "Gadget2"
+    package.pipeline = SimpleNamespace(
+        get_hostfile=lambda: Hostfile(find_ips=False),
+        _has_containerized_packages=lambda: False,
+    )
+    package.runtime_line_callback = lambda: None
+    return package
+
+
+def _write_bundle(destination: Path) -> Path:
+    files = {
+        "galaxy/galaxy.param": (
+            b"InitCondFile ICs/galaxy.dat\nOutputDir output/\nEnergyFile energy.txt\n"
+        ),
+        "galaxy/ICs/galaxy.dat": b"gadget2-initial-condition\x00\x01",
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "galaxy/galaxy.param",
+        "files": [
+            {
+                "path": name,
+                "role": (
+                    "gadget2_parameter_file"
+                    if name.endswith(".param")
+                    else "gadget2_initial_condition"
+                ),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, payload in files.items()
+        ],
+    }
+    manifest_bytes = json.dumps(manifest, sort_keys=True).encode()
+    with tarfile.open(destination, mode="w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(manifest_bytes)
+        archive.addfile(info, io.BytesIO(manifest_bytes))
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def test_agent_contract_exposes_bundle_profile_and_hides_legacy_defaults() -> None:
+    """Agents receive a scientific input contract rather than stock demos."""
+
+    package = object.__new__(gadget2_package.Gadget2)
+    package.config = _base_config()
+    package.env = {}
+    package.mod_env = {}
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    contract = package._deployment_contract().to_dict()
+
+    assert menu["input_bundle"]["input_binding"] == {
+        "schema_version": "jarvis.configuration-input-binding.v1",
+        "kind": "local_file",
+        "structure": "regular_file",
+    }
+    assert menu["parameter_path"]["default"] == ""
+    assert menu["out"]["default"] == "run"
+    assert all(
+        menu[name]["agent_visible"] is False
+        for name in {
+            "gadget2_path",
+            "test_case",
+            "output",
+            "time_max",
+            "buffer_size",
+            "part_alloc_factor",
+            "tree_alloc_factor",
+            "exec_mode",
+        }
+    )
+    assert [profile["name"] for profile in contract["execution_profiles"]] == [
+        "input_bundle"
+    ]
+    assert [item["id"] for item in contract["runtime_requirements"]] == ["gadget2"]
+
+
+def test_bundle_is_verified_and_staged_before_native_launch(tmp_path: Path) -> None:
+    """The solver runs from an owned copy while caller bytes remain immutable."""
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    source_bytes = bundle.read_bytes()
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+
+    package.start()
+
+    workdir = tmp_path / "shared" / "run" / "galaxy"
+    staged_parameter = workdir / "galaxy.param"
+    staged_ic = workdir / "ICs" / "galaxy.dat"
+    assert staged_parameter.read_bytes().startswith(b"InitCondFile")
+    assert staged_ic.read_bytes() == b"gadget2-initial-condition\x00\x01"
+    assert bundle.read_bytes() == source_bytes
+    command = _CapturedExec.commands[-1]
+    assert command == "Gadget2 galaxy.param"
+    assert _CapturedExec.infos[-1].cwd == str(workdir.resolve())
+    assert isinstance(_CapturedExec.infos[-1], gadget2_package.MpiExecInfo)
+
+
+def test_parameter_override_must_name_a_declared_bundle_file(tmp_path: Path) -> None:
+    """Alternate parameter selection cannot escape or guess outside the manifest."""
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    package = _package(
+        tmp_path,
+        _base_config(input_bundle=str(bundle), parameter_path="../galaxy.param"),
+    )
+
+    with pytest.raises(ValueError, match="confined manifest path"):
+        package.start()
+
+    package.config["parameter_path"] = "galaxy/missing.param"
+    with pytest.raises(ValueError, match="not declared by the input bundle"):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
+def test_native_configuration_fails_before_launch(tmp_path: Path) -> None:
+    """Missing input and invalid MPI resources are local configuration errors."""
+
+    package = _package(tmp_path, _base_config())
+    with pytest.raises(ValueError, match="requires input_bundle"):
+        package.start()
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    package.config = _base_config(input_bundle=str(bundle), nprocs=0)
+    with pytest.raises(ValueError, match="nprocs must be a positive integer"):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
+def test_native_process_failure_fails_the_package_lifecycle(tmp_path: Path) -> None:
+    """A failing Gadget2 rank cannot become a successful JARVIS execution."""
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+    _CapturedExec.return_code = 9
+
+    with pytest.raises(RuntimeError, match="Gadget2 execution failed"):
+        package.start()
+
+
+def test_legacy_stock_profile_retains_its_existing_launch_shape(tmp_path: Path) -> None:
+    """Existing configured stock pipelines still run their generated parameter."""
+
+    output = tmp_path / "legacy output"
+    output.mkdir()
+    parameter = output / "gassphere.param"
+    parameter.write_text("TimeMax 0.05\n", encoding="utf-8")
+    binary = tmp_path / "Gadget2 runtime"
+    binary.write_bytes(b"runtime-placeholder")
+    package = _package(
+        tmp_path,
+        _base_config(
+            output=str(output),
+            paramfile=str(parameter),
+            binary=str(binary),
+        ),
+    )
+
+    package.start()
+
+    inner = " ".join(
+        (
+            "cd",
+            shlex.quote(str(output.resolve())),
+            "&&",
+            shlex.quote(str(binary)),
+            "gassphere.param",
+        )
+    )
+    assert _CapturedExec.commands[-1] == f"bash -c {shlex.quote(inner)}"
+    assert _CapturedExec.infos[-1].cwd == str(output.resolve())
+    assert isinstance(_CapturedExec.infos[-1], gadget2_package.MpiExecInfo)
+
+
+def test_native_command_quotes_runtime_and_parameter_names(tmp_path: Path) -> None:
+    """Runtime discovery cannot turn a valid path into shell syntax."""
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+    package.gadget2_bin = "/runtime with space/Gadget2"
+
+    package.start()
+
+    assert _CapturedExec.commands[-1] == (
+        f"{shlex.quote('/runtime with space/Gadget2')} galaxy.param"
+    )
+
+
+def test_clean_uses_one_exact_recursive_output_without_wildcard(tmp_path: Path) -> None:
+    """Cleanup cannot erase prefix-matching sibling directories."""
+
+    package = _package(tmp_path, _base_config(out="results"))
+
+    package.clean()
+
+    assert _CapturedRm.calls == [
+        (str((tmp_path / "shared" / "results").resolve()), True)
+    ]
+    assert "*" not in _CapturedRm.calls[0][0]
+
+
+def test_default_hostfile_uses_local_output_lifecycle(tmp_path: Path) -> None:
+    """Local output preparation does not require SSH."""
+
+    package = _package(tmp_path, _base_config())
+
+    assert isinstance(package._node_exec_info(), LocalExecInfo)

--- a/test/unit/core/test_gadget2_package_runtime.py
+++ b/test/unit/core/test_gadget2_package_runtime.py
@@ -223,6 +223,15 @@ def test_agent_contract_exposes_bundle_profile_and_hides_legacy_defaults() -> No
     assert [item["id"] for item in contract["runtime_requirements"]] == ["gadget2"]
 
 
+def test_native_validation_treats_absent_deploy_mode_as_default() -> None:
+    """New pipeline members resolve an omitted deploy mode to native execution."""
+    package = object.__new__(gadget2_package.Gadget2)
+    package.config = _base_config(input_bundle="galaxy.tar")
+    del package.config["deploy_mode"]
+
+    package._validate_native_configuration()
+
+
 def test_bundle_is_verified_and_staged_before_native_launch(tmp_path: Path) -> None:
     """The solver runs from an owned copy while caller bytes remain immutable."""
 

--- a/test/unit/core/test_gadget2_package_runtime.py
+++ b/test/unit/core/test_gadget2_package_runtime.py
@@ -6,9 +6,10 @@ import hashlib
 import io
 import json
 import shlex
+import sys
 import tarfile
-from importlib.util import module_from_spec, spec_from_file_location
-from pathlib import Path
+from importlib import import_module
+from pathlib import Path, PurePosixPath
 from types import ModuleType, SimpleNamespace
 from typing import Any
 
@@ -25,19 +26,12 @@ from jarvis_cd.util.hostfile import Hostfile
 def _load_package() -> ModuleType:
     """Load the builtin package without changing repository imports."""
 
-    path = (
-        Path(__file__).resolve().parents[3]
-        / "builtin"
-        / "builtin"
-        / "gadget2"
-        / "pkg.py"
-    )
-    spec = spec_from_file_location("test_gadget2_runtime_package", path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"Could not load Gadget2 package from {path}")
-    module = module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    repository_root = Path(__file__).resolve().parents[3] / "builtin"
+    sys.path.insert(0, str(repository_root))
+    try:
+        return import_module("builtin.gadget2.pkg")
+    finally:
+        sys.path.remove(str(repository_root))
 
 
 gadget2_package = _load_package()
@@ -49,6 +43,8 @@ class _CapturedExec:
     commands: list[str] = []
     infos: list[Any] = []
     return_code = 0
+    emit_products = True
+    product_bytes = b"scientific-product\n"
 
     def __init__(self, command: str, exec_info: Any) -> None:
         self.command = command
@@ -58,8 +54,30 @@ class _CapturedExec:
         self.infos.append(exec_info)
 
     def run(self) -> _CapturedExec:
-        """Return the captured result."""
+        """Materialize parameter-declared products and return the result."""
 
+        if (
+            self.return_code == 0
+            and self.emit_products
+            and not self.command.startswith("bash -c ")
+        ):
+            cwd = Path(self.exec_info.cwd)
+            parameter_name = shlex.split(self.command)[-1]
+            parameter = cwd / parameter_name
+            contract = gadget2_package.parse_gadget2_output_contract(
+                parameter.read_text(encoding="utf-8"),
+                parameter_path=PurePosixPath(cwd.name) / parameter_name,
+            )
+            run_root = cwd.parent
+            for relative in (contract.energy_file, contract.info_file):
+                product = run_root.joinpath(*relative.parts)
+                product.parent.mkdir(parents=True, exist_ok=True)
+                product.write_bytes(self.product_bytes)
+            snapshot_base = run_root.joinpath(*contract.snapshot_file_base.parts)
+            snapshot_base.parent.mkdir(parents=True, exist_ok=True)
+            snapshot_base.with_name(f"{snapshot_base.name}_000").write_bytes(
+                self.product_bytes
+            )
         return self
 
 
@@ -103,6 +121,8 @@ def _capture_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     _CapturedExec.commands = []
     _CapturedExec.infos = []
     _CapturedExec.return_code = 0
+    _CapturedExec.emit_products = True
+    _CapturedExec.product_bytes = b"scientific-product\n"
     _CapturedRm.calls = []
     monkeypatch.setattr(gadget2_package, "Exec", _CapturedExec)
     monkeypatch.setattr(gadget2_package, "Mkdir", _CapturedMkdir)
@@ -150,7 +170,8 @@ def _write_bundle(
     destination: Path,
     *,
     parameter: bytes = (
-        b"InitCondFile ICs/galaxy.dat\nOutputDir output/\nEnergyFile energy.txt\n"
+        b"InitCondFile ICs/galaxy.dat\nOutputDir output/\n"
+        b"EnergyFile energy.txt\nInfoFile info.txt\nSnapshotFileBase snapshot\n"
     ),
 ) -> Path:
     files = {
@@ -225,6 +246,10 @@ def test_agent_contract_exposes_bundle_profile_and_hides_legacy_defaults() -> No
         "input_bundle"
     ]
     assert [item["id"] for item in contract["runtime_requirements"]] == ["gadget2"]
+    assert contract["execution_profiles"][0]["readiness"] == {
+        "mechanism": "process_exit",
+        "condition": "successful_exit_with_required_products",
+    }
 
 
 def test_native_validation_treats_absent_deploy_mode_as_default() -> None:
@@ -261,16 +286,40 @@ def test_bundle_is_verified_and_staged_before_native_launch(tmp_path: Path) -> N
 @pytest.mark.parametrize(
     ("parameter", "message"),
     [
-        (b"InitCondFile ICs/galaxy.dat\n", "declare OutputDir exactly once"),
         (
-            b"OutputDir output/\nOutputDir other/\n",
+            b"EnergyFile energy.txt\nInfoFile info.txt\nSnapshotFileBase snapshot\n",
             "declare OutputDir exactly once",
         ),
-        (b"OutputDir ../escape/\n", "confined POSIX path"),
-        (b"OutputDir /tmp/escape/\n", "confined POSIX path"),
-        (b"OutputDir C:/escape/\n", "confined POSIX path"),
-        (b"OutputDir output\\escape\n", "confined POSIX path"),
-        (b"OutputDir output path\n", "one path token"),
+        (
+            b"OutputDir output/\nOutputDir other/\nEnergyFile energy.txt\n"
+            b"InfoFile info.txt\nSnapshotFileBase snapshot\n",
+            "declare OutputDir exactly once",
+        ),
+        (
+            b"OutputDir ../escape/\nEnergyFile energy.txt\nInfoFile info.txt\n"
+            b"SnapshotFileBase snapshot\n",
+            "confined POSIX path",
+        ),
+        (
+            b"OutputDir /tmp/escape/\nEnergyFile energy.txt\nInfoFile info.txt\n"
+            b"SnapshotFileBase snapshot\n",
+            "confined POSIX path",
+        ),
+        (
+            b"OutputDir C:/escape/\nEnergyFile energy.txt\nInfoFile info.txt\n"
+            b"SnapshotFileBase snapshot\n",
+            "confined POSIX path",
+        ),
+        (
+            b"OutputDir output\\escape\nEnergyFile energy.txt\nInfoFile info.txt\n"
+            b"SnapshotFileBase snapshot\n",
+            "confined POSIX path",
+        ),
+        (
+            b"OutputDir output path\nEnergyFile energy.txt\nInfoFile info.txt\n"
+            b"SnapshotFileBase snapshot\n",
+            "one path token",
+        ),
     ],
 )
 def test_native_output_directory_is_single_and_confined(
@@ -332,6 +381,47 @@ def test_native_process_failure_fails_the_package_lifecycle(tmp_path: Path) -> N
 
     with pytest.raises(RuntimeError, match="Gadget2 execution failed"):
         package.start()
+
+
+def test_zero_exit_without_scientific_products_fails_lifecycle(tmp_path: Path) -> None:
+    """Gadget2's zero-status fatal paths cannot become successful executions."""
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+    _CapturedExec.emit_products = False
+
+    with pytest.raises(RuntimeError, match="without required non-empty products"):
+        package.start()
+
+
+def test_zero_byte_scientific_products_fail_lifecycle(tmp_path: Path) -> None:
+    """Placeholder files do not satisfy the native completion contract."""
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+    _CapturedExec.product_bytes = b""
+
+    with pytest.raises(RuntimeError, match="EnergyFile, InfoFile, SnapshotFileBase"):
+        package.start()
+
+
+def test_completion_uses_parameter_declared_product_names(tmp_path: Path) -> None:
+    """The native lifecycle does not guess stock Gadget2 filenames."""
+
+    parameter = (
+        b"InitCondFile ICs/galaxy.dat\nOutputDir products/\n"
+        b"EnergyFile conserved.dat\nInfoFile progress.log\n"
+        b"SnapshotFileBase states/galaxy\n"
+    )
+    bundle = _write_bundle(tmp_path / "galaxy.tar", parameter=parameter)
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+
+    package.start()
+
+    root = tmp_path / "shared" / "run" / "galaxy" / "products"
+    assert (root / "conserved.dat").stat().st_size > 0
+    assert (root / "progress.log").stat().st_size > 0
+    assert (root / "states" / "galaxy_000").stat().st_size > 0
 
 
 def test_legacy_stock_profile_retains_its_existing_launch_shape(tmp_path: Path) -> None:

--- a/test/unit/core/test_gadget2_package_runtime.py
+++ b/test/unit/core/test_gadget2_package_runtime.py
@@ -200,6 +200,10 @@ def test_agent_contract_exposes_bundle_profile_and_hides_legacy_defaults() -> No
     }
     assert menu["parameter_path"]["default"] == ""
     assert menu["out"]["default"] == "run"
+    assert menu["gadget2_path"]["default"] is None
+    assert menu["gadget2_path"]["required"] is False
+    assert menu["output"]["default"] is None
+    assert menu["output"]["required"] is False
     assert all(
         menu[name]["agent_visible"] is False
         for name in {

--- a/test/unit/core/test_pipeline_coverage.py
+++ b/test/unit/core/test_pipeline_coverage.py
@@ -319,6 +319,27 @@ class TestPipelineCoverage(unittest.TestCase):
             pipeline.packages[1]["config"]["interceptors"], ["darshan_clio"]
         )
 
+    def test_append_accepts_native_gadget2_without_hidden_legacy_paths(self):
+        """The advertised native profile does not require stock-case controls."""
+        pipeline = self._make_pipeline("append_gadget2_native")
+
+        pipeline.append(
+            "builtin.gadget2",
+            package_alias="galaxy",
+            config_args=[
+                "input_bundle=/tmp/galaxy.tar",
+                "parameter_path=galaxy/galaxy.param",
+                "out=galaxy-run",
+                "nprocs=4",
+                "ppn=4",
+            ],
+        )
+
+        config = pipeline.packages[0]["config"]
+        self.assertEqual(config["input_bundle"], "/tmp/galaxy.tar")
+        self.assertIsNone(config["gadget2_path"])
+        self.assertIsNone(config["output"])
+
     def test_append_rejects_unknown_interceptor_reference_atomically(self):
         """An application cannot reference an interceptor absent from the pipeline."""
         pipeline = self._make_pipeline("append_interceptor_missing")
@@ -826,6 +847,24 @@ class TestPipelineCoverage(unittest.TestCase):
             with self.assertRaises(ValueError) as ctx:
                 pipeline._validate_required_config("builtin.ior", {})
         self.assertIn("Missing required", str(ctx.exception))
+
+    def test_validate_required_honors_explicit_conditional_override(self):
+        """A package may defer a conditionally required field to configuration."""
+        pipeline = self._make_pipeline("vrc_conditional")
+
+        from unittest.mock import MagicMock, patch
+
+        mock_pkg = MagicMock()
+        mock_pkg.configure_menu.return_value = [
+            {
+                "name": "legacy_profile_path",
+                "default": None,
+                "required": False,
+            },
+        ]
+
+        with patch.object(pipeline, "_load_package_instance", return_value=mock_pkg):
+            pipeline._validate_required_config("builtin.ior", {})
 
 
 if __name__ == "__main__":

--- a/test/unit/core/test_pipeline_coverage.py
+++ b/test/unit/core/test_pipeline_coverage.py
@@ -320,14 +320,20 @@ class TestPipelineCoverage(unittest.TestCase):
         )
 
     def test_append_accepts_native_gadget2_without_hidden_legacy_paths(self):
-        """The advertised native profile does not require stock-case controls."""
+        """The MCP-shaped native profile needs no stock-case or deploy controls."""
         pipeline = self._make_pipeline("append_gadget2_native")
+        bundle = os.path.join(self.test_dir, "galaxy.tar")
+        with open(bundle, "wb") as stream:
+            stream.write(b"immutable-gadget2-input")
 
         pipeline.append(
             "builtin.gadget2",
             package_alias="galaxy",
-            config_args=[
-                "input_bundle=/tmp/galaxy.tar",
+        )
+        pipeline.configure_package(
+            "galaxy",
+            [
+                f"input_bundle={bundle}",
                 "parameter_path=galaxy/galaxy.param",
                 "out=galaxy-run",
                 "nprocs=4",
@@ -336,7 +342,9 @@ class TestPipelineCoverage(unittest.TestCase):
         )
 
         config = pipeline.packages[0]["config"]
-        self.assertEqual(config["input_bundle"], "/tmp/galaxy.tar")
+        self.assertNotEqual(config["input_bundle"], bundle)
+        self.assertTrue(os.path.isfile(config["input_bundle"]))
+        self.assertNotIn("deploy_mode", config)
         self.assertIsNone(config["gadget2_path"])
         self.assertIsNone(config["output"])
 


### PR DESCRIPTION
## Summary

- add an agent-facing native Gadget2 profile based on digest-verified, execution-owned input bundles
- preserve existing stock and container pipeline behavior behind hidden legacy controls
- add bounded artifact semantics for energy, runtime information, snapshots, restarts, and the complete result tree
- document the runtime and input contract and reject silent fallback to the default gassphere demonstration

## Scientific and safety contract

The native profile selects only a manifest-declared `.param` entrypoint, stages every verified file into package-owned storage, launches an operator-provided MPI-enabled Gadget2 runtime, propagates rank failures, and finalizes only when process success plus required energy, information, and snapshot products agree.

## Validation

- `uv run --no-sync --no-cache pytest -q test/unit/core/test_gadget2_package_runtime.py test/unit/core/test_gadget2_artifacts.py test/unit/core/test_input_bundle.py test/unit/core/test_artifact_spi.py test/unit/core/test_package_deployment_contract.py` (52 passed)
- `uv run --no-sync --no-cache pyright builtin/builtin/gadget2/pkg.py builtin/builtin/gadget2/artifacts.py test/unit/core/test_gadget2_package_runtime.py test/unit/core/test_gadget2_artifacts.py`
- scoped Ruff check and format

Ares live execution and scientific qualification are tracked in the benchmark repository and will pin this exact commit.