### PR TITLE
feat: add native STAR and DESeq2 workflow

### DIFF
--- a/builtin/builtin/rna_seq_star_deseq2/artifacts.py
+++ b/builtin/builtin/rna_seq_star_deseq2/artifacts.py
@@ -1,0 +1,276 @@
+"""Generated-artifact semantics for native STAR to DESeq2 workflows."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .result_contract import RnaSeqProduct, load_rnaseq_result
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _optional_absolute_path(value: object) -> PurePosixPath | None:
+    if not isinstance(value, str) or not value:
+        return None
+    path = PurePosixPath(value)
+    return path if path.is_absolute() else None
+
+
+def _configured_output_dir(
+    value: object, *, shared_dir: object, runtime_cwd: object
+) -> PurePosixPath:
+    raw = "run" if value in (None, "") else value
+    if not isinstance(raw, str) or not raw or "\\" in raw:
+        raise ValueError("RNA-seq artifacts require a printable output path")
+    path = PurePosixPath(raw)
+    if not path.is_absolute():
+        base = _optional_absolute_path(shared_dir) or _optional_absolute_path(
+            runtime_cwd
+        )
+        if base is None:
+            raise ValueError(
+                "relative RNA-seq artifact output requires shared_dir or runtime_cwd"
+            )
+        path = base / path
+    if any(part in {"", ".", ".."} for part in path.parts[1:]):
+        raise ValueError("RNA-seq artifact output is not confined")
+    shared = _optional_absolute_path(shared_dir)
+    if shared is not None and not path.is_relative_to(shared):
+        raise ValueError("RNA-seq artifact output escaped its shared root")
+    return path / "results"
+
+
+@dataclass(slots=True)
+class RnaSeqArtifactAdapter:
+    """Publish a closed differential-expression result and its native products."""
+
+    output_dir: PurePosixPath
+    _local_root: Path | None = None
+    _finalized: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for the authoritative process exit before publishing products."""
+
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Finalize products for a successful legacy completion callback."""
+
+        return self._finalize(return_code=0)
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Finalize native products using the authoritative driver exit status."""
+
+        return self._finalize(return_code=return_code)
+
+    def reset_artifacts(self) -> None:
+        """Permit discovery after an execution stream is replaced."""
+
+        self._finalized = False
+
+    def _local_output_path(self) -> Path:
+        if self._local_root is not None:
+            return self._local_root
+        return Path(self.output_dir.as_posix())
+
+    def _file(
+        self,
+        product: RnaSeqProduct,
+        *,
+        logical_name: str,
+        kind: str,
+        role: ArtifactRole,
+        format_name: str,
+        media_type: str,
+        state: ArtifactState,
+        metadata: dict[str, Any],
+    ) -> ArtifactObservation:
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=role,
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(
+                self.output_dir / product.relative_path
+            ),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=product.size_bytes,
+            checksum=f"sha256:{product.sha256}",
+            message="Closed STAR to DESeq2 product",
+            metadata=metadata,
+        )
+
+    def _finalize(self, *, return_code: int) -> list[ArtifactObservation]:
+        if self._finalized:
+            return []
+        self._finalized = True
+        local = self._local_output_path()
+        if return_code != 0 and not (local / "rnaseq-result.json").is_file():
+            return []
+        validated = load_rnaseq_result(local)
+        document = validated.document
+        state = (
+            ArtifactState.FINALIZED if return_code == 0 else ArtifactState.INCOMPLETE
+        )
+        metadata: dict[str, Any] = {
+            "application": "star_deseq2",
+            "comparison_condition": document["comparison_condition"],
+            "reference_condition": document["reference_condition"],
+            "sample_count": document["sample_count"],
+            "significant_gene_count": document["deseq2"]["significant_gene_count"],
+            "tested_gene_count": document["deseq2"]["tested_gene_count"],
+        }
+        products = validated.products
+        result_size = validated.result_path.stat().st_size
+        result_sha = _sha256(validated.result_path)
+        observations = [
+            ArtifactObservation(
+                logical_name="rna-seq-result-tree",
+                kind="scientific_result",
+                role=ArtifactRole.OUTPUT,
+                structure=ArtifactStructure.COLLECTION,
+                ownership=ArtifactOwnership.SHARED,
+                state=state,
+                location=ArtifactLocation.cluster_path(self.output_dir),
+                format="star-deseq2-result-tree",
+                size_bytes=result_size
+                + sum(product.size_bytes for product in products.values()),
+                message="STAR to DESeq2 result tree finalized",
+                metadata={**metadata, "member_count": len(products) + 1},
+            ),
+            ArtifactObservation(
+                logical_name="rna-seq-result",
+                kind="scientific_result",
+                role=ArtifactRole.OUTPUT,
+                structure=ArtifactStructure.FILE,
+                ownership=ArtifactOwnership.SHARED,
+                state=state,
+                location=ArtifactLocation.cluster_path(
+                    self.output_dir / "rnaseq-result.json"
+                ),
+                media_type="application/json",
+                format="jarvis.rnaseq-star-deseq2-result.v1",
+                size_bytes=result_size,
+                checksum=f"sha256:{result_sha}",
+                message="Closed STAR to DESeq2 result summary",
+                metadata=metadata,
+            ),
+        ]
+        file_specs = (
+            (
+                "differential-expression.tsv",
+                "differential-expression",
+                "scientific_table",
+                ArtifactRole.OUTPUT,
+                "deseq2-results-tsv",
+                "text/tab-separated-values",
+            ),
+            (
+                "gene-counts.tsv",
+                "gene-counts",
+                "scientific_table",
+                ArtifactRole.OUTPUT,
+                "star-gene-counts-tsv",
+                "text/tab-separated-values",
+            ),
+            (
+                "normalized-counts.tsv",
+                "normalized-counts",
+                "scientific_table",
+                ArtifactRole.OUTPUT,
+                "deseq2-normalized-counts-tsv",
+                "text/tab-separated-values",
+            ),
+            (
+                "samples.tsv",
+                "rna-seq-sample-design",
+                "configuration",
+                ArtifactRole.PROVENANCE,
+                "sample-design-tsv",
+                "text/tab-separated-values",
+            ),
+            (
+                "deseq2-session-info.txt",
+                "deseq2-session-info",
+                "provenance",
+                ArtifactRole.PROVENANCE,
+                "r-session-info",
+                "text/plain",
+            ),
+        )
+        for path, logical, kind, role, format_name, media_type in file_specs:
+            observations.append(
+                self._file(
+                    products[path],
+                    logical_name=logical,
+                    kind=kind,
+                    role=role,
+                    format_name=format_name,
+                    media_type=media_type,
+                    state=state,
+                    metadata=metadata,
+                )
+            )
+        alignments = [
+            product
+            for path, product in products.items()
+            if path.endswith("/Aligned.sortedByCoord.out.bam")
+        ]
+        observations.append(
+            ArtifactObservation(
+                logical_name="star-alignments",
+                kind="scientific_dataset",
+                role=ArtifactRole.OUTPUT,
+                structure=ArtifactStructure.COLLECTION,
+                ownership=ArtifactOwnership.SHARED,
+                state=state,
+                location=ArtifactLocation.cluster_path(self.output_dir / "star"),
+                media_type="application/octet-stream",
+                format="bam-collection",
+                size_bytes=sum(product.size_bytes for product in alignments),
+                message="Coordinate-sorted STAR alignment collection finalized",
+                metadata={**metadata, "member_count": len(alignments)},
+            )
+        )
+        return observations
+
+
+def adapter_from_package(package: dict[str, Any]) -> RnaSeqArtifactAdapter | None:
+    """Create artifact semantics only for native STAR to DESeq2 packages."""
+
+    if package.get("pkg_type") != "builtin.rna_seq_star_deseq2":
+        return None
+    if str(package.get("effective_deploy_mode") or "default").casefold() == "container":
+        return None
+    output_dir = _configured_output_dir(
+        package.get("out"),
+        shared_dir=package.get("shared_dir"),
+        runtime_cwd=package.get("runtime_cwd"),
+    )
+    return RnaSeqArtifactAdapter(output_dir)
+
+
+__all__ = ["RnaSeqArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/rna_seq_star_deseq2/deseq2_analysis.R
+++ b/builtin/builtin/rna_seq_star_deseq2/deseq2_analysis.R
@@ -1,0 +1,55 @@
+suppressPackageStartupMessages(library("DESeq2"))
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 7) {
+  stop("expected counts, design, reference, comparison, result, normalized, and session paths")
+}
+
+counts_path <- args[[1]]
+design_path <- args[[2]]
+reference_condition <- args[[3]]
+comparison_condition <- args[[4]]
+result_path <- args[[5]]
+normalized_path <- args[[6]]
+session_path <- args[[7]]
+
+counts <- read.delim(counts_path, check.names = FALSE, row.names = 1)
+design <- read.delim(design_path, check.names = FALSE, stringsAsFactors = FALSE)
+if (!identical(colnames(counts), design$sample)) {
+  stop("count columns and sample design differ")
+}
+if (!setequal(unique(design$condition), c(reference_condition, comparison_condition))) {
+  stop("declared conditions differ from sample design")
+}
+design$condition <- relevel(factor(design$condition), ref = reference_condition)
+rownames(design) <- design$sample
+
+dds <- DESeqDataSetFromMatrix(
+  countData = as.matrix(counts),
+  colData = design,
+  design = ~ condition
+)
+dds <- dds[rowSums(counts(dds)) >= 10, ]
+if (nrow(dds) < 10) {
+  stop("fewer than ten expressed genes remain after count filtering")
+}
+dds <- DESeq(dds, quiet = TRUE)
+res <- results(
+  dds,
+  contrast = c("condition", comparison_condition, reference_condition),
+  alpha = 0.05
+)
+result <- data.frame(gene_id = rownames(res), as.data.frame(res), check.names = FALSE)
+result <- result[order(result$padj, -abs(result$log2FoldChange), na.last = TRUE), ]
+write.table(result, result_path, sep = "\t", quote = FALSE, row.names = FALSE)
+
+normalized <- data.frame(
+  gene_id = rownames(dds),
+  as.data.frame(counts(dds, normalized = TRUE)),
+  check.names = FALSE
+)
+write.table(normalized, normalized_path, sep = "\t", quote = FALSE, row.names = FALSE)
+
+sink(session_path)
+sessionInfo()
+sink()

--- a/builtin/builtin/rna_seq_star_deseq2/native_runner.py
+++ b/builtin/builtin/rna_seq_star_deseq2/native_runner.py
@@ -1,0 +1,448 @@
+"""Run a supplied STAR to DESeq2 workflow without runtime installation or network use."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gzip
+import hashlib
+import json
+import math
+import re
+import shutil
+import subprocess
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+
+_SAMPLE_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9_.-]{0,63}")
+_REQUIRED_SAMPLE_COLUMNS = frozenset(
+    {"sample", "condition", "set_id", "accession", "fastq"}
+)
+_RESULT_SCHEMA = "jarvis.rnaseq-star-deseq2-result.v1"
+
+
+class RnaSeqExecutionError(RuntimeError):
+    """Raised when native RNA-seq inputs or products violate their contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class Sample:
+    """One supplied single-end RNA-seq sample."""
+
+    name: str
+    condition: str
+    set_id: int
+    accession: str
+    fastq: Path
+
+
+def _safe_relative(value: str, *, field: str) -> PurePosixPath:
+    if "\\" in value:
+        raise RnaSeqExecutionError(f"{field} must use portable separators")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise RnaSeqExecutionError(f"{field} must be a confined relative path")
+    return path
+
+
+def _resolve_input(root: Path, value: str, *, field: str) -> Path:
+    relative = _safe_relative(value, field=field)
+    candidate = root.joinpath(*relative.parts)
+    try:
+        candidate.resolve(strict=True).relative_to(root.resolve(strict=True))
+    except (OSError, ValueError) as exc:
+        raise RnaSeqExecutionError(f"{field} escapes the supplied input root") from exc
+    if candidate.is_symlink() or not candidate.is_file():
+        raise RnaSeqExecutionError(f"{field} is not a regular supplied file")
+    return candidate
+
+
+def read_samples(path: Path, *, input_root: Path) -> tuple[Sample, ...]:
+    """Read and validate a two-condition, replicated sample design."""
+
+    try:
+        with path.open("r", encoding="utf-8", newline="") as stream:
+            reader = csv.DictReader(stream, delimiter="\t")
+            if (
+                reader.fieldnames is None
+                or set(reader.fieldnames) != _REQUIRED_SAMPLE_COLUMNS
+            ):
+                raise RnaSeqExecutionError("RNA-seq sample table columns differ")
+            rows = tuple(reader)
+    except (OSError, UnicodeError, csv.Error) as exc:
+        raise RnaSeqExecutionError("RNA-seq sample table is unreadable") from exc
+    if not 4 <= len(rows) <= 64:
+        raise RnaSeqExecutionError("RNA-seq sample count must be between 4 and 64")
+    samples: list[Sample] = []
+    for row in rows:
+        name = row["sample"]
+        condition = row["condition"]
+        accession = row["accession"]
+        if _SAMPLE_PATTERN.fullmatch(name) is None:
+            raise RnaSeqExecutionError(f"invalid RNA-seq sample name: {name!r}")
+        if _SAMPLE_PATTERN.fullmatch(condition) is None:
+            raise RnaSeqExecutionError(f"invalid RNA-seq condition: {condition!r}")
+        if _SAMPLE_PATTERN.fullmatch(accession) is None:
+            raise RnaSeqExecutionError(f"invalid RNA-seq accession: {accession!r}")
+        try:
+            set_id = int(row["set_id"])
+        except ValueError as exc:
+            raise RnaSeqExecutionError("RNA-seq set_id must be an integer") from exc
+        if set_id <= 0:
+            raise RnaSeqExecutionError("RNA-seq set_id must be positive")
+        samples.append(
+            Sample(
+                name=name,
+                condition=condition,
+                set_id=set_id,
+                accession=accession,
+                fastq=_resolve_input(input_root, row["fastq"], field="sample fastq"),
+            )
+        )
+    names = [sample.name for sample in samples]
+    accessions = [sample.accession for sample in samples]
+    if len(names) != len(set(names)) or len(accessions) != len(set(accessions)):
+        raise RnaSeqExecutionError("RNA-seq sample names and accessions must be unique")
+    by_condition = Counter(sample.condition for sample in samples)
+    if len(by_condition) != 2 or any(count < 2 for count in by_condition.values()):
+        raise RnaSeqExecutionError("RNA-seq design requires two replicated conditions")
+    paired_sets = {
+        condition: {
+            sample.set_id for sample in samples if sample.condition == condition
+        }
+        for condition in by_condition
+    }
+    if len({frozenset(values) for values in paired_sets.values()}) != 1:
+        raise RnaSeqExecutionError(
+            "RNA-seq conditions must use the same replicate-set IDs"
+        )
+    return tuple(samples)
+
+
+def _read_length(path: Path) -> int:
+    try:
+        with gzip.open(path, "rb") as stream:
+            header = stream.readline()
+            sequence = stream.readline().rstrip(b"\r\n")
+            plus = stream.readline()
+            quality = stream.readline().rstrip(b"\r\n")
+    except (OSError, EOFError) as exc:
+        raise RnaSeqExecutionError(f"cannot read supplied FASTQ: {path.name}") from exc
+    if (
+        not header.startswith(b"@")
+        or not plus.startswith(b"+")
+        or not sequence
+        or len(sequence) != len(quality)
+    ):
+        raise RnaSeqExecutionError(f"supplied FASTQ is malformed: {path.name}")
+    return len(sequence)
+
+
+def _run(command: list[str], *, label: str) -> None:
+    print(f"[rnaseq] {label}: {command[0]}", flush=True)
+    try:
+        completed = subprocess.run(command, check=False)  # noqa: S603
+    except OSError as exc:
+        raise RnaSeqExecutionError(f"could not launch {label}") from exc
+    if completed.returncode != 0:
+        raise RnaSeqExecutionError(f"{label} exited with status {completed.returncode}")
+
+
+def _decompress(source: Path, destination: Path) -> None:
+    try:
+        with gzip.open(source, "rb") as compressed, destination.open("wb") as output:
+            shutil.copyfileobj(compressed, output)
+    except (OSError, EOFError) as exc:
+        raise RnaSeqExecutionError(f"could not decompress {source.name}") from exc
+    if destination.stat().st_size <= 0:
+        raise RnaSeqExecutionError(f"decompressed {source.name} is empty")
+
+
+def _write_counts(samples: tuple[Sample, ...], star_root: Path, output: Path) -> None:
+    genes: list[str] | None = None
+    columns: list[list[int]] = []
+    for sample in samples:
+        path = star_root / sample.name / "ReadsPerGene.out.tab"
+        try:
+            rows = [
+                line.split("\t")
+                for line in path.read_text(encoding="utf-8").splitlines()
+            ]
+        except (OSError, UnicodeError) as exc:
+            raise RnaSeqExecutionError(
+                f"STAR counts are unavailable for {sample.name}"
+            ) from exc
+        if len(rows) <= 4 or any(len(row) != 4 for row in rows):
+            raise RnaSeqExecutionError(f"STAR counts are malformed for {sample.name}")
+        observed_genes = [row[0] for row in rows[4:]]
+        if genes is None:
+            genes = observed_genes
+        elif observed_genes != genes:
+            raise RnaSeqExecutionError("STAR gene order differs across samples")
+        try:
+            columns.append([int(row[1]) for row in rows[4:]])
+        except ValueError as exc:
+            raise RnaSeqExecutionError(
+                f"STAR counts are non-integral for {sample.name}"
+            ) from exc
+    assert genes is not None
+    with output.open("w", encoding="utf-8", newline="\n") as stream:
+        stream.write("gene_id\t" + "\t".join(sample.name for sample in samples) + "\n")
+        for index, gene in enumerate(genes):
+            values = "\t".join(str(column[index]) for column in columns)
+            stream.write(f"{gene}\t{values}\n")
+
+
+def _star_metrics(path: Path) -> dict[str, int | float]:
+    values: dict[str, str] = {}
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if "|" in line:
+                name, value = line.split("|", 1)
+                values[name.strip()] = value.strip()
+    except (OSError, UnicodeError) as exc:
+        raise RnaSeqExecutionError(f"STAR log is unavailable: {path}") from exc
+    try:
+        return {
+            "input_reads": int(values["Number of input reads"]),
+            "uniquely_mapped_reads": int(values["Uniquely mapped reads number"]),
+            "uniquely_mapped_percent": float(
+                values["Uniquely mapped reads %"].rstrip("%")
+            ),
+        }
+    except (KeyError, ValueError) as exc:
+        raise RnaSeqExecutionError(f"STAR log omitted mapping metrics: {path}") from exc
+
+
+def _finite_or_none(value: str) -> float | None:
+    if value in {"", "NA", "NaN", "nan"}:
+        return None
+    parsed = float(value)
+    return parsed if math.isfinite(parsed) else None
+
+
+def _deseq_summary(path: Path) -> tuple[int, int, list[dict[str, Any]]]:
+    try:
+        with path.open("r", encoding="utf-8", newline="") as stream:
+            rows = tuple(csv.DictReader(stream, delimiter="\t"))
+    except (OSError, UnicodeError, csv.Error) as exc:
+        raise RnaSeqExecutionError("DESeq2 result table is unreadable") from exc
+    required = {
+        "gene_id",
+        "baseMean",
+        "log2FoldChange",
+        "lfcSE",
+        "stat",
+        "pvalue",
+        "padj",
+    }
+    if not rows or set(rows[0]) != required:
+        raise RnaSeqExecutionError("DESeq2 result columns differ")
+    significant: list[dict[str, Any]] = []
+    tested = 0
+    for row in rows:
+        padj = _finite_or_none(row["padj"])
+        fold = _finite_or_none(row["log2FoldChange"])
+        if padj is not None:
+            tested += 1
+        if padj is not None and fold is not None and padj <= 0.05 and abs(fold) >= 1.0:
+            significant.append(
+                {
+                    "gene_id": row["gene_id"],
+                    "log2_fold_change": fold,
+                    "adjusted_p_value": padj,
+                }
+            )
+    significant.sort(
+        key=lambda item: (item["adjusted_p_value"], -abs(item["log2_fold_change"]))
+    )
+    return tested, len(significant), significant[:20]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _artifact_records(paths: Iterable[Path], *, root: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for path in sorted(paths):
+        if path.is_symlink() or not path.is_file() or path.stat().st_size <= 0:
+            raise RnaSeqExecutionError(f"required RNA-seq product is missing: {path}")
+        relative = path.relative_to(root).as_posix()
+        records.append(
+            {
+                "path": relative,
+                "sha256": _sha256(path),
+                "size_bytes": path.stat().st_size,
+            }
+        )
+    return records
+
+
+def run_workflow(arguments: argparse.Namespace) -> dict[str, Any]:
+    """Execute STAR and DESeq2 and return the closed result document."""
+
+    input_root = arguments.input_root.resolve(strict=True)
+    samples_path = arguments.samples.resolve(strict=True)
+    samples = read_samples(samples_path, input_root=input_root)
+    conditions = list(dict.fromkeys(sample.condition for sample in samples))
+    reference_condition, comparison_condition = conditions
+    output_root = arguments.output_root.resolve()
+    work_root = arguments.work_root.resolve()
+    if (
+        output_root == work_root
+        or output_root in work_root.parents
+        or work_root in output_root.parents
+    ):
+        raise RnaSeqExecutionError("RNA-seq work and output roots must be separate")
+    for root in (output_root, work_root):
+        if root.exists() or root.is_symlink():
+            raise RnaSeqExecutionError(f"RNA-seq target already exists: {root}")
+        root.mkdir(parents=True)
+    genome = work_root / "genome.fa"
+    annotation = work_root / "genes.gtf"
+    _decompress(arguments.genome.resolve(strict=True), genome)
+    _decompress(arguments.annotation.resolve(strict=True), annotation)
+    index_root = work_root / "star-index"
+    index_root.mkdir()
+    read_length = max(_read_length(sample.fastq) for sample in samples)
+    _run(
+        [
+            arguments.star,
+            "--runMode",
+            "genomeGenerate",
+            "--runThreadN",
+            str(arguments.cores),
+            "--genomeDir",
+            str(index_root),
+            "--genomeFastaFiles",
+            str(genome),
+            "--sjdbGTFfile",
+            str(annotation),
+            "--sjdbOverhang",
+            str(read_length - 1),
+            "--genomeSAindexNbases",
+            "10",
+        ],
+        label="STAR genome generation",
+    )
+    star_root = output_root / "star"
+    star_root.mkdir()
+    for sample in samples:
+        sample_root = star_root / sample.name
+        sample_root.mkdir()
+        _run(
+            [
+                arguments.star,
+                "--runThreadN",
+                str(arguments.cores),
+                "--genomeDir",
+                str(index_root),
+                "--readFilesIn",
+                str(sample.fastq),
+                "--readFilesCommand",
+                "zcat",
+                "--outFileNamePrefix",
+                str(sample_root) + "/",
+                "--outSAMtype",
+                "BAM",
+                "SortedByCoordinate",
+                "--quantMode",
+                "GeneCounts",
+            ],
+            label=f"STAR alignment {sample.name}",
+        )
+    counts = output_root / "gene-counts.tsv"
+    _write_counts(samples, star_root, counts)
+    design = output_root / "samples.tsv"
+    shutil.copyfile(samples_path, design)
+    differential = output_root / "differential-expression.tsv"
+    normalized = output_root / "normalized-counts.tsv"
+    session_info = output_root / "deseq2-session-info.txt"
+    _run(
+        [
+            arguments.rscript,
+            str(arguments.deseq_script.resolve(strict=True)),
+            str(counts),
+            str(design),
+            reference_condition,
+            comparison_condition,
+            str(differential),
+            str(normalized),
+            str(session_info),
+        ],
+        label="DESeq2 differential expression",
+    )
+    tested, significant_count, top = _deseq_summary(differential)
+    mapping = {
+        sample.name: _star_metrics(star_root / sample.name / "Log.final.out")
+        for sample in samples
+    }
+    products = [counts, design, differential, normalized, session_info]
+    for sample in samples:
+        sample_root = star_root / sample.name
+        products.extend(
+            (
+                sample_root / "Aligned.sortedByCoord.out.bam",
+                sample_root / "ReadsPerGene.out.tab",
+                sample_root / "Log.final.out",
+            )
+        )
+    return {
+        "artifacts": _artifact_records(products, root=output_root),
+        "comparison_condition": comparison_condition,
+        "deseq2": {
+            "adjusted_p_value_threshold": 0.05,
+            "absolute_log2_fold_change_threshold": 1.0,
+            "significant_gene_count": significant_count,
+            "tested_gene_count": tested,
+            "top_significant_genes": top,
+        },
+        "mapping": mapping,
+        "reference_condition": reference_condition,
+        "sample_count": len(samples),
+        "schema_version": _RESULT_SCHEMA,
+        "star_read_length": read_length,
+    }
+
+
+def main() -> int:
+    """Parse the confined native execution contract and run it."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-root", required=True, type=Path)
+    parser.add_argument("--samples", required=True, type=Path)
+    parser.add_argument("--genome", required=True, type=Path)
+    parser.add_argument("--annotation", required=True, type=Path)
+    parser.add_argument("--output-root", required=True, type=Path)
+    parser.add_argument("--work-root", required=True, type=Path)
+    parser.add_argument("--deseq-script", required=True, type=Path)
+    parser.add_argument("--star", required=True)
+    parser.add_argument("--rscript", required=True)
+    parser.add_argument("--cores", required=True, type=int)
+    arguments = parser.parse_args()
+    if not 1 <= arguments.cores <= 64:
+        parser.error("--cores must be between 1 and 64")
+    result = run_workflow(arguments)
+    result_path = arguments.output_root / "rnaseq-result.json"
+    temporary = result_path.with_suffix(".json.partial")
+    temporary.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    temporary.replace(result_path)
+    print(
+        "[rnaseq] completed: "
+        f"{result['deseq2']['significant_gene_count']} significant genes",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builtin/builtin/rna_seq_star_deseq2/pkg.py
+++ b/builtin/builtin/rna_seq_star_deseq2/pkg.py
@@ -1,238 +1,427 @@
-"""
-This module provides classes and methods to launch the rna_seq_star_deseq2
-application.  Snakemake workflow for RNA-seq differential expression analysis
-with STAR aligner and DESeq2.
-"""
+"""Launch a supplied STAR to DESeq2 differential-expression workflow."""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+from .result_contract import load_rnaseq_result
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, LocalExecInfo, PsshExecInfo
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ReadinessContract,
+    RuntimeRequirement,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
+
+_EXPECTED_ROLES = {
+    "gene_annotation": 1,
+    "reference_genome": 1,
+    "sample_design": 1,
+}
 
 
 class RnaSeqStarDeseq2(Application):
+    """Align supplied single-end RNA-seq reads and compare two conditions.
+
+    The agent-facing native profile accepts one digest-verified bundle carrying
+    the reads, sample design, reference genome, and gene annotation. It never
+    installs software or accesses the network during scheduled execution. The
+    historical container profile remains available for existing pipelines but
+    is intentionally hidden from the scientific contract.
     """
-    RnaSeqStarDeseq2 class supporting both default (bare-metal) and container
-    deployment.
 
-    Set deploy_mode='container' to build and run the RNA-seq pipeline inside a
-    Docker/Podman/Apptainer container.  Set deploy_mode='default' to use a
-    system-installed environment.
-    """
+    def _init(self) -> None:
+        self.star_bin: str | None = None
+        self.rscript_bin: str | None = None
 
-    def _init(self):
-        pass
-
-    def _configure_menu(self):
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
             {
-                'name': 'nprocs',
-                'msg': 'Number of MPI processes',
-                'type': int,
-                'default': 1,
+                "name": "input_bundle",
+                "msg": (
+                    "Digest-verified bundle containing replicated single-end "
+                    "FASTQ reads, one sample design, one reference genome, and "
+                    "one matching gene annotation"
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                'name': 'cores',
-                'msg': 'Number of Snakemake cores',
-                'type': int,
-                'default': 4,
+                "name": "out",
+                "msg": (
+                    "Output directory. Relative paths resolve under the JARVIS "
+                    "package shared directory."
+                ),
+                "type": str,
+                "default": "run",
             },
             {
-                'name': 'out',
-                'msg': 'Output directory for results',
-                'type': str,
-                'default': '/tmp/rnaseq_out',
+                "name": "cores",
+                "msg": "CPU cores used by STAR for indexing and alignment",
+                "type": int,
+                "default": 4,
             },
             {
-                'name': 'replicates',
-                'msg': ('Run the full snakemake RNA-seq workflow this '
-                        'many times back-to-back in one container exec, '
-                        'each into rep_NNN/ under `out`. Each replicate '
-                        'rebuilds STAR index, aligns FASTQs, and writes '
-                        'BAM + DESeq2 results, so I/O scales linearly.'),
-                'type': int,
-                'default': 1,
+                "name": "nprocs",
+                "msg": "Legacy process count; the native workflow is one batch process",
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
             },
             {
-                'name': 'parallel_reps',
-                'msg': ('Per-host replicate concurrency. When > 1, the '
-                        'replicates loop fans across hosts via PsshExecInfo '
-                        'and each host runs this many in parallel using '
-                        '`wait -n` batching. Default 1 preserves the '
-                        'original host[0]-only sequential loop.'),
-                'type': int,
-                'default': 1,
+                "name": "ppn",
+                "msg": "Legacy processes per node",
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
             },
             {
-                'name': 'parallel_scratch_root',
-                'msg': ('Root dir for per-rep SNAKEMAKE_SCRATCH_DIR when '
-                        'parallel_reps > 1. Each rep gets '
-                        '`<root>/rnaseq-scratch-<rep>`. Default /tmp keeps '
-                        'snakemake/STAR intermediates on node-local '
-                        'disk; point at a FUSE mount (e.g. '
-                        '/mnt/dumbwarp/scratch) to route every '
-                        'STAR-index / BAM / DESeq2 R/W through that '
-                        'adapter.'),
-                'type': str,
-                'default': '/tmp',
+                "name": "replicates",
+                "msg": "Legacy image-baked workflow repetition count",
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
             },
             {
-                'name': 'omp_threads',
-                'msg': ('OMP_NUM_THREADS for each parallel replicate. '
-                        'Snakemake threading is governed separately by '
-                        '`cores`. 0 = unset.'),
-                'type': int,
-                'default': 0,
+                "name": "parallel_reps",
+                "msg": "Legacy image-baked per-host repetition concurrency",
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
             },
             {
-                'name': 'base_image',
-                'msg': 'Base Docker image for build container',
-                'type': str,
-                'default': 'sci-hpc-base',
+                "name": "parallel_scratch_root",
+                "msg": "Legacy image-baked scratch root",
+                "type": str,
+                "default": "/tmp",
+                "agent_visible": False,
+            },
+            {
+                "name": "omp_threads",
+                "msg": "Legacy image-baked OpenMP thread count",
+                "type": int,
+                "default": 0,
+                "agent_visible": False,
+            },
+            {
+                "name": "base_image",
+                "msg": "Legacy container build base image",
+                "type": str,
+                "default": "sci-hpc-base",
+                "agent_visible": False,
             },
         ]
 
-    # ------------------------------------------------------------------
-    # Container Dockerfile generators
-    # ------------------------------------------------------------------
+    @staticmethod
+    def _discover(program: str, environment: dict[str, str]) -> str | None:
+        return program if shutil.which(program, path=environment.get("PATH")) else None
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe the native STAR and DESeq2 runtime and completion contract."""
+
+        environment = self._deployment_environment()
+        star = self._discover("STAR", environment) or "STAR"
+        rscript = self._discover("Rscript", environment) or "Rscript"
+        star_probe = probe_program(
+            star,
+            environment=environment,
+            arguments=("--version",),
+            timeout_seconds=10,
+        )
+        deseq_probe = probe_program(
+            rscript,
+            environment=environment,
+            arguments=(
+                "-e",
+                "suppressPackageStartupMessages(library(DESeq2));cat(as.character(packageVersion('DESeq2')))",
+            ),
+            timeout_seconds=20,
+        )
+        return PackageDeploymentContract(
+            package="builtin.rna_seq_star_deseq2",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="native_supplied_reads",
+                    execution_kind="batch",
+                    when=(
+                        ConfigurationCondition("deploy_mode", "equals", "default"),
+                        ConfigurationCondition("input_bundle", "is_not_empty"),
+                    ),
+                    runtime_requirements=("star", "deseq2"),
+                    readiness=ReadinessContract(
+                        mechanism="process_exit",
+                        condition="successful_exit_with_required_products",
+                    ),
+                    description=(
+                        "Align one supplied replicated two-condition RNA-seq "
+                        "study with STAR and calculate differential expression "
+                        "with DESeq2."
+                    ),
+                ),
+            ),
+            runtime_requirements=(
+                RuntimeRequirement(
+                    requirement_id="star",
+                    description="STAR aligner available through PATH",
+                    required_capabilities=("rna_seq_alignment", "gene_counting"),
+                    available_capabilities=(
+                        ("rna_seq_alignment", "gene_counting")
+                        if star_probe.status.usable is True
+                        else ()
+                    ),
+                    status=star_probe.status,
+                ),
+                RuntimeRequirement(
+                    requirement_id="deseq2",
+                    description="R runtime with the DESeq2 package",
+                    required_capabilities=("differential_expression",),
+                    available_capabilities=(
+                        ("differential_expression",)
+                        if deseq_probe.status.usable is True
+                        else ()
+                    ),
+                    status=deseq_probe.status,
+                ),
+            ),
+        )
+
+    def _build_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Build the retained legacy container image only when requested."""
+
+        if self.config.get("deploy_mode") != "container":
             return None
-        content = self._read_build_script('build.sh', {
-            'BASE_IMAGE': self.config.get('base_image', 'sci-hpc-base'),
-        })
-        return content, 'snakemake'
+        content = self._read_build_script(
+            "build.sh", {"BASE_IMAGE": self.config.get("base_image", "sci-hpc-base")}
+        )
+        return content, "snakemake"
 
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Create the retained legacy deployment image only when requested."""
+
+        if self.config.get("deploy_mode") != "container":
             return None
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': 'ubuntu:24.04',
-        })
-        return content, 'snakemake'
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {"BUILD_IMAGE": self.build_image_name(), "DEPLOY_BASE": "ubuntu:24.04"},
+        )
+        return content, "snakemake"
 
-    # ------------------------------------------------------------------
-    # Configuration
-    # ------------------------------------------------------------------
+    def _configure(self, **kwargs: Any) -> None:
+        """Validate the selected profile and prepare package-owned storage."""
 
-    def _configure(self, **kwargs):
-        """
-        Configure rna_seq_star_deseq2.
-
-        Calls super()._configure() which updates self.config and (when
-        deploy_mode == 'container') triggers build_phase / build_deploy_phase.
-
-        In default mode, also creates the output directory on all nodes.
-        """
         super()._configure(**kwargs)
+        if self.config.get("deploy_mode", "default") == "default":
+            self._validate_native_configuration()
+            environment = self._deployment_environment()
+            self.star_bin = self._discover("STAR", environment)
+            self.rscript_bin = self._discover("Rscript", environment)
+            self._ensure_output_root()
 
-        if self.config.get('deploy_mode') == 'default':
-            if self.config['out']:
-                Mkdir(self.config['out'],
-                      PsshExecInfo(hostfile=self.hostfile,
-                                   env=self.env)).run()
+    def _validate_native_configuration(self) -> None:
+        bundle = self.config.get("input_bundle")
+        if not isinstance(bundle, str) or not bundle:
+            raise ValueError("native STAR to DESeq2 requires input_bundle")
+        cores = self.config.get("cores")
+        if (
+            isinstance(cores, bool)
+            or not isinstance(cores, int)
+            or not 1 <= cores <= 64
+        ):
+            raise ValueError("cores must be an integer between 1 and 64")
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
-
-    def start(self):
-        """
-        Launch rna_seq_star_deseq2.
-
-        run_rnaseq.sh takes the output directory as its first positional
-        argument. Snakemake runs in a /tmp scratch workdir (snakemake
-        uses atomic write-then-rename, which wrp_cte_fuse does not
-        support) and the final results tree is staged into ``out`` via
-        plain cp — which exercises the CTE adapter when ``out`` is on
-        the FUSE mountpoint.
-        """
-        out_root = self.config['out']
-        replicates = max(int(self.config.get('replicates', 1) or 1), 1)
-        parallel = max(int(self.config.get('parallel_reps', 1) or 1), 1)
-        omp = int(self.config.get('omp_threads', 0) or 0)
-
-        if parallel <= 1:
-            # Single-host sequential path (original).
-            if replicates == 1:
-                cmd = f"/opt/run_rnaseq.sh '{out_root}'"
-            else:
-                cmd = (
-                    "set -e; "
-                    f"for i in $(seq 1 {replicates}); do "
-                    f"  rep=$(printf 'rep_%03d' \"$i\"); "
-                    f"  echo \"=== rna_seq replicate $rep ($i/{replicates}) ===\"; "
-                    f"  /opt/run_rnaseq.sh '{out_root}/'$rep || exit 1; "
-                    f"done"
-                )
-            if self.config.get('deploy_mode') == 'container':
-                Exec(cmd, LocalExecInfo(
-                    container=self._container_engine,
-                    container_image=self.deploy_image_name(),
-                    shared_dir=self.shared_dir,
-                    private_dir=self.private_dir,
-                    env=self.mod_env,
-                )).run()
-            else:
-                Exec(cmd, LocalExecInfo(env=self.mod_env)).run()
-            return
-
-        # parallel_reps > 1: PsshExecInfo fan-out + per-host wait -n
-        # batching. Snakemake's /tmp/rnaseq-scratch is wiped at start of
-        # each invocation; concurrent runs on the same host need a per-
-        # rep scratch dir, which the runner script honors via
-        # SNAKEMAKE_SCRATCH_DIR (mirroring biobb/montage's pattern).
-        nhosts = max(len(self.hostfile.hosts), 1) if self.hostfile else 1
-        local_reps = (replicates + nhosts - 1) // nhosts
-        scratch_root = (self.config.get('parallel_scratch_root')
-                        or '/tmp').rstrip('/')
-        omp_export = (
-            f"export OMP_NUM_THREADS={omp}; " if omp > 0 else ""
+    def _output_root(self) -> Path:
+        return self.resolve_shared_path(
+            self.config.get("out"), field="out", default="run"
         )
-        cmd = (
-            f"set -e; "
-            f"{omp_export}"
-            f"LOCAL={local_reps}; "
-            f"PAR={parallel}; "
-            f"OUT='{out_root}'; "
-            f"H=$(hostname -s); "
-            f"echo \"[rnaseq-parallel] host=$H reps=$LOCAL parallel=$PAR omp=${{OMP_NUM_THREADS:-default}}\"; "
-            f"PIDS=(); "
-            f"for i in $(seq 1 $LOCAL); do "
-            f"  ( "
-            f"    rep=$(printf 'rep_%03d-%s' \"$i\" \"$H\"); "
-            f"    RNASEQ_SCRATCH_DIR=\"{scratch_root}/rnaseq-scratch-$rep\" "
-            f"    /opt/run_rnaseq.sh \"$OUT/$rep\" "
-            f"      && echo \"[rnaseq-parallel] host=$H $rep DONE\" "
-            f"      || {{ echo \"[rnaseq-parallel] host=$H $rep FAILED\" >&2; exit 1; }} "
-            f"  ) & "
-            f"  PIDS+=($!); "
-            f"  if [ \"${{#PIDS[@]}}\" -ge $PAR ]; then "
-            f"    wait -n; "
-            f"    PIDS=(\"${{PIDS[@]:1}}\"); "
-            f"  fi; "
-            f"done; "
-            f"wait"
+
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
+
+    def _ensure_output_root(self) -> None:
+        output = str(self._output_root())
+        result = Mkdir(output, self._node_exec_info(env=self.env)).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to create RNA-seq output directory {output}: {failures}"
+            )
+
+    @staticmethod
+    def _bundle_members(
+        bundle: MaterializedInputBundle,
+    ) -> dict[str, Path | tuple[Path, ...]]:
+        by_role: dict[str, list[Path]] = {}
+        for item in bundle.manifest.files:
+            by_role.setdefault(item.role, []).append(bundle.root / item.path)
+        if set(by_role) != {*_EXPECTED_ROLES, "single_end_fastq"}:
+            raise ValueError(
+                "RNA-seq input bundle contains unsupported or missing roles"
+            )
+        for role, expected_count in _EXPECTED_ROLES.items():
+            if len(by_role[role]) != expected_count:
+                raise ValueError(f"RNA-seq input bundle requires exactly one {role}")
+        fastqs = by_role["single_end_fastq"]
+        if not 4 <= len(fastqs) <= 64:
+            raise ValueError("RNA-seq input bundle requires 4 to 64 FASTQ files")
+        design = by_role["sample_design"][0]
+        if design != bundle.entrypoint:
+            raise ValueError(
+                "RNA-seq input bundle entrypoint must be its sample design"
+            )
+        return {
+            "sample_design": design,
+            "reference_genome": by_role["reference_genome"][0],
+            "gene_annotation": by_role["gene_annotation"][0],
+            "single_end_fastq": tuple(fastqs),
+        }
+
+    def _prepare_native_input(self) -> tuple[Path, Path, Path, Path, Path]:
+        """Verify and stage one closed study without accepting stale products."""
+
+        self._validate_native_configuration()
+        self._ensure_output_root()
+        root = self._output_root()
+        for name in ("input", "results", "work"):
+            target = root / name
+            if target.exists() or target.is_symlink():
+                raise ValueError(f"RNA-seq execution target already exists: {name}")
+        configured = self.config.get("input_bundle")
+        assert isinstance(configured, str) and configured
+        if self.shared_dir is None:
+            raise RuntimeError("RNA-seq input bundles require shared storage")
+        bundle = extract_input_bundle(
+            configured, Path(self.shared_dir) / "input-bundles"
         )
-        if self.config.get('deploy_mode') == 'container':
-            Exec(cmd, PsshExecInfo(
-                hostfile=self.hostfile,
+        members = self._bundle_members(bundle)
+        stage_input_bundle(bundle, root / "input")
+
+        def staged(role: str) -> Path:
+            source = members[role]
+            assert isinstance(source, Path)
+            return root / "input" / source.relative_to(bundle.root)
+
+        return (
+            root / "input",
+            staged("sample_design"),
+            staged("reference_genome"),
+            staged("gene_annotation"),
+            root,
+        )
+
+    def _start_native(self) -> None:
+        input_root, samples, genome, annotation, root = self._prepare_native_input()
+        star = self.star_bin or self._discover("STAR", self.mod_env)
+        rscript = self.rscript_bin or self._discover("Rscript", self.mod_env)
+        if star is None:
+            raise RuntimeError("STAR is unavailable through PATH")
+        if rscript is None:
+            raise RuntimeError("Rscript with DESeq2 is unavailable through PATH")
+        runner = Path(__file__).with_name("native_runner.py").resolve()
+        deseq = Path(__file__).with_name("deseq2_analysis.R").resolve()
+        arguments = [
+            sys.executable,
+            str(runner),
+            "--input-root",
+            str(input_root),
+            "--samples",
+            str(samples),
+            "--genome",
+            str(genome),
+            "--annotation",
+            str(annotation),
+            "--output-root",
+            str(root / "results"),
+            "--work-root",
+            str(root / "work"),
+            "--deseq-script",
+            str(deseq),
+            "--star",
+            star,
+            "--rscript",
+            rscript,
+            "--cores",
+            str(self.config["cores"]),
+        ]
+        result = Exec(
+            " ".join(shlex.quote(argument) for argument in arguments),
+            LocalExecInfo(
+                env=self.mod_env,
+                cwd=str(root),
+                line_callback=self.runtime_line_callback(),
+            ),
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"STAR to DESeq2 workflow failed: {failures}")
+        load_rnaseq_result(root / "results")
+
+    def _start_legacy_container(self) -> None:
+        """Retain the historical image-baked workflow for explicit container users."""
+
+        out_root = self.config.get("out")
+        if not isinstance(out_root, str) or not out_root:
+            raise ValueError("legacy RNA-seq output must be a path string")
+        configured_replicates = self.config.get("replicates", 1)
+        if isinstance(configured_replicates, bool) or not isinstance(
+            configured_replicates, int
+        ):
+            raise ValueError("legacy RNA-seq replicates must be an integer")
+        replicates = max(configured_replicates, 1)
+        command = (
+            f"/opt/run_rnaseq.sh {shlex.quote(out_root)}"
+            if replicates == 1
+            else "set -e; "
+            + f"for i in $(seq 1 {replicates}); do "
+            + 'rep=$(printf "rep_%03d" "$i"); '
+            + f"/opt/run_rnaseq.sh {shlex.quote(out_root)}/$rep || exit 1; done"
+        )
+        result = Exec(
+            command,
+            LocalExecInfo(
                 container=self._container_engine,
                 container_image=self.deploy_image_name(),
                 shared_dir=self.shared_dir,
                 private_dir=self.private_dir,
                 env=self.mod_env,
-            )).run()
+            ),
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"Legacy STAR to DESeq2 workflow failed: {failures}")
+
+    def start(self) -> None:
+        """Run the selected native or explicit legacy profile."""
+
+        if self.config.get("deploy_mode", "default") == "container":
+            self._start_legacy_container()
         else:
-            Exec(cmd, PsshExecInfo(
-                hostfile=self.hostfile, env=self.mod_env)).run()
+            self._start_native()
 
-    def stop(self):
-        """Stop rna_seq_star_deseq2 (no-op -- runs to completion)."""
-        pass
+    def stop(self) -> None:
+        """Do nothing because this package is a bounded batch process."""
 
-    def clean(self):
-        """Remove rna_seq_star_deseq2 output directory."""
-        if self.config['out']:
-            Rm(self.config['out'] + '*',
-               PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+    def clean(self) -> None:
+        """Remove the exact package-owned output directory."""
+
+        output = str(self._output_root())
+        Rm(output, self._node_exec_info(env=self.env), recursive=True).run()

--- a/builtin/builtin/rna_seq_star_deseq2/result_contract.py
+++ b/builtin/builtin/rna_seq_star_deseq2/result_contract.py
@@ -1,0 +1,240 @@
+"""Closed result validation shared by RNA-seq lifecycle and artifact semantics."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+RESULT_NAME = "rnaseq-result.json"
+RESULT_SCHEMA = "jarvis.rnaseq-star-deseq2-result.v1"
+_TOP_LEVEL_FIELDS = {
+    "artifacts",
+    "comparison_condition",
+    "deseq2",
+    "mapping",
+    "reference_condition",
+    "sample_count",
+    "schema_version",
+    "star_read_length",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class RnaSeqProduct:
+    """One result-declared, digest-verified RNA-seq product."""
+
+    relative_path: PurePosixPath
+    local_path: Path
+    sha256: str
+    size_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedRnaSeqResult:
+    """A closed RNA-seq result and all of its verified products."""
+
+    result_path: Path
+    document: dict[str, Any]
+    products: dict[str, RnaSeqProduct]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _relative_path(value: object) -> PurePosixPath:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise RuntimeError("RNA-seq result contains an invalid artifact path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise RuntimeError("RNA-seq result artifact path is not confined")
+    return path
+
+
+def _positive_integer(value: object, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise RuntimeError(f"RNA-seq result {field} must be a positive integer")
+    return value
+
+
+def _validate_mapping(
+    document: dict[str, Any], *, sample_count: int
+) -> tuple[str, ...]:
+    mapping = document.get("mapping")
+    if not isinstance(mapping, dict) or len(mapping) != sample_count:
+        raise RuntimeError("RNA-seq result mapping summary differs from sample count")
+    names: list[str] = []
+    for name, raw in mapping.items():
+        if not isinstance(name, str) or not name or not isinstance(raw, dict):
+            raise RuntimeError("RNA-seq result contains an invalid sample mapping")
+        if set(raw) != {
+            "input_reads",
+            "uniquely_mapped_percent",
+            "uniquely_mapped_reads",
+        }:
+            raise RuntimeError("RNA-seq sample mapping fields differ")
+        input_reads = _positive_integer(raw["input_reads"], field="input_reads")
+        mapped_reads = raw["uniquely_mapped_reads"]
+        percent = raw["uniquely_mapped_percent"]
+        if (
+            isinstance(mapped_reads, bool)
+            or not isinstance(mapped_reads, int)
+            or not 0 <= mapped_reads <= input_reads
+            or isinstance(percent, bool)
+            or not isinstance(percent, (int, float))
+            or not 0 <= float(percent) <= 100
+        ):
+            raise RuntimeError("RNA-seq sample mapping metric is outside its bounds")
+        names.append(name)
+    return tuple(names)
+
+
+def _validate_deseq2(document: dict[str, Any]) -> None:
+    summary = document.get("deseq2")
+    if not isinstance(summary, dict) or set(summary) != {
+        "absolute_log2_fold_change_threshold",
+        "adjusted_p_value_threshold",
+        "significant_gene_count",
+        "tested_gene_count",
+        "top_significant_genes",
+    }:
+        raise RuntimeError("RNA-seq DESeq2 summary fields differ")
+    tested = _positive_integer(summary["tested_gene_count"], field="tested_gene_count")
+    significant = summary["significant_gene_count"]
+    top = summary["top_significant_genes"]
+    if (
+        isinstance(significant, bool)
+        or not isinstance(significant, int)
+        or not 0 <= significant <= tested
+        or not isinstance(top, list)
+        or len(top) > min(significant, 20)
+    ):
+        raise RuntimeError("RNA-seq DESeq2 summary values are inconsistent")
+    for item in top:
+        if not isinstance(item, dict) or set(item) != {
+            "adjusted_p_value",
+            "gene_id",
+            "log2_fold_change",
+        }:
+            raise RuntimeError("RNA-seq significant-gene record fields differ")
+
+
+def load_rnaseq_result(output_root: Path) -> ValidatedRnaSeqResult:
+    """Load a result only when its closed document and exact products agree."""
+
+    root = output_root.resolve(strict=True)
+    if root.is_symlink() or not root.is_dir():
+        raise RuntimeError("RNA-seq output root is not a real directory")
+    result_path = root / RESULT_NAME
+    if (
+        result_path.is_symlink()
+        or not result_path.is_file()
+        or not 0 < result_path.stat().st_size <= 2 * 1024 * 1024
+    ):
+        raise RuntimeError("RNA-seq result document is missing, unsafe, or oversized")
+    try:
+        document = json.loads(result_path.read_text(encoding="utf-8", errors="strict"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("RNA-seq result document is not valid JSON") from exc
+    if (
+        not isinstance(document, dict)
+        or set(document) != _TOP_LEVEL_FIELDS
+        or document.get("schema_version") != RESULT_SCHEMA
+    ):
+        raise RuntimeError("RNA-seq result document has the wrong schema")
+    sample_count = _positive_integer(document.get("sample_count"), field="sample_count")
+    if not 4 <= sample_count <= 64:
+        raise RuntimeError("RNA-seq sample count is outside its supported bound")
+    read_length = _positive_integer(
+        document.get("star_read_length"), field="star_read_length"
+    )
+    if read_length > 1000:
+        raise RuntimeError("RNA-seq read length is outside its supported bound")
+    reference = document.get("reference_condition")
+    comparison = document.get("comparison_condition")
+    if (
+        not isinstance(reference, str)
+        or not reference
+        or not isinstance(comparison, str)
+        or not comparison
+        or reference == comparison
+    ):
+        raise RuntimeError("RNA-seq result conditions are invalid")
+    sample_names = _validate_mapping(document, sample_count=sample_count)
+    _validate_deseq2(document)
+
+    raw_products = document.get("artifacts")
+    expected_count = 5 + 3 * sample_count
+    if not isinstance(raw_products, list) or len(raw_products) != expected_count:
+        raise RuntimeError(
+            "RNA-seq result artifact count differs from its sample count"
+        )
+    products: dict[str, RnaSeqProduct] = {}
+    for raw in raw_products:
+        if not isinstance(raw, dict) or set(raw) != {"path", "sha256", "size_bytes"}:
+            raise RuntimeError("RNA-seq result artifact record fields differ")
+        relative = _relative_path(raw["path"])
+        expected_sha = raw["sha256"]
+        expected_size = raw["size_bytes"]
+        if (
+            relative.as_posix() in products
+            or not isinstance(expected_sha, str)
+            or len(expected_sha) != 64
+            or not set(expected_sha).issubset("0123456789abcdef")
+            or isinstance(expected_size, bool)
+            or not isinstance(expected_size, int)
+            or expected_size <= 0
+        ):
+            raise RuntimeError("RNA-seq result artifact identity is invalid")
+        lexical = root.joinpath(*relative.parts)
+        if lexical.is_symlink():
+            raise RuntimeError(f"RNA-seq artifact is a symbolic link: {relative}")
+        candidate = lexical.resolve(strict=True)
+        if (
+            not candidate.is_relative_to(root)
+            or candidate.is_symlink()
+            or not candidate.is_file()
+            or candidate.stat().st_size != expected_size
+            or _sha256(candidate) != expected_sha
+        ):
+            raise RuntimeError(f"RNA-seq artifact differs from result: {relative}")
+        products[relative.as_posix()] = RnaSeqProduct(
+            relative_path=relative,
+            local_path=candidate,
+            sha256=expected_sha,
+            size_bytes=expected_size,
+        )
+    required = {
+        "gene-counts.tsv",
+        "samples.tsv",
+        "differential-expression.tsv",
+        "normalized-counts.tsv",
+        "deseq2-session-info.txt",
+    }
+    for name in sample_names:
+        required.update(
+            {
+                f"star/{name}/Aligned.sortedByCoord.out.bam",
+                f"star/{name}/ReadsPerGene.out.tab",
+                f"star/{name}/Log.final.out",
+            }
+        )
+    if set(products) != required:
+        raise RuntimeError("RNA-seq result does not declare the complete product set")
+    return ValidatedRnaSeqResult(result_path, document, products)
+
+
+__all__ = [
+    "RESULT_NAME",
+    "RESULT_SCHEMA",
+    "RnaSeqProduct",
+    "ValidatedRnaSeqResult",
+    "load_rnaseq_result",
+]

--- a/jarvis_cd/configuration_input.py
+++ b/jarvis_cd/configuration_input.py
@@ -7,15 +7,24 @@ import os
 import re
 import stat
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
 
 from jarvis_cd.deployment import ConfigurationInputBinding
 from jarvis_cd.util.private_path import reject_private_path_redirection
 
-MAX_CONFIGURATION_INPUT_BYTES = 16 * 1024 * 1024
+MAX_CONFIGURATION_INPUT_BYTES = 512 * 1024 * 1024
 _PARAMETER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _SAFE_SUFFIX_PATTERN = re.compile(r"^\.[A-Za-z0-9][A-Za-z0-9._-]{0,31}$")
+
+
+@dataclass(frozen=True, slots=True)
+class _FileFingerprint:
+    """Stable size and SHA-256 identity for one bounded regular file."""
+
+    size_bytes: int
+    sha256: str
 
 
 def materialize_configuration_inputs(
@@ -74,13 +83,12 @@ def materialize_configuration_inputs(
                 f"declared configuration input {parameter!r} must be a path string"
             )
         source = _configuration_input_source(value, parameter=parameter)
-        payload, digest = _read_bounded_regular_file(source, parameter=parameter)
+        fingerprint = _fingerprint_bounded_regular_file(source, parameter=parameter)
         target = _materialized_target(
             shared_root,
             parameter=parameter,
             source=source,
-            payload=payload,
-            digest=digest,
+            fingerprint=fingerprint,
         )
         materialized[parameter] = str(target)
     return materialized
@@ -115,7 +123,7 @@ def configuration_input_materialization_matches(
     try:
         ConfigurationInputBinding.from_dict(cast(Mapping[str, object], raw_binding))
         source = _configuration_input_source(requested, parameter=parameter)
-        source_payload, source_digest = _read_bounded_regular_file(
+        source_fingerprint = _fingerprint_bounded_regular_file(
             source,
             parameter=parameter,
         )
@@ -124,17 +132,17 @@ def configuration_input_materialization_matches(
         target = Path(os.path.abspath(os.fspath(materialized)))
         reject_private_path_redirection(target)
         if target.parent != expected_root or target.name != _materialized_name(
-            source, source_digest
+            source, source_fingerprint.sha256
         ):
             return False
-        target_payload, target_digest = _read_bounded_regular_file(
+        target_fingerprint = _fingerprint_bounded_regular_file(
             target,
             parameter=parameter,
             require_single_link=True,
         )
     except (OSError, RuntimeError, TypeError, ValueError):
         return False
-    return source_digest == target_digest and source_payload == target_payload
+    return source_fingerprint == target_fingerprint
 
 
 def _configuration_input_source(
@@ -157,13 +165,52 @@ def _configuration_input_source(
     return source
 
 
-def _read_bounded_regular_file(
+def _fingerprint_bounded_regular_file(
     path: Path,
     *,
     parameter: str,
     require_single_link: bool = False,
-) -> tuple[bytes, str]:
-    """Read one stable regular file through a no-follow descriptor."""
+) -> _FileFingerprint:
+    """Hash one stable bounded file without retaining its payload in memory."""
+
+    descriptor, linked_before, opened_before = _open_bounded_regular_file(
+        path,
+        parameter=parameter,
+        require_single_link=require_single_link,
+    )
+    digest = hashlib.sha256()
+    observed_size = 0
+    try:
+        while chunk := os.read(descriptor, 1024 * 1024):
+            observed_size += len(chunk)
+            if observed_size > MAX_CONFIGURATION_INPUT_BYTES:
+                raise ValueError(
+                    f"declared configuration input {parameter!r} exceeded its bound"
+                )
+            digest.update(chunk)
+        opened_after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    _validate_file_after_read(
+        path,
+        parameter=parameter,
+        linked_before=linked_before,
+        opened_before=opened_before,
+        opened_after=opened_after,
+        observed_size=observed_size,
+        require_single_link=require_single_link,
+    )
+    return _FileFingerprint(observed_size, digest.hexdigest())
+
+
+def _open_bounded_regular_file(
+    path: Path,
+    *,
+    parameter: str,
+    require_single_link: bool,
+) -> tuple[int, os.stat_result, os.stat_result]:
+    """Open one stable bounded regular file without following its final link."""
+
     try:
         linked_before = path.lstat()
     except OSError as exc:
@@ -193,29 +240,32 @@ def _read_bounded_regular_file(
         raise ValueError(
             f"declared configuration input {parameter!r} could not be opened safely"
         ) from exc
-    try:
-        opened_before = os.fstat(descriptor)
-        if (
-            not stat.S_ISREG(opened_before.st_mode)
-            or _is_path_redirection(opened_before)
-            or _file_identity(opened_before) != _file_identity(linked_before)
-            or (require_single_link and opened_before.st_nlink != 1)
-        ):
-            raise ValueError(
-                f"declared configuration input {parameter!r} changed before reading"
-            )
-        chunks: list[bytes] = []
-        remaining = MAX_CONFIGURATION_INPUT_BYTES + 1
-        while remaining:
-            chunk = os.read(descriptor, min(1024 * 1024, remaining))
-            if not chunk:
-                break
-            chunks.append(chunk)
-            remaining -= len(chunk)
-        payload = b"".join(chunks)
-        opened_after = os.fstat(descriptor)
-    finally:
+    opened_before = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(opened_before.st_mode)
+        or _is_path_redirection(opened_before)
+        or _file_identity(opened_before) != _file_identity(linked_before)
+        or (require_single_link and opened_before.st_nlink != 1)
+    ):
         os.close(descriptor)
+        raise ValueError(
+            f"declared configuration input {parameter!r} changed before reading"
+        )
+    return descriptor, linked_before, opened_before
+
+
+def _validate_file_after_read(
+    path: Path,
+    *,
+    parameter: str,
+    linked_before: os.stat_result,
+    opened_before: os.stat_result,
+    opened_after: os.stat_result,
+    observed_size: int,
+    require_single_link: bool,
+) -> None:
+    """Reject a file that changed identity while it was being streamed."""
+
     try:
         linked_after = path.lstat()
     except OSError as exc:
@@ -223,8 +273,8 @@ def _read_bounded_regular_file(
             f"declared configuration input {parameter!r} changed while reading"
         ) from exc
     if (
-        len(payload) > MAX_CONFIGURATION_INPUT_BYTES
-        or len(payload) != opened_before.st_size
+        observed_size > MAX_CONFIGURATION_INPUT_BYTES
+        or observed_size != opened_before.st_size
         or _is_path_redirection(linked_after)
         or (require_single_link and linked_after.st_nlink != 1)
         or _file_identity(opened_after) != _file_identity(opened_before)
@@ -233,7 +283,55 @@ def _read_bounded_regular_file(
         raise ValueError(
             f"declared configuration input {parameter!r} changed while reading"
         )
-    return payload, hashlib.sha256(payload).hexdigest()
+
+
+def _copy_bounded_regular_file(
+    source: Path,
+    destination_descriptor: int,
+    *,
+    parameter: str,
+    expected: _FileFingerprint,
+) -> None:
+    """Stream one stable source into an already-created private destination."""
+
+    source_descriptor, linked_before, opened_before = _open_bounded_regular_file(
+        source,
+        parameter=parameter,
+        require_single_link=False,
+    )
+    digest = hashlib.sha256()
+    observed_size = 0
+    try:
+        while chunk := os.read(source_descriptor, 1024 * 1024):
+            observed_size += len(chunk)
+            if observed_size > MAX_CONFIGURATION_INPUT_BYTES:
+                raise ValueError(
+                    f"declared configuration input {parameter!r} exceeded its bound"
+                )
+            digest.update(chunk)
+            offset = 0
+            while offset < len(chunk):
+                written = os.write(destination_descriptor, chunk[offset:])
+                if written <= 0:
+                    raise OSError("short write while materializing configuration input")
+                offset += written
+        opened_after = os.fstat(source_descriptor)
+    finally:
+        os.close(source_descriptor)
+    _validate_file_after_read(
+        source,
+        parameter=parameter,
+        linked_before=linked_before,
+        opened_before=opened_before,
+        opened_after=opened_after,
+        observed_size=observed_size,
+        require_single_link=False,
+    )
+    observed = _FileFingerprint(observed_size, digest.hexdigest())
+    if observed != expected:
+        raise ValueError(
+            f"declared configuration input {parameter!r} changed before materialization"
+        )
 
 
 def _materialized_target(
@@ -241,8 +339,7 @@ def _materialized_target(
     *,
     parameter: str,
     source: Path,
-    payload: bytes,
-    digest: str,
+    fingerprint: _FileFingerprint,
 ) -> Path:
     bindings_root = shared_root / "configuration-inputs"
     parameter_root = bindings_root / parameter
@@ -253,32 +350,32 @@ def _materialized_target(
         if os.name != "nt":
             directory.chmod(0o700)
 
-    target = parameter_root / _materialized_name(source, digest)
+    target = parameter_root / _materialized_name(source, fingerprint.sha256)
     if target == source:
         return target
     if target.exists():
-        existing, existing_digest = _read_bounded_regular_file(
+        existing = _fingerprint_bounded_regular_file(
             target,
             parameter=parameter,
             require_single_link=True,
         )
-        if existing_digest == digest and existing == payload:
+        if existing == fingerprint:
             return target
 
     descriptor, temporary_name = tempfile.mkstemp(
-        prefix=f".{digest}.",
+        prefix=f".{fingerprint.sha256}.",
         suffix=".tmp",
         dir=parameter_root,
     )
     temporary = Path(temporary_name)
     descriptor_open = True
     try:
-        offset = 0
-        while offset < len(payload):
-            written = os.write(descriptor, payload[offset:])
-            if written <= 0:
-                raise OSError("short write while materializing configuration input")
-            offset += written
+        _copy_bounded_regular_file(
+            source,
+            descriptor,
+            parameter=parameter,
+            expected=fingerprint,
+        )
         os.fsync(descriptor)
         if os.name != "nt":
             descriptor_chmod = cast(Any, getattr(os, "fchmod"))
@@ -294,12 +391,12 @@ def _materialized_target(
             os.close(descriptor)
         if temporary.exists():
             temporary.unlink()
-    persisted, persisted_digest = _read_bounded_regular_file(
+    persisted = _fingerprint_bounded_regular_file(
         target,
         parameter=parameter,
         require_single_link=True,
     )
-    if persisted_digest != digest or persisted != payload:
+    if persisted != fingerprint:
         raise RuntimeError(
             f"materialized configuration input {parameter!r} failed verification"
         )

--- a/test/unit/core/test_configuration_input_materialization.py
+++ b/test/unit/core/test_configuration_input_materialization.py
@@ -11,6 +11,7 @@ from typing import Any
 import pytest
 
 from jarvis_cd.configuration_input import (
+    MAX_CONFIGURATION_INPUT_BYTES,
     configuration_input_materialization_matches,
     materialize_configuration_inputs,
 )
@@ -194,6 +195,66 @@ def test_malformed_declared_input_binding_fails_closed(tmp_path: Path) -> None:
                 }
             ],
             config={"script": str(source)},
+            shared_dir=(tmp_path / "shared").resolve(),
+        )
+
+
+def test_scientific_bundle_above_legacy_limit_is_streamed(tmp_path: Path) -> None:
+    """Large bounded inputs materialize without the obsolete 16 MiB ceiling."""
+
+    source = tmp_path / "study.tar"
+    chunk = b"bounded-scientific-input\n" * 4096
+    with source.open("wb") as stream:
+        while stream.tell() <= 17 * 1024 * 1024:
+            stream.write(chunk)
+    shared_dir = (tmp_path / "shared").resolve()
+    shared_dir.mkdir()
+
+    configured = materialize_configuration_inputs(
+        menu=[
+            {
+                "name": "input_bundle",
+                "input_binding": dict(_INPUT_BINDING),
+            }
+        ],
+        config={"input_bundle": str(source)},
+        shared_dir=shared_dir,
+    )
+
+    target = Path(configured["input_bundle"])
+    assert target.stat().st_size == source.stat().st_size
+    assert configuration_input_materialization_matches(
+        menu=[
+            {
+                "name": "input_bundle",
+                "input_binding": dict(_INPUT_BINDING),
+            }
+        ],
+        parameter="input_bundle",
+        requested=source,
+        materialized=target,
+        shared_dir=shared_dir,
+    )
+
+
+def test_configuration_input_still_rejects_files_above_global_bound(
+    tmp_path: Path,
+) -> None:
+    """Streaming does not remove the global denial-of-service size bound."""
+
+    source = tmp_path / "oversized.tar"
+    with source.open("wb") as stream:
+        stream.truncate(MAX_CONFIGURATION_INPUT_BYTES + 1)
+
+    with pytest.raises(ValueError, match="must be one bounded regular file"):
+        materialize_configuration_inputs(
+            menu=[
+                {
+                    "name": "input_bundle",
+                    "input_binding": dict(_INPUT_BINDING),
+                }
+            ],
+            config={"input_bundle": str(source)},
             shared_dir=(tmp_path / "shared").resolve(),
         )
 

--- a/test/unit/core/test_rnaseq_native_artifacts.py
+++ b/test/unit/core/test_rnaseq_native_artifacts.py
@@ -1,0 +1,221 @@
+"""Native runner and closed-artifact tests for STAR to DESeq2."""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import hashlib
+import json
+import sys
+from importlib import import_module
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_module(name: str) -> ModuleType:
+    repository_root = Path(__file__).resolve().parents[3] / "builtin"
+    sys.path.insert(0, str(repository_root))
+    try:
+        return import_module(name)
+    finally:
+        sys.path.remove(str(repository_root))
+
+
+runner = _load_module("builtin.rna_seq_star_deseq2.native_runner")
+contract = _load_module("builtin.rna_seq_star_deseq2.result_contract")
+artifacts = _load_module("builtin.rna_seq_star_deseq2.artifacts")
+
+
+def _write_fastq(path: Path, *, sequence: str = "ACGT") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(path, "wt", encoding="ascii", newline="\n") as stream:
+        stream.write(f"@read\n{sequence}\n+\n{'I' * len(sequence)}\n")
+
+
+def _write_samples(root: Path, *, second_set: int = 2) -> Path:
+    rows = (
+        ("a1", "control", 1, "SRR1", "reads/a1.fastq.gz"),
+        ("a2", "control", second_set, "SRR2", "reads/a2.fastq.gz"),
+        ("b1", "treated", 1, "SRR3", "reads/b1.fastq.gz"),
+        ("b2", "treated", 2, "SRR4", "reads/b2.fastq.gz"),
+    )
+    for row in rows:
+        _write_fastq(root / row[4])
+    path = root / "samples.tsv"
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.writer(stream, delimiter="\t", lineterminator="\n")
+        writer.writerow(("sample", "condition", "set_id", "accession", "fastq"))
+        writer.writerows(rows)
+    return path
+
+
+def test_sample_design_requires_paired_replicates_and_confined_reads(
+    tmp_path: Path,
+) -> None:
+    samples = _write_samples(tmp_path)
+
+    observed = runner.read_samples(samples, input_root=tmp_path)
+
+    assert [sample.name for sample in observed] == ["a1", "a2", "b1", "b2"]
+    assert {sample.condition for sample in observed} == {"control", "treated"}
+
+    unpaired_root = tmp_path / "unpaired"
+    unpaired_root.mkdir()
+    unpaired = _write_samples(unpaired_root, second_set=3)
+    with pytest.raises(runner.RnaSeqExecutionError, match="same replicate-set IDs"):
+        runner.read_samples(unpaired, input_root=unpaired_root)
+
+    text = samples.read_text(encoding="utf-8").replace(
+        "reads/a1.fastq.gz", "../a1.fastq.gz"
+    )
+    samples.write_text(text, encoding="utf-8")
+    with pytest.raises(runner.RnaSeqExecutionError, match="confined relative path"):
+        runner.read_samples(samples, input_root=tmp_path)
+
+
+def test_star_gene_counts_require_identical_gene_order(tmp_path: Path) -> None:
+    sample_path = _write_samples(tmp_path)
+    samples = runner.read_samples(sample_path, input_root=tmp_path)
+    star = tmp_path / "star"
+    for index, sample in enumerate(samples):
+        sample_root = star / sample.name
+        sample_root.mkdir(parents=True)
+        genes = ("gene1", "gene2") if index != 3 else ("gene2", "gene1")
+        (sample_root / "ReadsPerGene.out.tab").write_text(
+            "N_unmapped\t0\t0\t0\n"
+            "N_multimapping\t0\t0\t0\n"
+            "N_noFeature\t0\t0\t0\n"
+            "N_ambiguous\t0\t0\t0\n"
+            + "".join(f"{gene}\t{index + 1}\t0\t0\n" for gene in genes),
+            encoding="utf-8",
+        )
+
+    with pytest.raises(runner.RnaSeqExecutionError, match="gene order differs"):
+        runner._write_counts(samples, star, tmp_path / "counts.tsv")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_closed_result(root: Path) -> dict[str, object]:
+    root.mkdir(parents=True, exist_ok=True)
+    samples = ("a1", "a2", "b1", "b2")
+    paths = [
+        "gene-counts.tsv",
+        "samples.tsv",
+        "differential-expression.tsv",
+        "normalized-counts.tsv",
+        "deseq2-session-info.txt",
+    ]
+    for sample in samples:
+        paths.extend(
+            (
+                f"star/{sample}/Aligned.sortedByCoord.out.bam",
+                f"star/{sample}/ReadsPerGene.out.tab",
+                f"star/{sample}/Log.final.out",
+            )
+        )
+    records: list[dict[str, object]] = []
+    for relative in paths:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(f"product:{relative}\n".encode())
+        records.append(
+            {
+                "path": relative,
+                "sha256": _sha256(path),
+                "size_bytes": path.stat().st_size,
+            }
+        )
+    document: dict[str, object] = {
+        "artifacts": records,
+        "comparison_condition": "treated",
+        "deseq2": {
+            "adjusted_p_value_threshold": 0.05,
+            "absolute_log2_fold_change_threshold": 1.0,
+            "significant_gene_count": 0,
+            "tested_gene_count": 10,
+            "top_significant_genes": [],
+        },
+        "mapping": {
+            sample: {
+                "input_reads": 100,
+                "uniquely_mapped_reads": 80,
+                "uniquely_mapped_percent": 80.0,
+            }
+            for sample in samples
+        },
+        "reference_condition": "control",
+        "sample_count": 4,
+        "schema_version": contract.RESULT_SCHEMA,
+        "star_read_length": 100,
+    }
+    (root / contract.RESULT_NAME).write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return document
+
+
+def test_closed_result_rejects_changed_products(tmp_path: Path) -> None:
+    _write_closed_result(tmp_path)
+
+    validated = contract.load_rnaseq_result(tmp_path)
+    assert len(validated.products) == 17
+
+    (tmp_path / "gene-counts.tsv").write_text("changed\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="differs from result"):
+        contract.load_rnaseq_result(tmp_path)
+
+
+def test_artifact_adapter_finalizes_result_tables_and_alignment_collection(
+    tmp_path: Path,
+) -> None:
+    _write_closed_result(tmp_path)
+    adapter = artifacts.RnaSeqArtifactAdapter(
+        artifacts.PurePosixPath("/cluster/run/results"),
+        _local_root=tmp_path,
+    )
+
+    observed = adapter.finalize_artifacts_for_exit(0)
+
+    by_name = {item.logical_name: item for item in observed}
+    assert set(by_name) == {
+        "rna-seq-result-tree",
+        "rna-seq-result",
+        "differential-expression",
+        "gene-counts",
+        "normalized-counts",
+        "rna-seq-sample-design",
+        "deseq2-session-info",
+        "star-alignments",
+    }
+    assert all(item.state.value == "finalized" for item in observed)
+    assert by_name["star-alignments"].metadata["member_count"] == 4
+    assert by_name["rna-seq-result"].checksum.startswith("sha256:")
+    assert adapter.finalize_artifacts_for_exit(0) == []
+
+
+def test_failed_process_without_closed_result_publishes_nothing(tmp_path: Path) -> None:
+    adapter = artifacts.RnaSeqArtifactAdapter(
+        artifacts.PurePosixPath("/cluster/run/results"),
+        _local_root=tmp_path,
+    )
+
+    assert adapter.finalize_artifacts_for_exit(2) == []
+
+
+def test_adapter_resolves_relative_output_below_shared_storage() -> None:
+    adapter = artifacts.adapter_from_package(
+        {
+            "pkg_type": "builtin.rna_seq_star_deseq2",
+            "effective_deploy_mode": "default",
+            "out": "study",
+            "shared_dir": "/cluster/shared",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.output_dir.as_posix() == "/cluster/shared/study/results"

--- a/test/unit/core/test_rnaseq_package_runtime.py
+++ b/test/unit/core/test_rnaseq_package_runtime.py
@@ -1,0 +1,295 @@
+"""Runtime-contract tests for the builtin STAR to DESeq2 package."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import sys
+import tarfile
+from importlib import import_module
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+)
+from jarvis_cd.util.hostfile import Hostfile
+
+
+def _load_package() -> ModuleType:
+    repository_root = Path(__file__).resolve().parents[3] / "builtin"
+    sys.path.insert(0, str(repository_root))
+    try:
+        return import_module("builtin.rna_seq_star_deseq2.pkg")
+    finally:
+        sys.path.remove(str(repository_root))
+
+
+rnaseq_package = _load_package()
+
+
+class _CapturedExec:
+    commands: list[str] = []
+    infos: list[Any] = []
+    return_code = 0
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": self.return_code}
+        self.commands.append(command)
+        self.infos.append(exec_info)
+
+    def run(self) -> _CapturedExec:
+        return self
+
+
+class _CapturedMkdir:
+    def __init__(self, path: str, exec_info: Any) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedMkdir:
+        Path(self.path).mkdir(parents=True, exist_ok=True)
+        return self
+
+
+class _CapturedRm:
+    calls: list[tuple[str, bool]] = []
+
+    def __init__(self, path: str, exec_info: Any, *, recursive: bool = False) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.recursive = recursive
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedRm:
+        self.calls.append((self.path, self.recursive))
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _capture_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    _CapturedExec.commands = []
+    _CapturedExec.infos = []
+    _CapturedExec.return_code = 0
+    _CapturedRm.calls = []
+    monkeypatch.setattr(rnaseq_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(rnaseq_package, "Mkdir", _CapturedMkdir)
+    monkeypatch.setattr(rnaseq_package, "Rm", _CapturedRm)
+
+
+def _base_config(**overrides: Any) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "deploy_mode": "default",
+        "input_bundle": "",
+        "out": "run",
+        "cores": 4,
+        "nprocs": 1,
+        "ppn": 1,
+    }
+    config.update(overrides)
+    return config
+
+
+def _package(tmp_path: Path, config: dict[str, Any]) -> Any:
+    package = object.__new__(rnaseq_package.RnaSeqStarDeseq2)
+    package.config = config
+    package.shared_dir = tmp_path / "shared"
+    package.private_dir = tmp_path / "private"
+    package.env = {}
+    package.mod_env = {"PATH": "/runtime/bin"}
+    package.star_bin = "STAR"
+    package.rscript_bin = "Rscript"
+    package.pipeline = SimpleNamespace(
+        get_hostfile=lambda: Hostfile(find_ips=False),
+        _has_containerized_packages=lambda: False,
+    )
+    package.runtime_line_callback = lambda: None
+    return package
+
+
+def _write_bundle(
+    destination: Path, *, annotation_role: str = "gene_annotation"
+) -> Path:
+    files = {
+        "samples.tsv": (
+            "sample\tcondition\tset_id\taccession\tfastq\n"
+            "a1\ta\t1\tSRR1\treads/a1.fastq.gz\n"
+            "a2\ta\t2\tSRR2\treads/a2.fastq.gz\n"
+            "b1\tb\t1\tSRR3\treads/b1.fastq.gz\n"
+            "b2\tb\t2\tSRR4\treads/b2.fastq.gz\n"
+        ).encode(),
+        "reference/genome.fa.gz": b"genome",
+        "reference/genes.gtf.gz": b"annotation",
+        "reads/a1.fastq.gz": b"read-a1",
+        "reads/a2.fastq.gz": b"read-a2",
+        "reads/b1.fastq.gz": b"read-b1",
+        "reads/b2.fastq.gz": b"read-b2",
+    }
+    roles = {
+        "samples.tsv": "sample_design",
+        "reference/genome.fa.gz": "reference_genome",
+        "reference/genes.gtf.gz": annotation_role,
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "samples.tsv",
+        "files": [
+            {
+                "path": name,
+                "role": roles.get(name, "single_end_fastq"),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, payload in files.items()
+        ],
+    }
+    manifest_bytes = json.dumps(manifest, sort_keys=True).encode()
+    with tarfile.open(destination, mode="w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(manifest_bytes)
+        archive.addfile(info, io.BytesIO(manifest_bytes))
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def test_agent_contract_exposes_native_study_and_hides_legacy_controls() -> None:
+    package = object.__new__(rnaseq_package.RnaSeqStarDeseq2)
+    package.config = _base_config()
+    package.env = {"PATH": ""}
+    package.mod_env = {"PATH": ""}
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    contract = package._deployment_contract().to_dict()
+
+    assert menu["input_bundle"]["input_binding"] == {
+        "schema_version": "jarvis.configuration-input-binding.v1",
+        "kind": "local_file",
+        "structure": "regular_file",
+    }
+    assert menu["out"]["default"] == "run"
+    assert menu["cores"]["default"] == 4
+    assert all(
+        menu[name]["agent_visible"] is False
+        for name in {
+            "nprocs",
+            "ppn",
+            "replicates",
+            "parallel_reps",
+            "parallel_scratch_root",
+            "omp_threads",
+            "base_image",
+        }
+    )
+    assert [profile["name"] for profile in contract["execution_profiles"]] == [
+        "native_supplied_reads"
+    ]
+    assert [item["id"] for item in contract["runtime_requirements"]] == [
+        "star",
+        "deseq2",
+    ]
+    assert contract["execution_profiles"][0]["readiness"] == {
+        "mechanism": "process_exit",
+        "condition": "successful_exit_with_required_products",
+    }
+
+
+def test_bundle_is_verified_and_staged_before_native_launch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle = _write_bundle(tmp_path / "study.tar")
+    source = bundle.read_bytes()
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+    validated: list[Path] = []
+    monkeypatch.setattr(
+        rnaseq_package,
+        "load_rnaseq_result",
+        lambda path: validated.append(path),
+    )
+
+    package.start()
+
+    root = tmp_path / "shared" / "run"
+    assert (root / "input" / "samples.tsv").is_file()
+    assert (root / "input" / "reads" / "a1.fastq.gz").read_bytes() == b"read-a1"
+    assert bundle.read_bytes() == source
+    assert validated == [(root / "results").resolve()]
+    command = _CapturedExec.commands[-1]
+    assert "native_runner.py" in command
+    assert "--samples" in command
+    assert "--genome" in command
+    assert "--annotation" in command
+    assert "--cores 4" in command
+    assert _CapturedExec.infos[-1].cwd == str(root.resolve())
+
+
+def test_bundle_roles_are_closed_before_launch(tmp_path: Path) -> None:
+    bundle = _write_bundle(tmp_path / "study.tar", annotation_role="support_file")
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+
+    with pytest.raises(ValueError, match="unsupported or missing roles"):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
+@pytest.mark.parametrize("cores", [0, 65, True, "4"])
+def test_native_configuration_rejects_invalid_core_counts(
+    tmp_path: Path, cores: object
+) -> None:
+    package = _package(
+        tmp_path,
+        _base_config(input_bundle="study.tar", cores=cores),
+    )
+
+    with pytest.raises(ValueError, match="cores must be an integer"):
+        package.start()
+
+
+def test_native_configuration_requires_a_supplied_bundle(tmp_path: Path) -> None:
+    package = _package(tmp_path, _base_config())
+
+    with pytest.raises(ValueError, match="requires input_bundle"):
+        package.start()
+
+
+def test_stale_execution_tree_cannot_satisfy_completion(tmp_path: Path) -> None:
+    bundle = _write_bundle(tmp_path / "study.tar")
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+    stale = tmp_path / "shared" / "run" / "results"
+    stale.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="target already exists: results"):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
+def test_native_process_failure_fails_package_lifecycle(tmp_path: Path) -> None:
+    bundle = _write_bundle(tmp_path / "study.tar")
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+    _CapturedExec.return_code = 9
+
+    with pytest.raises(RuntimeError, match="workflow failed"):
+        package.start()
+
+
+def test_clean_uses_one_exact_recursive_output_without_wildcard(tmp_path: Path) -> None:
+    package = _package(tmp_path, _base_config(out="results"))
+
+    package.clean()
+
+    assert _CapturedRm.calls == [
+        (str((tmp_path / "shared" / "results").resolve()), True)
+    ]
+    assert "*" not in _CapturedRm.calls[0][0]


### PR DESCRIPTION
## Summary

- add a native, supplied-input `builtin.rna_seq_star_deseq2` workflow for replicated STAR alignment and DESeq2 analysis
- stage digest-verified regular-file inputs without buffering large configuration payloads into memory
- publish package-owned alignment, count, differential-expression, normalized-count, session, and result artifacts
- fail closed when the study bundle or required runtime is unavailable

## Validation

- focused JARVIS tests pass for package metadata, input staging, command construction, artifact ownership, and large-input streaming
- direct FastMCP/JARVIS execution completed on Ares as Slurm job `22651` and execution `jarvis_540a87c025f94886b0e41b670747a103`
- independent benchmark validation read 600,000 FASTQ records, parsed six coordinate-sorted BAM files, reconstructed 7,127 STAR count rows, and checked DESeq2 outputs from 42 digest-matched files
- full benchmark gates: Ruff and formatting green, Pyright 0 errors, pytest 308 passed with zero skips/failures

## Stack

This draft is stacked on #198 because the scientific-package improvements were developed cumulatively. The Ares run is admission evidence for the later frozen model campaign, not itself a model-trial result.