### PR TITLE
feat: add maintained scientific execution profiles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,8 +81,11 @@ jobs:
             builtin/builtin/paraview/artifacts.py \
             builtin/builtin/gray_scott/progress.py \
             builtin/builtin/gray_scott/artifacts.py \
+            builtin/builtin/adios2_gray_scott/pkg.py \
             builtin/builtin/adios2_gray_scott/progress.py \
-            builtin/builtin/adios2_gray_scott/artifacts.py
+            builtin/builtin/adios2_gray_scott/artifacts.py \
+            builtin/builtin/adios2_pdf_calc/pkg.py \
+            builtin/builtin/adios2_pdf_calc/artifacts.py
 
       - name: Lint runtime contracts
         run: |
@@ -98,7 +101,8 @@ jobs:
             builtin/builtin/lammps/artifacts.py \
             builtin/builtin/paraview/artifacts.py \
             builtin/builtin/gray_scott \
-            builtin/builtin/adios2_gray_scott
+            builtin/builtin/adios2_gray_scott \
+            builtin/builtin/adios2_pdf_calc
           uv run --frozen ruff format --check \
             jarvis_cd/artifacts \
             jarvis_cd/core/scheduler.py \
@@ -108,8 +112,11 @@ jobs:
             builtin/builtin/paraview/artifacts.py \
             builtin/builtin/gray_scott/progress.py \
             builtin/builtin/gray_scott/artifacts.py \
+            builtin/builtin/adios2_gray_scott/pkg.py \
             builtin/builtin/adios2_gray_scott/progress.py \
-            builtin/builtin/adios2_gray_scott/artifacts.py
+            builtin/builtin/adios2_gray_scott/artifacts.py \
+            builtin/builtin/adios2_pdf_calc/pkg.py \
+            builtin/builtin/adios2_pdf_calc/artifacts.py
 
       - name: Run tests with coverage
         run: bash ci/run_tests.sh

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,4 +8,5 @@ include builtin/builtin/paraview/service.py
 include builtin/builtin/paraview/service_http.py
 include builtin/builtin/paraview/service_supervisor.py
 include builtin/builtin/wfcommons/artifacts.py
+include builtin/builtin/xcompact3d/artifacts.py
 include wfcommons-schema.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,5 @@ include builtin/builtin/paraview/artifacts.py
 include builtin/builtin/paraview/service.py
 include builtin/builtin/paraview/service_http.py
 include builtin/builtin/paraview/service_supervisor.py
+include builtin/builtin/wfcommons/artifacts.py
+include wfcommons-schema.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,9 @@ include builtin/builtin/paraview/artifacts.py
 include builtin/builtin/paraview/service.py
 include builtin/builtin/paraview/service_http.py
 include builtin/builtin/paraview/service_supervisor.py
+recursive-include builtin/builtin/lbm_cfd *.md *.py
+recursive-include builtin/builtin/openfoam *.md *.py
+recursive-include builtin/builtin/wrf *.md *.py
 include builtin/builtin/wfcommons/artifacts.py
 include builtin/builtin/xcompact3d/artifacts.py
 include wfcommons-schema.json

--- a/builtin/builtin/adios2_gray_scott/README.md
+++ b/builtin/builtin/adios2_gray_scott/README.md
@@ -43,6 +43,34 @@ V: the activator chemical, which is produced during the reaction and also remove
 | **Noise(noise)** | add noise for the simulation | 0.01~0.1 |
 | **I/O frequency(plotgap)** | the frequecey of I/O between simulation steps  | 1~10 |
 
+## Portable source and configuration bundles
+
+`input_bundle` selects the source-build profile. The value is a regular tar
+archive using the closed `jarvis.package-input-bundle.v1` manifest. The
+manifest must declare exactly one `build_spec`, at least one
+`scientific_input`, and the `adios2_configuration` referenced by each selected
+scientific input. Source and license members may use descriptive roles such as
+`upstream_source` and `upstream_license`.
+
+`configuration_path` selects one manifest-declared `scientific_input` by a
+confined POSIX-relative path. When it is empty, the manifest entrypoint is
+used. JARVIS verifies every archive member digest and validates the selected
+Gray-Scott JSON before scheduler submission. Output, checkpoint, restart, and
+ADIOS2 paths in bundle configurations must be relative, so their materialized
+locations remain owned by the execution.
+
+```bash
+jarvis ppl append adios2_gray_scott \
+  input_bundle=/staged/gray-scott-source.tar \
+  configuration_path=config/feed-low.json \
+  nprocs=4 ppn=4
+```
+
+The source build requires CMake, MPI compilers, and an MPI-enabled ADIOS2
+development installation. JARVIS configures and builds the `gray-scott` target
+inside the package's execution-owned workspace. Internet source discovery and
+mutable checkout paths are not used.
+
 
 
 

--- a/builtin/builtin/adios2_gray_scott/pkg.py
+++ b/builtin/builtin/adios2_gray_scott/pkg.py
@@ -1,41 +1,219 @@
-"""
-This module provides classes and methods to launch the Gray Scott application.
-Gray Scott is a 3D 7-point stencil code for modeling the diffusion of two
-substances.
-"""
+"""Launch the ADIOS2 Gray-Scott reaction-diffusion application."""
 
-from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
-from jarvis_cd.shell.process import Mkdir, Rm
-from jarvis_cd.util.config_parser import JsonFile
+from __future__ import annotations
+
+import json
+import math
 import os
 import shlex
-from typing import Any
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, NamedTuple, cast
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
+from jarvis_cd.shell.process import Mkdir, Rm
+from jarvis_cd.util.config_parser import JsonFile
+
+_SCIENTIFIC_INPUT_ROLE = "scientific_input"
+_BUILD_SPEC_ROLE = "build_spec"
+_ADIOS_CONFIG_ROLE = "adios2_configuration"
+_CONFIGURATION_REQUIRED_FIELDS = {
+    "Du",
+    "Dv",
+    "F",
+    "L",
+    "adios_config",
+    "adios_memory_selection",
+    "adios_span",
+    "checkpoint",
+    "checkpoint_freq",
+    "checkpoint_output",
+    "dt",
+    "k",
+    "mesh_type",
+    "noise",
+    "output",
+    "plotgap",
+    "steps",
+}
+_CONFIGURATION_OPTIONAL_FIELDS = {"restart", "restart_input"}
+
+
+class GrayScottBundleConfiguration(NamedTuple):
+    """Validated paths and scientific values selected from one input bundle."""
+
+    path: Path
+    values: Mapping[str, object]
+    build_spec: Path
+    adios_config: Path
+
+
+def _safe_bundle_member(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise ValueError(f"{label} must name a declared scientific_input member")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{label} must name a declared scientific_input member")
+    return path.as_posix()
+
+
+def _relative_output_path(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise ValueError(f"{label} must be a relative bundle path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{label} must be a relative bundle path")
+    return path.as_posix()
+
+
+def _finite_number(
+    values: Mapping[str, object],
+    name: str,
+    *,
+    positive: bool,
+) -> float:
+    value = values[name]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"Gray-Scott {name} must be numeric")
+    parsed = float(value)
+    if (
+        not math.isfinite(parsed)
+        or (positive and parsed <= 0)
+        or (not positive and parsed < 0)
+    ):
+        qualifier = "positive" if positive else "non-negative"
+        raise ValueError(f"Gray-Scott {name} must be finite and {qualifier}")
+    return parsed
+
+
+def _positive_integer(values: Mapping[str, object], name: str) -> int:
+    value = values[name]
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"Gray-Scott {name} must be a positive integer")
+    return value
+
+
+def _validate_scientific_configuration(values: object) -> Mapping[str, object]:
+    if not isinstance(values, dict):
+        raise ValueError("Gray-Scott scientific configuration must be a JSON object")
+    fields = set(values)
+    missing = _CONFIGURATION_REQUIRED_FIELDS - fields
+    unknown = fields - _CONFIGURATION_REQUIRED_FIELDS - _CONFIGURATION_OPTIONAL_FIELDS
+    if missing or unknown:
+        raise ValueError(
+            "Gray-Scott scientific configuration fields are invalid: "
+            f"missing={sorted(missing)}, unknown={sorted(unknown)}"
+        )
+    for name in ("Du", "Dv", "dt"):
+        _finite_number(values, name, positive=True)
+    for name in ("F", "k", "noise"):
+        _finite_number(values, name, positive=False)
+    for name in ("L", "steps", "plotgap", "checkpoint_freq"):
+        _positive_integer(values, name)
+    if values["plotgap"] > values["steps"]:
+        raise ValueError("Gray-Scott plotgap cannot exceed steps")
+    for name in (
+        "checkpoint",
+        "adios_span",
+        "adios_memory_selection",
+    ):
+        if not isinstance(values[name], bool):
+            raise ValueError(f"Gray-Scott {name} must be boolean")
+    restart = values.get("restart", False)
+    if not isinstance(restart, bool):
+        raise ValueError("Gray-Scott restart must be boolean")
+    mesh_type = values["mesh_type"]
+    if not isinstance(mesh_type, str) or not mesh_type.strip():
+        raise ValueError("Gray-Scott mesh_type must be a non-empty string")
+    _relative_output_path(values["output"], label="Gray-Scott output")
+    _relative_output_path(
+        values["checkpoint_output"], label="Gray-Scott checkpoint output"
+    )
+    if restart:
+        _relative_output_path(
+            values.get("restart_input"), label="Gray-Scott restart input"
+        )
+    return values
+
+
+def resolve_bundle_configuration(
+    bundle: MaterializedInputBundle,
+    configuration_path: str,
+) -> GrayScottBundleConfiguration:
+    """Resolve and validate one scientific configuration from a verified bundle."""
+
+    selected_path = _safe_bundle_member(
+        configuration_path or bundle.manifest.entrypoint,
+        label="configuration_path",
+    )
+    roles = {item.path: item.role for item in bundle.manifest.files}
+    if roles.get(selected_path) != _SCIENTIFIC_INPUT_ROLE:
+        raise ValueError(
+            "configuration_path must name a declared scientific_input member"
+        )
+    build_specs = [path for path, role in roles.items() if role == _BUILD_SPEC_ROLE]
+    if len(build_specs) != 1:
+        raise ValueError("Gray-Scott input bundle requires exactly one build_spec")
+    selected = bundle.root / PurePosixPath(selected_path)
+    try:
+        values = json.loads(selected.read_text(encoding="utf-8", errors="strict"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            "Gray-Scott scientific configuration is not valid JSON"
+        ) from exc
+    validated = _validate_scientific_configuration(values)
+    adios_path = _safe_bundle_member(
+        validated["adios_config"],
+        label="Gray-Scott adios_config",
+    )
+    if roles.get(adios_path) != _ADIOS_CONFIG_ROLE:
+        raise ValueError(
+            "Gray-Scott adios_config must name a declared adios2_configuration member"
+        )
+    return GrayScottBundleConfiguration(
+        path=selected,
+        values=validated,
+        build_spec=bundle.root / PurePosixPath(build_specs[0]),
+        adios_config=bundle.root / PurePosixPath(adios_path),
+    )
+
+
+def _combined_probe_status(*statuses: RuntimeStatus) -> RuntimeStatus:
+    if statuses and all(status.usable is True for status in statuses):
+        return RuntimeStatus("ready", "runtime_probe_succeeded")
+    if any(status.usable is False for status in statuses):
+        return RuntimeStatus("unavailable", "software_not_found")
+    return RuntimeStatus("unknown", "runtime_probe_inconclusive")
 
 
 class Adios2GrayScott(Application):
-    """
-    This class provides methods to launch the GrayScott application.
-    """
+    """Run an installed or digest-bound source build of ADIOS2 Gray-Scott."""
 
-    def _init(self):
-        """
-        Initialize paths
-        """
+    def _init(self) -> None:
         self.adios2_xml_path = f"{self.shared_dir}/adios2.xml"
         self.settings_json_path = f"{self.shared_dir}/settings-files.json"
         self.var_json_path = f"{self.shared_dir}/var.json"
         self.operator_json_path = f"{self.shared_dir}/operator.json"
-        self.process = None  # Store process handle for async execution
+        self.process: Any = None
 
-    def _configure_menu(self):
-        """
-        Create a CLI menu for the configurator method.
-        For thorough documentation of these parameters, view:
-        https://github.com/scs-lab/jarvis-util/wiki/3.-Argument-Parsing
-
-        :return: List(dict)
-        """
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
             {
                 "name": "nprocs",
@@ -43,129 +221,106 @@ class Adios2GrayScott(Application):
                 "type": int,
                 "default": 4,
             },
-            {
-                "name": "ppn",
-                "msg": "Processes per node",
-                "type": int,
-                "default": 16,
-            },
+            {"name": "ppn", "msg": "Processes per node", "type": int, "default": 16},
             {
                 "name": "executable",
-                "msg": "ADIOS2 Gray-Scott producer executable or absolute path",
+                "msg": "Installed ADIOS2 Gray-Scott executable available through PATH",
                 "type": str,
                 "default": "adios2-gray-scott",
             },
             {
-                "name": "L",
-                "msg": "Grid size of cube",
-                "type": int,
-                "default": 32,
+                "name": "input_bundle",
+                "msg": (
+                    "Optional digest-verified source and scientific-configuration "
+                    "bundle. Its manifest must declare one build_spec, an ADIOS2 "
+                    "configuration, and one or more scientific_input files."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                "name": "Du",
-                "msg": "Diffusion rate of substance U",
-                "type": float,
-                "default": 0.2,
+                "name": "configuration_path",
+                "msg": (
+                    "Relative scientific_input member selected from input_bundle; "
+                    "empty selects the manifest entrypoint"
+                ),
+                "type": str,
+                "default": "",
             },
-            {
-                "name": "Dv",
-                "msg": "Diffusion rate of substance V",
-                "type": float,
-                "default": 0.1,
-            },
-            {
-                "name": "F",
-                "msg": "Feed rate of U",
-                "type": float,
-                "default": 0.01,
-            },
-            {
-                "name": "k",
-                "msg": "Kill rate of V",
-                "type": float,
-                "default": 0.05,
-            },
-            {
-                "name": "dt",
-                "msg": "Timestep",
-                "type": float,
-                "default": 2.0,
-            },
+            {"name": "L", "msg": "Grid size of cube", "type": int, "default": 32},
+            {"name": "Du", "msg": "Diffusion rate of U", "type": float, "default": 0.2},
+            {"name": "Dv", "msg": "Diffusion rate of V", "type": float, "default": 0.1},
+            {"name": "F", "msg": "Feed rate of U", "type": float, "default": 0.01},
+            {"name": "k", "msg": "Kill rate of V", "type": float, "default": 0.05},
+            {"name": "dt", "msg": "Timestep", "type": float, "default": 2.0},
             {
                 "name": "steps",
-                "msg": "Total number of steps to simulate",
+                "msg": "Total simulation steps",
                 "type": int,
                 "default": 100,
             },
             {
                 "name": "plotgap",
-                "msg": "Number of steps between output",
+                "msg": "Steps between outputs",
                 "type": int,
                 "default": 10,
             },
-            {
-                "name": "noise",
-                "msg": "Amount of noise",
-                "type": float,
-                "default": 0.01,
-            },
-            {
-                "name": "out_file",
-                "msg": "Absolute path to output file",
-                "type": str,
-                "default": None,
-            },
+            {"name": "noise", "msg": "Initial noise", "type": float, "default": 0.01},
+            {"name": "out_file", "msg": "Output dataset", "type": str, "default": None},
             {
                 "name": "checkpoint",
-                "msg": "Perform checkpoints",
+                "msg": "Write checkpoints",
                 "type": bool,
                 "default": True,
             },
             {
                 "name": "checkpoint_freq",
-                "msg": "Frequency of the checkpoints",
+                "msg": "Checkpoint interval",
                 "type": int,
                 "default": 70,
             },
             {
                 "name": "checkpoint_output",
-                "msg": "Output location of the checkpoint",
+                "msg": "Checkpoint dataset",
                 "type": str,
                 "default": "ckpt.bp",
             },
             {
                 "name": "restart",
-                "msg": "Perform restarts",
+                "msg": "Restart from a checkpoint",
                 "type": bool,
                 "default": False,
             },
             {
                 "name": "restart_input",
-                "msg": "Input for the restart",
+                "msg": "Restart checkpoint",
                 "type": str,
                 "default": "ckpt.bp",
             },
             {
                 "name": "adios_span",
-                "msg": "???",
+                "msg": "Enable ADIOS span mode",
                 "type": bool,
                 "default": False,
             },
             {
                 "name": "adios_memory_selection",
-                "msg": "???",
+                "msg": "Enable ADIOS memory selection",
                 "type": bool,
                 "default": False,
             },
             {
                 "name": "mesh_type",
-                "msg": "???",
+                "msg": "Mesh representation",
                 "type": str,
                 "default": "image",
             },
             {
                 "name": "engine",
-                "msg": "Engine to be used",
+                "msg": "ADIOS2 engine",
                 "choices": [
                     "bp5",
                     "hermes",
@@ -180,108 +335,200 @@ class Adios2GrayScott(Application):
             },
             {
                 "name": "full_run",
-                "msg": "Whill postprocessing be executed?",
+                "msg": "Execute postprocessing",
                 "type": bool,
                 "default": True,
             },
-            {
-                "name": "limit",
-                "msg": "Limit the value of data to track",
-                "type": int,
-                "default": 0,
-            },
+            {"name": "limit", "msg": "Value-tracking limit", "type": int, "default": 0},
             {
                 "name": "db_path",
-                "msg": "Path where the DB will be stored",
+                "msg": "Metadata database path",
                 "type": str,
                 "default": "benchmark_metadata.db",
             },
             {
                 "name": "Execution_order",
-                "msg": "Path where the bp5 will be stored",
+                "msg": "IOWarp execution order",
                 "type": str,
                 "default": "1",
             },
             {
                 "name": "run_async",
-                "msg": "Run in background for parallel execution with consumer",
+                "msg": "Run producer asynchronously",
                 "type": bool,
                 "default": False,
             },
         ]
 
-    # jarvis pkg config adios2_gray_scott ppn=20 full_run=true engine=hermes db_path=/mnt/nvme/jcernudagarcia/metadata.db out_file=gs.bp nprocs=1
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        environment = self._deployment_environment()
+        installed_probe = probe_program(
+            "adios2-gray-scott", environment=environment, arguments=("--help",)
+        )
+        cmake_probe = probe_program(
+            "cmake", environment=environment, arguments=("--version",)
+        )
+        adios_probe = probe_program(
+            "adios2-config", environment=environment, arguments=("--version",)
+        )
+        mpi_c_probe = probe_program(
+            "mpicc", environment=environment, arguments=("--version",)
+        )
+        mpi_cxx_probe = probe_program(
+            "mpic++", environment=environment, arguments=("--version",)
+        )
+        source_status = _combined_probe_status(
+            cmake_probe.status,
+            adios_probe.status,
+            mpi_c_probe.status,
+            mpi_cxx_probe.status,
+        )
+        installed_capabilities = (
+            ("mpi_execution", "reaction_diffusion")
+            if installed_probe.status.usable is True
+            else ()
+        )
+        source_capabilities = (
+            ("mpi_execution", "reaction_diffusion", "source_build")
+            if source_status.usable is True
+            else ()
+        )
+        completed = ReadinessContract("process_exit", "successful_exit")
+        return PackageDeploymentContract(
+            package="builtin.adios2_gray_scott",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="installed_executable",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    runtime_requirements=("gray_scott_installed",),
+                    readiness=completed,
+                    description="Run an installed Gray-Scott producer using package parameters.",
+                ),
+                ExecutionProfile(
+                    name="source_bundle",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    runtime_requirements=("gray_scott_source_build",),
+                    readiness=completed,
+                    description=(
+                        "Build verified source and run one manifest-declared "
+                        "scientific configuration in an execution-owned workspace."
+                    ),
+                ),
+            ),
+            runtime_requirements=(
+                RuntimeRequirement(
+                    requirement_id="gray_scott_installed",
+                    description="Installed MPI ADIOS2 Gray-Scott producer",
+                    required_capabilities=("mpi_execution", "reaction_diffusion"),
+                    available_capabilities=installed_capabilities,
+                    status=installed_probe.status,
+                ),
+                RuntimeRequirement(
+                    requirement_id="gray_scott_source_build",
+                    description="CMake and MPI-enabled ADIOS2 development runtime",
+                    required_capabilities=(
+                        "mpi_execution",
+                        "reaction_diffusion",
+                        "source_build",
+                    ),
+                    available_capabilities=source_capabilities,
+                    status=source_status,
+                    provider_resolutions=(
+                        ProviderResolution("spack", "spec", "adios2+mpi"),
+                        ProviderResolution("spack", "spec", "cmake"),
+                        ProviderResolution("spack", "spec", "openmpi"),
+                    ),
+                ),
+            ),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    requires=(
+                        ConfigurationCondition("configuration_path", "is_empty"),
+                    ),
+                    description="configuration_path is valid only with input_bundle.",
+                ),
+            ),
+        )
 
-    def _configure(self, **kwargs):
-        """
-        Converts the Jarvis configuration to application-specific configuration.
-        E.g., OrangeFS produces an orangefs.xml file.
+    def _configure(self, **kwargs: Any) -> None:
+        super()._configure(**kwargs)
+        self._validate_common_configuration()
+        config = cast(dict[str, Any], self.config)
+        configured_bundle = config.get("input_bundle")
+        if configured_bundle not in (None, ""):
+            if not isinstance(configured_bundle, str):
+                raise TypeError("input_bundle must be a path string")
+            bundle = extract_input_bundle(
+                configured_bundle, self._shared_root() / "input-bundles"
+            )
+            selected = resolve_bundle_configuration(
+                bundle, str(config.get("configuration_path") or "")
+            )
+            self._apply_scientific_values(selected.values)
+            return
+        if config.get("configuration_path") not in (None, ""):
+            raise ValueError("configuration_path requires input_bundle")
+        self._configure_generated_settings()
 
-        :param kwargs: Configuration parameters for this pkg.
-        :return: None
-        """
-        if self.config["out_file"] is None:
-            adios_dir = os.path.join(self.shared_dir, "gray-scott-output")
-            self.config["out_file"] = os.path.join(adios_dir, "data/out.bp")
-            Mkdir(adios_dir, PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
-        settings_json = {
-            "L": self.config["L"],
-            "Du": self.config["Du"],
-            "Dv": self.config["Dv"],
-            "F": self.config["F"],
-            "k": self.config["k"],
-            "dt": self.config["dt"],
-            "plotgap": self.config["plotgap"],
-            "steps": self.config["steps"],
-            "noise": self.config["noise"],
-            "output": self.config["out_file"],
-            "checkpoint": self.config["checkpoint"],
-            "checkpoint_freq": self.config["checkpoint_freq"],
-            "checkpoint_output": self.config["checkpoint_output"],
-            "restart": self.config["restart"],
-            "restart_input": self.config["restart_input"],
-            "adios_span": self.config["adios_span"],
-            "adios_memory_selection": self.config["adios_memory_selection"],
-            "mesh_type": self.config["mesh_type"],
-            "adios_config": f"{self.adios2_xml_path}",
-        }
-        output_dir = os.path.dirname(self.config["out_file"])
-        db_dir = os.path.dirname(self.config["db_path"])
+    def _shared_root(self) -> Path:
+        shared_dir = self.shared_dir
+        if not isinstance(shared_dir, (str, os.PathLike)) or not os.fspath(shared_dir):
+            raise RuntimeError("Gray-Scott requires a JARVIS package shared directory")
+        return Path(shared_dir)
+
+    def _validate_common_configuration(self) -> None:
+        for name in ("nprocs", "ppn"):
+            value = self.config.get(name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        executable = self.config.get("executable")
+        if not isinstance(executable, str) or not executable.strip():
+            raise ValueError("ADIOS2 Gray-Scott executable must be a non-empty string")
+
+    def _apply_scientific_values(self, values: Mapping[str, object]) -> None:
+        config = cast(dict[str, Any], self.config)
+        mapping = {name: name for name in values if name != "output"}
+        mapping["output"] = "out_file"
+        for source, destination in mapping.items():
+            config[destination] = values[source]
+
+    def _configure_generated_settings(self) -> None:
+        config = cast(dict[str, Any], self.config)
+        if config["out_file"] is None:
+            config["out_file"] = str(
+                self.resolve_shared_path(
+                    "gray-scott-output/data/out.bp", field="out_file"
+                )
+            )
+        output_dir = os.path.dirname(str(config["out_file"]))
+        db_dir = os.path.dirname(
+            str(self.resolve_shared_path(config["db_path"], field="db_path"))
+        )
         Mkdir(
             [output_dir, db_dir], PsshExecInfo(hostfile=self.hostfile, env=self.env)
         ).run()
+        self._write_settings(
+            Path(self.settings_json_path), config, self.adios2_xml_path
+        )
+        self._configure_adios_template()
 
-        JsonFile(self.settings_json_path).save(settings_json)
-        print(f"Using engine {self.config['engine']}")
-        if self.config["engine"].lower() in ["bp5", "bp5_derived"]:
+    def _configure_adios_template(self) -> None:
+        engine = str(self.config["engine"]).lower()
+        if engine in {"bp5", "bp5_derived"}:
             self.copy_template_file(
                 f"{self.pkg_dir}/config/adios2.xml", self.adios2_xml_path
             )
-        elif self.config["engine"].lower() == "sst":
+        elif engine == "sst":
             self.copy_template_file(
                 f"{self.pkg_dir}/config/sst.xml", self.adios2_xml_path
             )
-        elif self.config["engine"].lower() in ["hermes", "hermes_derived"]:
+        elif engine in {"hermes", "hermes_derived", "iowarp", "iowarp_derived"}:
+            template = "hermes.xml" if engine.startswith("hermes") else "iowarp.xml"
             self.copy_template_file(
-                f"{self.pkg_dir}/config/hermes.xml",
-                self.adios2_xml_path,
-                replacements={
-                    "PPN": self.config["ppn"],
-                    "VARFILE": self.var_json_path,
-                    "OPFILE": self.operator_json_path,
-                    "DBFILE": self.config["db_path"],
-                    "Order": self.config["Execution_order"],
-                },
-            )
-            self.copy_template_file(
-                f"{self.pkg_dir}/config/var.yaml", self.var_json_path
-            )
-            self.copy_template_file(
-                f"{self.pkg_dir}/config/operator.yaml", self.operator_json_path
-            )
-        elif self.config["engine"].lower() in ["iowarp", "iowarp_derived"]:
-            self.copy_template_file(
-                f"{self.pkg_dir}/config/iowarp.xml",
+                f"{self.pkg_dir}/config/{template}",
                 self.adios2_xml_path,
                 replacements={
                     "PPN": self.config["ppn"],
@@ -298,92 +545,132 @@ class Adios2GrayScott(Application):
                 f"{self.pkg_dir}/config/operator.yaml", self.operator_json_path
             )
         else:
-            raise Exception("Engine not defined")
+            raise ValueError(f"unsupported ADIOS2 engine: {engine}")
 
-    def start(self):
-        """
-        Launch an application. E.g., OrangeFS will launch the servers, clients,
-        and metadata services on all necessary pkgs.
+    @staticmethod
+    def _write_settings(
+        path: Path, values: Mapping[str, object], adios_config: str
+    ) -> None:
+        payload = {
+            "L": values["L"],
+            "Du": values["Du"],
+            "Dv": values["Dv"],
+            "F": values["F"],
+            "k": values["k"],
+            "dt": values["dt"],
+            "plotgap": values["plotgap"],
+            "steps": values["steps"],
+            "noise": values["noise"],
+            "output": values["out_file"],
+            "checkpoint": values["checkpoint"],
+            "checkpoint_freq": values["checkpoint_freq"],
+            "checkpoint_output": values["checkpoint_output"],
+            "restart": values.get("restart", False),
+            "restart_input": values.get("restart_input", "ckpt.bp"),
+            "adios_span": values["adios_span"],
+            "adios_memory_selection": values["adios_memory_selection"],
+            "mesh_type": values["mesh_type"],
+            "adios_config": adios_config,
+        }
+        JsonFile(str(path)).save(payload)
 
-        :return: None
-        """
-        # print(self.env['HERMES_CLIENT_CONF'])
-        line_callback = self.runtime_line_callback()
-        executable = self.config.get("executable", "adios2-gray-scott")
-        if not isinstance(executable, str) or not executable.strip():
-            raise ValueError("ADIOS2 Gray-Scott executable must be a non-empty string")
+    def _prepare_bundle_run(self) -> tuple[str, str]:
+        configured = self.config.get("input_bundle")
+        if not isinstance(configured, str) or not configured:
+            raise RuntimeError("Gray-Scott input bundle was not persisted")
+        bundle = extract_input_bundle(configured, self._shared_root() / "input-bundles")
+        selected = resolve_bundle_configuration(
+            bundle, str(self.config.get("configuration_path") or "")
+        )
+        run_dir = self.resolve_shared_path("run", field="input_bundle workspace")
+        stage_input_bundle(bundle, run_dir)
+        relative_configuration = selected.path.relative_to(bundle.root)
+        relative_build_spec = selected.build_spec.relative_to(bundle.root)
+        relative_adios = selected.adios_config.relative_to(bundle.root)
+        staged_values = dict(selected.values)
+        for source in ("output", "checkpoint_output", "restart_input"):
+            value = staged_values.get(source)
+            if value is not None:
+                staged_values[source] = str(run_dir / PurePosixPath(str(value)))
+        self._apply_scientific_values(staged_values)
+        self.adios2_xml_path = str(run_dir / relative_adios)
+        self.settings_json_path = str(run_dir / relative_configuration)
+        output_dir = Path(str(self.config["out_file"])).parent
+        output_dir.mkdir(parents=True, exist_ok=True)
+        if self.config.get("checkpoint"):
+            Path(str(self.config["checkpoint_output"])).parent.mkdir(
+                parents=True, exist_ok=True
+            )
+        self._write_settings(
+            Path(self.settings_json_path), self.config, self.adios2_xml_path
+        )
+        build_dir = run_dir / "build"
+        source_dir = (run_dir / relative_build_spec).parent
+        local_info = LocalExecInfo(env=self.mod_env, cwd=str(run_dir), timeout=900)
+        configure = " ".join(
+            (
+                "cmake",
+                "-S",
+                shlex.quote(str(source_dir)),
+                "-B",
+                shlex.quote(str(build_dir)),
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_C_COMPILER=mpicc",
+                "-DCMAKE_CXX_COMPILER=mpic++",
+            )
+        )
+        self._raise_for_exec_failure(
+            Exec(configure, local_info).run(), operation="Gray-Scott configure"
+        )
+        build = f"cmake --build {shlex.quote(str(build_dir))} --parallel 4 --target gray-scott"
+        self._raise_for_exec_failure(
+            Exec(build, local_info).run(), operation="Gray-Scott build"
+        )
+        return str(build_dir / "bin" / "gray-scott"), str(run_dir)
+
+    def start(self) -> None:
+        """Build when requested and launch the selected Gray-Scott simulation."""
+        configured_bundle = self.config.get("input_bundle")
+        if configured_bundle not in (None, ""):
+            executable, cwd = self._prepare_bundle_run()
+        else:
+            executable = str(self.config.get("executable") or "")
+            cwd = str(Path(self.settings_json_path).parent)
         command = f"{shlex.quote(executable)} {shlex.quote(self.settings_json_path)}"
-        if self.config["engine"].lower() in [
-            "bp5_derived",
-            "hermes_derived",
-            "iowarp_derived",
-        ]:
-            derived = 1
-            self.process = Exec(
-                f"{command} {derived}",
-                MpiExecInfo(
-                    nprocs=self.config["nprocs"],
-                    ppn=self.config["ppn"],
-                    hostfile=self.hostfile,
-                    env=self.mod_env,
-                    exec_async=self.config["run_async"],
-                    line_callback=line_callback,
-                ),
-            )
-            result = self.process.run()
-            if not self.config["run_async"]:
-                self._raise_for_exec_failure(result, operation="ADIOS2 Gray-Scott")
-        elif self.config["engine"].lower() in ["hermes", "bp5", "iowarp", "sst"]:
-            derived = 0
-            self.process = Exec(
-                f"{command} {derived}",
-                MpiExecInfo(
-                    nprocs=self.config["nprocs"],
-                    ppn=self.config["ppn"],
-                    hostfile=self.hostfile,
-                    env=self.mod_env,
-                    exec_async=self.config["run_async"],
-                    line_callback=line_callback,
-                ),
-            )
-            result = self.process.run()
-            if not self.config["run_async"]:
-                self._raise_for_exec_failure(result, operation="ADIOS2 Gray-Scott")
+        derived = int(str(self.config["engine"]).lower().endswith("_derived"))
+        self.process = Exec(
+            f"{command} {derived}",
+            MpiExecInfo(
+                nprocs=self.config["nprocs"],
+                ppn=self.config["ppn"],
+                hostfile=self.hostfile,
+                env=self.mod_env,
+                cwd=cwd,
+                exec_async=self.config["run_async"],
+                line_callback=self.runtime_line_callback(),
+            ),
+        )
+        result = self.process.run()
+        if not self.config["run_async"]:
+            self._raise_for_exec_failure(result, operation="ADIOS2 Gray-Scott")
 
-    def wait(self):
-        """
-        Wait for async process to complete.
-
-        :return: None
-        """
+    def wait(self) -> None:
+        """Wait for an asynchronous producer and propagate its terminal status."""
         if self.process:
             self.process.wait_all()
             self._raise_for_exec_failure(
-                self.process,
-                operation="ADIOS2 Gray-Scott async producer",
+                self.process, operation="ADIOS2 Gray-Scott async producer"
             )
 
-    def stop(self):
-        """
-        Stop a running application. E.g., OrangeFS will terminate the servers,
-        clients, and metadata services.
-
-        :return: None
-        """
-        # If running async, wait for completion instead of killing
+    def stop(self) -> None:
+        """Wait for asynchronous work or terminate a still-owned process."""
         if self.config.get("run_async", False) and self.process:
-            print("Waiting for async gray-scott producer to complete...")
-            self.process.wait_all()
-            self._raise_for_exec_failure(
-                self.process,
-                operation="ADIOS2 Gray-Scott async producer",
-            )
+            self.wait()
         elif self.process:
             self.process.kill_all()
 
     @staticmethod
     def _raise_for_exec_failure(result: Any, *, operation: str) -> None:
-        """Raise when an execution has no status or any host exits nonzero."""
         exit_codes = getattr(result, "exit_code", None)
         if not isinstance(exit_codes, dict) or not exit_codes:
             raise RuntimeError(f"{operation} returned no process exit status")
@@ -398,18 +685,18 @@ class Adios2GrayScott(Application):
             )
             raise RuntimeError(f"{operation} failed with exit status: {details}")
 
-    def clean(self):
-        """
-        Destroy all data for an application. E.g., OrangeFS will delete all
-        metadata and data directories in addition to the orangefs.xml file.
-
-        :return: None
-        """
-        output_file = [
-            self.config["out_file"],
-            self.config["checkpoint_output"],
-            self.config["db_path"],
+    def clean(self) -> None:
+        """Remove configured simulation output and restart state."""
+        output_file: list[object] = [
+            self.config.get("out_file"),
+            self.config.get("checkpoint_output"),
+            self.config.get("db_path"),
         ]
-
-        print(f"Removing {output_file}")
-        Rm(output_file, PsshExecInfo(hostfile=self.hostfile)).run()
+        Rm(
+            [
+                os.fspath(value)
+                for value in output_file
+                if isinstance(value, (str, os.PathLike)) and os.fspath(value)
+            ],
+            PsshExecInfo(hostfile=self.hostfile),
+        ).run()

--- a/builtin/builtin/adios2_gray_scott/pkg.py
+++ b/builtin/builtin/adios2_gray_scott/pkg.py
@@ -269,7 +269,12 @@ class Adios2GrayScott(Application):
                 "default": 10,
             },
             {"name": "noise", "msg": "Initial noise", "type": float, "default": 0.01},
-            {"name": "out_file", "msg": "Output dataset", "type": str, "default": None},
+            {
+                "name": "out_file",
+                "msg": "Optional output dataset; empty uses execution-owned storage",
+                "type": str,
+                "default": "",
+            },
             {
                 "name": "checkpoint",
                 "msg": "Write checkpoints",
@@ -497,7 +502,7 @@ class Adios2GrayScott(Application):
 
     def _configure_generated_settings(self) -> None:
         config = cast(dict[str, Any], self.config)
-        if config["out_file"] is None:
+        if not config["out_file"]:
             config["out_file"] = str(
                 self.resolve_shared_path(
                     "gray-scott-output/data/out.bp", field="out_file"

--- a/builtin/builtin/adios2_gray_scott_analysis/INSTALL.md
+++ b/builtin/builtin/adios2_gray_scott_analysis/INSTALL.md
@@ -1,0 +1,5 @@
+# Installation
+
+The installed-executable profile requires `gray-scott-analyze` on `PATH` with an ADIOS2 runtime.
+
+The source-bundle profile requires CMake, an MPI C++ compiler, and ADIOS2 development libraries. JARVIS verifies and stages the complete source bundle in package-owned storage, configures it with CMake, and builds only the `gray-scott-analyze` target.

--- a/builtin/builtin/adios2_gray_scott_analysis/README.md
+++ b/builtin/builtin/adios2_gray_scott_analysis/README.md
@@ -1,0 +1,7 @@
+# ADIOS2 Gray-Scott Analysis
+
+`builtin.adios2_gray_scott_analysis` compares the final three-dimensional fields from two completed ADIOS2 Gray-Scott BP datasets. It reports per-field morphology and a paired V-field comparison as one validated JSON artifact.
+
+The package can run an installed `gray-scott-analyze` executable or build only that target from a digest-verified input bundle. The bundle must declare exactly one `build_spec`, exactly one `analysis_source`, and the two selected configurations as `scientific_input` files.
+
+This is an application package. It does not infer datasets, configurations, or thresholds, and it does not replace the Gray-Scott simulation package.

--- a/builtin/builtin/adios2_gray_scott_analysis/USE.md
+++ b/builtin/builtin/adios2_gray_scott_analysis/USE.md
@@ -1,0 +1,11 @@
+# Usage
+
+Add `builtin.adios2_gray_scott_analysis` after two Gray-Scott simulations have completed. Configure:
+
+- `low_input` and `high_input` as the exact absolute BP collection paths.
+- `low_configuration` and `high_configuration` as absolute JSON files for the installed profile, or as manifest-relative `scientific_input` members for the source-bundle profile.
+- `active_threshold` as the V concentration threshold used to classify active cells.
+- `output_file` as the JSON comparison destination.
+- `input_bundle` only when building the analyzer from verified source.
+
+JARVIS validates both datasets and configurations before launch. Successful process exit is accepted only when the analyzer produces the closed `jarvis.gray-scott-morphology.v1` result bound to both input configurations and the requested threshold.

--- a/builtin/builtin/adios2_gray_scott_analysis/artifacts.py
+++ b/builtin/builtin/adios2_gray_scott_analysis/artifacts.py
@@ -1,0 +1,247 @@
+"""Artifact semantics for paired Gray-Scott morphology analysis."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+
+_RESULT_SCHEMA = "jarvis.gray-scott-morphology.v1"
+_CASE_FIELDS = {
+    "configuration",
+    "element_count",
+    "final_simulation_step",
+    "output_steps",
+    "shape",
+    "u",
+    "v",
+}
+_METRIC_FIELDS = {
+    "active_fraction",
+    "active_threshold",
+    "component_count",
+    "interface_density",
+    "largest_component_fraction_of_active",
+    "max",
+    "mean",
+    "min",
+    "standard_deviation",
+    "surface_to_active",
+}
+_COMPARISON_FIELDS = {
+    "max_absolute_v_difference",
+    "pearson_v_correlation",
+    "relative_v_l2_difference",
+    "v_rms_difference",
+}
+
+
+@dataclass
+class GrayScottAnalysisArtifactAdapter:
+    """Report the closed paired morphology comparison after process exit."""
+
+    output_path: PurePosixPath
+    active_threshold: float
+    low_input: str
+    high_input: str
+    artifact_id: str = field(default_factory=new_artifact_id)
+    _terminal: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Return no provisional record for the bounded JSON output."""
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Finalize using successful-exit semantics."""
+        return self.finalize_artifacts_for_exit(0)
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Emit one finalized or explicitly incomplete comparison record."""
+        if self._terminal:
+            return []
+        self._terminal = True
+        valid, size_bytes = _valid_result(
+            Path(self.output_path.as_posix()), self.active_threshold
+        )
+        finalized = return_code == 0 and valid
+        return [
+            ArtifactObservation(
+                artifact_id=self.artifact_id,
+                logical_name="gray-scott-morphology-comparison",
+                kind="scientific_analysis",
+                role=ArtifactRole.VALIDATION,
+                structure=ArtifactStructure.FILE,
+                ownership=ArtifactOwnership.SHARED,
+                state=ArtifactState.FINALIZED
+                if finalized
+                else ArtifactState.INCOMPLETE,
+                location=ArtifactLocation.cluster_path(self.output_path)
+                if valid
+                else None,
+                media_type="application/json",
+                format=_RESULT_SCHEMA,
+                size_bytes=size_bytes,
+                message=(
+                    "Gray-Scott morphology comparison finalized"
+                    if finalized
+                    else "Gray-Scott morphology comparison is missing or incomplete"
+                ),
+                metadata={
+                    "active_threshold": self.active_threshold,
+                    "application": "gray_scott",
+                    "analysis": "paired_morphology",
+                    "high_input": self.high_input,
+                    "low_input": self.low_input,
+                    "return_code": return_code,
+                },
+            )
+        ]
+
+    def reset_artifacts(self) -> None:
+        """Allow one later execution lifecycle to report a fresh result."""
+        self._terminal = False
+
+
+def _finite_number(value: object) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(float(value))
+    )
+
+
+def _valid_case(value: object, active_threshold: float | None) -> bool:
+    if not isinstance(value, dict) or set(value) != _CASE_FIELDS:
+        return False
+    shape = value["shape"]
+    if (
+        not isinstance(value["configuration"], dict)
+        or isinstance(value["element_count"], bool)
+        or not isinstance(value["element_count"], int)
+        or value["element_count"] <= 0
+        or isinstance(value["final_simulation_step"], bool)
+        or not isinstance(value["final_simulation_step"], int)
+        or value["final_simulation_step"] < 0
+        or isinstance(value["output_steps"], bool)
+        or not isinstance(value["output_steps"], int)
+        or value["output_steps"] <= 0
+        or not isinstance(shape, list)
+        or len(shape) != 3
+        or any(
+            isinstance(item, bool) or not isinstance(item, int) or item <= 0
+            for item in shape
+        )
+    ):
+        return False
+    if math.prod(shape) != value["element_count"]:
+        return False
+    for field_name in ("u", "v"):
+        metrics = value[field_name]
+        if not isinstance(metrics, dict) or set(metrics) != _METRIC_FIELDS:
+            return False
+        if (
+            isinstance(metrics["component_count"], bool)
+            or not isinstance(metrics["component_count"], int)
+            or metrics["component_count"] < 0
+            or not all(
+                _finite_number(metrics[name])
+                for name in _METRIC_FIELDS - {"component_count"}
+            )
+        ):
+            return False
+        if (
+            active_threshold is not None
+            and metrics["active_threshold"] != active_threshold
+        ):
+            return False
+    return True
+
+
+def _valid_result(
+    path: Path,
+    active_threshold: float | None = None,
+) -> tuple[bool, int | None]:
+    try:
+        status = path.lstat()
+        if (
+            path.is_symlink()
+            or not path.is_file()
+            or not 0 < status.st_size <= 16 * 1024 * 1024
+        ):
+            return False, None
+        value = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+        valid = (
+            isinstance(value, dict)
+            and set(value) == {"schema_version", "cases", "comparison"}
+            and value.get("schema_version") == _RESULT_SCHEMA
+            and isinstance(value.get("cases"), dict)
+            and isinstance(value.get("comparison"), dict)
+        )
+        if valid:
+            cases = value["cases"]
+            comparison = value["comparison"]
+            valid = (
+                set(cases) == {"feed_low", "feed_high"}
+                and set(comparison) == _COMPARISON_FIELDS
+                and all(_finite_number(comparison[name]) for name in comparison)
+                and all(
+                    _valid_case(cases[name], active_threshold)
+                    for name in ("feed_low", "feed_high")
+                )
+            )
+        return valid, status.st_size if valid else None
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False, None
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> GrayScottAnalysisArtifactAdapter | None:
+    """Create artifact semantics only for the maintained analysis package."""
+    if package.get("pkg_type") != "builtin.adios2_gray_scott_analysis":
+        return None
+    output = _absolute_posix_path(package.get("output_file"))
+    threshold = package.get("active_threshold", 0.1)
+    if (
+        isinstance(threshold, bool)
+        or not isinstance(threshold, (int, float))
+        or not math.isfinite(float(threshold))
+        or float(threshold) < 0
+    ):
+        raise ValueError("Gray-Scott analysis threshold must be non-negative")
+    low_input = package.get("low_input")
+    high_input = package.get("high_input")
+    if not isinstance(low_input, str) or not isinstance(high_input, str):
+        raise ValueError("Gray-Scott analysis artifact inputs must be paths")
+    return GrayScottAnalysisArtifactAdapter(
+        output, float(threshold), low_input, high_input
+    )
+
+
+def _absolute_posix_path(value: object) -> PurePosixPath:
+    if not isinstance(value, str) or not value:
+        raise ValueError("Gray-Scott analysis artifact output must be an absolute path")
+    path = PurePosixPath(value)
+    if not path.is_absolute() or path.as_posix() != value or ".." in path.parts:
+        raise ValueError(
+            "Gray-Scott analysis artifact output must be a normalized absolute path"
+        )
+    return path
+
+
+__all__ = ["GrayScottAnalysisArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/adios2_gray_scott_analysis/pkg.py
+++ b/builtin/builtin/adios2_gray_scott_analysis/pkg.py
@@ -453,12 +453,6 @@ class Adios2GrayScottAnalysis(Application):
 
     def _configure(self, **kwargs: Any) -> None:
         super()._configure(**kwargs)
-        output = self.resolve_shared_path(
-            self.config.get("output_file"),
-            field="output_file",
-            default="gray-scott-morphology.json",
-        )
-        cast(dict[str, Any], self.config)["output_file"] = str(output)
         self._validate_configuration()
         configured = self.config.get("input_bundle")
         if configured not in (None, ""):
@@ -514,8 +508,9 @@ class Adios2GrayScottAnalysis(Application):
             self.config.get("high_input"), label="high_input", directory=True
         )
         output = self.config.get("output_file")
-        if not isinstance(output, str) or not Path(output).is_absolute():
-            raise ValueError("output_file must resolve to an absolute path")
+        if not isinstance(output, str) or not output:
+            raise ValueError("output_file must be a non-empty path")
+        self._output_path()
         if self.config.get("input_bundle") in (None, ""):
             self._absolute_existing_path(
                 self.config.get("low_configuration"),
@@ -527,6 +522,14 @@ class Adios2GrayScottAnalysis(Application):
                 label="high_configuration",
                 directory=False,
             )
+
+    def _output_path(self) -> Path:
+        """Resolve the configured result beneath the package shared directory."""
+        return self.resolve_shared_path(
+            self.config.get("output_file"),
+            field="output_file",
+            default="gray-scott-morphology.json",
+        )
 
     def _prepare_bundle_run(self) -> tuple[str, Path, Path, Path]:
         configured = self.config.get("input_bundle")
@@ -569,6 +572,8 @@ class Adios2GrayScottAnalysis(Application):
     def start(self) -> None:
         """Build if requested, analyze both inputs, and validate the result."""
         self._validate_configuration()
+        output = self._output_path()
+        cast(dict[str, Any], self.config)["output_file"] = str(output)
         configured = self.config.get("input_bundle")
         if configured not in (None, ""):
             executable, low_config, high_config, cwd = self._prepare_bundle_run()
@@ -584,14 +589,13 @@ class Adios2GrayScottAnalysis(Application):
                 label="high_configuration",
                 directory=False,
             )
-            cwd = Path(str(self.config["output_file"])).parent
+            cwd = output.parent
         low_input = self._absolute_existing_path(
             self.config["low_input"], label="low_input", directory=True
         )
         high_input = self._absolute_existing_path(
             self.config["high_input"], label="high_input", directory=True
         )
-        output = Path(str(self.config["output_file"]))
         output.parent.mkdir(parents=True, exist_ok=True)
         threshold = _finite_number(
             self.config.get("active_threshold"), label="active_threshold"

--- a/builtin/builtin/adios2_gray_scott_analysis/pkg.py
+++ b/builtin/builtin/adios2_gray_scott_analysis/pkg.py
@@ -1,0 +1,662 @@
+"""Run a paired morphology analysis over ADIOS2 Gray-Scott outputs."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import shlex
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, NamedTuple, cast
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
+from jarvis_cd.shell.process import Rm
+
+_RESULT_SCHEMA = "jarvis.gray-scott-morphology.v1"
+_BUILD_SPEC_ROLE = "build_spec"
+_ANALYSIS_SOURCE_ROLE = "analysis_source"
+_SCIENTIFIC_INPUT_ROLE = "scientific_input"
+_CONFIGURATION_REQUIRED_FIELDS = {
+    "Du",
+    "Dv",
+    "F",
+    "L",
+    "adios_config",
+    "adios_memory_selection",
+    "adios_span",
+    "checkpoint",
+    "checkpoint_freq",
+    "checkpoint_output",
+    "dt",
+    "k",
+    "mesh_type",
+    "noise",
+    "output",
+    "plotgap",
+    "steps",
+}
+_CONFIGURATION_OPTIONAL_FIELDS = {"restart", "restart_input"}
+_CASE_FIELDS = {
+    "configuration",
+    "element_count",
+    "final_simulation_step",
+    "output_steps",
+    "shape",
+    "u",
+    "v",
+}
+_METRIC_FIELDS = {
+    "active_fraction",
+    "active_threshold",
+    "component_count",
+    "interface_density",
+    "largest_component_fraction_of_active",
+    "max",
+    "mean",
+    "min",
+    "standard_deviation",
+    "surface_to_active",
+}
+_COMPARISON_FIELDS = {
+    "max_absolute_v_difference",
+    "pearson_v_correlation",
+    "relative_v_l2_difference",
+    "v_rms_difference",
+}
+
+
+class AnalysisConfiguration(NamedTuple):
+    """One manifest-bound Gray-Scott configuration."""
+
+    path: Path
+    values: Mapping[str, object]
+
+
+class GrayScottAnalysisBundle(NamedTuple):
+    """Build inputs and paired scientific configurations from one bundle."""
+
+    build_spec: Path
+    analysis_source: Path
+    low: AnalysisConfiguration
+    high: AnalysisConfiguration
+
+
+def _safe_bundle_member(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise ValueError(f"{label} must name a declared scientific_input member")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{label} must name a declared scientific_input member")
+    return path.as_posix()
+
+
+def _finite_number(value: object, *, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{label} must be numeric")
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"{label} must be finite")
+    return parsed
+
+
+def _positive_integer(value: object, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+def _validate_configuration_document(value: object) -> Mapping[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError("Gray-Scott configuration must be a JSON object")
+    fields = set(value)
+    missing = _CONFIGURATION_REQUIRED_FIELDS - fields
+    unknown = fields - _CONFIGURATION_REQUIRED_FIELDS - _CONFIGURATION_OPTIONAL_FIELDS
+    if missing or unknown:
+        raise ValueError(
+            "Gray-Scott configuration fields are invalid: "
+            f"missing={sorted(missing)}, unknown={sorted(unknown)}"
+        )
+    for name in ("Du", "Dv", "dt"):
+        if _finite_number(value[name], label=f"Gray-Scott {name}") <= 0:
+            raise ValueError(f"Gray-Scott {name} must be positive")
+    for name in ("F", "k", "noise"):
+        if _finite_number(value[name], label=f"Gray-Scott {name}") < 0:
+            raise ValueError(f"Gray-Scott {name} must be non-negative")
+    for name in ("L", "steps", "plotgap", "checkpoint_freq"):
+        _positive_integer(value[name], label=f"Gray-Scott {name}")
+    if cast(int, value["plotgap"]) > cast(int, value["steps"]):
+        raise ValueError("Gray-Scott plotgap cannot exceed steps")
+    for name in ("checkpoint", "adios_span", "adios_memory_selection"):
+        if not isinstance(value[name], bool):
+            raise ValueError(f"Gray-Scott {name} must be boolean")
+    if "restart" in value and not isinstance(value["restart"], bool):
+        raise ValueError("Gray-Scott restart must be boolean")
+    for name in ("adios_config", "checkpoint_output", "mesh_type", "output"):
+        if not isinstance(value[name], str) or not value[name]:
+            raise ValueError(f"Gray-Scott {name} must be a non-empty string")
+    return value
+
+
+def _load_configuration(path: Path) -> Mapping[str, object]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("Gray-Scott configuration is not valid UTF-8 JSON") from exc
+    return _validate_configuration_document(value)
+
+
+def resolve_analysis_bundle(
+    bundle: MaterializedInputBundle,
+    low_configuration: str,
+    high_configuration: str,
+) -> GrayScottAnalysisBundle:
+    """Resolve the sole analyzer build and two declared configurations."""
+    roles = {item.path: item.role for item in bundle.manifest.files}
+    build_specs = [path for path, role in roles.items() if role == _BUILD_SPEC_ROLE]
+    analysis_sources = [
+        path for path, role in roles.items() if role == _ANALYSIS_SOURCE_ROLE
+    ]
+    if len(build_specs) != 1:
+        raise ValueError("Gray-Scott analysis bundle requires one build_spec")
+    if len(analysis_sources) != 1:
+        raise ValueError("Gray-Scott analysis bundle requires one analysis_source")
+    low_member = _safe_bundle_member(low_configuration, label="low_configuration")
+    high_member = _safe_bundle_member(high_configuration, label="high_configuration")
+    if low_member == high_member:
+        raise ValueError("paired Gray-Scott configurations must be distinct")
+    for label, member in (
+        ("low_configuration", low_member),
+        ("high_configuration", high_member),
+    ):
+        if roles.get(member) != _SCIENTIFIC_INPUT_ROLE:
+            raise ValueError(f"{label} must name a declared scientific_input member")
+    low_path = bundle.root / PurePosixPath(low_member)
+    high_path = bundle.root / PurePosixPath(high_member)
+    return GrayScottAnalysisBundle(
+        build_spec=bundle.root / PurePosixPath(build_specs[0]),
+        analysis_source=bundle.root / PurePosixPath(analysis_sources[0]),
+        low=AnalysisConfiguration(low_path, _load_configuration(low_path)),
+        high=AnalysisConfiguration(high_path, _load_configuration(high_path)),
+    )
+
+
+def _validate_metrics(value: object, *, threshold: float, label: str) -> None:
+    if not isinstance(value, dict) or set(value) != _METRIC_FIELDS:
+        raise ValueError(f"{label} metric fields are invalid")
+    for name in _METRIC_FIELDS - {"component_count"}:
+        _finite_number(value[name], label=f"{label}.{name}")
+    if value["active_threshold"] != threshold:
+        raise ValueError(f"{label} active threshold differs from the request")
+    if (
+        isinstance(value["component_count"], bool)
+        or not isinstance(value["component_count"], int)
+        or value["component_count"] < 0
+    ):
+        raise ValueError(f"{label}.component_count must be a non-negative integer")
+
+
+def _validate_case(
+    value: object,
+    expected_configuration: Mapping[str, object],
+    *,
+    threshold: float,
+    label: str,
+) -> None:
+    if not isinstance(value, dict) or set(value) != _CASE_FIELDS:
+        raise ValueError(f"{label} result fields are invalid")
+    if value["configuration"] != expected_configuration:
+        raise ValueError(f"{label} configuration differs from the bound input")
+    _positive_integer(value["element_count"], label=f"{label}.element_count")
+    if (
+        isinstance(value["final_simulation_step"], bool)
+        or not isinstance(value["final_simulation_step"], int)
+        or value["final_simulation_step"] < 0
+    ):
+        raise ValueError(f"{label}.final_simulation_step must be non-negative")
+    _positive_integer(value["output_steps"], label=f"{label}.output_steps")
+    shape = value["shape"]
+    if not isinstance(shape, list) or len(shape) != 3:
+        raise ValueError(f"{label}.shape must have three dimensions")
+    for index, extent in enumerate(shape):
+        _positive_integer(extent, label=f"{label}.shape[{index}]")
+    if math.prod(cast(list[int], shape)) != value["element_count"]:
+        raise ValueError(f"{label}.shape does not match element_count")
+    _validate_metrics(value["u"], threshold=threshold, label=f"{label}.u")
+    _validate_metrics(value["v"], threshold=threshold, label=f"{label}.v")
+
+
+def validate_result_document(
+    path: Path,
+    low_configuration: Mapping[str, object],
+    high_configuration: Mapping[str, object],
+    *,
+    active_threshold: float,
+) -> dict[str, Any]:
+    """Validate a closed result bound to both configurations and threshold."""
+    try:
+        status = path.lstat()
+        if (
+            path.is_symlink()
+            or not path.is_file()
+            or not 0 < status.st_size <= 16 * 1024 * 1024
+        ):
+            raise ValueError("Gray-Scott analysis result is not a bounded regular file")
+        value = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("Gray-Scott analysis result is not valid UTF-8 JSON") from exc
+    if not isinstance(value, dict) or set(value) != {
+        "schema_version",
+        "cases",
+        "comparison",
+    }:
+        raise ValueError("Gray-Scott analysis result fields are invalid")
+    if value["schema_version"] != _RESULT_SCHEMA:
+        raise ValueError("Gray-Scott analysis result schema is invalid")
+    cases = value["cases"]
+    if not isinstance(cases, dict) or set(cases) != {"feed_low", "feed_high"}:
+        raise ValueError("Gray-Scott analysis cases are invalid")
+    _validate_case(
+        cases["feed_low"],
+        low_configuration,
+        threshold=active_threshold,
+        label="feed_low",
+    )
+    _validate_case(
+        cases["feed_high"],
+        high_configuration,
+        threshold=active_threshold,
+        label="feed_high",
+    )
+    comparison = value["comparison"]
+    if not isinstance(comparison, dict) or set(comparison) != _COMPARISON_FIELDS:
+        raise ValueError("Gray-Scott comparison fields are invalid")
+    for name in _COMPARISON_FIELDS:
+        _finite_number(comparison[name], label=f"comparison.{name}")
+    return cast(dict[str, Any], value)
+
+
+def _combined_probe_status(*statuses: RuntimeStatus) -> RuntimeStatus:
+    if statuses and all(status.usable is True for status in statuses):
+        return RuntimeStatus("ready", "runtime_probe_succeeded")
+    if any(status.usable is False for status in statuses):
+        return RuntimeStatus("unavailable", "software_not_found")
+    return RuntimeStatus("unknown", "runtime_probe_inconclusive")
+
+
+class Adios2GrayScottAnalysis(Application):
+    """Compare morphology from two completed Gray-Scott BP datasets."""
+
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "nprocs",
+                "msg": "Analyzer process count",
+                "type": int,
+                "default": 1,
+            },
+            {
+                "name": "ppn",
+                "msg": "Analyzer processes per node",
+                "type": int,
+                "default": 1,
+            },
+            {
+                "name": "executable",
+                "msg": "Installed gray-scott-analyze executable",
+                "type": str,
+                "default": "gray-scott-analyze",
+            },
+            {
+                "name": "input_bundle",
+                "msg": "Optional digest-verified analyzer source and paired configuration bundle",
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
+            },
+            {
+                "name": "low_input",
+                "msg": "Completed low-feed ADIOS2 BP dataset",
+                "type": str,
+                "default": None,
+            },
+            {
+                "name": "low_configuration",
+                "msg": "Low-feed configuration path or scientific_input bundle member",
+                "type": str,
+                "default": None,
+            },
+            {
+                "name": "high_input",
+                "msg": "Completed high-feed ADIOS2 BP dataset",
+                "type": str,
+                "default": None,
+            },
+            {
+                "name": "high_configuration",
+                "msg": "High-feed configuration path or scientific_input bundle member",
+                "type": str,
+                "default": None,
+            },
+            {
+                "name": "active_threshold",
+                "msg": "V concentration threshold used for morphology",
+                "type": float,
+                "default": 0.1,
+            },
+            {
+                "name": "output_file",
+                "msg": "Closed JSON morphology comparison",
+                "type": str,
+                "default": "gray-scott-morphology.json",
+            },
+        ]
+
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        environment = self._deployment_environment()
+        installed = probe_program(
+            "gray-scott-analyze",
+            environment=environment,
+            arguments=("--help",),
+            accepted_return_codes=(0, 1),
+        )
+        source = _combined_probe_status(
+            probe_program(
+                "cmake", environment=environment, arguments=("--version",)
+            ).status,
+            probe_program(
+                "adios2-config", environment=environment, arguments=("--version",)
+            ).status,
+            probe_program(
+                "mpic++", environment=environment, arguments=("--version",)
+            ).status,
+        )
+        completed = ReadinessContract("process_exit", "successful_exit")
+        return PackageDeploymentContract(
+            package="builtin.adios2_gray_scott_analysis",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="installed_executable",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    runtime_requirements=("gray_scott_analysis_installed",),
+                    readiness=completed,
+                    description="Analyze two completed BP datasets with an installed executable.",
+                ),
+                ExecutionProfile(
+                    name="source_bundle",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    runtime_requirements=("gray_scott_analysis_source_build",),
+                    readiness=completed,
+                    description="Build one verified analyzer target and compare two completed BP datasets.",
+                ),
+            ),
+            runtime_requirements=(
+                RuntimeRequirement(
+                    requirement_id="gray_scott_analysis_installed",
+                    description="Installed ADIOS2 Gray-Scott morphology analyzer",
+                    required_capabilities=("gray_scott_morphology",),
+                    available_capabilities=(
+                        ("gray_scott_morphology",)
+                        if installed.status.usable is True
+                        else ()
+                    ),
+                    status=installed.status,
+                ),
+                RuntimeRequirement(
+                    requirement_id="gray_scott_analysis_source_build",
+                    description="CMake, C++ compiler, and ADIOS2 development runtime",
+                    required_capabilities=("gray_scott_morphology", "source_build"),
+                    available_capabilities=(
+                        ("gray_scott_morphology", "source_build")
+                        if source.usable is True
+                        else ()
+                    ),
+                    status=source,
+                    provider_resolutions=(
+                        ProviderResolution("spack", "spec", "adios2"),
+                        ProviderResolution("spack", "spec", "cmake"),
+                    ),
+                ),
+            ),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    requires=(
+                        ConfigurationCondition("low_configuration", "is_not_empty"),
+                        ConfigurationCondition("high_configuration", "is_not_empty"),
+                    ),
+                    description="Installed analysis requires two external configuration files.",
+                ),
+            ),
+        )
+
+    def _configure(self, **kwargs: Any) -> None:
+        super()._configure(**kwargs)
+        output = self.resolve_shared_path(
+            self.config.get("output_file"),
+            field="output_file",
+            default="gray-scott-morphology.json",
+        )
+        cast(dict[str, Any], self.config)["output_file"] = str(output)
+        self._validate_configuration()
+        configured = self.config.get("input_bundle")
+        if configured not in (None, ""):
+            if not isinstance(configured, str):
+                raise TypeError("input_bundle must be a path string")
+            bundle = extract_input_bundle(
+                configured, self._shared_root() / "input-bundles"
+            )
+            resolve_analysis_bundle(
+                bundle,
+                str(self.config["low_configuration"]),
+                str(self.config["high_configuration"]),
+            )
+
+    def _shared_root(self) -> Path:
+        shared_dir = self.shared_dir
+        if not isinstance(shared_dir, (str, os.PathLike)) or not os.fspath(shared_dir):
+            raise RuntimeError(
+                "Gray-Scott analysis requires a package shared directory"
+            )
+        return Path(shared_dir)
+
+    @staticmethod
+    def _absolute_existing_path(value: object, *, label: str, directory: bool) -> Path:
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{label} is required")
+        path = Path(os.path.expandvars(value))
+        if not path.is_absolute() or path.is_symlink():
+            raise ValueError(f"{label} must be a normalized absolute path")
+        if directory and not path.is_dir():
+            raise ValueError(f"{label} must be an existing BP directory")
+        if not directory and not path.is_file():
+            raise ValueError(f"{label} must be an existing regular file")
+        return path.resolve(strict=True)
+
+    def _validate_configuration(self) -> None:
+        for name in ("nprocs", "ppn"):
+            _positive_integer(self.config.get(name), label=name)
+        threshold = _finite_number(
+            self.config.get("active_threshold"), label="active_threshold"
+        )
+        if threshold < 0:
+            raise ValueError("active_threshold must be non-negative")
+        executable = self.config.get("executable")
+        if not isinstance(executable, str) or not executable.strip():
+            raise ValueError(
+                "Gray-Scott analysis executable must be a non-empty string"
+            )
+        self._absolute_existing_path(
+            self.config.get("low_input"), label="low_input", directory=True
+        )
+        self._absolute_existing_path(
+            self.config.get("high_input"), label="high_input", directory=True
+        )
+        output = self.config.get("output_file")
+        if not isinstance(output, str) or not Path(output).is_absolute():
+            raise ValueError("output_file must resolve to an absolute path")
+        if self.config.get("input_bundle") in (None, ""):
+            self._absolute_existing_path(
+                self.config.get("low_configuration"),
+                label="low_configuration",
+                directory=False,
+            )
+            self._absolute_existing_path(
+                self.config.get("high_configuration"),
+                label="high_configuration",
+                directory=False,
+            )
+
+    def _prepare_bundle_run(self) -> tuple[str, Path, Path, Path]:
+        configured = self.config.get("input_bundle")
+        if not isinstance(configured, str) or not configured:
+            raise RuntimeError("Gray-Scott analysis input bundle was not persisted")
+        bundle = extract_input_bundle(configured, self._shared_root() / "input-bundles")
+        selected = resolve_analysis_bundle(
+            bundle,
+            str(self.config.get("low_configuration") or ""),
+            str(self.config.get("high_configuration") or ""),
+        )
+        run_dir = self.resolve_shared_path("run", field="input_bundle workspace")
+        stage_input_bundle(bundle, run_dir)
+        build_dir = run_dir / "build"
+        source_dir = (run_dir / selected.build_spec.relative_to(bundle.root)).parent
+        local_info = LocalExecInfo(env=self.mod_env, cwd=str(run_dir), timeout=900)
+        configure = " ".join(
+            (
+                "cmake",
+                "-S",
+                shlex.quote(str(source_dir)),
+                "-B",
+                shlex.quote(str(build_dir)),
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_C_COMPILER=mpicc",
+                "-DCMAKE_CXX_COMPILER=mpic++",
+            )
+        )
+        self._raise_for_exec_failure(
+            Exec(configure, local_info).run(), operation="Gray-Scott analysis configure"
+        )
+        build = f"cmake --build {shlex.quote(str(build_dir))} --parallel 4 --target gray-scott-analyze"
+        self._raise_for_exec_failure(
+            Exec(build, local_info).run(), operation="Gray-Scott analysis build"
+        )
+        low = run_dir / selected.low.path.relative_to(bundle.root)
+        high = run_dir / selected.high.path.relative_to(bundle.root)
+        return str(build_dir / "bin" / "gray-scott-analyze"), low, high, run_dir
+
+    def start(self) -> None:
+        """Build if requested, analyze both inputs, and validate the result."""
+        self._validate_configuration()
+        configured = self.config.get("input_bundle")
+        if configured not in (None, ""):
+            executable, low_config, high_config, cwd = self._prepare_bundle_run()
+        else:
+            executable = str(self.config["executable"])
+            low_config = self._absolute_existing_path(
+                self.config["low_configuration"],
+                label="low_configuration",
+                directory=False,
+            )
+            high_config = self._absolute_existing_path(
+                self.config["high_configuration"],
+                label="high_configuration",
+                directory=False,
+            )
+            cwd = Path(str(self.config["output_file"])).parent
+        low_input = self._absolute_existing_path(
+            self.config["low_input"], label="low_input", directory=True
+        )
+        high_input = self._absolute_existing_path(
+            self.config["high_input"], label="high_input", directory=True
+        )
+        output = Path(str(self.config["output_file"]))
+        output.parent.mkdir(parents=True, exist_ok=True)
+        threshold = _finite_number(
+            self.config.get("active_threshold"), label="active_threshold"
+        )
+        command = " ".join(
+            shlex.quote(str(value))
+            for value in (
+                executable,
+                low_input,
+                low_config,
+                high_input,
+                high_config,
+                threshold,
+                output,
+            )
+        )
+        result = Exec(
+            command,
+            MpiExecInfo(
+                nprocs=self.config["nprocs"],
+                ppn=self.config["ppn"],
+                hostfile=self.hostfile,
+                env=self.mod_env,
+                cwd=str(cwd),
+                line_callback=self.runtime_line_callback(),
+            ),
+        ).run()
+        self._raise_for_exec_failure(result, operation="Gray-Scott analysis")
+        validate_result_document(
+            output,
+            _load_configuration(low_config),
+            _load_configuration(high_config),
+            active_threshold=threshold,
+        )
+
+    @staticmethod
+    def _raise_for_exec_failure(result: Any, *, operation: str) -> None:
+        exit_codes = getattr(result, "exit_code", None)
+        if not isinstance(exit_codes, dict) or not exit_codes:
+            raise RuntimeError(f"{operation} returned no process exit status")
+        failures = {
+            str(host): code
+            for host, code in exit_codes.items()
+            if isinstance(code, bool) or not isinstance(code, int) or code != 0
+        }
+        if failures:
+            details = ", ".join(
+                f"{host}={code!r}" for host, code in sorted(failures.items())
+            )
+            raise RuntimeError(f"{operation} failed with exit status: {details}")
+
+    def stop(self) -> None:
+        """The morphology analyzer is a bounded batch application."""
+
+    def clean(self) -> None:
+        """Remove the configured comparison result."""
+        output = self.config.get("output_file")
+        if isinstance(output, str) and output:
+            Rm(output, PsshExecInfo(hostfile=self.hostfile)).run()
+
+
+__all__ = [
+    "Adios2GrayScottAnalysis",
+    "AnalysisConfiguration",
+    "GrayScottAnalysisBundle",
+    "resolve_analysis_bundle",
+    "validate_result_document",
+]

--- a/builtin/builtin/adios2_pdf_calc/README.md
+++ b/builtin/builtin/adios2_pdf_calc/README.md
@@ -17,12 +17,36 @@ PDF Calc reads ADIOS2 data produced by the Gray-Scott simulation and computes st
 |-----------|------|---------|-------------|
 | `nprocs` | int | 2 | Number of MPI processes |
 | `ppn` | int | 16 | Processes per node |
+| `executable` | str | `pdf_calc` | Installed executable resolved through `PATH` |
+| `input_bundle` | str | empty | Optional digest-verified source bundle |
 | `input_file` | str | *Required* | Input file from Gray-Scott simulation |
 | `output_file` | str | *Required* | Output file for PDF analysis results |
 | `nbins` | int | 1000 | Number of bins for PDF calculation |
 | `output_inputdata` | str | NO | Write original variables (YES/NO) |
 
 ## Usage
+
+### Digest-verified source build
+
+When `pdf_calc` is not installed, `input_bundle` may point to a regular tar
+archive using `jarvis.package-input-bundle.v1`. Its manifest must declare
+exactly one `build_spec` and one `adios2_configuration`. JARVIS verifies the
+complete archive before submission, then builds the `pdf_calc` target in an
+execution-owned workspace using CMake, MPI compilers, and the active ADIOS2
+development environment.
+
+```bash
+jarvis ppl append adios2_pdf_calc \
+  input_bundle=/staged/gray-scott-source.tar \
+  input_file=/shared/gray-scott/feed-low.bp \
+  output_file=feed-low-pdf.bp \
+  nbins=128 nprocs=1 ppn=1
+```
+
+Relative output paths are scoped to the PDF Calc package shared directory.
+Absolute input paths allow explicit consumption of a prior pipeline product.
+There is no implicit developer checkout, and a nonzero `pdf_calc` exit fails
+the package lifecycle.
 
 ### Standalone Usage
 

--- a/builtin/builtin/adios2_pdf_calc/artifacts.py
+++ b/builtin/builtin/adios2_pdf_calc/artifacts.py
@@ -1,0 +1,133 @@
+"""Artifact semantics owned by the builtin ADIOS2 PDF Calc package."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+from jarvis_cd.progress import LineBuffer
+
+_WRITER_RE = re.compile(
+    r"^PDF analysis writes using engine type:\s*(?P<engine>[A-Za-z0-9_+-]+)\s*$"
+)
+
+
+@dataclass
+class Adios2PdfCalcArtifactAdapter:
+    """Track the configured PDF analysis dataset through process completion."""
+
+    output_path: PurePosixPath
+    engine: str
+    bins: int
+    artifact_id: str = field(default_factory=new_artifact_id)
+    _lines: LineBuffer = field(default_factory=LineBuffer)
+    _announced: bool = False
+    _terminal: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Announce output only after native PDF Calc writer initialization."""
+        observations: list[ArtifactObservation] = []
+        for line in self._lines.feed(text, finalize=False):
+            match = _WRITER_RE.fullmatch(line.strip())
+            if match is None or self._terminal or self._announced:
+                continue
+            if match.group("engine").casefold() != self.engine.casefold():
+                raise ValueError(
+                    "PDF Calc reported an engine that differs from configuration"
+                )
+            self._announced = True
+            observations.append(self._observation(ArtifactState.PRODUCING))
+        return observations
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Finalize a successful stream for callers without process status."""
+        return self.finalize_artifacts_for_exit(0)
+
+    def finalize_artifacts_for_exit(
+        self,
+        return_code: int,
+    ) -> list[ArtifactObservation]:
+        """Finalize or mark incomplete from authoritative process status."""
+        if self._terminal:
+            return []
+        self._lines.feed("", finalize=True)
+        self._terminal = True
+        state = (
+            ArtifactState.FINALIZED if return_code == 0 else ArtifactState.INCOMPLETE
+        )
+        return [self._observation(state, return_code=return_code)]
+
+    def reset_artifacts(self) -> None:
+        """Reset parsing for a fresh PDF Calc execution."""
+        self._lines.reset()
+        self._announced = False
+        self._terminal = False
+
+    def _observation(
+        self,
+        state: ArtifactState,
+        *,
+        return_code: int | None = None,
+    ) -> ArtifactObservation:
+        metadata: dict[str, str | int] = {
+            "application": "gray_scott",
+            "analysis": "probability_density",
+            "engine": self.engine,
+            "bins": self.bins,
+        }
+        if return_code is not None:
+            metadata["return_code"] = return_code
+        if state is ArtifactState.FINALIZED:
+            message = "Gray-Scott PDF analysis finalized"
+        elif state is ArtifactState.INCOMPLETE:
+            message = "Gray-Scott PDF analysis is incomplete after process failure"
+        else:
+            message = "Gray-Scott PDF analysis is being produced"
+        return ArtifactObservation(
+            artifact_id=self.artifact_id,
+            logical_name="gray-scott-pdf-analysis",
+            kind="analysis_dataset",
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(self.output_path),
+            media_type="application/x-adios2-bp",
+            format=f"adios2-{self.engine.casefold()}-pdf",
+            message=message,
+            metadata=metadata,
+        )
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> Adios2PdfCalcArtifactAdapter | None:
+    """Create artifact semantics only for builtin ADIOS2 PDF Calc."""
+    if package.get("pkg_type") != "builtin.adios2_pdf_calc":
+        return None
+    output_path = _absolute_posix_path(package.get("output_file"))
+    bins = package.get("nbins", 1000)
+    if isinstance(bins, bool) or not isinstance(bins, int) or bins <= 0:
+        raise ValueError("PDF Calc artifact bins must be a positive integer")
+    engine = str(package.get("engine") or "bp5").casefold()
+    return Adios2PdfCalcArtifactAdapter(output_path, engine, bins)
+
+
+def _absolute_posix_path(value: object) -> PurePosixPath:
+    if not isinstance(value, str) or not value:
+        raise ValueError("PDF Calc artifact output must be an absolute path")
+    path = PurePosixPath(value)
+    if not path.is_absolute() or path.as_posix() != value or ".." in path.parts:
+        raise ValueError("PDF Calc artifact output must be a normalized absolute path")
+    return path

--- a/builtin/builtin/adios2_pdf_calc/pkg.py
+++ b/builtin/builtin/adios2_pdf_calc/pkg.py
@@ -1,210 +1,384 @@
-"""
-This module provides classes and methods to launch the PDF Calc application.
-PDF Calc analyzes Gray-Scott simulation output and computes the probability
-distribution function (PDF) for each 2D slice of the U and V variables.
-"""
-from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
-from jarvis_cd.shell.process import Rm
+"""Run ADIOS2 PDF Calc against a Gray-Scott scientific dataset."""
+
+from __future__ import annotations
+
 import os
+import shlex
+import shutil
+import time
+from pathlib import Path, PurePosixPath
+from typing import Any, cast
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
+from jarvis_cd.shell.process import Rm
+
+
+def _combined_probe_status(*statuses: RuntimeStatus) -> RuntimeStatus:
+    if statuses and all(status.usable is True for status in statuses):
+        return RuntimeStatus("ready", "runtime_probe_succeeded")
+    if any(status.usable is False for status in statuses):
+        return RuntimeStatus("unavailable", "software_not_found")
+    return RuntimeStatus("unknown", "runtime_probe_inconclusive")
+
+
+def _bundle_member_for_role(
+    bundle: MaterializedInputBundle,
+    role: str,
+) -> Path:
+    members = [item.path for item in bundle.manifest.files if item.role == role]
+    if len(members) != 1:
+        raise ValueError(f"PDF Calc input bundle requires exactly one {role}")
+    return bundle.root / PurePosixPath(members[0])
+
+
+def validate_pdf_source_bundle(bundle: MaterializedInputBundle) -> None:
+    """Require the source build and ADIOS2 configuration used by PDF Calc."""
+    _bundle_member_for_role(bundle, "build_spec")
+    _bundle_member_for_role(bundle, "adios2_configuration")
 
 
 class Adios2PdfCalc(Application):
-    """
-    This class provides methods to launch the PDF Calc application.
-    """
-    def _init(self):
-        """
-        Initialize paths
-        """
-        self.adios2_xml_path = f'{self.shared_dir}/adios2.xml'
-        self.adios2_xml_runtime = f'{self.private_dir}/adios2.xml'  # Copy to private dir for execution
+    """Calculate per-slice PDFs using an installed or bundle-built executable."""
 
-        # Ensure PATH is available for MPI detection
-        # This runs every time the package is loaded (including at start time)
-        import os
-        if 'PATH' not in self.env:
-            system_path = os.environ.get('PATH', '')
-            if system_path:
-                self.env['PATH'] = system_path
-                self.mod_env['PATH'] = system_path
+    def _init(self) -> None:
+        self.adios2_xml_path = f"{self.shared_dir}/adios2.xml"
 
-    def _configure_menu(self):
-        """
-        Create a CLI menu for the configurator method.
-        For thorough documentation of these parameters, view:
-        https://github.com/scs-lab/jarvis-util/wiki/3.-Argument-Parsing
-
-        :return: List(dict)
-        """
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
+            {"name": "nprocs", "msg": "Number of processes", "type": int, "default": 2},
+            {"name": "ppn", "msg": "Processes per node", "type": int, "default": 16},
             {
-                'name': 'nprocs',
-                'msg': 'Number of processes to spawn',
-                'type': int,
-                'default': 2,
+                "name": "executable",
+                "msg": "Installed pdf_calc executable available through PATH",
+                "type": str,
+                "default": "pdf_calc",
             },
             {
-                'name': 'ppn',
-                'msg': 'Processes per node',
-                'type': int,
-                'default': 16,
+                "name": "input_bundle",
+                "msg": (
+                    "Optional digest-verified PDF Calc source bundle declaring "
+                    "one build_spec and one adios2_configuration"
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                'name': 'input_file',
-                'msg': 'Input file from Gray-Scott simulation',
-                'type': str,
-                'default': None,
+                "name": "input_file",
+                "msg": "Gray-Scott input dataset",
+                "type": str,
+                "default": None,
             },
             {
-                'name': 'output_file',
-                'msg': 'Output file for PDF analysis results',
-                'type': str,
-                'default': None,
+                "name": "output_file",
+                "msg": "PDF output dataset",
+                "type": str,
+                "default": None,
             },
             {
-                'name': 'nbins',
-                'msg': 'Number of bins for PDF calculation',
-                'type': int,
-                'default': 1000,
+                "name": "nbins",
+                "msg": "Number of PDF bins",
+                "type": int,
+                "default": 1000,
             },
             {
-                'name': 'output_inputdata',
-                'msg': 'Write original variables in output (YES/NO)',
-                'type': str,
-                'default': 'NO',
+                "name": "output_inputdata",
+                "msg": "Copy original variables (YES/NO)",
+                "type": str,
+                "default": "NO",
             },
             {
-                'name': 'wait_for_producer',
-                'msg': 'Wait for producer to complete before starting',
-                'type': bool,
-                'default': True,
+                "name": "wait_for_producer",
+                "msg": "Wait for the input dataset",
+                "type": bool,
+                "default": True,
             },
             {
-                'name': 'engine',
-                'msg': 'ADIOS2 engine to use for reading',
-                'choices': ['bp5', 'sst'],
-                'type': str,
-                'default': 'bp5',
+                "name": "engine",
+                "msg": "ADIOS2 engine",
+                "choices": ["bp5", "sst"],
+                "type": str,
+                "default": "bp5",
             },
         ]
 
-    def _configure(self, **kwargs):
-        """
-        Converts the Jarvis configuration to application-specific configuration.
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        environment = self._deployment_environment()
+        installed_probe = probe_program(
+            "pdf_calc", environment=environment, arguments=("--help",)
+        )
+        cmake_probe = probe_program(
+            "cmake", environment=environment, arguments=("--version",)
+        )
+        adios_probe = probe_program(
+            "adios2-config", environment=environment, arguments=("--version",)
+        )
+        mpi_c_probe = probe_program(
+            "mpicc", environment=environment, arguments=("--version",)
+        )
+        mpi_cxx_probe = probe_program(
+            "mpic++", environment=environment, arguments=("--version",)
+        )
+        source_status = _combined_probe_status(
+            cmake_probe.status,
+            adios_probe.status,
+            mpi_c_probe.status,
+            mpi_cxx_probe.status,
+        )
+        installed_capabilities = (
+            ("mpi_execution", "probability_density")
+            if installed_probe.status.usable is True
+            else ()
+        )
+        source_capabilities = (
+            ("mpi_execution", "probability_density", "source_build")
+            if source_status.usable is True
+            else ()
+        )
+        completed = ReadinessContract("process_exit", "successful_exit")
+        return PackageDeploymentContract(
+            package="builtin.adios2_pdf_calc",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="installed_executable",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    runtime_requirements=("pdf_calc_installed",),
+                    readiness=completed,
+                ),
+                ExecutionProfile(
+                    name="source_bundle",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    runtime_requirements=("pdf_calc_source_build",),
+                    readiness=completed,
+                    description=(
+                        "Build verified PDF Calc source in an execution-owned "
+                        "workspace before analyzing the configured input dataset."
+                    ),
+                ),
+            ),
+            runtime_requirements=(
+                RuntimeRequirement(
+                    requirement_id="pdf_calc_installed",
+                    description="Installed MPI ADIOS2 PDF Calc executable",
+                    required_capabilities=("mpi_execution", "probability_density"),
+                    available_capabilities=installed_capabilities,
+                    status=installed_probe.status,
+                ),
+                RuntimeRequirement(
+                    requirement_id="pdf_calc_source_build",
+                    description="CMake and MPI-enabled ADIOS2 development runtime",
+                    required_capabilities=(
+                        "mpi_execution",
+                        "probability_density",
+                        "source_build",
+                    ),
+                    available_capabilities=source_capabilities,
+                    status=source_status,
+                    provider_resolutions=(
+                        ProviderResolution("spack", "spec", "adios2+mpi"),
+                        ProviderResolution("spack", "spec", "cmake"),
+                        ProviderResolution("spack", "spec", "openmpi"),
+                    ),
+                ),
+            ),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_file", "is_empty"),),
+                    requires=(ConfigurationCondition("input_file", "is_not_empty"),),
+                    description="PDF Calc requires one input dataset.",
+                ),
+                ConfigurationRule(
+                    when=(ConfigurationCondition("output_file", "is_empty"),),
+                    requires=(ConfigurationCondition("output_file", "is_not_empty"),),
+                    description="PDF Calc requires one output dataset.",
+                ),
+            ),
+        )
 
-        :param kwargs: Configuration parameters for this pkg.
-        :return: None
-        """
-        # Ensure pdf_calc binary location is in PATH
-        # This is needed for MPI execution to find the binary
-        import os
-        pdf_calc_bin_dir = '/workspace/external/iowarp-gray-scott/build/bin'
-        if os.path.exists(pdf_calc_bin_dir):
-            # If PATH doesn't exist in our env, initialize it from system PATH
-            if 'PATH' not in self.env:
-                system_path = os.environ.get('PATH', '')
-                if system_path:
-                    self.env['PATH'] = system_path
-                    self.mod_env['PATH'] = system_path
-            # Now prepend our bin directory
-            self.prepend_env('PATH', pdf_calc_bin_dir)
+    def _configure(self, **kwargs: Any) -> None:
+        super()._configure(**kwargs)
+        self._validate_configuration()
+        config = cast(dict[str, Any], self.config)
+        configured_bundle = config.get("input_bundle")
+        if configured_bundle not in (None, ""):
+            if not isinstance(configured_bundle, str):
+                raise TypeError("input_bundle must be a path string")
+            bundle = extract_input_bundle(
+                configured_bundle, self._shared_root() / "input-bundles"
+            )
+            validate_pdf_source_bundle(bundle)
+            return
+        template = (
+            "sst.xml" if str(self.config["engine"]).lower() == "sst" else "adios2.xml"
+        )
+        self.copy_template_file(
+            f"{self.pkg_dir}/config/{template}", self.adios2_xml_path
+        )
 
-        # Validate required parameters
-        if self.config['input_file'] is None:
-            raise ValueError('input_file parameter is required for pdf_calc')
-        if self.config['output_file'] is None:
-            raise ValueError('output_file parameter is required for pdf_calc')
+    def _shared_root(self) -> Path:
+        shared_dir = self.shared_dir
+        if not isinstance(shared_dir, (str, os.PathLike)) or not os.fspath(shared_dir):
+            raise RuntimeError("PDF Calc requires a JARVIS package shared directory")
+        return Path(shared_dir)
 
-        # Copy ADIOS2 XML configuration based on engine type
-        print(f"Using engine {self.config['engine']} for pdf_calc")
-        if self.config['engine'].lower() == 'sst':
-            # Use SST configuration for streaming
-            self.copy_template_file(f'{self.pkg_dir}/config/sst.xml',
-                                self.adios2_xml_path)
+    def _validate_configuration(self) -> None:
+        for name in ("nprocs", "ppn", "nbins"):
+            value = self.config.get(name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        for name in ("input_file", "output_file"):
+            value = self.config.get(name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{name} parameter is required for PDF Calc")
+        executable = self.config.get("executable")
+        if not isinstance(executable, str) or not executable.strip():
+            raise ValueError("PDF Calc executable must be a non-empty string")
+        output_inputdata = str(self.config.get("output_inputdata", "NO")).upper()
+        if output_inputdata not in {"YES", "NO"}:
+            raise ValueError("output_inputdata must be YES or NO")
+
+    def _prepare_bundle_run(self) -> tuple[str, Path, Path]:
+        configured = self.config.get("input_bundle")
+        if not isinstance(configured, str) or not configured:
+            raise RuntimeError("PDF Calc input bundle was not persisted")
+        bundle = extract_input_bundle(configured, self._shared_root() / "input-bundles")
+        validate_pdf_source_bundle(bundle)
+        build_spec = _bundle_member_for_role(bundle, "build_spec")
+        adios_config = _bundle_member_for_role(bundle, "adios2_configuration")
+        run_dir = self.resolve_shared_path("run", field="input_bundle workspace")
+        stage_input_bundle(bundle, run_dir)
+        staged_build_spec = run_dir / build_spec.relative_to(bundle.root)
+        staged_adios_config = run_dir / adios_config.relative_to(bundle.root)
+        runtime_adios = run_dir / "adios2.xml"
+        if staged_adios_config != runtime_adios:
+            shutil.copyfile(staged_adios_config, runtime_adios)
+        build_dir = run_dir / "build"
+        local_info = LocalExecInfo(env=self.mod_env, cwd=str(run_dir), timeout=900)
+        configure = " ".join(
+            (
+                "cmake",
+                "-S",
+                shlex.quote(str(staged_build_spec.parent)),
+                "-B",
+                shlex.quote(str(build_dir)),
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_C_COMPILER=mpicc",
+                "-DCMAKE_CXX_COMPILER=mpic++",
+            )
+        )
+        self._raise_for_exec_failure(
+            Exec(configure, local_info).run(), operation="PDF Calc configure"
+        )
+        build = f"cmake --build {shlex.quote(str(build_dir))} --parallel 4 --target pdf_calc"
+        self._raise_for_exec_failure(
+            Exec(build, local_info).run(), operation="PDF Calc build"
+        )
+        return str(build_dir / "bin" / "pdf_calc"), run_dir, runtime_adios
+
+    def start(self) -> None:
+        """Run PDF Calc and propagate its authoritative process status."""
+        self._validate_configuration()
+        config = cast(dict[str, Any], self.config)
+        configured_bundle = config.get("input_bundle")
+        if configured_bundle not in (None, ""):
+            executable, working_dir, runtime_adios = self._prepare_bundle_run()
         else:
-            # Use BP5 configuration (default)
-            self.copy_template_file(f'{self.pkg_dir}/config/adios2.xml',
-                                self.adios2_xml_path)
+            executable = str(config["executable"])
+            input_path = Path(os.path.expandvars(str(config["input_file"]))).resolve()
+            working_dir = input_path.parent
+            runtime_adios = working_dir / "adios2.xml"
+            shutil.copyfile(self.adios2_xml_path, runtime_adios)
+        input_file = Path(os.path.expandvars(str(config["input_file"]))).resolve()
+        output_value = str(config["output_file"])
+        output_file = (
+            Path(os.path.expandvars(output_value)).resolve()
+            if Path(output_value).is_absolute()
+            else self.resolve_shared_path(output_value, field="output_file")
+        )
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        config["input_file"] = str(input_file)
+        config["output_file"] = str(output_file)
+        if self.config.get("wait_for_producer", True):
+            self._wait_for_input(input_file)
+        command = " ".join(
+            (
+                shlex.quote(executable),
+                shlex.quote(str(input_file)),
+                shlex.quote(str(output_file)),
+                str(self.config["nbins"]),
+            )
+        )
+        if str(self.config["output_inputdata"]).upper() == "YES":
+            command += " YES"
+        result = Exec(
+            command,
+            MpiExecInfo(
+                nprocs=self.config["nprocs"],
+                ppn=self.config["ppn"],
+                hostfile=self.hostfile,
+                env=self.mod_env,
+                cwd=str(working_dir),
+                line_callback=self.runtime_line_callback(),
+            ),
+        ).run()
+        self._raise_for_exec_failure(result, operation="PDF Calc")
+        if not runtime_adios.is_file() and configured_bundle not in (None, ""):
+            raise RuntimeError("PDF Calc ADIOS2 configuration was not materialized")
 
-    def start(self):
-        """
-        Launch the PDF Calc application.
+    def _wait_for_input(self, input_file: Path) -> None:
+        if str(self.config["engine"]).lower() == "sst":
+            time.sleep(10)
+            return
+        for _ in range(60):
+            if input_file.exists():
+                time.sleep(5)
+                return
+            time.sleep(1)
+        raise TimeoutError("PDF Calc input dataset was not available after 60 seconds")
 
-        :return: None
-        """
-        import shutil
-        import time
+    @staticmethod
+    def _raise_for_exec_failure(result: Any, *, operation: str) -> None:
+        exit_codes = getattr(result, "exit_code", None)
+        if not isinstance(exit_codes, dict) or not exit_codes:
+            raise RuntimeError(f"{operation} returned no process exit status")
+        failures = {
+            str(host): code
+            for host, code in exit_codes.items()
+            if isinstance(code, bool) or not isinstance(code, int) or code != 0
+        }
+        if failures:
+            details = ", ".join(
+                f"{host}={code!r}" for host, code in sorted(failures.items())
+            )
+            raise RuntimeError(f"{operation} failed with exit status: {details}")
 
-        # Copy ADIOS2 XML to working directory where pdf_calc will look for it
-        working_dir = os.path.dirname(self.config['input_file'])
-        runtime_xml = os.path.join(working_dir, 'adios2.xml')
-        shutil.copy(self.adios2_xml_path, runtime_xml)
-        print(f"Copied ADIOS2 config to {runtime_xml}")
+    def stop(self) -> None:
+        """PDF Calc is a bounded batch application with no persistent process."""
 
-        # If wait_for_producer is enabled, handle differently for SST vs BP5
-        if self.config.get('wait_for_producer', True):
-            if self.config['engine'].lower() == 'sst':
-                # For SST, just wait a fixed time for producer to start streaming
-                print("Waiting 10 seconds for SST producer to initialize...")
-                time.sleep(10)
-            else:
-                # For BP5, wait for file to exist
-                print("Waiting for producer to create output file...")
-                wait_time = 0
-                max_wait = 60
-                while wait_time < max_wait:
-                    if os.path.exists(self.config['input_file']):
-                        print(f"Output file found after {wait_time} seconds")
-                        # Give a bit more time for the first timestep to be written
-                        time.sleep(5)
-                        break
-                    time.sleep(1)
-                    wait_time += 1
-
-                if wait_time >= max_wait:
-                    print(f"Warning: Output file not found after {max_wait} seconds, attempting to open anyway...")
-
-        # Build the pdf_calc command with full path
-        pdf_calc_bin = os.path.join(working_dir, 'build/bin/pdf_calc')
-        pdf_cmd = (f'{pdf_calc_bin} {self.config["input_file"]} '
-                  f'{self.config["output_file"]} '
-                  f'{self.config["nbins"]}')
-
-        # Add optional output_inputdata parameter if set to YES
-        output_inputdata = str(self.config['output_inputdata']).upper()
-        if output_inputdata == 'YES':
-            pdf_cmd += f' {output_inputdata}'
-
-        # Change to working directory before executing
-        import os as os_module
-        original_cwd = os_module.getcwd()
-        os_module.chdir(working_dir)
-
-        # Execute pdf_calc with MPI
-        Exec(pdf_cmd,
-             MpiExecInfo(nprocs=self.config['nprocs'],
-                         ppn=self.config['ppn'],
-                         hostfile=self.hostfile,
-                         env=self.mod_env)).run()
-
-        # Restore original directory
-        os_module.chdir(original_cwd)
-
-    def stop(self):
-        """
-        Stop a running application.
-
-        :return: None
-        """
-        pass
-
-    def clean(self):
-        """
-        Destroy all data for the PDF Calc application.
-
-        :return: None
-        """
-        if self.config['output_file']:
-            print(f'Removing {self.config["output_file"]}')
-            Rm(self.config['output_file'], PsshExecInfo(hostfile=self.hostfile)).run()
+    def clean(self) -> None:
+        """Remove the configured PDF output dataset."""
+        output = self.config.get("output_file")
+        if output:
+            Rm(str(output), PsshExecInfo(hostfile=self.hostfile)).run()

--- a/builtin/builtin/biobb_wf_md_setup/README.md
+++ b/builtin/builtin/biobb_wf_md_setup/README.md
@@ -18,7 +18,7 @@ fails. A successful process exit is the authoritative completion signal.
 Native execution requires:
 
 - `python3` with `biobb-model` and `biobb-gromacs` importable; and
-- `gmx` available through `PATH`.
+- `gmx` or the MPI-build name `gmx_mpi` available through `PATH`.
 
 The deployment descriptor reports these as separate runtime requirements. It
 also provides provider-neutral hints for Python distributions and a `gromacs`

--- a/builtin/builtin/biobb_wf_md_setup/README.md
+++ b/builtin/builtin/biobb_wf_md_setup/README.md
@@ -1,66 +1,87 @@
-# biobb_wf_md_setup
+# BioBB molecular-dynamics setup
 
-BioExcel Building Blocks 5-stage MD setup pipeline (fix side chain →
-pdb2gmx → editconf → solvate → solvate top). The native workflow runs
-GROMACS through `biobb_*` Python wrappers; container mode is wired via
-`/opt/run_batch.sh` inside the SIF.
+`builtin.biobb_wf_md_setup` prepares one caller-supplied PDB structure with
+BioExcel Building Blocks and GROMACS. The native profile performs five real
+stages:
 
-## Native workflow parameters (`_configure_menu`)
+1. copy the immutable caller input into package-owned storage;
+2. repair missing side chains with `biobb_model`;
+3. construct coordinates and topology with `pdb2gmx`;
+4. center the solute and construct the selected periodic box with `editconf`;
+5. solvate the system and update its topology with `solvate`.
 
-These parameters live in pkg.py / the pipeline YAML and tune what the
-GROMACS pipeline actually does:
+The package fails if any BioBB block, product check, or semantic output parser
+fails. A successful process exit is the authoritative completion signal.
 
-| Parameter | Default | Effect on I/O | Effect on compute |
-|---|---|---|---|
-| `pdb_file` | `/opt/biobb-bench/1AKI.pdb` | bigger PDB → bigger .gro / topology writes (~linear in atom count) | bigger PDB → more GROMACS work (super-linear) |
-| `replicates` | `1` | loops the 5-stage pipeline N times under `rep_NNN/` — I/O scales **linearly** in N | compute scales linearly in N too |
-| `nprocs` / `ppn` | `1` / `1` | unused in container mode (GROMACS is launched single-threaded by the wrapper) | unused in container mode |
-| `out` | `/tmp/biobb_out` | controls where the final per-rep tree gets staged via `cp -r`; sub-directory on NFS dominates the write traffic in container mode | n/a |
+## Native runtime
 
-**Compute-dominated stages**: `fix_side_chain` (~50%), `editconf`
-(~10%), `solvate` (~30%). `pdb2gmx` is mostly I/O on small PDBs.
+Native execution requires:
 
-## I/O-only benchmark mode (bind-mount override)
+- `python3` with `biobb-model` and `biobb-gromacs` importable; and
+- `gmx` available through `PATH`.
 
-For benchmarking storage rather than GROMACS, bind-mount
-`biobb_io_only.sh` over `/opt/run_batch.sh` in the YAML:
+The deployment descriptor reports these as separate runtime requirements. It
+also provides provider-neutral hints for Python distributions and a `gromacs`
+Spack spec. No container is required for the native profile.
+
+The scientific configuration is:
+
+| Parameter | Meaning | Default |
+|---|---|---|
+| `pdb_file` | Required caller-owned regular PDB input | none |
+| `out` | Package-owned result directory | `run` |
+| `force_field` | GROMACS force field passed to `pdb2gmx` | `amber99sb-ildn` |
+| `water_type` | Water model passed to `pdb2gmx` | `tip3p` |
+| `box_type` | `cubic`, `triclinic`, `dodecahedron`, or `octahedron` | `cubic` |
+| `distance_to_molecule` | Solute-to-box clearance in nanometers | `1.0` |
+| `ignore_input_hydrogens` | Reconstruct input hydrogens | `true` |
+| `merge_chains` | Merge input chains into one molecule | `false` |
+
+Example package configuration:
 
 ```yaml
-container_binds:
-  - ${HOME}/jarvis-bench-scripts/biobb_io_only.sh:/opt/run_batch.sh
-  - ${HOME}/jarvis-runs:${HOME}/jarvis-runs
-env:
-  BIOBB_FIX_MB:  "32"    # fix_side_chain stage size
-  BIOBB_P2G_MB:  "128"   # pdb2gmx .gro size
-  BIOBB_EDIT_MB: "128"   # editconf .gro size
-  BIOBB_SOLV_MB: "700"   # solvate .gro size (the heavy one)
-  BIOBB_TOP_MB:  "16"    # both topology .zip files
+- pkg_type: builtin.biobb_wf_md_setup
+  pkg_name: lysozyme_dodecahedron
+  pdb_file: /shared/inputs/1aki.pdb
+  out: run
+  force_field: amber99sb-ildn
+  water_type: tip3p
+  box_type: dodecahedron
+  distance_to_molecule: 1.0
+  ignore_input_hydrogens: true
+  merge_chains: false
 ```
 
-The proxy script writes `/dev/urandom` blocks at the configured sizes
-into the same `rep_NNN-<hostname>/` layout the real workflow uses, so
-storage backends see the same file count + naming.
+JARVIS copies `pdb_file` to `out/input.pdb` before execution. Existing files,
+links, empty files, non-PDB inputs, and inputs larger than 32 MiB fail locally
+before a scientific process starts.
 
-### Per-replicate budget = FIX + P2G + EDIT + SOLV + 2 × TOP
+## Outputs
 
-Default = 32 + 128 + 128 + 700 + 16 + 16 = **1020 MiB/rep**.
+The native workflow produces these exact files beneath `out`:
 
-## Tuning matrix (I/O-only mode)
+| File | Meaning |
+|---|---|
+| `biobb-result.json` | Closed result, parameters, stage states, metrics, and product hashes |
+| `fixed.pdb` | Side-chain-repaired structure |
+| `processed.gro` | Coordinates produced by `pdb2gmx` |
+| `processed_topology.zip` | Initial GROMACS topology bundle |
+| `boxed.gro` | Centered solute in the selected periodic box |
+| `solvated.gro` | Solvated coordinates |
+| `solvated_topology.zip` | Solvated topology bundle |
 
-| Goal | Knob | Rule of thumb |
-|---|---|---|
-| **More I/O per rep** | bump `BIOBB_SOLV_MB` (largest single stage) | 2× → ~1.6× total/rep |
-| **More I/O total** | bump `replicates` | linear |
-| **Smaller files** | drop the per-stage MB knobs, bump `replicates` | shifts toward open/close overhead |
-| **Shorter wall** | drop `replicates` (each rep is one full dd-pass through the budget) | linear |
-| **Bypass compute** | use the bind-mount mode above | wall ≈ I/O bytes ÷ NFS bw |
+The result uses schema `jarvis.biobb-md-setup-result.v1`. It records the input
+hash, scientific parameters, per-stage outcome, coordinate atom counts, box
+volume, topology molecule counts, solvent count, and the size and SHA-256 hash
+of every declared product. The artifact adapter checks those paths, sizes, and
+hashes before finalizing them. A nonzero process or driver result leaves every
+available product explicitly incomplete.
 
-## Measured calibration (ares, 4-node SLURM, NFS-backed overlay)
+## Legacy container benchmarking
 
-I/O-only mode, `replicates: 20`, default per-stage MB:
-
-- **Wall**: 225 s (3.8 min)
-- **I/O written**: 20 GiB (20 × 1020 MiB) → ≥20 GB target ✓
-- **Effective write rate**: ~92 MB/s (single-host NFS stream)
-
-YAML lives at `builtin/pipelines/ares/biobb_wf_md_setup_apptainer_test.yaml`.
+The prior container and Apptainer batch modes remain available for existing
+storage experiments. Their replication, parallel scratch, OpenMP, MD extension,
+and base-image controls are deliberately hidden from generic agent catalogs:
+they describe a synthetic container benchmark, not the ordinary scientific
+cell above. Native qualification and agent-facing use do not build or require
+Docker images.

--- a/builtin/builtin/biobb_wf_md_setup/artifacts.py
+++ b/builtin/builtin/biobb_wf_md_setup/artifacts.py
@@ -1,0 +1,368 @@
+"""Generated-artifact semantics for the builtin BioBB MD-setup package."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import posixpath
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+)
+
+RESULT_SCHEMA = "jarvis.biobb-md-setup-result.v1"
+RESULT_NAME = "biobb-result.json"
+_MAX_RESULT_BYTES = 1024 * 1024
+_MAX_PRODUCT_BYTES = 512 * 1024 * 1024
+_PRODUCTS = {
+    "fixed.pdb": (
+        "biobb-fixed-structure",
+        "molecular_structure",
+        "pdb",
+        "chemical/x-pdb",
+    ),
+    "processed.gro": (
+        "biobb-processed-coordinates",
+        "molecular_structure",
+        "gromacs-gro",
+        "chemical/x-gro",
+    ),
+    "processed_topology.zip": (
+        "biobb-processed-topology",
+        "scientific_dataset",
+        "gromacs-topology-zip",
+        "application/zip",
+    ),
+    "boxed.gro": (
+        "biobb-boxed-coordinates",
+        "molecular_structure",
+        "gromacs-gro",
+        "chemical/x-gro",
+    ),
+    "solvated.gro": (
+        "biobb-solvated-coordinates",
+        "molecular_structure",
+        "gromacs-gro",
+        "chemical/x-gro",
+    ),
+    "solvated_topology.zip": (
+        "biobb-solvated-topology",
+        "scientific_dataset",
+        "gromacs-topology-zip",
+        "application/zip",
+    ),
+}
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA-256 digest of one bounded file."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(slots=True)
+class BiobbMdSetupArtifactAdapter:
+    """Report one closed BioBB result and its exact declared products."""
+
+    output_dir: PurePosixPath
+    _local_root: Path | None = None
+    _finalized: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for authoritative process completion before reporting files."""
+
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Finalize products for a successful legacy completion callback."""
+
+        return self._finalize(return_code=0)
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Finalize products using the authoritative driver exit status."""
+
+        return self._finalize(return_code=return_code)
+
+    def reset_artifacts(self) -> None:
+        """Permit discovery after an execution stream is replaced."""
+
+        self._finalized = False
+
+    def _local_output_path(self) -> Path:
+        """Project the declared cluster directory into this host filesystem."""
+
+        if self._local_root is not None:
+            return self._local_root
+        return Path(self.output_dir.as_posix())
+
+    def _result(self) -> tuple[Path, dict[str, Any]]:
+        """Load and validate the bounded package-owned result document."""
+
+        raw_root = self._local_output_path()
+        if raw_root.is_symlink():
+            raise RuntimeError("BioBB output root is not a real directory")
+        try:
+            root = raw_root.resolve(strict=True)
+        except OSError as exc:
+            raise RuntimeError("BioBB output root is unavailable") from exc
+        if root.is_symlink() or not root.is_dir():
+            raise RuntimeError("BioBB output root is not a real directory")
+        path = root / RESULT_NAME
+        if (
+            path.is_symlink()
+            or not path.is_file()
+            or path.stat().st_size <= 0
+            or path.stat().st_size > _MAX_RESULT_BYTES
+        ):
+            raise RuntimeError("BioBB result is missing, unsafe, or oversized")
+        try:
+            document = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError("BioBB result is not valid JSON") from exc
+        if (
+            not isinstance(document, dict)
+            or document.get("schema_version") != RESULT_SCHEMA
+            or document.get("status") not in {"completed", "failed"}
+        ):
+            raise RuntimeError("BioBB result has the wrong schema")
+        return path, document
+
+    def _members(
+        self, document: dict[str, Any]
+    ) -> list[tuple[Path, PurePosixPath, tuple[str, str, str, str]]]:
+        """Resolve and digest-check every exact result-declared product."""
+
+        values = document.get("artifacts")
+        if not isinstance(values, list) or len(values) > len(_PRODUCTS):
+            raise RuntimeError("BioBB result has an invalid artifact list")
+        root = self._local_output_path().resolve(strict=True)
+        members: list[tuple[Path, PurePosixPath, tuple[str, str, str, str]]] = []
+        seen: set[str] = set()
+        for item in values:
+            if not isinstance(item, dict):
+                raise RuntimeError("BioBB result has an invalid artifact member")
+            relative = item.get("path")
+            expected_format = item.get("format")
+            expected_size = item.get("size_bytes")
+            expected_hash = item.get("sha256")
+            if not isinstance(relative, str):
+                raise RuntimeError("BioBB result declared an unknown artifact")
+            candidate = Path(relative)
+            if candidate.is_absolute() or ".." in candidate.parts:
+                raise RuntimeError(
+                    f"BioBB artifact escaped its output root: {relative}"
+                )
+            if relative not in _PRODUCTS:
+                raise RuntimeError("BioBB result declared an unknown artifact")
+            if relative in seen:
+                raise RuntimeError("BioBB result declared a duplicate artifact")
+            seen.add(relative)
+            identity = _PRODUCTS[relative]
+            if expected_format != identity[2]:
+                raise RuntimeError("BioBB artifact format differs from its contract")
+            unresolved = root / candidate
+            if unresolved.is_symlink():
+                raise RuntimeError(f"BioBB artifact is missing or unsafe: {relative}")
+            path = unresolved.resolve(strict=False)
+            if not path.is_relative_to(root):
+                raise RuntimeError(
+                    f"BioBB artifact escaped its output root: {relative}"
+                )
+            if path.is_symlink() or not path.is_file():
+                raise RuntimeError(f"BioBB artifact is missing or unsafe: {relative}")
+            size = path.stat().st_size
+            if (
+                isinstance(expected_size, bool)
+                or not isinstance(expected_size, int)
+                or expected_size != size
+                or not 0 < size <= _MAX_PRODUCT_BYTES
+            ):
+                raise RuntimeError(f"BioBB artifact size differs: {relative}")
+            if (
+                not isinstance(expected_hash, str)
+                or len(expected_hash) != 64
+                or _sha256(path) != expected_hash
+            ):
+                raise RuntimeError(f"BioBB artifact hash differs: {relative}")
+            members.append((path, PurePosixPath(relative), identity))
+        if document.get("status") == "completed" and seen != set(_PRODUCTS):
+            raise RuntimeError("completed BioBB result omitted required products")
+        return members
+
+    @staticmethod
+    def _metadata(document: dict[str, Any]) -> dict[str, Any]:
+        """Project bounded scientific values into each artifact observation."""
+
+        parameters = document.get("parameters")
+        metrics = document.get("metrics")
+        if not isinstance(parameters, dict) or not isinstance(metrics, dict):
+            raise RuntimeError("BioBB result omitted parameters or metrics")
+        return {
+            "application": "biobb_wf_md_setup",
+            "box_type": parameters.get("box_type"),
+            "distance_to_molecule": parameters.get("distance_to_molecule"),
+            "force_field": parameters.get("force_field"),
+            "water_type": parameters.get("water_type"),
+            "boxed_volume_nm3": metrics.get("boxed_volume_nm3"),
+            "solvated_atom_count": metrics.get("solvated_atom_count"),
+            "solvent_molecule_count": metrics.get("solvent_molecule_count"),
+        }
+
+    def _observation(
+        self,
+        path: Path,
+        cluster_path: PurePosixPath,
+        *,
+        logical_name: str,
+        kind: str,
+        format_name: str,
+        media_type: str,
+        state: ArtifactState,
+        metadata: dict[str, Any],
+    ) -> ArtifactObservation:
+        """Create one exact file observation."""
+
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(cluster_path),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=path.stat().st_size,
+            checksum=f"sha256:{_sha256(path)}",
+            message="Closed BioBB molecular-dynamics setup product",
+            metadata=metadata,
+        )
+
+    def _finalize(self, *, return_code: int) -> list[ArtifactObservation]:
+        """Validate and report the exact result-declared files once."""
+
+        if self._finalized:
+            return []
+        self._finalized = True
+        result_path, document = self._result()
+        declared_return_code = document.get("return_code")
+        if isinstance(declared_return_code, bool) or not isinstance(
+            declared_return_code, int
+        ):
+            raise RuntimeError("BioBB result omitted its process return code")
+        members = self._members(document)
+        state = (
+            ArtifactState.FINALIZED
+            if return_code == 0
+            and declared_return_code == 0
+            and document["status"] == "completed"
+            else ArtifactState.INCOMPLETE
+        )
+        metadata = self._metadata(document)
+        observations = [
+            self._observation(
+                result_path,
+                self.output_dir / RESULT_NAME,
+                logical_name="biobb-md-setup-result",
+                kind="scientific_result",
+                format_name=RESULT_SCHEMA,
+                media_type="application/json",
+                state=state,
+                metadata=metadata,
+            )
+        ]
+        observations.extend(
+            self._observation(
+                path,
+                self.output_dir / relative,
+                logical_name=identity[0],
+                kind=identity[1],
+                format_name=identity[2],
+                media_type=identity[3],
+                state=state,
+                metadata=metadata,
+            )
+            for path, relative, identity in members
+        )
+        return observations
+
+
+def adapter_from_package(package: dict[str, Any]) -> BiobbMdSetupArtifactAdapter | None:
+    """Create artifact semantics only for builtin BioBB MD setup."""
+
+    if package.get("pkg_type") != "builtin.biobb_wf_md_setup":
+        return None
+    output_dir = _configured_output_dir(
+        package.get("out"),
+        shared_dir=package.get("shared_dir"),
+        runtime_cwd=package.get("runtime_cwd"),
+    )
+    deploy_mode = str(package.get("effective_deploy_mode") or "default").casefold()
+    if deploy_mode == "container":
+        roots = tuple(
+            root
+            for root in (
+                _optional_absolute_path(package.get("shared_dir")),
+                _optional_absolute_path(package.get("private_dir")),
+            )
+            if root is not None
+        )
+        if not any(output_dir.is_relative_to(root) for root in roots):
+            return None
+    return BiobbMdSetupArtifactAdapter(output_dir)
+
+
+def _configured_output_dir(
+    value: object,
+    *,
+    shared_dir: object,
+    runtime_cwd: object,
+) -> PurePosixPath:
+    """Resolve the normalized absolute output directory used by the package."""
+
+    raw = "run" if value in (None, "") else value
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("BioBB artifacts require a printable output path")
+    path = PurePosixPath(raw)
+    if not path.is_absolute():
+        base = _optional_absolute_path(shared_dir)
+        if base is None:
+            base = _optional_absolute_path(runtime_cwd)
+        if base is None:
+            raise ValueError(
+                "relative BioBB artifact output requires shared_dir or runtime_cwd"
+            )
+        path = base / path
+    normalized = PurePosixPath(posixpath.normpath(path.as_posix()))
+    if not normalized.is_absolute() or ".." in normalized.parts:
+        raise ValueError("BioBB artifacts require a normalized absolute output path")
+    return normalized
+
+
+def _optional_absolute_path(value: object) -> PurePosixPath | None:
+    """Return a normalized absolute POSIX path when one is available."""
+
+    if not isinstance(value, str) or not value:
+        return None
+    path = PurePosixPath(value)
+    if not path.is_absolute() or ".." in path.parts:
+        return None
+    return path
+
+
+__all__ = ["BiobbMdSetupArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/biobb_wf_md_setup/pkg.py
+++ b/builtin/builtin/biobb_wf_md_setup/pkg.py
@@ -1,180 +1,511 @@
-"""
-This module provides classes and methods to launch the biobb_wf_md_setup
-application.  BioExcel Building Blocks MD setup pipeline: fetch PDB,
-fix side chains, topology, box, solvation via GROMACS.
-"""
+"""Launch the BioBB five-stage molecular-dynamics setup workflow."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+from pathlib import Path
+from typing import Any
+
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, LocalExecInfo, PsshExecInfo
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    probe_program,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
+
+_MAX_PDB_BYTES = 32 * 1024 * 1024
+_NATIVE_INPUT_NAME = "input.pdb"
+_FORCE_FIELDS = frozenset(
+    {
+        "amber03",
+        "amber94",
+        "amber96",
+        "amber99",
+        "amber99sb",
+        "amber99sb-ildn",
+        "amberGS",
+        "charmm27",
+        "gromos43a1",
+        "gromos43a2",
+        "gromos45a3",
+        "gromos53a5",
+        "gromos53a6",
+        "gromos54a7",
+        "oplsaa",
+    }
+)
+_WATER_TYPES = frozenset({"spc", "spce", "tip3p", "tip4p", "tip5p", "tips3p"})
+_BOX_TYPES = frozenset({"cubic", "triclinic", "dodecahedron", "octahedron"})
 
 
 class BiobbWfMdSetup(Application):
-    """
-    BiobbWfMdSetup class supporting both default (bare-metal) and container
-    deployment.
+    """Prepare one caller-supplied molecular structure with BioBB and GROMACS.
 
-    Set deploy_mode='container' to build and run the biobb MD setup pipeline
-    inside a Docker/Podman/Apptainer container with GROMACS 2026.
-    Set deploy_mode='default' to use a system-installed environment.
+    Native mode copies an immutable PDB into package-owned storage and runs the
+    package-owned five-stage driver. Legacy container benchmarking remains
+    available but is not exposed as an agent-facing scientific profile.
     """
 
-    def _init(self):
-        pass
+    def _init(self) -> None:
+        self.python_bin: str | None = None
 
-    def _configure_menu(self):
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
             {
-                'name': 'nprocs',
-                'msg': 'Number of MPI processes',
-                'type': int,
-                'default': 1,
+                "name": "nprocs",
+                "msg": "Legacy process count; native MD setup is serial",
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
             },
             {
-                'name': 'ppn',
-                'msg': 'Processes per node',
-                'type': int,
-                'default': 1,
+                "name": "ppn",
+                "msg": "Legacy processes per node; native MD setup is serial",
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
             },
             {
-                'name': 'pdb_file',
-                'msg': 'Path to input PDB file',
-                'type': str,
-                'default': '/opt/biobb-bench/1AKI.pdb',
+                "name": "pdb_file",
+                "msg": (
+                    "Caller-supplied PDB structure. JARVIS copies it into the "
+                    "execution-owned output directory before launch."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                'name': 'out',
-                'msg': 'Output directory for results',
-                'type': str,
-                'default': '/tmp/biobb_out',
+                "name": "out",
+                "msg": (
+                    "Output directory. Relative paths resolve under the JARVIS "
+                    "package shared directory."
+                ),
+                "type": str,
+                "default": "run",
             },
             {
-                'name': 'replicates',
-                'msg': ('Number of times to run the MD-setup pipeline '
-                        'back-to-back inside the same container exec. '
-                        'Used to scale I/O for benchmarking when the '
-                        'bundled lysozyme PDB is too small to dominate '
-                        'wall time on its own.'),
-                'type': int,
-                'default': 1,
+                "name": "force_field",
+                "msg": "GROMACS force field used to construct the topology",
+                "type": str,
+                "default": "amber99sb-ildn",
             },
             {
-                'name': 'parallel_scratch_root',
-                'msg': ('Root dir for per-rep BIOBB_SCRATCH_DIR when '
-                        'parallel_reps > 1. Each rep gets '
-                        '`<root>/biobb-scratch-<rep>`. Default /dev/shm '
-                        '(node-local tmpfs). Point at a FUSE mount '
-                        'to route every GROMACS/biobb intermediate '
-                        'through that adapter.'),
-                'type': str,
-                'default': '/dev/shm',
+                "name": "water_type",
+                "msg": "GROMACS water model used by pdb2gmx and solvation",
+                "type": str,
+                "default": "tip3p",
             },
             {
-                'name': 'parallel_reps',
-                'msg': ('Per-host replicate concurrency. When > 1, the '
-                        'replicates loop fans across hosts via '
-                        'PsshExecInfo and each host runs this many in '
-                        'parallel using `wait -n` batching. Default 1 '
-                        'preserves the original host[0]-only sequential '
-                        'loop.'),
-                'type': int,
-                'default': 1,
+                "name": "box_type",
+                "msg": "Periodic simulation-box geometry",
+                "type": str,
+                "default": "cubic",
             },
             {
-                'name': 'omp_threads',
-                'msg': ('OMP_NUM_THREADS for each parallel replicate. '
-                        'Set to roughly cores_per_node / parallel_reps so '
-                        'concurrent GROMACS instances on the same host '
-                        'don\'t oversubscribe. 0 = leave unset (GROMACS '
-                        'auto-detects which over-grabs when run in '
-                        'parallel).'),
-                'type': int,
-                'default': 0,
+                "name": "distance_to_molecule",
+                "msg": "Minimum solute-to-box distance in nanometers",
+                "type": float,
+                "default": 1.0,
             },
             {
-                'name': 'md_steps',
-                'msg': ('Production MD step count for the biobb_md_extend '
-                        'post-step. Each step is 2 fs by default, so 5000 '
-                        'steps ≈ 10 ps simulated time. 0 = skip the MD '
-                        'extension entirely (legacy setup-only behavior).'),
-                'type': int,
-                'default': 0,
+                "name": "ignore_input_hydrogens",
+                "msg": "Regenerate hydrogens while constructing the topology",
+                "type": bool,
+                "default": True,
             },
             {
-                'name': 'md_nstxout',
-                'msg': ('XTC frame stride for the production MD '
-                        '(`nstxout-compressed` in the .mdp). Lower = more '
-                        'frames written = more I/O without changing '
-                        'compute. The per-rep trajectory file size is '
-                        'roughly md_steps / md_nstxout * frame_size.'),
-                'type': int,
-                'default': 100,
+                "name": "merge_chains",
+                "msg": "Merge all input chains into one molecule definition",
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'md_extend_script',
-                'msg': ('In-container path to the md-extend helper '
-                        'script. Bind the host script at this path via '
-                        '`container_binds` (e.g. '
-                        '${HOME}/jarvis-bench-scripts/biobb_md_extend.sh:'
-                        '/opt/biobb_md_extend.sh) and set md_steps > 0 '
-                        'to enable.'),
-                'type': str,
-                'default': '/opt/biobb_md_extend.sh',
+                "name": "replicates",
+                "msg": (
+                    "Number of times to run the MD-setup pipeline "
+                    "back-to-back inside the same container exec. "
+                    "Used to scale I/O for benchmarking when the "
+                    "bundled lysozyme PDB is too small to dominate "
+                    "wall time on its own."
+                ),
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
             },
             {
-                'name': 'base_image',
-                'msg': 'Base Docker image for build container',
-                'type': str,
-                'default': 'sci-hpc-base',
+                "name": "parallel_scratch_root",
+                "msg": (
+                    "Root dir for per-rep BIOBB_SCRATCH_DIR when "
+                    "parallel_reps > 1. Each rep gets "
+                    "`<root>/biobb-scratch-<rep>`. Default /dev/shm "
+                    "(node-local tmpfs). Point at a FUSE mount "
+                    "to route every GROMACS/biobb intermediate "
+                    "through that adapter."
+                ),
+                "type": str,
+                "default": "/dev/shm",
+                "agent_visible": False,
+            },
+            {
+                "name": "parallel_reps",
+                "msg": (
+                    "Per-host replicate concurrency. When > 1, the "
+                    "replicates loop fans across hosts via "
+                    "PsshExecInfo and each host runs this many in "
+                    "parallel using `wait -n` batching. Default 1 "
+                    "preserves the original host[0]-only sequential "
+                    "loop."
+                ),
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
+            },
+            {
+                "name": "omp_threads",
+                "msg": (
+                    "OMP_NUM_THREADS for each parallel replicate. "
+                    "Set to roughly cores_per_node / parallel_reps so "
+                    "concurrent GROMACS instances on the same host "
+                    "don't oversubscribe. 0 = leave unset (GROMACS "
+                    "auto-detects which over-grabs when run in "
+                    "parallel)."
+                ),
+                "type": int,
+                "default": 0,
+                "agent_visible": False,
+            },
+            {
+                "name": "md_steps",
+                "msg": (
+                    "Production MD step count for the biobb_md_extend "
+                    "post-step. Each step is 2 fs by default, so 5000 "
+                    "steps ≈ 10 ps simulated time. 0 = skip the MD "
+                    "extension entirely (legacy setup-only behavior)."
+                ),
+                "type": int,
+                "default": 0,
+                "agent_visible": False,
+            },
+            {
+                "name": "md_nstxout",
+                "msg": (
+                    "XTC frame stride for the production MD "
+                    "(`nstxout-compressed` in the .mdp). Lower = more "
+                    "frames written = more I/O without changing "
+                    "compute. The per-rep trajectory file size is "
+                    "roughly md_steps / md_nstxout * frame_size."
+                ),
+                "type": int,
+                "default": 100,
+                "agent_visible": False,
+            },
+            {
+                "name": "md_extend_script",
+                "msg": (
+                    "In-container path to the md-extend helper "
+                    "script. Bind the host script at this path via "
+                    "`container_binds` (e.g. "
+                    "${HOME}/jarvis-bench-scripts/biobb_md_extend.sh:"
+                    "/opt/biobb_md_extend.sh) and set md_steps > 0 "
+                    "to enable."
+                ),
+                "type": str,
+                "default": "/opt/biobb_md_extend.sh",
+                "agent_visible": False,
+            },
+            {
+                "name": "base_image",
+                "msg": "Base Docker image for build container",
+                "type": str,
+                "default": "sci-hpc-base",
+                "agent_visible": False,
             },
         ]
+
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe the native BioBB and GROMACS runtime requirements."""
+
+        environment = self._deployment_environment()
+        biobb_probe = probe_program(
+            "python3",
+            environment=environment,
+            arguments=("-c", "import biobb_gromacs, biobb_model"),
+            timeout_seconds=10,
+        )
+        gromacs_probe = probe_program(
+            "gmx",
+            environment=environment,
+            arguments=("--version",),
+            timeout_seconds=10,
+        )
+        requirements = (
+            RuntimeRequirement(
+                requirement_id="biobb_python",
+                description="Python runtime with BioBB model and GROMACS blocks",
+                required_capabilities=("biobb_md_setup",),
+                available_capabilities=(
+                    ("biobb_md_setup",) if biobb_probe.status.usable is True else ()
+                ),
+                status=biobb_probe.status,
+                provider_resolutions=(
+                    ProviderResolution("python", "distribution", "biobb-gromacs"),
+                    ProviderResolution("python", "distribution", "biobb-model"),
+                ),
+            ),
+            RuntimeRequirement(
+                requirement_id="gromacs",
+                description="GROMACS command-line runtime available through PATH",
+                required_capabilities=("molecular_dynamics_preparation",),
+                available_capabilities=(
+                    ("molecular_dynamics_preparation",)
+                    if gromacs_probe.status.usable is True
+                    else ()
+                ),
+                status=gromacs_probe.status,
+                provider_resolutions=(ProviderResolution("spack", "spec", "gromacs"),),
+            ),
+        )
+        return PackageDeploymentContract(
+            package="builtin.biobb_wf_md_setup",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="native_md_setup",
+                    execution_kind="batch",
+                    when=(
+                        ConfigurationCondition("deploy_mode", "equals", "default"),
+                        ConfigurationCondition("pdb_file", "is_not_empty"),
+                    ),
+                    runtime_requirements=("biobb_python", "gromacs"),
+                    readiness=ReadinessContract(
+                        mechanism="process_exit", condition="successful_exit"
+                    ),
+                    description=(
+                        "Prepare one caller-supplied PDB through side-chain repair, "
+                        "topology generation, box construction, and solvation."
+                    ),
+                ),
+            ),
+            runtime_requirements=requirements,
+        )
 
     # ------------------------------------------------------------------
     # Container Dockerfile generators
     # ------------------------------------------------------------------
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _build_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
             return None
-        content = self._read_build_script('build.sh', {
-            'BASE_IMAGE': self.config.get('base_image', 'sci-hpc-base'),
-        })
-        return content, 'gromacs2026'
+        content = self._read_build_script(
+            "build.sh",
+            {
+                "BASE_IMAGE": self.config.get("base_image", "sci-hpc-base"),
+            },
+        )
+        return content, "gromacs2026"
 
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
             return None
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': 'ubuntu:24.04',
-        })
-        return content, 'gromacs2026'
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {
+                "BUILD_IMAGE": self.build_image_name(),
+                "DEPLOY_BASE": "ubuntu:24.04",
+            },
+        )
+        return content, "gromacs2026"
 
     # ------------------------------------------------------------------
     # Configuration
     # ------------------------------------------------------------------
 
-    def _configure(self, **kwargs):
-        """
-        Configure biobb_wf_md_setup.
+    def _configure(self, **kwargs: Any) -> None:
+        """Validate native settings and prepare package-owned output storage."""
 
-        Calls super()._configure() which updates self.config and (when
-        deploy_mode == 'container') triggers build_phase / build_deploy_phase.
-
-        In default mode, also creates the output directory on all nodes.
-        """
         super()._configure(**kwargs)
+        if self.config.get("deploy_mode") == "default":
+            self._validate_native_configuration()
+            self.python_bin = self._discover_python(self._deployment_environment())
+            self._ensure_output_dir()
 
-        if self.config.get('deploy_mode') == 'default':
-            if self.config['out']:
-                Mkdir(self.config['out'],
-                      PsshExecInfo(hostfile=self.hostfile,
-                                   env=self.env)).run()
+    @staticmethod
+    def _discover_python(environment: dict[str, str]) -> str | None:
+        """Return a Python command from the activated package environment."""
+
+        for candidate in ("python3", "python"):
+            if shutil.which(candidate, path=environment.get("PATH")) is not None:
+                return candidate
+        return None
+
+    def _output_dir(self) -> Path:
+        """Return the normalized package-owned output root."""
+
+        return self.resolve_shared_path(
+            self.config.get("out"), field="out", default="run"
+        )
+
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        """Return local or parallel-SSH execution according to the hostfile."""
+
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
+
+    def _ensure_output_dir(self) -> None:
+        """Create the exact output root on every participating host."""
+
+        output_dir = str(self._output_dir())
+        result = Mkdir(output_dir, self._node_exec_info(env=self.env)).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to create BioBB output directory {output_dir}: {failures}"
+            )
+
+    def _validate_native_configuration(self) -> None:
+        """Reject missing input and unsupported scientific settings locally."""
+
+        pdb_file = self.config.get("pdb_file")
+        if not isinstance(pdb_file, str) or not pdb_file:
+            raise ValueError("native BioBB MD setup requires pdb_file")
+        for name, supported in (
+            ("force_field", _FORCE_FIELDS),
+            ("water_type", _WATER_TYPES),
+            ("box_type", _BOX_TYPES),
+        ):
+            value = self.config.get(name)
+            if not isinstance(value, str) or value not in supported:
+                raise ValueError(f"unsupported {name}: {value!r}")
+        distance = self.config.get("distance_to_molecule")
+        if (
+            isinstance(distance, bool)
+            or not isinstance(distance, (int, float))
+            or not 0 < float(distance) <= 10
+        ):
+            raise ValueError(
+                "distance_to_molecule must be greater than 0 and at most 10"
+            )
+        for name in ("ignore_input_hydrogens", "merge_chains"):
+            if not isinstance(self.config.get(name), bool):
+                raise ValueError(f"{name} must be a boolean")
+
+    def _stage_native_input(self) -> Path:
+        """Copy one bounded caller PDB into execution-owned storage."""
+
+        self._validate_native_configuration()
+        self._ensure_output_dir()
+        configured = self.config.get("pdb_file")
+        if not isinstance(configured, str):
+            raise ValueError("native BioBB MD setup requires pdb_file")
+        source = Path(
+            os.path.abspath(os.path.expandvars(os.path.expanduser(configured)))
+        )
+        try:
+            status = source.lstat()
+        except OSError as exc:
+            raise ValueError("pdb_file is not a readable bounded regular PDB") from exc
+        if (
+            source.is_symlink()
+            or not source.is_file()
+            or source.suffix.casefold() != ".pdb"
+            or status.st_size <= 0
+            or status.st_size > _MAX_PDB_BYTES
+        ):
+            raise ValueError("pdb_file is not a bounded regular PDB")
+        destination = self._output_dir() / _NATIVE_INPUT_NAME
+        if destination.exists() or destination.is_symlink():
+            raise ValueError("BioBB staged input already exists")
+        shutil.copyfile(source, destination, follow_symlinks=False)
+        os.chmod(destination, 0o600)
+        return destination
+
+    def _start_native(self) -> None:
+        """Execute the package-owned BioBB workflow and propagate failure."""
+
+        staged = self._stage_native_input()
+        python_bin = self.python_bin or self._discover_python(self.mod_env)
+        if python_bin is None:
+            raise RuntimeError("BioBB Python runtime is unavailable through PATH")
+        script = Path(__file__).with_name("run_md_setup.py").resolve()
+        force_field = self.config.get("force_field")
+        water_type = self.config.get("water_type")
+        box_type = self.config.get("box_type")
+        distance = self.config.get("distance_to_molecule")
+        if (
+            not isinstance(force_field, str)
+            or not isinstance(water_type, str)
+            or not isinstance(box_type, str)
+            or isinstance(distance, bool)
+            or not isinstance(distance, (int, float))
+        ):
+            raise RuntimeError("validated BioBB scientific configuration was lost")
+        args = [
+            python_bin,
+            str(script),
+            str(staged),
+            str(staged.parent),
+            "--force-field",
+            force_field,
+            "--water-type",
+            water_type,
+            "--box-type",
+            box_type,
+            "--distance-to-molecule",
+            str(float(distance)),
+            "--gmx",
+            "gmx",
+        ]
+        if self.config.get("ignore_input_hydrogens") is True:
+            args.append("--ignore-input-hydrogens")
+        if self.config.get("merge_chains") is True:
+            args.append("--merge-chains")
+        command = " ".join(shlex.quote(argument) for argument in args)
+        result = Exec(
+            command,
+            LocalExecInfo(
+                env=self.mod_env,
+                cwd=str(staged.parent),
+                line_callback=self.runtime_line_callback(),
+            ),
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"BioBB MD setup failed: {failures}")
+
+    def _legacy_integer(self, name: str, default: int) -> int:
+        """Read one legacy container integer without permissive coercion."""
+
+        value = self.config.get(name, default)
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"{name} must be an integer")
+        return value
+
+    def _legacy_string(self, name: str, default: str) -> str:
+        """Read one legacy container string without implicit serialization."""
+
+        value = self.config.get(name, default)
+        if not isinstance(value, str):
+            raise ValueError(f"{name} must be a string")
+        return value
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
-    def start(self):
+    def start(self) -> None:
         """
         Launch biobb_wf_md_setup.
 
@@ -190,12 +521,12 @@ class BiobbWfMdSetup(Application):
         pdb_file config point at either a single PDB or a directory of
         PDBs.
         """
-        if self.config.get('deploy_mode') == 'container':
-            replicates = max(int(self.config.get('replicates', 1) or 1), 1)
-            parallel = max(int(self.config.get('parallel_reps', 1) or 1), 1)
-            omp = int(self.config.get('omp_threads', 0) or 0)
-            pdb_in = self.config['pdb_file']
-            out_root = self.config['out']
+        if self.config.get("deploy_mode") == "container":
+            replicates = max(self._legacy_integer("replicates", 1), 1)
+            parallel = max(self._legacy_integer("parallel_reps", 1), 1)
+            omp = self._legacy_integer("omp_threads", 0)
+            pdb_in = self._legacy_string("pdb_file", "")
+            out_root = self._legacy_string("out", "run")
 
             if parallel <= 1:
                 # Original single-host sequential path. Preserved for
@@ -208,17 +539,20 @@ class BiobbWfMdSetup(Application):
                         f"set -e; "
                         f"for i in $(seq 1 {replicates}); do "
                         f"  rep=$(printf 'rep_%03d' \"$i\"); "
-                        f"  echo \"=== biobb replicate $rep ($i/{replicates}) ===\"; "
+                        f'  echo "=== biobb replicate $rep ($i/{replicates}) ==="; '
                         f"  /opt/run_batch.sh '{pdb_in}' '{out_root}/'$rep || exit 1; "
                         f"done"
                     )
-                Exec(cmd, LocalExecInfo(
-                    container=self._container_engine,
-                    container_image=self.deploy_image_name(),
-                    shared_dir=self.shared_dir,
-                    private_dir=self.private_dir,
-                    env=self.mod_env,
-                )).run()
+                Exec(
+                    cmd,
+                    LocalExecInfo(
+                        container=self._container_engine,
+                        container_image=self.deploy_image_name(),
+                        shared_dir=self.shared_dir,
+                        private_dir=self.private_dir,
+                        env=self.mod_env,
+                    ),
+                ).run()
                 return
 
             # parallel_reps > 1: fan replicates across every host in the
@@ -237,31 +571,27 @@ class BiobbWfMdSetup(Application):
             # fail with "File exists / Invalid argument".
             nhosts = max(len(self.hostfile.hosts), 1) if self.hostfile else 1
             local_reps = (replicates + nhosts - 1) // nhosts  # ceil
-            scratch_root = (self.config.get('parallel_scratch_root')
-                            or '/dev/shm').rstrip('/')
-            omp_export = (
-                f"export OMP_NUM_THREADS={omp}; " if omp > 0 else ""
-            )
+            scratch_root = self._legacy_string(
+                "parallel_scratch_root", "/dev/shm"
+            ).rstrip("/")
+            omp_export = f"export OMP_NUM_THREADS={omp}; " if omp > 0 else ""
             # MD extension: when md_steps > 0, chain the in-container
             # helper script after /opt/run_batch.sh in each rep. Adds
             # an EM + production-NVT pass on top of the setup-only biobb
             # pipeline so the workflow generates real trajectory data
             # decoupled from compute step count via nstxout-compressed.
-            md_steps = int(self.config.get('md_steps', 0) or 0)
-            md_nstxout = int(self.config.get('md_nstxout', 100) or 100)
-            md_extend_script = self.config.get('md_extend_script') or \
-                '/opt/biobb_md_extend.sh'
+            md_steps = self._legacy_integer("md_steps", 0)
+            md_nstxout = self._legacy_integer("md_nstxout", 100)
+            md_extend_script = self._legacy_string(
+                "md_extend_script", "/opt/biobb_md_extend.sh"
+            )
             md_export = ""
             md_chain = ""
             if md_steps > 0:
                 md_export = (
-                    f"export MD_STEPS={md_steps}; "
-                    f"export MD_NSTXOUT={md_nstxout}; "
+                    f"export MD_STEPS={md_steps}; export MD_NSTXOUT={md_nstxout}; "
                 )
-                md_chain = (
-                    f"      && {md_extend_script} "
-                    f"\"$BIOBB_SCRATCH_DIR\" \"$out\" "
-                )
+                md_chain = f'      && {md_extend_script} "$BIOBB_SCRATCH_DIR" "$out" '
             # Build command. Bash $$, $!, ${{}}, ${{#PIDS[@]}}, ${{PIDS[@]:1}}
             # all need doubled braces / escape so f-string passes them
             # through untouched.
@@ -275,48 +605,55 @@ class BiobbWfMdSetup(Application):
                 f"PDB='{pdb_in}'; "
                 f"OUT='{out_root}'; "
                 f"H=$(hostname -s); "
-                f"echo \"[biobb-parallel] host=$H reps=$LOCAL parallel=$PAR omp=${{OMP_NUM_THREADS:-default}} md_steps=${{MD_STEPS:-0}} md_nstxout=${{MD_NSTXOUT:-0}}\"; "
+                f'echo "[biobb-parallel] host=$H reps=$LOCAL parallel=$PAR omp=${{OMP_NUM_THREADS:-default}} md_steps=${{MD_STEPS:-0}} md_nstxout=${{MD_NSTXOUT:-0}}"; '
                 f"PIDS=(); "
                 f"for i in $(seq 1 $LOCAL); do "
                 f"  ( "
-                f"    rep=$(printf 'rep_%03d-%s' \"$i\" \"$H\"); "
-                f"    out=\"$OUT/$rep\"; "
-                f"    export BIOBB_SCRATCH_DIR=\"{scratch_root}/biobb-scratch-$rep\"; "
-                f"    /opt/run_batch.sh \"$PDB\" \"$out\" "
+                f'    rep=$(printf \'rep_%03d-%s\' "$i" "$H"); '
+                f'    out="$OUT/$rep"; '
+                f'    export BIOBB_SCRATCH_DIR="{scratch_root}/biobb-scratch-$rep"; '
+                f'    /opt/run_batch.sh "$PDB" "$out" '
                 f"{md_chain}"
-                f"      && echo \"[biobb-parallel] host=$H $rep DONE\" "
-                f"      || {{ echo \"[biobb-parallel] host=$H $rep FAILED\" >&2; exit 1; }} "
+                f'      && echo "[biobb-parallel] host=$H $rep DONE" '
+                f'      || {{ echo "[biobb-parallel] host=$H $rep FAILED" >&2; exit 1; }} '
                 f"  ) & "
                 f"  PIDS+=($!); "
-                f"  if [ \"${{#PIDS[@]}}\" -ge $PAR ]; then "
+                f'  if [ "${{#PIDS[@]}}" -ge $PAR ]; then '
                 f"    wait -n; "
-                f"    PIDS=(\"${{PIDS[@]:1}}\"); "
+                f'    PIDS=("${{PIDS[@]:1}}"); '
                 f"  fi; "
                 f"done; "
                 f"wait"
             )
-            Exec(cmd, PsshExecInfo(
-                hostfile=self.hostfile,
-                container=self._container_engine,
-                container_image=self.deploy_image_name(),
-                shared_dir=self.shared_dir,
-                private_dir=self.private_dir,
-                env=self.mod_env,
-            )).run()
+            Exec(
+                cmd,
+                PsshExecInfo(
+                    hostfile=self.hostfile,
+                    container=self._container_engine,
+                    container_image=self.deploy_image_name(),
+                    shared_dir=self.shared_dir,
+                    private_dir=self.private_dir,
+                    env=self.mod_env,
+                ),
+            ).run()
         else:
-            cmd = ' '.join([
-                'python3', '/opt/run_md_setup.py',
-                self.config['pdb_file'],
-                self.config['out'],
-            ])
-            Exec(cmd, LocalExecInfo(env=self.mod_env)).run()
+            self._start_native()
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop biobb_wf_md_setup (no-op -- runs to completion)."""
         pass
 
-    def clean(self):
-        """Remove biobb_wf_md_setup output directory."""
-        if self.config['out']:
-            Rm(self.config['out'] + '*',
-               PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+    def clean(self) -> None:
+        """Remove only the exact configured BioBB output directory."""
+
+        output_dir = self._output_dir()
+        if output_dir == Path(output_dir.anchor):
+            raise ValueError("refusing to clean a filesystem root as BioBB output")
+        result = Rm(
+            str(output_dir),
+            self._node_exec_info(env=self.env),
+            recursive=True,
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"Failed to clean BioBB output {output_dir}: {failures}")

--- a/builtin/builtin/biobb_wf_md_setup/pkg.py
+++ b/builtin/builtin/biobb_wf_md_setup/pkg.py
@@ -24,6 +24,7 @@ from jarvis_cd.shell.process import Mkdir, Rm
 
 _MAX_PDB_BYTES = 32 * 1024 * 1024
 _NATIVE_INPUT_NAME = "input.pdb"
+_GROMACS_EXECUTABLES = ("gmx", "gmx_mpi")
 _FORCE_FIELDS = frozenset(
     {
         "amber03",
@@ -57,6 +58,7 @@ class BiobbWfMdSetup(Application):
 
     def _init(self) -> None:
         self.python_bin: str | None = None
+        self.gmx_bin: str | None = None
 
     def _configure_menu(self) -> list[dict[str, Any]]:
         return [
@@ -238,14 +240,16 @@ class BiobbWfMdSetup(Application):
         """Describe the native BioBB and GROMACS runtime requirements."""
 
         environment = self._deployment_environment()
+        python_program = self._discover_python(environment) or "python3"
+        gromacs_program = self._discover_gromacs(environment) or "gmx"
         biobb_probe = probe_program(
-            "python3",
+            python_program,
             environment=environment,
             arguments=("-c", "import biobb_gromacs, biobb_model"),
             timeout_seconds=10,
         )
         gromacs_probe = probe_program(
-            "gmx",
+            gromacs_program,
             environment=environment,
             arguments=("--version",),
             timeout_seconds=10,
@@ -338,6 +342,7 @@ class BiobbWfMdSetup(Application):
         if self.config.get("deploy_mode") == "default":
             self._validate_native_configuration()
             self.python_bin = self._discover_python(self._deployment_environment())
+            self.gmx_bin = self._discover_gromacs(self._deployment_environment())
             self._ensure_output_dir()
 
     @staticmethod
@@ -345,6 +350,15 @@ class BiobbWfMdSetup(Application):
         """Return a Python command from the activated package environment."""
 
         for candidate in ("python3", "python"):
+            if shutil.which(candidate, path=environment.get("PATH")) is not None:
+                return candidate
+        return None
+
+    @staticmethod
+    def _discover_gromacs(environment: dict[str, str]) -> str | None:
+        """Return the first supported GROMACS executable available through PATH."""
+
+        for candidate in _GROMACS_EXECUTABLES:
             if shutil.which(candidate, path=environment.get("PATH")) is not None:
                 return candidate
         return None
@@ -439,6 +453,9 @@ class BiobbWfMdSetup(Application):
         python_bin = self.python_bin or self._discover_python(self.mod_env)
         if python_bin is None:
             raise RuntimeError("BioBB Python runtime is unavailable through PATH")
+        gmx_bin = self.gmx_bin or self._discover_gromacs(self.mod_env)
+        if gmx_bin is None:
+            raise RuntimeError("GROMACS runtime is unavailable through PATH")
         script = Path(__file__).with_name("run_md_setup.py").resolve()
         force_field = self.config.get("force_field")
         water_type = self.config.get("water_type")
@@ -466,7 +483,7 @@ class BiobbWfMdSetup(Application):
             "--distance-to-molecule",
             str(float(distance)),
             "--gmx",
-            "gmx",
+            gmx_bin,
         ]
         if self.config.get("ignore_input_hydrogens") is True:
             args.append("--ignore-input-hydrogens")

--- a/builtin/builtin/biobb_wf_md_setup/run_batch.sh
+++ b/builtin/builtin/biobb_wf_md_setup/run_batch.sh
@@ -74,7 +74,7 @@ else
     PASS=0; FAIL=0
     for p in "${PDBS[@]}"; do
         tag=$(basename "$p" .pdb)
-        if ls "$OUT_DIR/$tag/"*_solvate.gro >/dev/null 2>&1; then
+        if [ -s "$OUT_DIR/$tag/solvated.gro" ]; then
             PASS=$((PASS+1))
         else
             FAIL=$((FAIL+1))

--- a/builtin/builtin/biobb_wf_md_setup/run_md_setup.py
+++ b/builtin/builtin/biobb_wf_md_setup/run_md_setup.py
@@ -1,63 +1,415 @@
-#!/opt/biobb-env/bin/python
-"""Five-step MD setup for a single PDB. Exit 0 on full success."""
-import os, sys, shutil, time
-pdb_in = sys.argv[1]
-workdir = sys.argv[2]
-os.makedirs(workdir, exist_ok=True)
-os.chdir(workdir)
-code = os.path.splitext(os.path.basename(pdb_in))[0]
-t0 = time.time()
-results = {}
+#!/usr/bin/env python3
+"""Run and record one five-stage BioBB molecular-dynamics setup cell."""
 
-local = os.path.join(workdir, code + '.pdb')
-if not os.path.exists(local):
-    shutil.copy(pdb_in, local)
-results['1_stage'] = 'PASS'
+from __future__ import annotations
 
-from biobb_model.model.fix_side_chain import fix_side_chain
-from biobb_gromacs.gromacs.pdb2gmx   import pdb2gmx
-from biobb_gromacs.gromacs.editconf  import editconf
-from biobb_gromacs.gromacs.solvate   import solvate
+import argparse
+import hashlib
+import json
+import math
+import os
+import shutil
+import time
+import zipfile
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
 
-def ok(path):
-    return os.path.isfile(path) and os.path.getsize(path) > 0
+RESULT_SCHEMA = "jarvis.biobb-md-setup-result.v1"
+RESULT_NAME = "biobb-result.json"
 
-fixed = os.path.join(workdir, code + '_fixed.pdb')
-try:
-    fix_side_chain(input_pdb_path=local, output_pdb_path=fixed)
-    results['2_fix_side_chain'] = 'PASS' if ok(fixed) else 'FAIL'
-except Exception as e:
-    results['2_fix_side_chain'] = f'FAIL: {e}'
 
-gro  = os.path.join(workdir, code + '_pdb2gmx.gro')
-topz = os.path.join(workdir, code + '_pdb2gmx_top.zip')
-if results['2_fix_side_chain'] == 'PASS':
+@dataclass(frozen=True, slots=True)
+class RunConfiguration:
+    """Closed scientific configuration for one BioBB MD-setup execution."""
+
+    input_pdb: Path
+    output_dir: Path
+    force_field: str
+    water_type: str
+    box_type: str
+    distance_to_molecule: float
+    ignore_input_hydrogens: bool
+    merge_chains: bool
+    gmx: str
+
+
+@dataclass(frozen=True, slots=True)
+class BioBBFunctions:
+    """Loaded BioBB entrypoints used by the package-owned driver."""
+
+    fix_side_chain: Callable[..., Any]
+    pdb2gmx: Callable[..., Any]
+    editconf: Callable[..., Any]
+    solvate: Callable[..., Any]
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA-256 digest of one bounded file."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _require_file(path: Path, description: str) -> None:
+    """Require one nonempty regular, non-symlink stage product."""
+
+    if path.is_symlink() or not path.is_file() or path.stat().st_size <= 0:
+        raise RuntimeError(f"BioBB did not produce {description}: {path.name}")
+
+
+def _pdb_atom_count(path: Path) -> int:
+    """Count coordinate records in a PDB file."""
+
+    with path.open("r", encoding="utf-8", errors="replace") as stream:
+        return sum(line.startswith(("ATOM  ", "HETATM")) for line in stream)
+
+
+def _gro_metrics(path: Path) -> dict[str, Any]:
+    """Read the atom count and periodic-box volume from a GROMACS GRO file."""
+
+    lines = path.read_text(encoding="utf-8", errors="strict").splitlines()
+    if len(lines) < 3:
+        raise RuntimeError(f"GRO output is truncated: {path.name}")
     try:
-        pdb2gmx(input_pdb_path=fixed, output_gro_path=gro, output_top_zip_path=topz)
-        results['3_pdb2gmx'] = 'PASS' if ok(gro) else 'FAIL'
-    except Exception as e:
-        results['3_pdb2gmx'] = f'FAIL: {e}'
+        atom_count = int(lines[1].strip())
+        values = [float(value) for value in lines[-1].split()]
+    except ValueError as exc:
+        raise RuntimeError(f"GRO output is malformed: {path.name}") from exc
+    if atom_count <= 0 or len(lines) < atom_count + 3 or len(values) not in {3, 9}:
+        raise RuntimeError(f"GRO output is malformed: {path.name}")
+    if len(values) == 3:
+        volume = values[0] * values[1] * values[2]
+    else:
+        first = (values[0], values[3], values[4])
+        second = (values[5], values[1], values[6])
+        third = (values[7], values[8], values[2])
+        volume = abs(
+            first[0] * (second[1] * third[2] - second[2] * third[1])
+            - first[1] * (second[0] * third[2] - second[2] * third[0])
+            + first[2] * (second[0] * third[1] - second[1] * third[0])
+        )
+    if not math.isfinite(volume) or volume <= 0:
+        raise RuntimeError(f"GRO output has an invalid box: {path.name}")
+    return {
+        "atom_count": atom_count,
+        "box_values_nm": values,
+        "box_volume_nm3": volume,
+    }
 
-    if results.get('3_pdb2gmx') == 'PASS':
-        box = os.path.join(workdir, code + '_editconf.gro')
+
+def _topology_molecule_counts(path: Path) -> dict[str, int]:
+    """Read the closed ``[ molecules ]`` table from a topology ZIP archive."""
+
+    counts: dict[str, int] = {}
+    try:
+        with zipfile.ZipFile(path) as archive:
+            candidates = sorted(
+                name
+                for name in archive.namelist()
+                if not name.endswith("/") and name.casefold().endswith(".top")
+            )
+            if not candidates:
+                raise RuntimeError("topology archive has no .top member")
+            text = archive.read(candidates[0]).decode("utf-8", errors="strict")
+    except (OSError, UnicodeError, zipfile.BadZipFile, KeyError) as exc:
+        raise RuntimeError(f"cannot read topology archive: {path.name}") from exc
+    in_molecules = False
+    for raw_line in text.splitlines():
+        line = raw_line.split(";", maxsplit=1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_molecules = line[1:-1].strip().casefold() == "molecules"
+            continue
+        if not in_molecules:
+            continue
+        fields = line.split()
+        if len(fields) < 2:
+            continue
         try:
-            editconf(input_gro_path=gro, output_gro_path=box,
-                     properties={'box_type': 'cubic', 'distance_to_molecule': 1.0})
-            results['4_editconf'] = 'PASS' if ok(box) else 'FAIL'
-        except Exception as e:
-            results['4_editconf'] = f'FAIL: {e}'
+            count = int(fields[-1])
+        except ValueError as exc:
+            raise RuntimeError("topology molecules table is malformed") from exc
+        if count < 0:
+            raise RuntimeError("topology molecule count cannot be negative")
+        name = fields[0]
+        counts[name] = counts.get(name, 0) + count
+    if not counts:
+        raise RuntimeError("topology archive has no molecule counts")
+    return counts
 
-        if results.get('4_editconf') == 'PASS':
-            sol    = os.path.join(workdir, code + '_solvate.gro')
-            soltop = os.path.join(workdir, code + '_solvate_top.zip')
-            try:
-                solvate(input_solute_gro_path=box, output_gro_path=sol,
-                        input_top_zip_path=topz, output_top_zip_path=soltop)
-                results['5_solvate'] = 'PASS' if ok(sol) else 'FAIL'
-            except Exception as e:
-                results['5_solvate'] = f'FAIL: {e}'
 
-print(f"\n=== {code} results ({time.time()-t0:.1f}s) ===")
-for k, v in results.items():
-    print(f"  {k}: {v}")
-sys.exit(0 if all(v == 'PASS' for v in results.values()) else 1)
+def _load_functions() -> BioBBFunctions:
+    """Import BioBB lazily so package inspection needs no scientific runtime."""
+
+    from biobb_gromacs.gromacs.editconf import (  # pyright: ignore[reportMissingImports]
+        editconf,
+    )
+    from biobb_gromacs.gromacs.pdb2gmx import (  # pyright: ignore[reportMissingImports]
+        pdb2gmx,
+    )
+    from biobb_gromacs.gromacs.solvate import (  # pyright: ignore[reportMissingImports]
+        solvate,
+    )
+    from biobb_model.model.fix_side_chain import (  # pyright: ignore[reportMissingImports]
+        fix_side_chain,
+    )
+
+    return BioBBFunctions(fix_side_chain, pdb2gmx, editconf, solvate)
+
+
+def _invoke(name: str, function: Callable[..., Any], **kwargs: Any) -> dict[str, Any]:
+    """Execute one BioBB block and return a closed successful stage record."""
+
+    started = time.monotonic()
+    return_code = function(**kwargs)
+    if isinstance(return_code, int) and not isinstance(return_code, bool):
+        if return_code != 0:
+            raise RuntimeError(f"BioBB stage {name} returned {return_code}")
+    return {
+        "name": name,
+        "status": "completed",
+        "elapsed_seconds": round(time.monotonic() - started, 6),
+    }
+
+
+def _artifact(root: Path, path: Path, *, format_name: str) -> dict[str, Any]:
+    """Describe one exact output relative to the owned result root."""
+
+    resolved_root = root.resolve(strict=True)
+    resolved = path.resolve(strict=True)
+    if path.is_symlink() or not resolved.is_relative_to(resolved_root):
+        raise RuntimeError(f"BioBB output escaped its owned root: {path}")
+    size = resolved.stat().st_size
+    if not resolved.is_file() or size <= 0:
+        raise RuntimeError(f"BioBB output is missing: {path.name}")
+    return {
+        "path": resolved.relative_to(resolved_root).as_posix(),
+        "format": format_name,
+        "size_bytes": size,
+        "sha256": _sha256(resolved),
+    }
+
+
+def run(
+    config: RunConfiguration,
+    *,
+    functions: BioBBFunctions | None = None,
+) -> int:
+    """Execute the BioBB workflow and write a machine-readable result document."""
+
+    root = config.output_dir.resolve(strict=True)
+    input_path = config.input_pdb.resolve(strict=True)
+    if (
+        config.input_pdb.is_symlink()
+        or not input_path.is_file()
+        or not input_path.is_relative_to(root)
+    ):
+        raise ValueError("input PDB must be a regular file in the output directory")
+    loaded = functions or _load_functions()
+    fixed = root / "fixed.pdb"
+    processed = root / "processed.gro"
+    processed_topology = root / "processed_topology.zip"
+    boxed = root / "boxed.gro"
+    solvated = root / "solvated.gro"
+    solvated_topology = root / "solvated_topology.zip"
+    stages: list[dict[str, Any]] = [
+        {"name": "stage_input", "status": "completed", "elapsed_seconds": 0.0}
+    ]
+    output_specs: list[tuple[Path, str]] = []
+    status = "completed"
+    error: dict[str, str] | None = None
+    started = time.monotonic()
+    try:
+        stages.append(
+            _invoke(
+                "fix_side_chain",
+                loaded.fix_side_chain,
+                input_pdb_path=str(input_path),
+                output_pdb_path=str(fixed),
+            )
+        )
+        _require_file(fixed, "side-chain-repaired PDB")
+        output_specs.append((fixed, "pdb"))
+        stages.append(
+            _invoke(
+                "pdb2gmx",
+                loaded.pdb2gmx,
+                input_pdb_path=str(fixed),
+                output_gro_path=str(processed),
+                output_top_zip_path=str(processed_topology),
+                properties={
+                    "force_field": config.force_field,
+                    "water_type": config.water_type,
+                    "ignh": config.ignore_input_hydrogens,
+                    "merge": config.merge_chains,
+                    "gmx_path": config.gmx,
+                },
+            )
+        )
+        _require_file(processed, "pdb2gmx coordinates")
+        _require_file(processed_topology, "pdb2gmx topology")
+        output_specs.extend(
+            ((processed, "gromacs-gro"), (processed_topology, "gromacs-topology-zip"))
+        )
+        stages.append(
+            _invoke(
+                "editconf",
+                loaded.editconf,
+                input_gro_path=str(processed),
+                output_gro_path=str(boxed),
+                properties={
+                    "box_type": config.box_type,
+                    "distance_to_molecule": config.distance_to_molecule,
+                    "center_molecule": True,
+                    "gmx_path": config.gmx,
+                },
+            )
+        )
+        _require_file(boxed, "boxed coordinates")
+        output_specs.append((boxed, "gromacs-gro"))
+        stages.append(
+            _invoke(
+                "solvate",
+                loaded.solvate,
+                input_solute_gro_path=str(boxed),
+                output_gro_path=str(solvated),
+                input_top_zip_path=str(processed_topology),
+                output_top_zip_path=str(solvated_topology),
+                properties={"gmx_path": config.gmx},
+            )
+        )
+        _require_file(solvated, "solvated coordinates")
+        _require_file(solvated_topology, "solvated topology")
+        output_specs.extend(
+            ((solvated, "gromacs-gro"), (solvated_topology, "gromacs-topology-zip"))
+        )
+    except Exception as exc:
+        status = "failed"
+        error = {"type": type(exc).__name__, "message": str(exc)[:2048]}
+        stages.append(
+            {
+                "name": "workflow",
+                "status": "failed",
+                "elapsed_seconds": round(time.monotonic() - started, 6),
+                "error": error,
+            }
+        )
+
+    metrics: dict[str, Any] = {"input_pdb_atom_count": _pdb_atom_count(input_path)}
+    if status == "completed":
+        try:
+            boxed_metrics = _gro_metrics(boxed)
+            solvated_metrics = _gro_metrics(solvated)
+            molecule_counts = _topology_molecule_counts(solvated_topology)
+            metrics.update(
+                {
+                    "boxed_atom_count": boxed_metrics["atom_count"],
+                    "boxed_volume_nm3": boxed_metrics["box_volume_nm3"],
+                    "solvated_atom_count": solvated_metrics["atom_count"],
+                    "solvated_volume_nm3": solvated_metrics["box_volume_nm3"],
+                    "molecule_counts": molecule_counts,
+                    "solvent_molecule_count": molecule_counts.get(
+                        "SOL", molecule_counts.get("WAT")
+                    ),
+                }
+            )
+        except Exception as exc:
+            status = "failed"
+            error = {"type": type(exc).__name__, "message": str(exc)[:2048]}
+            stages.append(
+                {
+                    "name": "validate_outputs",
+                    "status": "failed",
+                    "elapsed_seconds": round(time.monotonic() - started, 6),
+                    "error": error,
+                }
+            )
+    artifacts = [
+        _artifact(root, path, format_name=format_name)
+        for path, format_name in output_specs
+        if path.exists() and not path.is_symlink() and path.is_file()
+    ]
+    result: dict[str, Any] = {
+        "schema_version": RESULT_SCHEMA,
+        "status": status,
+        "return_code": 0 if status == "completed" else 1,
+        "elapsed_seconds": round(time.monotonic() - started, 6),
+        "parameters": {
+            "force_field": config.force_field,
+            "water_type": config.water_type,
+            "box_type": config.box_type,
+            "distance_to_molecule": config.distance_to_molecule,
+            "ignore_input_hydrogens": config.ignore_input_hydrogens,
+            "merge_chains": config.merge_chains,
+        },
+        "input": {
+            "path": input_path.relative_to(root).as_posix(),
+            "size_bytes": input_path.stat().st_size,
+            "sha256": _sha256(input_path),
+        },
+        "stages": stages,
+        "metrics": metrics,
+        "artifacts": artifacts,
+    }
+    if error is not None:
+        result["error"] = error
+    (root / RESULT_NAME).write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return int(result["return_code"])
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> RunConfiguration:
+    """Parse one closed command-line execution request."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_pdb", type=Path)
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--force-field", default="amber99sb-ildn")
+    parser.add_argument("--water-type", default="tip3p")
+    parser.add_argument("--box-type", default="cubic")
+    parser.add_argument("--distance-to-molecule", default=1.0, type=float)
+    parser.add_argument("--ignore-input-hydrogens", action="store_true")
+    parser.add_argument("--merge-chains", action="store_true")
+    parser.add_argument("--gmx", default="gmx")
+    args = parser.parse_args(argv)
+    return RunConfiguration(
+        input_pdb=args.input_pdb,
+        output_dir=args.output_dir,
+        force_field=args.force_field,
+        water_type=args.water_type,
+        box_type=args.box_type,
+        distance_to_molecule=args.distance_to_molecule,
+        ignore_input_hydrogens=args.ignore_input_hydrogens,
+        merge_chains=args.merge_chains,
+        gmx=args.gmx,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run one command-line BioBB MD-setup cell."""
+
+    config = _parse_args(argv)
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    root = config.output_dir.resolve(strict=True)
+    source = config.input_pdb.resolve(strict=True)
+    if not source.is_relative_to(root):
+        if config.input_pdb.is_symlink() or not source.is_file():
+            raise ValueError("input PDB must be a regular file")
+        staged = root / "input.pdb"
+        if staged.exists() or staged.is_symlink():
+            raise ValueError("staged input already exists")
+        shutil.copyfile(source, staged, follow_symlinks=False)
+        os.chmod(staged, 0o600)
+        config = replace(config, input_pdb=staged, output_dir=root)
+    return run(config)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builtin/builtin/biobb_wf_md_setup/run_md_setup.py
+++ b/builtin/builtin/biobb_wf_md_setup/run_md_setup.py
@@ -248,7 +248,7 @@ def run(
                     "water_type": config.water_type,
                     "ignh": config.ignore_input_hydrogens,
                     "merge": config.merge_chains,
-                    "gmx_path": config.gmx,
+                    "binary_path": config.gmx,
                 },
             )
         )
@@ -267,7 +267,7 @@ def run(
                     "box_type": config.box_type,
                     "distance_to_molecule": config.distance_to_molecule,
                     "center_molecule": True,
-                    "gmx_path": config.gmx,
+                    "binary_path": config.gmx,
                 },
             )
         )
@@ -281,7 +281,7 @@ def run(
                 output_gro_path=str(solvated),
                 input_top_zip_path=str(processed_topology),
                 output_top_zip_path=str(solvated_topology),
-                properties={"gmx_path": config.gmx},
+                properties={"binary_path": config.gmx},
             )
         )
         _require_file(solvated, "solvated coordinates")

--- a/builtin/builtin/darshan/pkg.py
+++ b/builtin/builtin/darshan/pkg.py
@@ -2,23 +2,27 @@
 This module provides classes and methods to inject the Darshan interceptor.
 Darshan is ....
 """
+
+import os
+from typing import Any, cast
+
 from jarvis_cd.core.pkg import Interceptor
 from jarvis_cd.shell import PsshExecInfo
 from jarvis_cd.shell.process import Mkdir
-import os
 
 
 class Darshan(Interceptor):
     """
     This class provides methods to inject the Darshan interceptor.
     """
-    def _init(self):
+
+    def _init(self) -> None:
         """
         Initialize paths
         """
         pass
 
-    def _configure_menu(self):
+    def _configure_menu(self) -> list[dict[str, Any]]:
         """
         Create a CLI menu for the configurator method.
         For thorough documentation of these parameters, view:
@@ -28,26 +32,26 @@ class Darshan(Interceptor):
         """
         return [
             {
-                'name': 'log_dir',
-                'msg': 'Where darshan should place data',
-                'type': str,
-                'default': f'{os.getenv("HOME")}/darshan_logs',
+                "name": "log_dir",
+                "msg": "Where darshan should place data",
+                "type": str,
+                "default": f"{os.getenv('HOME')}/darshan_logs",
             },
             {
-                'name': 'job_id',
-                'msg': 'A semantic ID for the job to identify log files',
-                'type': str,
-                'default': 'myjob',
+                "name": "job_id",
+                "msg": "A semantic ID for the job to identify log files",
+                "type": str,
+                "default": "myjob",
             },
             {
-                'name': 'darshan_lib_container',
-                'msg': 'Path to libdarshan.so inside the container (container mode only)',
-                'type': str,
-                'default': '/opt/darshan/lib/libdarshan.so',
+                "name": "darshan_lib_container",
+                "msg": "Path to libdarshan.so inside the container (container mode only)",
+                "type": str,
+                "default": "/opt/darshan/lib/libdarshan.so",
             },
         ]
 
-    def _configure(self, **kwargs):
+    def _configure(self, **kwargs: Any) -> None:
         """
         Converts the Jarvis configuration to application-specific configuration.
         E.g., OrangeFS produces an orangefs.xml file.
@@ -55,22 +59,44 @@ class Darshan(Interceptor):
         :param kwargs: Configuration parameters for this pkg.
         :return: None
         """
-        self.env['DARSHAN_LOG_DIR'] = self.config['log_dir']
-        self.env['PBS_JOBID'] = self.config['job_id']
-        if self.config['deploy_mode'] == 'container':
-            self.config['DARSHAN_LIB'] = self.config['darshan_lib_container']
+        config = cast(dict[str, Any], self.config)
+        log_dir = config.get("log_dir")
+        job_id = config.get("job_id")
+        deploy_mode = config.get("deploy_mode")
+        if not isinstance(log_dir, str) or not log_dir:
+            raise ValueError("Darshan log_dir must be a non-empty string")
+        if not isinstance(job_id, str) or not job_id:
+            raise ValueError("Darshan job_id must be a non-empty string")
+        if deploy_mode == "container":
+            library = config.get("darshan_lib_container")
+            if not isinstance(library, str) or not library:
+                raise ValueError(
+                    "Darshan container library path must be a non-empty string"
+                )
         else:
-            self.config['DARSHAN_LIB'] = self.find_library('darshan')
-            if self.config['DARSHAN_LIB'] is None:
-                raise Exception('Could not find darshan')
-            print(f'Found libdarshan.so at {self.config["DARSHAN_LIB"]}')
-        Mkdir(self.env['DARSHAN_LOG_DIR'],
-              PsshExecInfo(hostfile=self.hostfile)).run()
+            library = self.find_library("darshan")
+            if library is None:
+                raise RuntimeError("Could not find darshan")
+            print(f"Found libdarshan.so at {library}")
+        config["DARSHAN_LIB"] = library
+        self.env["DARSHAN_LOG_DIR"] = log_dir
+        self.env["PBS_JOBID"] = job_id
+        Mkdir(log_dir, PsshExecInfo(hostfile=self.hostfile)).run()
 
-    def modify_env(self):
+    def modify_env(self) -> None:
         """
         Modify the jarvis environment.
 
         :return: None
         """
-        self.prepend_env('LD_PRELOAD', self.config['DARSHAN_LIB'])
+        config = cast(dict[str, Any], self.config)
+        log_dir = config.get("log_dir")
+        job_id = config.get("job_id")
+        library = config.get("DARSHAN_LIB")
+        if not all(isinstance(value, str) and value for value in (log_dir, job_id)):
+            raise ValueError("Darshan runtime configuration is incomplete")
+        if not isinstance(library, str) or not library:
+            raise ValueError("Darshan library was not resolved during configuration")
+        self.setenv("DARSHAN_LOG_DIR", cast(str, log_dir))
+        self.setenv("PBS_JOBID", cast(str, job_id))
+        self.prepend_env("LD_PRELOAD", library)

--- a/builtin/builtin/dlio_benchmark/README.md
+++ b/builtin/builtin/dlio_benchmark/README.md
@@ -1,57 +1,68 @@
-DLIO is an I/O benchmark for Deep Learning, aiming at emulating the I/O behavior of various deep learning applications.
+# DLIO Benchmark
 
-# Installation
+`builtin.dlio_benchmark` runs one native
+[DLIO Benchmark](https://github.com/argonne-lcf/dlio_benchmark) workload
+configuration under MPI. The package expects `dlio_benchmark` and the MPI
+launcher to be resolved in the JARVIS pipeline environment before execution.
+It does not install Python dependencies or discover software at run time.
+
+The package owns the mechanics shared by DLIO studies:
+
+- optional dataset generation followed by one training I/O phase;
+- explicit dataset, output, and checkpoint locations;
+- typed reader, dataset, epoch, computation, and checkpoint controls;
+- checked MPI and cache-policy process status;
+- native output, generated dataset, and checkpoint artifact lifecycles.
+
+Scientific sweeps and comparisons remain explicit pipeline composition. For
+example, compare reader concurrency by adding separately named DLIO steps with
+different `read_threads` values and a shared, pre-generated dataset. This keeps
+every measured cell visible in the pipeline rather than hiding a study inside
+the package.
+
+## Cache policy
+
+`cache_policy=none` is the portable default and makes no cold-cache claim.
+`cache_policy=sync` flushes dirty buffers without evicting the page cache.
+`cache_policy=drop_caches` is an explicit privileged request. It uses
+noninteractive `sudo -n` and fails the package if the site has not authorized
+the operation. The package never silently falls back between policies.
+
+## Important settings
+
+| Setting | Default | Meaning |
+|---|---:|---|
+| `workload` | `unet3d_a100` | Installed DLIO workload profile |
+| `generate_data` | `false` | Generate data before the training I/O phase |
+| `data_path` | empty | `data/<workload>` below package shared storage |
+| `output_path` | `output` | Native DLIO output collection |
+| `read_threads` | unset | Reader threads per rank |
+| `nprocs` / `ppn` | `8` / `8` | MPI ranks and ranks per node |
+| `timeout_seconds` | `3600` | Maximum runtime for each MPI phase |
+| `checkpoint` | `true` | Enable checkpoint writes for supported workloads |
+| `checkpoint_path` | empty | `checkpoints/<workload>` below package shared storage |
+| `cache_policy` | `none` | `none`, `sync`, or `drop_caches` |
+
+Additional typed controls cover training-file count, samples per file, record
+and resize lengths, batch size, training and evaluation phases, epochs, emulated
+computation time, model checkpoint size, checkpoint timing, `fsync`, and
+DFTracer enablement.
+
+## Example
 
 ```bash
-git clone https://github.com/argonne-lcf/dlio_benchmark
-cd dlio_benchmark/
-pip install .
-```
-
-# DLIO
-
-## 1. Create a Resource Graph
-
-If you haven't already, create a resource graph. This only needs to be done
-once throughout the lifetime of Jarvis. No need to repeat if you have already
-done this for a different pipeline.
-
-If you are running distributed tests, set path to the hostfile you are  using.
-```bash
-jarvis hostfile set /path/to/hostfile
-```
-
-Next, collect the resources from each of those pkgs. Walkthrough will give
-a command line tutorial on how to build the hostfile.
-```bash
-jarvis resource-graph build +walkthrough
-```
-
-## 2. Create a Pipeline
-
-The Jarvis pipeline will store all configuration data.
-```bash
-jarvis pipeline create dlio_test
-```
-
-## 4. Add pkgs to the Pipeline
-
-Create a Jarvis pipeline
-```bash
-jarvis pipeline append dlio_benchmark workload=unet3d_a100 generate_data=True data_path=/path/to/generated_data checkpoint_path=/path/to/checkpoints
-```
-Note: you can modify the dlio_benchmark configuration file by changing the modifying the dlio_benchmark.yaml file directly, and then execute `jarvis ppl update` to update the configuration. 
-
-## 5. Run Experiment
-
-Run the experiment
-```bash
+jarvis pipeline create dlio-study
+jarvis pipeline append dlio_benchmark \
+  workload=resnet50_v100 \
+  generate_data=true \
+  num_files_train=256 \
+  read_threads=4 \
+  checkpoint_size_bytes=104857600 \
+  cache_policy=sync \
+  nprocs=4 ppn=4
 jarvis pipeline run
 ```
 
-## 6. Clean Data
-
-Clean produced data
-```bash
-jarvis pipeline clean
-```
+The output is a normal JARVIS batch execution. A zero native process exit
+finalizes the declared artifact collections; a nonzero exit leaves them
+explicitly incomplete and fails the package.

--- a/builtin/builtin/dlio_benchmark/artifacts.py
+++ b/builtin/builtin/dlio_benchmark/artifacts.py
@@ -1,0 +1,195 @@
+"""Artifact semantics owned by builtin DLIO Benchmark."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts.provider import ArtifactObservation
+from jarvis_cd.artifacts.schema import (
+    ArtifactLocation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+
+
+@dataclass(slots=True)
+class DlioBenchmarkArtifactAdapter:
+    """Track native DLIO datasets, measurements, and checkpoints."""
+
+    workload: str
+    cache_policy: str
+    data_path: PurePosixPath | None
+    output_path: PurePosixPath
+    checkpoint_path: PurePosixPath | None
+    data_artifact_id: str = field(default_factory=new_artifact_id)
+    output_artifact_id: str = field(default_factory=new_artifact_id)
+    checkpoint_artifact_id: str = field(default_factory=new_artifact_id)
+    _started: bool = False
+    _terminal: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Announce configured products when the native process starts writing."""
+        if self._started or self._terminal or not text:
+            return []
+        self._started = True
+        return self._observations(ArtifactState.PRODUCING)
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Wait for the authoritative process status before terminalization."""
+        return []
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Finalize or mark every declared product incomplete from process exit."""
+        if self._terminal:
+            return []
+        self._terminal = True
+        state = (
+            ArtifactState.FINALIZED if return_code == 0 else ArtifactState.INCOMPLETE
+        )
+        return self._observations(state, return_code=return_code)
+
+    def reset_artifacts(self) -> None:
+        """Reset stream state when JARVIS replaces the owned output stream."""
+        self._started = False
+        self._terminal = False
+
+    def _observations(
+        self,
+        state: ArtifactState,
+        *,
+        return_code: int | None = None,
+    ) -> list[ArtifactObservation]:
+        metadata: dict[str, str | int] = {
+            "application": "dlio",
+            "workload": self.workload,
+            "cache_policy": self.cache_policy,
+        }
+        if return_code is not None:
+            metadata["return_code"] = return_code
+        observations: list[ArtifactObservation] = []
+        if self.data_path is not None:
+            observations.append(
+                self._observation(
+                    artifact_id=self.data_artifact_id,
+                    logical_name="dlio-generated-dataset",
+                    kind="scientific_dataset",
+                    role=ArtifactRole.INTERMEDIATE,
+                    path=self.data_path,
+                    state=state,
+                    format_name="dlio-generated-dataset",
+                    metadata=metadata,
+                )
+            )
+        observations.append(
+            self._observation(
+                artifact_id=self.output_artifact_id,
+                logical_name="dlio-native-results",
+                kind="scientific_measurement",
+                role=ArtifactRole.OUTPUT,
+                path=self.output_path,
+                state=state,
+                format_name="dlio-native-output-directory",
+                metadata=metadata,
+            )
+        )
+        if self.checkpoint_path is not None:
+            observations.append(
+                self._observation(
+                    artifact_id=self.checkpoint_artifact_id,
+                    logical_name="dlio-checkpoints",
+                    kind="model_checkpoint",
+                    role=ArtifactRole.CHECKPOINT,
+                    path=self.checkpoint_path,
+                    state=state,
+                    format_name="dlio-checkpoint-collection",
+                    metadata=metadata,
+                )
+            )
+        return observations
+
+    @staticmethod
+    def _observation(
+        *,
+        artifact_id: str,
+        logical_name: str,
+        kind: str,
+        role: ArtifactRole,
+        path: PurePosixPath,
+        state: ArtifactState,
+        format_name: str,
+        metadata: dict[str, str | int],
+    ) -> ArtifactObservation:
+        """Build one stable lifecycle revision."""
+        if state is ArtifactState.FINALIZED:
+            message = f"{logical_name} finalized after successful DLIO exit"
+        elif state is ArtifactState.INCOMPLETE:
+            message = f"{logical_name} incomplete after DLIO process failure"
+        else:
+            message = f"{logical_name} is being produced"
+        return ArtifactObservation(
+            artifact_id=artifact_id,
+            logical_name=logical_name,
+            kind=kind,
+            role=role,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(path),
+            media_type="application/octet-stream",
+            format=format_name,
+            message=message,
+            metadata=metadata,
+        )
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> DlioBenchmarkArtifactAdapter | None:
+    """Create native DLIO artifact semantics from normalized package config."""
+    if package.get("pkg_type") != "builtin.dlio_benchmark":
+        return None
+    workload = package.get("workload")
+    if not isinstance(workload, str) or not workload:
+        raise ValueError("DLIO artifact provider requires a workload")
+    cache_policy = package.get("cache_policy", "none")
+    if not isinstance(cache_policy, str) or not cache_policy:
+        raise ValueError("DLIO artifact provider requires an explicit cache policy")
+    output_path = _absolute_path(package.get("output_path"), field="output_path")
+    data_path = (
+        _absolute_path(package.get("data_path"), field="data_path")
+        if package.get("generate_data") is True
+        else None
+    )
+    checkpoint_path = (
+        _absolute_path(package.get("checkpoint_path"), field="checkpoint_path")
+        if package.get("checkpoint_supported") is True
+        and package.get("checkpoint") is True
+        else None
+    )
+    return DlioBenchmarkArtifactAdapter(
+        workload=workload,
+        cache_policy=cache_policy,
+        data_path=data_path,
+        output_path=output_path,
+        checkpoint_path=checkpoint_path,
+    )
+
+
+def _absolute_path(value: object, *, field: str) -> PurePosixPath:
+    """Require one normalized absolute cluster artifact path."""
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"DLIO {field} must be a non-empty absolute path")
+    path = PurePosixPath(value)
+    if not path.is_absolute() or path.as_posix() != value or ".." in path.parts:
+        raise ValueError(f"DLIO {field} must be a normalized absolute path")
+    return path
+
+
+__all__ = ["DlioBenchmarkArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/dlio_benchmark/pkg.py
+++ b/builtin/builtin/dlio_benchmark/pkg.py
@@ -1,276 +1,614 @@
-"""
-This module provides classes and methods to launch the DlioBenchmark application.
-DlioBenchmark is ....
-"""
-from jarvis_cd.core.pkg import Application, Color
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
+"""Launch native DLIO Benchmark workloads with explicit execution semantics."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+from typing import Any, cast
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Rm
+from jarvis_cd.runtime_callback import RuntimePhaseLineCallback
+
+_WORKLOAD_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+_CACHE_POLICIES = ("none", "sync", "drop_caches")
 
 
 class DlioBenchmark(Application):
-    """
-    This class provides methods to launch the DlioBenchmark application.
-    """
-    def _init(self):
-        """
-        Initialize paths
-        """
-        pass
+    """Run one configured DLIO data-generation and training I/O workload."""
 
-    def _configure_menu(self):
-        """
-        Create a CLI menu for the configurator method.
-        For thorough documentation of these parameters, view:
-        https://github.com/scs-lab/jarvis-util/wiki/3.-Argument-Parsing
+    def _init(self) -> None:
+        """Initialize the bounded batch package."""
 
-        :return: List(dict)
-        """
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        """Return agent-visible DLIO workload and execution controls."""
         return [
-            # workload related configurations
             {
-                'name': 'workload',  # The name of the parameter
-                'msg': 'specify the workload name',  # Describe this parameter
-                'type': str,  # What is the parameter type?
-                'default': 'unet3d_a100',  # What is the default value if not required?
-                'choices': [],
-                'args': [],
+                "name": "workload",
+                "msg": "Installed DLIO workload profile name",
+                "type": str,
+                "default": "unet3d_a100",
+                "choices": [],
+                "args": [],
             },
             {
-                'name': 'generate_data',
-                'msg': 'Does require to generate data before training?',
-                'type': bool,
-                'default': False,
-                'choices': [],
-                'args': [],
+                "name": "generate_data",
+                "msg": "Generate the configured dataset before the training I/O phase",
+                "type": bool,
+                "default": False,
+                "choices": [],
+                "args": [],
             },
             {
-                'name': 'checkpoint_supported',
-                'msg': 'Does the workload support checkpointing?',
-                'type': bool,
-                'default': True,
-                'choices': [],
-                'args': [],
-            }, 
-            {
-                'name': 'checkpoint',
-                'msg': 'Enable/disable checkpoint',
-                'type': bool,
-                'default': True,
-                'choices': [],
-                'args': [],
-            }, 
-            # dataset related configurations
-            {
-                'name': 'data_path',
-                'msg': 'The path of the dataset',
-                'type': str,
-                'default': None,
-                'choices': [],
-                'args': [],
+                "name": "evaluation",
+                "msg": "Run the selected workload's evaluation I/O phase",
+                "type": bool,
+                "default": False,
+                "choices": [],
+                "args": [],
             },
             {
-                'name': 'num_files_train',
-                'msg': 'Number of files used for training',
-                'type': int,
-                'default': None,
-                'choices': [],
-                'args': [],
-            },
-            # reader related configurations
-            {
-                'name': 'batch_size',
-                'msg': 'Number of samples read per iteration',
-                'type': int,
-                'default': None,
-                'choices': [],
-                'args': [],
+                "name": "checkpoint_supported",
+                "msg": "Whether the selected workload has checkpoint configuration",
+                "type": bool,
+                "default": True,
+                "choices": [],
+                "args": [],
             },
             {
-                'name': 'read_threads',
-                'msg': 'Number of read threads in dataloader',
-                'type': int,
-                'default': None,
-                'choices': [],
-                'args': [],
-            }, 
-            # train related configurations
-            {
-                'name': 'epochs',
-                'msg': 'Number of epochs to run',
-                'type': int,
-                'default': None,
-                'choices': [],
-                'args': [],
-            },
-            # checkpoint related configurations
-            {
-                'name': 'checkpoint_path',
-                'msg': 'Path of the checkpoint files',
-                'type': str,
-                'default': None,
-                'choices': [],
-                'args': [],
-            }, 
-            {
-                'name': 'checkpoint_after_epoch',
-                'msg': 'Checkpoint after the specified epoch id',
-                'type': int,
-                'default': None,
-                'choices': [],
-                'args': [],
-            }, 
-            {
-                'name': 'epochs_between_checkpoints',
-                'msg': 'Checkpoint interval (unit: epochs)',
-                'type': int,
-                'default': None,
-                'choices': [],
-                'args': [],
-            }, 
-            # process related configuration
-            {
-                'name': 'nprocs',
-                'msg': 'Number of processes',
-                'type': int,
-                'default': 8,
+                "name": "checkpoint",
+                "msg": "Write checkpoints during the training I/O phase",
+                "type": bool,
+                "default": True,
+                "choices": [],
+                "args": [],
             },
             {
-                'name': 'ppn',
-                'msg': 'The number of processes per node',
-                'type': int,
-                'default': 8,
+                "name": "data_path",
+                "msg": (
+                    "Dataset directory. Empty uses data/<workload> below the "
+                    "execution-owned package shared directory."
+                ),
+                "type": str,
+                "default": "",
+                "choices": [],
+                "args": [],
             },
-            # Run with tracing or not
             {
-                'name': 'tracing',
-                'msg': 'Enable/disable tracing (running with/without DFTracer)',
-                'type': bool,
-                'default': False,
-            }, 
+                "name": "output_path",
+                "msg": (
+                    "Native DLIO output directory. Relative paths resolve below "
+                    "the execution-owned package shared directory."
+                ),
+                "type": str,
+                "default": "output",
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "checkpoint_path",
+                "msg": (
+                    "Checkpoint directory. Empty uses checkpoints/<workload> below "
+                    "the execution-owned package shared directory."
+                ),
+                "type": str,
+                "default": "",
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "num_files_train",
+                "msg": "Number of files in the training dataset",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "num_samples_per_file",
+                "msg": "Samples represented by each generated training file",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "record_length_bytes",
+                "msg": "Generated training-record payload size in bytes",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "record_length_bytes_resize",
+                "msg": (
+                    "Generated record resize target in bytes; empty uses "
+                    "record_length_bytes when that value is set"
+                ),
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "batch_size",
+                "msg": "Samples read per training iteration",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "read_threads",
+                "msg": "Reader threads per DLIO rank",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "epochs",
+                "msg": "Training I/O epochs",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "train_computation_time",
+                "msg": "Emulated computation time in seconds per training iteration",
+                "type": float,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "checkpoint_size_bytes",
+                "msg": "Emulated model checkpoint size in bytes",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "checkpoint_fsync",
+                "msg": "Require DLIO to fsync checkpoint writes",
+                "type": bool,
+                "default": False,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "checkpoint_after_epoch",
+                "msg": "First epoch after which DLIO writes a checkpoint",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "epochs_between_checkpoints",
+                "msg": "Number of epochs between checkpoints",
+                "type": int,
+                "default": None,
+                "choices": [],
+                "args": [],
+            },
+            {
+                "name": "nprocs",
+                "msg": "Number of MPI ranks",
+                "type": int,
+                "default": 8,
+            },
+            {
+                "name": "ppn",
+                "msg": "MPI ranks per node",
+                "type": int,
+                "default": 8,
+            },
+            {
+                "name": "timeout_seconds",
+                "msg": "Maximum runtime in seconds for each DLIO MPI phase",
+                "type": int,
+                "default": 3600,
+            },
+            {
+                "name": "tracing",
+                "msg": "Enable DFTracer through its runtime environment contract",
+                "type": bool,
+                "default": False,
+            },
+            {
+                "name": "cache_policy",
+                "msg": (
+                    "Cache handling before training: none, unprivileged sync, or "
+                    "explicit noninteractive privileged drop_caches"
+                ),
+                "type": str,
+                "default": "none",
+                "choices": list(_CACHE_POLICIES),
+                "args": [],
+            },
         ]
 
-    def _configure(self, **kwargs):
-        """
-        Converts the Jarvis configuration to application-specific configuration.
-        E.g., OrangeFS produces an orangefs.xml file.
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe the pre-resolved native DLIO runtime and batch completion."""
+        probe = probe_program(
+            "dlio_benchmark",
+            environment=self._deployment_environment(),
+            arguments=("--help",),
+        )
+        capabilities = (
+            ("distributed_training_io", "native_dlio_outputs")
+            if probe.status.usable is True
+            else ()
+        )
+        runtime = RuntimeRequirement(
+            requirement_id="dlio",
+            description=(
+                "DLIO Benchmark runtime resolved in the pipeline environment before "
+                "execution"
+            ),
+            required_capabilities=("distributed_training_io", "native_dlio_outputs"),
+            available_capabilities=capabilities,
+            status=probe.status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="path",
+                    query_kind="program",
+                    query_value="dlio_benchmark",
+                ),
+            ),
+        )
+        completed = ReadinessContract(
+            mechanism="process_exit",
+            condition="successful_exit",
+        )
+        return PackageDeploymentContract(
+            package="builtin.dlio_benchmark",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="train_existing_data",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("generate_data", "equals", False),),
+                    runtime_requirements=("dlio",),
+                    readiness=completed,
+                    description=(
+                        "Run one native DLIO workload configuration against an "
+                        "existing dataset and retain its native outputs."
+                    ),
+                ),
+                ExecutionProfile(
+                    name="generate_and_train",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("generate_data", "equals", True),),
+                    runtime_requirements=("dlio",),
+                    readiness=completed,
+                    description=(
+                        "Generate the configured dataset, then run one native DLIO "
+                        "workload configuration and retain both product groups."
+                    ),
+                ),
+            ),
+            runtime_requirements=(runtime,),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("checkpoint", "equals", True),),
+                    requires=(
+                        ConfigurationCondition("checkpoint_supported", "equals", True),
+                    ),
+                    description=(
+                        "Checkpoint output can be enabled only for a workload whose "
+                        "DLIO profile supports checkpoint configuration."
+                    ),
+                ),
+            ),
+        )
 
-        :param kwargs: Configuration parameters for this pkg.
-        :return: None
-        """
-        # reconfigure data_path
-        if self.config['data_path'] is None:
-            self.config['data_path'] = f"data/{self.config['workload']}"
-        elif f"data/{self.config['workload']}" not in self.config['data_path']:
-            self.config['data_path'] = f"{self.config['data_path']}/data/{self.config['workload']}"  
+    def _configure(self, **kwargs: Any) -> None:
+        """Validate execution controls and persist normalized artifact paths."""
+        super()._configure(**kwargs)
+        self._validate_configuration()
+        config = cast(dict[str, Any], self.config)
+        config["data_path"] = str(self._data_path())
+        config["output_path"] = str(self._output_path())
+        config["checkpoint_path"] = str(self._checkpoint_path())
 
-        # reconfigure checkpoint path
-        if self.config['checkpoint_supported']:
-            if self.config['checkpoint_path'] is None:
-                self.config['checkpoint_path'] = f"checkpoints/{self.config['workload']}"
-            elif f"checkpoints/{self.config['workload']}" not in self.config['checkpoint_path']:
-                self.config['checkpoint_path'] = f"{self.config['checkpoint_path']}/checkpoints/{self.config['workload']}" 
+    def _validate_configuration(self) -> None:
+        """Reject unsafe or ambiguous values before any process is launched."""
+        config = cast(dict[str, Any], self.config)
+        if config.get("deploy_mode", "default") != "default":
+            raise ValueError("builtin.dlio_benchmark supports native execution only")
+        workload = config.get("workload")
+        if (
+            not isinstance(workload, str)
+            or _WORKLOAD_PATTERN.fullmatch(workload) is None
+        ):
+            raise ValueError("workload must be a DLIO profile token")
+        for field in (
+            "generate_data",
+            "evaluation",
+            "checkpoint_supported",
+            "checkpoint",
+            "checkpoint_fsync",
+            "tracing",
+        ):
+            if not isinstance(config.get(field), bool):
+                raise TypeError(f"{field} must be a boolean")
+        if config["checkpoint"] and not config["checkpoint_supported"]:
+            raise ValueError("checkpoint requires checkpoint_supported=true")
+        for field in ("nprocs", "ppn", "timeout_seconds"):
+            self._positive_integer(field, required=True)
+        if cast(int, config["ppn"]) > cast(int, config["nprocs"]):
+            raise ValueError("ppn cannot exceed nprocs")
+        for field in (
+            "num_files_train",
+            "num_samples_per_file",
+            "record_length_bytes",
+            "record_length_bytes_resize",
+            "batch_size",
+            "read_threads",
+            "epochs",
+            "checkpoint_size_bytes",
+            "checkpoint_after_epoch",
+            "epochs_between_checkpoints",
+        ):
+            self._positive_integer(field, required=False)
+        computation_time = config.get("train_computation_time")
+        if computation_time is not None and (
+            isinstance(computation_time, bool)
+            or not isinstance(computation_time, (int, float))
+            or computation_time < 0
+        ):
+            raise ValueError("train_computation_time must be a non-negative number")
+        cache_policy = config.get("cache_policy")
+        if cache_policy not in _CACHE_POLICIES:
+            raise ValueError(
+                "cache_policy must be one of: " + ", ".join(_CACHE_POLICIES)
+            )
+        self._data_path()
+        self._output_path()
+        self._checkpoint_path()
 
-    def start(self):
-        """
-        Launch an application. E.g., OrangeFS will launch the servers, clients,
-        and metadata services on all necessary pkgs.
+    def _positive_integer(self, field: str, *, required: bool) -> int | None:
+        """Validate one optional or required positive integer setting."""
+        value = self.config.get(field)
+        if value is None and not required:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{field} must be a positive integer")
+        return value
 
-        :return: None
-        """
-        
-        # step1: generate data if it is required before training
-        if self.config['generate_data']:
-            # construct the command
-            gen_cmd = [
-                'dlio_benchmark',
-                f'workload={self.config['workload']}',
-                f'++workload.workflow.generate_data=True',
-                f'++workload.workflow.train=False',
-                f'++workload.dataset.data_folder={self.config['data_path']}' 
-            ]
+    def _data_path(self) -> Path:
+        """Return the configured dataset directory."""
+        return self.resolve_shared_path(
+            self.config.get("data_path"),
+            field="data_path",
+            default=f"data/{self.config['workload']}",
+        )
 
-            if self.config['num_files_train'] is not None:
-                gen_cmd.append(f'++workload.dataset.num_files_train={self.config['num_files_train']}')
+    def _output_path(self) -> Path:
+        """Return the package-owned native-output directory."""
+        return self.resolve_shared_path(
+            self.config.get("output_path"),
+            field="output_path",
+            default="output",
+        )
 
-            # run the command to generate data
-            Exec(' '.join(gen_cmd),
-                MpiExecInfo(env=self.mod_env,
-                            hostfile=self.hostfile,
-                            nprocs=self.config['nprocs'],
-                            ppn=self.config['ppn'])).run()
+    def _checkpoint_path(self) -> Path:
+        """Return the configured checkpoint directory."""
+        return self.resolve_shared_path(
+            self.config.get("checkpoint_path"),
+            field="checkpoint_path",
+            default=f"checkpoints/{self.config['workload']}",
+        )
 
-        # step2: clear the system cache
-        Exec('sudo drop_caches',
-             PsshExecInfo(env=self.env,
-                        hostfile=self.hostfile)).run()
-        
-        # step3: run the benchmark with the workload
-        if self.config['tracing']:
-            self.mod_env['DFTRACER_ENABLE'] = '1'
-            self.mod_env['DFTRACER_INC_METADATA'] = '1'   
-
-        run_cmd = [
-            'dlio_benchmark',
-            f'workload={self.config['workload']}',
-            f'++workload.workflow.generate_data=False',
-            f'++workload.workflow.train=Train',
-            f'++workload.dataset.data_folder={self.config['data_path']}'  
+    def _command(self, *, generate_only: bool, output_path: Path) -> str:
+        """Build one shell-safe native DLIO invocation."""
+        workflow_checkpoint = bool(
+            not generate_only
+            and self.config["checkpoint_supported"]
+            and self.config["checkpoint"]
+        )
+        overrides = [
+            f"workload={self.config['workload']}",
+            f"++workload.workflow.generate_data={'true' if generate_only else 'false'}",
+            f"++workload.workflow.train={'false' if generate_only else 'true'}",
+            "++workload.workflow.evaluation="
+            + ("true" if self.config["evaluation"] and not generate_only else "false"),
+            f"++workload.dataset.data_folder={self._data_path()}",
+            f"++workload.output.folder={output_path}",
         ]
+        if not self.config["evaluation"]:
+            overrides.append("++workload.dataset.num_files_eval=0")
+        optional = (
+            ("num_files_train", "workload.dataset.num_files_train"),
+            ("num_samples_per_file", "workload.dataset.num_samples_per_file"),
+            ("record_length_bytes", "workload.dataset.record_length_bytes"),
+            (
+                "record_length_bytes_resize",
+                "workload.dataset.record_length_bytes_resize",
+            ),
+            ("batch_size", "workload.reader.batch_size"),
+            ("read_threads", "workload.reader.read_threads"),
+            ("epochs", "workload.train.epochs"),
+            ("train_computation_time", "workload.train.computation_time"),
+        )
+        for field, setting in optional:
+            value = self.config.get(field)
+            if field == "record_length_bytes_resize" and value is None:
+                value = self.config.get("record_length_bytes")
+            if value is not None:
+                overrides.append(f"++{setting}={value}")
+        if self.config["checkpoint_supported"]:
+            overrides.extend(
+                (
+                    "++workload.workflow.checkpoint="
+                    + ("true" if workflow_checkpoint else "false"),
+                    f"++workload.checkpoint.checkpoint_folder={self._checkpoint_path()}",
+                )
+            )
+            if not generate_only:
+                checkpoint_size = self.config.get("checkpoint_size_bytes")
+                if checkpoint_size is not None:
+                    overrides.append(
+                        f"++workload.model.model_size_bytes={checkpoint_size}"
+                    )
+                overrides.append(
+                    "++workload.checkpoint.fsync="
+                    + ("true" if self.config["checkpoint_fsync"] else "false")
+                )
+                for field, setting in (
+                    ("checkpoint_after_epoch", "checkpoint_after_epoch"),
+                    ("epochs_between_checkpoints", "epochs_between_checkpoints"),
+                ):
+                    value = self.config.get(field)
+                    if value is not None:
+                        overrides.append(f"++workload.checkpoint.{setting}={value}")
+        return " ".join(
+            ("dlio_benchmark", *(shlex.quote(value) for value in overrides))
+        )
 
-        if self.config['num_files_train'] is not None:
-            run_cmd.append(f'++workload.dataset.num_files_train={self.config['num_files_train']}')
-        
-        if self.config['batch_size'] is not None:
-            run_cmd.append(f'++workload.reader.batch_size={self.config['batch_size']}')
-        
-        if self.config['read_threads'] is not None:
-            run_cmd.append(f'++workload.reader.read_threads={self.config['read_threads']}')
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        """Return local or PSSH execution for node-scoped cache operations."""
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
 
-        if self.config['epochs'] is not None:
-            run_cmd.append(f'++workload.train.epochs={self.config['epochs']}')
-        
-        if self.config['checkpoint_supported']:
-            run_cmd.append(f'++workload.workflow.checkpoint={self.config['checkpoint']}')
-            run_cmd.append(f'++workload.checkpoint.checkpoint_folder={self.config['checkpoint_path']}')
-            if self.config['checkpoint_after_epoch'] is not None:
-                run_cmd.append(f'++workload.checkpoint.checkpoint_after_epoch={self.config['checkpoint_after_epoch']}')
-            if self.config['epochs_between_checkpoints'] is not None:
-                run_cmd.append(f'++workload.checkpoint.epochs_between_checkpoints={self.config['epochs_between_checkpoints']}') 
-        #print(f"self.env = {self.env}", flush=True)
-        # run the benchmark command
-        Exec(' '.join(run_cmd),
-             MpiExecInfo(env=self.mod_env,
-                         hostfile=self.hostfile,
-                         nprocs=self.config['nprocs'],
-                         ppn=self.config['ppn'])).run()
-        
+    @staticmethod
+    def _raise_for_exec_failure(result: Any, operation: str) -> None:
+        """Require a concrete zero status from every participating process."""
+        exit_codes = getattr(result, "exit_code", None)
+        if not isinstance(exit_codes, dict) or not exit_codes:
+            raise RuntimeError(f"{operation} returned no process exit status")
+        failures = {
+            str(host): code
+            for host, code in exit_codes.items()
+            if isinstance(code, bool) or not isinstance(code, int) or code != 0
+        }
+        if failures:
+            rendered = ", ".join(
+                f"{host}={code!r}" for host, code in sorted(failures.items())
+            )
+            raise RuntimeError(f"{operation} failed with exit status: {rendered}")
 
-    def stop(self):
-        """
-        Stop a running application. E.g., OrangeFS will terminate the servers,
-        clients, and metadata services.
+    def _apply_cache_policy(self) -> None:
+        """Apply only the exact cache policy selected by the operator or agent."""
+        policy = self.config["cache_policy"]
+        if policy == "none":
+            return
+        if policy == "sync":
+            command = "sync"
+        elif policy == "drop_caches":
+            command = "sync && sudo -n sh -c 'echo 3 > /proc/sys/vm/drop_caches'"
+        else:
+            raise ValueError(f"unsupported cache policy: {policy!r}")
+        result = Exec(command, self._node_exec_info(env=self.env, timeout=60)).run()
+        self._raise_for_exec_failure(result, f"DLIO cache policy {policy}")
 
-        :return: None
-        """
-        pass
+    def start(self) -> None:
+        """Generate optional input data, apply cache policy, and run DLIO."""
+        self._validate_configuration()
+        output_path = self._output_path()
+        training_output = output_path / "training"
+        paths = [output_path, training_output]
+        if self.config["generate_data"]:
+            paths.extend((self._data_path(), output_path / "data-generation"))
+        if self.config["checkpoint_supported"] and self.config["checkpoint"]:
+            paths.append(self._checkpoint_path())
+        for path in paths:
+            path.mkdir(parents=True, exist_ok=True)
 
-    def clean(self):
-        """
-        Destroy all data for an application. E.g., OrangeFS will delete all
-        metadata and data directories in addition to the orangefs.xml file.
+        environment = dict(self.mod_env)
+        if self.config["tracing"]:
+            environment.update(
+                {
+                    "DFTRACER_ENABLE": "1",
+                    "DFTRACER_INC_METADATA": "1",
+                }
+            )
+        callback = self.runtime_line_callback()
+        intermediate_callback = (
+            RuntimePhaseLineCallback(callback, terminal=False)
+            if callback is not None
+            else None
+        )
+        terminal_callback = (
+            RuntimePhaseLineCallback(callback, terminal=True)
+            if callback is not None
+            else None
+        )
+        try:
+            if self.config["generate_data"]:
+                generation_output = output_path / "data-generation"
+                generation = Exec(
+                    self._command(generate_only=True, output_path=generation_output),
+                    MpiExecInfo(
+                        env=environment,
+                        hostfile=self.hostfile,
+                        nprocs=self.config["nprocs"],
+                        ppn=self.config["ppn"],
+                        cwd=str(generation_output),
+                        line_callback=intermediate_callback,
+                        timeout=self.config["timeout_seconds"],
+                    ),
+                ).run()
+                self._raise_for_exec_failure(generation, "DLIO data generation")
 
-        :return: None
-        """
-        # clear data path
-        Rm(self.config['data_path'] + '*',
-           PsshExecInfo(env=self.env,
-                        hostfile=self.hostfile)).run()
+            self._apply_cache_policy()
+            workload = Exec(
+                self._command(generate_only=False, output_path=training_output),
+                MpiExecInfo(
+                    env=environment,
+                    hostfile=self.hostfile,
+                    nprocs=self.config["nprocs"],
+                    ppn=self.config["ppn"],
+                    cwd=str(training_output),
+                    line_callback=terminal_callback,
+                    timeout=self.config["timeout_seconds"],
+                ),
+            ).run()
+            self._raise_for_exec_failure(workload, "DLIO workload")
+        except Exception:
+            if terminal_callback is not None:
+                terminal_callback.finalize_process(1)
+            raise
 
-        self.log(f'Removing dataset {self.config['data_path']}', Color.YELLOW)
+    def stop(self) -> None:
+        """Do nothing because DLIO stages are bounded synchronous processes."""
 
-        # clear checkpoint
-        Rm(self.config['checkpoint_path'] + '*',
-           PsshExecInfo(env=self.env,
-                        hostfile=self.hostfile)).run()
-        
-        self.log(f'Removing checkpoints {self.config['checkpoint_path']}', Color.YELLOW)
+    def clean(self) -> None:
+        """Remove only package-owned products below the package shared root."""
+        if self.shared_dir is None:
+            raise RuntimeError("DLIO cleanup requires a package shared directory")
+        shared = Path(self.shared_dir).resolve(strict=False)
+        candidates = [self._output_path(), self._checkpoint_path()]
+        if self.config.get("generate_data"):
+            candidates.append(self._data_path())
+        owned = [str(path) for path in candidates if path.is_relative_to(shared)]
+        if not owned:
+            return
+        result = Rm(
+            owned,
+            self._node_exec_info(env=self.env),
+            recursive=True,
+        ).run()
+        self._raise_for_exec_failure(result, "DLIO package cleanup")
+
+
+__all__ = ["DlioBenchmark", "RuntimeStatus"]

--- a/builtin/builtin/gadget2/README.md
+++ b/builtin/builtin/gadget2/README.md
@@ -1,48 +1,79 @@
-GADGET is a freely available code for cosmological N-body/SPH simulations on massively parallel computers with distributed memory. GADGET uses an explicit communication model that is implemented with the standardized MPI communication interface. The code can be run on essentially all supercomputer systems presently in use, including clusters of workstations or individual PCs.
+# Gadget2
 
-GADGET computes gravitational forces with a hierarchical tree algorithm (optionally in combination with a particle-mesh scheme for long-range gravitational forces) and represents fluids by means of smoothed particle hydrodynamics (SPH). The code can be used for studies of isolated systems, or for simulations that include the cosmological expansion of space, both with or without periodic boundary conditions. In all these types of simulations, GADGET follows the evolution of a self-gravitating collisionless N-body system, and allows gas dynamics to be optionally included. Both the force computation and the time stepping of GADGET are fully adaptive, with a dynamic range which is, in principle, unlimited.
+The JARVIS Gadget2 package runs distributed-memory N-body and SPH simulations.
+The agent-facing profile accepts a complete, digest-verified JARVIS input bundle
+instead of selecting one of the repository's stock demonstrations. This lets a
+caller supply a scientific parameter file, initial conditions, and any related
+support files without giving the package authority over arbitrary host paths.
 
-https://wwwmpa.mpa-garching.mpg.de/gadget/
+The Gadget2 project is documented at
+<https://wwwmpa.mpa-garching.mpg.de/gadget/>.
 
-# Installation
+## Native runtime
 
-```bash
-spack install hdf5@1.14.1 gsl@2.1 fftw@2
-scspkg create gadget2
-cd $(scspkg pkg src gadget2)
-git clone https://github.com/lukemartinlogan/gadget2.git
-export GADGET2_PATH=$(scspkg pkg src gadget2)/gadget2
-export FFTW_PATH=$(spack find --format "{PREFIX}" fftw@2)
+Provide an MPI-enabled `Gadget2` or `gadget2` executable through `PATH`. The
+runtime must be built with the FFTW 2, GSL, MPI, and optional HDF5 dependencies
+required by its selected compile-time options. JARVIS probes the executable and
+reports the runtime readiness through the package deployment contract.
+
+The benchmark and scientific profile do not install software or select an
+arbitrary source repository at runtime. Site operators prepare and pin the
+runtime independently.
+
+## Scientific input bundle
+
+The `input_bundle` must be a JARVIS input-bundle archive. Its manifest declares
+every file, its SHA-256 digest, size, role, and one entrypoint. The entrypoint is
+normally a `.param` file. `parameter_path` can select another declared `.param`
+member, but cannot name an undeclared or escaping path.
+
+For example, a bundle can contain:
+
+```text
+jarvis-input-manifest.json
+galaxy/
+  galaxy.param
+  ICs/
+    galaxy_littleendian.dat
 ```
 
-# Create environment
+The parameter file can use paths relative to its own directory, such as:
 
-```bash
-spack load hdf5@1.14.1 gsl@2.1 fftw@2
-jarvis env build gadget2 +GADGET2_PATH +FFTW_PATH
+```text
+InitCondFile  ICs/galaxy_littleendian.dat
+OutputDir     output/
+EnergyFile   energy.txt
+InfoFile     info.txt
+SnapshotFileBase snapshot
 ```
 
-# Gassphere Pipeline
+JARVIS verifies the archive, extracts it into package-owned storage, copies the
+verified tree into the configured output root, and runs Gadget2 from the
+parameter file's directory. The caller-owned archive is never modified.
+
+## Pipeline example
 
 ```bash
-jarvis pipeline create gassphere
-jarvis pipeline env copy gadget2
-jarvis pipeline append gadget2
-jarvis pkg configure gadget2 \
-test_case=gadget2 \
-out=${HOME}/gadget2
-jarvis pipeline run
+jarvis ppl create galaxy-study
+jarvis ppl append builtin.gadget2 galaxy \
+  input_bundle=/data/inputs/galaxy-study.tar \
+  parameter_path=galaxy/galaxy.param \
+  out=galaxy-run \
+  nprocs=8 \
+  ppn=4
+jarvis ppl run
 ```
 
-# NGenIC Pipeline
+Relative `out` paths resolve beneath the package shared directory. The package
+reports the bounded result tree, energy and runtime tables, snapshot sets, and
+restart sets through JARVIS artifact semantics. A zero process exit is not
+sufficient for finalization: required energy, information, and snapshot products
+must also exist.
 
-```bash
-jarvis pipeline create gassphere
-jarvis pipeline env copy gadget2
-jarvis pipeline append gadget2
-jarvis pkg configure gadget2 \
-test_case=gassphere-ngen \
-out=${HOME}/gadget2 \
-ic=hello
-jarvis pipeline run
-```
+## Retained stock profile
+
+Existing pipelines that configure `gadget2_path`, `test_case`, and `output`
+continue to use the historical stock-case profile. Those controls remain hidden
+from agent-facing metadata so a generated scientific study cannot silently fall
+back to the default `gassphere` example. New scientific workflows should use an
+input bundle.

--- a/builtin/builtin/gadget2/artifacts.py
+++ b/builtin/builtin/gadget2/artifacts.py
@@ -1,0 +1,399 @@
+"""Generated-artifact semantics for the builtin Gadget2 package."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import posixpath
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+from jarvis_cd.artifacts.schema import JsonValue
+from jarvis_cd.input_bundle import extract_input_bundle
+
+_MAX_DISCOVERED_FILES = 4096
+_MAX_REPORTED_MEMBERS = 512
+_MAX_CHECKSUM_BYTES = 256 * 1024 * 1024
+_LOG_PRODUCTS = {
+    "energy.txt": (
+        "gadget2-energy",
+        "scientific_dataset",
+        "gadget2-energy-table",
+        "text/plain",
+    ),
+    "info.txt": (
+        "gadget2-info",
+        "scientific_log",
+        "gadget2-timestep-log",
+        "text/plain",
+    ),
+    "cpu.txt": (
+        "gadget2-cpu",
+        "performance_log",
+        "gadget2-cpu-log",
+        "text/plain",
+    ),
+    "timings.txt": (
+        "gadget2-timings",
+        "performance_log",
+        "gadget2-timing-log",
+        "text/plain",
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _OutputFile:
+    """One safe regular file below the package-owned result root."""
+
+    relative_path: PurePosixPath
+    size_bytes: int
+
+
+@dataclass
+class Gadget2ArtifactAdapter:
+    """Discover bounded Gadget2 logs, snapshots, and restart state."""
+
+    output_dir: PurePosixPath
+    input_paths: frozenset[PurePosixPath] = frozenset()
+    _local_root: Path | None = None
+    _finalized: bool = False
+    _collection_artifact_id: str = field(default_factory=new_artifact_id)
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for authoritative process completion before inspecting outputs."""
+
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Finalize outputs for a successful legacy completion callback."""
+
+        return self._finalize(return_code=0)
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Finalize outputs with the authoritative process completion state."""
+
+        return self._finalize(return_code=return_code)
+
+    def reset_artifacts(self) -> None:
+        """Permit discovery after an execution stream is replaced."""
+
+        self._finalized = False
+
+    def _local_output_path(self) -> Path:
+        """Project the declared cluster directory into this host filesystem."""
+
+        if self._local_root is not None:
+            return self._local_root
+        return Path(self.output_dir.as_posix())
+
+    def _discover_files(self) -> tuple[list[_OutputFile], bool]:
+        """Walk the owned output tree without following links and with a bound."""
+
+        root = self._local_output_path()
+        if not root.exists():
+            return [], False
+        if root.is_symlink() or not root.is_dir():
+            raise RuntimeError(f"Gadget2 output root is not a real directory: {root}")
+        files: list[_OutputFile] = []
+        truncated = False
+        try:
+            for current, directory_names, file_names in os.walk(
+                root, topdown=True, followlinks=False
+            ):
+                current_path = Path(current)
+                directory_names[:] = [
+                    name
+                    for name in sorted(directory_names)
+                    if not (current_path / name).is_symlink()
+                ]
+                for name in sorted(file_names):
+                    path = current_path / name
+                    if path.is_symlink() or not path.is_file():
+                        continue
+                    relative = PurePosixPath(path.relative_to(root).as_posix())
+                    if relative in self.input_paths:
+                        continue
+                    if len(files) >= _MAX_DISCOVERED_FILES:
+                        truncated = True
+                        break
+                    files.append(_OutputFile(relative, path.stat().st_size))
+                if truncated:
+                    break
+        except OSError as exc:
+            raise RuntimeError(
+                f"cannot inspect Gadget2 output directory {root}: {exc}"
+            ) from exc
+        return files, truncated
+
+    def _finalize(self, *, return_code: int) -> list[ArtifactObservation]:
+        if self._finalized:
+            return []
+        self._finalized = True
+        files, truncated = self._discover_files()
+        if not files and not truncated:
+            return []
+        by_basename: dict[str, list[_OutputFile]] = {}
+        for item in files:
+            by_basename.setdefault(item.relative_path.name.casefold(), []).append(item)
+        snapshots = [
+            item
+            for item in files
+            if item.relative_path.name.casefold().startswith("snapshot_")
+        ]
+        restarts = [
+            item
+            for item in files
+            if item.relative_path.name.casefold().startswith("restart.")
+        ]
+        missing = [
+            name
+            for name in ("energy.txt", "info.txt")
+            if len(by_basename.get(name, ())) != 1
+        ]
+        if not snapshots:
+            missing.append("snapshot")
+        valid = return_code == 0 and not truncated and not missing
+        state = ArtifactState.FINALIZED if valid else ArtifactState.INCOMPLETE
+        if missing:
+            message = "Gadget2 result is missing required products: " + ", ".join(
+                missing
+            )
+        elif truncated:
+            message = "Gadget2 output discovery reached its safety bound"
+        elif return_code != 0:
+            message = f"Gadget2 process exited with status {return_code}"
+        else:
+            message = "Gadget2 result tree finalized"
+        observations = [
+            self._collection_observation(files, state=state, message=message)
+        ]
+        for basename, identity in _LOG_PRODUCTS.items():
+            matches = by_basename.get(basename, ())
+            if len(matches) == 1:
+                observations.append(
+                    self._file_observation(matches[0], identity=identity, state=state)
+                )
+        if snapshots:
+            observations.append(
+                self._set_observation(
+                    snapshots,
+                    logical_name="gadget2-snapshots",
+                    kind="scientific_dataset",
+                    format_name="gadget2-snapshot-set",
+                    media_type="application/x-gadget2-snapshot",
+                    state=state,
+                )
+            )
+        if restarts:
+            observations.append(
+                self._set_observation(
+                    restarts,
+                    logical_name="gadget2-restarts",
+                    kind="checkpoint",
+                    format_name="gadget2-restart-set",
+                    media_type="application/x-gadget2-restart",
+                    state=state,
+                )
+            )
+        return observations
+
+    def _collection_observation(
+        self,
+        files: list[_OutputFile],
+        *,
+        state: ArtifactState,
+        message: str,
+    ) -> ArtifactObservation:
+        """Describe the bounded package-owned result tree."""
+
+        names: list[JsonValue] = [
+            item.relative_path.as_posix() for item in files[:_MAX_REPORTED_MEMBERS]
+        ]
+        return ArtifactObservation(
+            artifact_id=self._collection_artifact_id,
+            logical_name="gadget2-results",
+            kind="scientific_dataset",
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(self.output_dir),
+            format="gadget2-output-tree",
+            size_bytes=sum(item.size_bytes for item in files),
+            message=message,
+            metadata={
+                "application": "gadget2",
+                "completion_signal": "process_exit",
+                "member_count_observed": len(files),
+                "member_names": names,
+                "member_names_truncated": len(files) > len(names),
+            },
+        )
+
+    def _file_observation(
+        self,
+        item: _OutputFile,
+        *,
+        identity: tuple[str, str, str, str],
+        state: ArtifactState,
+    ) -> ArtifactObservation:
+        """Describe one exact Gadget2 log or table."""
+
+        logical_name, kind, format_name, media_type = identity
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(
+                self.output_dir / item.relative_path
+            ),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=item.size_bytes,
+            checksum=self._checksum(item),
+            message="Gadget2 product finalized",
+            metadata={"application": "gadget2"},
+        )
+
+    def _set_observation(
+        self,
+        items: list[_OutputFile],
+        *,
+        logical_name: str,
+        kind: str,
+        format_name: str,
+        media_type: str,
+        state: ArtifactState,
+    ) -> ArtifactObservation:
+        """Describe one bounded set of snapshots or per-rank restart files."""
+
+        paths: list[JsonValue] = [
+            item.relative_path.as_posix() for item in items[:_MAX_REPORTED_MEMBERS]
+        ]
+        parents = {item.relative_path.parent for item in items}
+        location = self.output_dir
+        if len(parents) == 1:
+            location /= next(iter(parents))
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(location),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=sum(item.size_bytes for item in items),
+            message="Gadget2 product set finalized",
+            metadata={
+                "application": "gadget2",
+                "member_count": len(items),
+                "member_names": paths,
+                "member_names_truncated": len(items) > len(paths),
+            },
+        )
+
+    def _checksum(self, item: _OutputFile) -> str | None:
+        """Hash one bounded output file."""
+
+        if item.size_bytes > _MAX_CHECKSUM_BYTES:
+            return None
+        path = self._local_output_path() / item.relative_path
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                digest.update(chunk)
+        return f"sha256:{digest.hexdigest()}"
+
+
+def adapter_from_package(package: dict[str, Any]) -> Gadget2ArtifactAdapter | None:
+    """Create artifact semantics for the builtin Gadget2 package."""
+
+    if package.get("pkg_type") != "builtin.gadget2":
+        return None
+    input_bundle = package.get("input_bundle")
+    if not isinstance(input_bundle, str) or not input_bundle:
+        return None
+    output_dir = _configured_output_dir(
+        package.get("out"),
+        shared_dir=package.get("shared_dir"),
+        runtime_cwd=package.get("runtime_cwd"),
+    )
+    deploy_mode = str(package.get("effective_deploy_mode") or "default").casefold()
+    if deploy_mode == "container":
+        roots = tuple(
+            root
+            for root in (
+                _optional_absolute_path(package.get("shared_dir")),
+                _optional_absolute_path(package.get("private_dir")),
+            )
+            if root is not None
+        )
+        if not any(output_dir.is_relative_to(root) for root in roots):
+            return None
+    shared_dir = _optional_absolute_path(package.get("shared_dir"))
+    if shared_dir is None:
+        raise ValueError("Gadget2 input-bundle artifacts require shared_dir")
+    materialized = extract_input_bundle(
+        input_bundle, Path(shared_dir.as_posix()) / "input-bundles"
+    )
+    input_paths = frozenset(
+        PurePosixPath(item.path) for item in materialized.manifest.files
+    )
+    return Gadget2ArtifactAdapter(output_dir, input_paths)
+
+
+def _configured_output_dir(
+    value: object,
+    *,
+    shared_dir: object,
+    runtime_cwd: object,
+) -> PurePosixPath:
+    """Resolve the normalized absolute output directory used by the package."""
+
+    raw = "run" if value in (None, "") else value
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("Gadget2 artifacts require a printable output path")
+    path = PurePosixPath(raw)
+    if not path.is_absolute():
+        base = _optional_absolute_path(shared_dir)
+        if base is None:
+            base = _optional_absolute_path(runtime_cwd)
+        if base is None:
+            raise ValueError(
+                "relative Gadget2 artifact output requires shared_dir or runtime_cwd"
+            )
+        path = base / path
+    normalized = PurePosixPath(posixpath.normpath(path.as_posix()))
+    if not normalized.is_absolute() or ".." in normalized.parts:
+        raise ValueError("Gadget2 artifacts require a normalized absolute output path")
+    return normalized
+
+
+def _optional_absolute_path(value: object) -> PurePosixPath | None:
+    """Return a normalized absolute POSIX path when one is available."""
+
+    if not isinstance(value, str) or not value:
+        return None
+    path = PurePosixPath(value)
+    if not path.is_absolute() or ".." in path.parts:
+        return None
+    return path

--- a/builtin/builtin/gadget2/artifacts.py
+++ b/builtin/builtin/gadget2/artifacts.py
@@ -9,6 +9,10 @@ from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from .output_contract import (
+    Gadget2OutputContract,
+    parse_gadget2_output_contract,
+)
 from jarvis_cd.artifacts import (
     ArtifactLocation,
     ArtifactObservation,
@@ -25,25 +29,25 @@ _MAX_DISCOVERED_FILES = 4096
 _MAX_REPORTED_MEMBERS = 512
 _MAX_CHECKSUM_BYTES = 256 * 1024 * 1024
 _LOG_PRODUCTS = {
-    "energy.txt": (
+    "energy_file": (
         "gadget2-energy",
         "scientific_dataset",
         "gadget2-energy-table",
         "text/plain",
     ),
-    "info.txt": (
+    "info_file": (
         "gadget2-info",
         "scientific_log",
         "gadget2-timestep-log",
         "text/plain",
     ),
-    "cpu.txt": (
+    "cpu_file": (
         "gadget2-cpu",
         "performance_log",
         "gadget2-cpu-log",
         "text/plain",
     ),
-    "timings.txt": (
+    "timings_file": (
         "gadget2-timings",
         "performance_log",
         "gadget2-timing-log",
@@ -66,6 +70,7 @@ class Gadget2ArtifactAdapter:
 
     output_dir: PurePosixPath
     input_paths: frozenset[PurePosixPath] = frozenset()
+    declared_outputs: Gadget2OutputContract | None = None
     _local_root: Path | None = None
     _finalized: bool = False
     _collection_artifact_id: str = field(default_factory=new_artifact_id)
@@ -146,26 +151,33 @@ class Gadget2ArtifactAdapter:
         files, truncated = self._discover_files()
         if not files and not truncated:
             return []
-        by_basename: dict[str, list[_OutputFile]] = {}
-        for item in files:
-            by_basename.setdefault(item.relative_path.name.casefold(), []).append(item)
+        declared = self.declared_outputs
+        if declared is None:
+            raise RuntimeError("Gadget2 artifact discovery requires declared outputs")
+        by_path = {item.relative_path: item for item in files}
+        snapshot_base = declared.snapshot_file_base
         snapshots = [
             item
             for item in files
-            if item.relative_path.name.casefold().startswith("snapshot_")
+            if item.relative_path.parent == snapshot_base.parent
+            and item.relative_path.name.startswith(f"{snapshot_base.name}_")
         ]
         restarts = [
             item
             for item in files
-            if item.relative_path.name.casefold().startswith("restart.")
+            if item.relative_path.parent == declared.output_dir
+            and item.relative_path.name.casefold().startswith("restart.")
         ]
-        missing = [
-            name
-            for name in ("energy.txt", "info.txt")
-            if len(by_basename.get(name, ())) != 1
-        ]
-        if not snapshots:
-            missing.append("snapshot")
+        missing: list[str] = []
+        for label, path in (
+            ("EnergyFile", declared.energy_file),
+            ("InfoFile", declared.info_file),
+        ):
+            product = by_path.get(path)
+            if product is None or product.size_bytes <= 0:
+                missing.append(label)
+        if not any(snapshot.size_bytes > 0 for snapshot in snapshots):
+            missing.append("SnapshotFileBase")
         valid = return_code == 0 and not truncated and not missing
         state = ArtifactState.FINALIZED if valid else ArtifactState.INCOMPLETE
         if missing:
@@ -181,11 +193,15 @@ class Gadget2ArtifactAdapter:
         observations = [
             self._collection_observation(files, state=state, message=message)
         ]
-        for basename, identity in _LOG_PRODUCTS.items():
-            matches = by_basename.get(basename, ())
-            if len(matches) == 1:
+        for field_name, identity in _LOG_PRODUCTS.items():
+            declared_path = getattr(declared, field_name)
+            if declared_path is not None and declared_path in by_path:
                 observations.append(
-                    self._file_observation(matches[0], identity=identity, state=state)
+                    self._file_observation(
+                        by_path[declared_path],
+                        identity=identity,
+                        state=state,
+                    )
                 )
         if snapshots:
             observations.append(
@@ -355,10 +371,45 @@ def adapter_from_package(package: dict[str, Any]) -> Gadget2ArtifactAdapter | No
     materialized = extract_input_bundle(
         input_bundle, Path(shared_dir.as_posix()) / "input-bundles"
     )
+    parameter_path = _selected_parameter_path(
+        package.get("parameter_path"),
+        entrypoint=materialized.manifest.entrypoint,
+        declared=frozenset(item.path for item in materialized.manifest.files),
+    )
+    parameter = materialized.root / parameter_path
+    try:
+        parameter_text = parameter.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise ValueError("Gadget2 parameter file must be readable UTF-8 text") from exc
+    declared_outputs = parse_gadget2_output_contract(
+        parameter_text,
+        parameter_path=parameter_path,
+    )
     input_paths = frozenset(
         PurePosixPath(item.path) for item in materialized.manifest.files
     )
-    return Gadget2ArtifactAdapter(output_dir, input_paths)
+    return Gadget2ArtifactAdapter(output_dir, input_paths, declared_outputs)
+
+
+def _selected_parameter_path(
+    value: object,
+    *,
+    entrypoint: str,
+    declared: frozenset[str],
+) -> PurePosixPath:
+    """Resolve the package-selected parameter within the bundle manifest."""
+
+    raw = entrypoint if value in (None, "") else value
+    if not isinstance(raw, str) or not raw or "\\" in raw:
+        raise ValueError("Gadget2 parameter_path must be a manifest path")
+    path = PurePosixPath(raw)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError("Gadget2 parameter_path must be a confined manifest path")
+    if path.as_posix() not in declared:
+        raise ValueError("Gadget2 parameter_path is not declared by the input bundle")
+    if path.suffix.casefold() != ".param":
+        raise ValueError("Gadget2 parameter_path must end in .param")
+    return path
 
 
 def _configured_output_dir(

--- a/builtin/builtin/gadget2/output_contract.py
+++ b/builtin/builtin/gadget2/output_contract.py
@@ -1,0 +1,129 @@
+"""Parse confined output declarations from Gadget2 parameter files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+_REQUIRED_FIELDS = (
+    "OutputDir",
+    "EnergyFile",
+    "InfoFile",
+    "SnapshotFileBase",
+)
+_OPTIONAL_FIELDS = ("CpuFile", "TimingsFile")
+
+
+@dataclass(frozen=True, slots=True)
+class Gadget2OutputContract:
+    """Output paths declared by one Gadget2 parameter file.
+
+    Every path is relative to the root into which the input bundle is staged.
+    """
+
+    output_dir: PurePosixPath
+    energy_file: PurePosixPath
+    info_file: PurePosixPath
+    snapshot_file_base: PurePosixPath
+    cpu_file: PurePosixPath | None = None
+    timings_file: PurePosixPath | None = None
+
+
+def parse_gadget2_output_contract(
+    text: str,
+    *,
+    parameter_path: PurePosixPath,
+) -> Gadget2OutputContract:
+    """Return the exact confined outputs declared by a parameter file.
+
+    :param text: UTF-8 decoded Gadget2 parameter contents.
+    :param parameter_path: Parameter path relative to the staged bundle root.
+    :raises ValueError: If a required declaration is absent, duplicated, or unsafe.
+    """
+
+    parameter_path = _confined_path(parameter_path.as_posix(), field="parameter_path")
+    values: dict[str, list[str]] = {
+        name: [] for name in (*_REQUIRED_FIELDS, *_OPTIONAL_FIELDS)
+    }
+    for raw_line in text.splitlines():
+        statement = raw_line.partition("%")[0].partition(";")[0].strip()
+        if not statement:
+            continue
+        tokens = statement.split()
+        field = tokens[0]
+        if field not in values:
+            continue
+        if len(tokens) != 2:
+            raise ValueError(f"Gadget2 {field} must contain one path token")
+        values[field].append(tokens[1])
+
+    for field in _REQUIRED_FIELDS:
+        if len(values[field]) != 1:
+            raise ValueError(
+                f"Gadget2 parameter file must declare {field} exactly once"
+            )
+    for field in _OPTIONAL_FIELDS:
+        if len(values[field]) > 1:
+            raise ValueError(f"Gadget2 parameter file may declare {field} at most once")
+
+    parameter_dir = parameter_path.parent
+    output_dir = _join_confined(
+        parameter_dir,
+        values["OutputDir"][0],
+        field="OutputDir",
+    )
+
+    def product(field: str) -> PurePosixPath:
+        return _join_confined(output_dir, values[field][0], field=field)
+
+    def optional_product(field: str) -> PurePosixPath | None:
+        if not values[field]:
+            return None
+        return _join_confined(output_dir, values[field][0], field=field)
+
+    return Gadget2OutputContract(
+        output_dir=output_dir,
+        energy_file=product("EnergyFile"),
+        info_file=product("InfoFile"),
+        snapshot_file_base=product("SnapshotFileBase"),
+        cpu_file=optional_product("CpuFile"),
+        timings_file=optional_product("TimingsFile"),
+    )
+
+
+def _join_confined(
+    base: PurePosixPath,
+    value: str,
+    *,
+    field: str,
+) -> PurePosixPath:
+    """Join one untrusted relative token below a previously confined base."""
+
+    relative = _confined_path(value, field=field)
+    joined = base / relative
+    try:
+        joined.relative_to(base)
+    except ValueError as exc:
+        raise ValueError(f"Gadget2 {field} escapes its declared output root") from exc
+    return joined
+
+
+def _confined_path(value: str, *, field: str) -> PurePosixPath:
+    """Parse one bounded printable relative POSIX path."""
+
+    if (
+        not value
+        or len(value) > 1024
+        or "\\" in value
+        or any(ord(character) < 32 for character in value)
+    ):
+        raise ValueError(f"Gadget2 {field} must use a confined POSIX path")
+    path = PurePosixPath(value)
+    if (
+        not path.parts
+        or path.is_absolute()
+        or ".." in path.parts
+        or (path.parts and ":" in path.parts[0])
+    ):
+        raise ValueError(f"Gadget2 {field} must use a confined POSIX path")
+    return path

--- a/builtin/builtin/gadget2/pkg.py
+++ b/builtin/builtin/gadget2/pkg.py
@@ -8,6 +8,10 @@ import shutil
 from pathlib import Path, PurePosixPath
 from typing import Any, cast
 
+from .output_contract import (
+    Gadget2OutputContract,
+    parse_gadget2_output_contract,
+)
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.deployment import (
     ConfigurationCondition,
@@ -195,7 +199,8 @@ class Gadget2(Application):
                     when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
                     runtime_requirements=("gadget2",),
                     readiness=ReadinessContract(
-                        mechanism="process_exit", condition="successful_exit"
+                        mechanism="process_exit",
+                        condition="successful_exit_with_required_products",
                     ),
                     description=(
                         "Run one caller-supplied Gadget2 parameter and "
@@ -339,7 +344,7 @@ class Gadget2(Application):
             raise ValueError("selected Gadget2 parameter_path is not a regular file")
         return selected
 
-    def _prepare_native_input(self) -> Path:
+    def _prepare_native_input(self) -> tuple[Path, Gadget2OutputContract]:
         """Verify and copy one complete simulation bundle into owned storage."""
 
         self._validate_native_configuration()
@@ -359,49 +364,32 @@ class Gadget2(Application):
         staged = self._output_dir() / relative
         if staged.is_symlink() or not staged.is_file():
             raise RuntimeError("staged Gadget2 parameter file is unavailable")
-        self._prepare_native_output_directory(staged)
-        return staged
+        contract = self._prepare_native_output_directory(staged, relative=relative)
+        self._assert_native_outputs_absent(contract)
+        return staged, contract
 
-    @staticmethod
-    def _prepare_native_output_directory(parameter: Path) -> Path:
+    def _prepare_native_output_directory(
+        self,
+        parameter: Path,
+        *,
+        relative: Path,
+    ) -> Gadget2OutputContract:
         """Create the parameter-declared output directory inside owned storage."""
 
         try:
-            lines = parameter.read_text(encoding="utf-8").splitlines()
+            text = parameter.read_text(encoding="utf-8")
         except (OSError, UnicodeError) as exc:
             raise ValueError(
                 "Gadget2 parameter file must be readable UTF-8 text"
             ) from exc
-        values: list[str] = []
-        for raw_line in lines:
-            statement = raw_line.partition("%")[0].partition(";")[0].strip()
-            if not statement:
-                continue
-            tokens = statement.split()
-            if tokens[0] != "OutputDir":
-                continue
-            if len(tokens) != 2:
-                raise ValueError("Gadget2 OutputDir must contain one path token")
-            values.append(tokens[1])
-        if len(values) != 1:
-            raise ValueError(
-                "Gadget2 parameter file must declare OutputDir exactly once"
-            )
-
-        raw_output = values[0]
-        if "\\" in raw_output:
-            raise ValueError("Gadget2 OutputDir must use a confined POSIX path")
-        relative = PurePosixPath(raw_output)
-        if (
-            relative.is_absolute()
-            or ".." in relative.parts
-            or (relative.parts and ":" in relative.parts[0])
-        ):
-            raise ValueError("Gadget2 OutputDir must use a confined POSIX path")
-        lexical_target = parameter.parent.joinpath(*relative.parts)
+        contract = parse_gadget2_output_contract(
+            text,
+            parameter_path=PurePosixPath(relative.as_posix()),
+        )
+        lexical_target = self._output_dir().joinpath(*contract.output_dir.parts)
         if lexical_target.is_symlink():
             raise ValueError("Gadget2 OutputDir cannot be a symbolic link")
-        root = parameter.parent.resolve()
+        root = self._output_dir().resolve()
         target = lexical_target.resolve(strict=False)
         try:
             target.relative_to(root)
@@ -413,12 +401,83 @@ class Gadget2(Application):
             raise RuntimeError("could not create Gadget2 OutputDir") from exc
         if target.is_symlink() or not target.is_dir():
             raise ValueError("Gadget2 OutputDir must resolve to a directory")
-        return target
+        return contract
+
+    def _contract_path(self, relative: PurePosixPath) -> Path:
+        """Resolve one parsed output path below the package-owned run root."""
+
+        root = self._output_dir().resolve()
+        lexical = self._output_dir().joinpath(*relative.parts)
+        resolved = lexical.resolve(strict=False)
+        try:
+            resolved.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(
+                "Gadget2 output path escapes staged input storage"
+            ) from exc
+        return lexical
+
+    def _snapshot_products(
+        self,
+        contract: Gadget2OutputContract,
+    ) -> list[Path]:
+        """Return bounded regular snapshots matching the declared file base."""
+
+        base = self._contract_path(contract.snapshot_file_base)
+        parent = base.parent
+        if parent.is_symlink() or not parent.is_dir():
+            return []
+        products: list[Path] = []
+        for candidate in parent.glob(f"{base.name}_*"):
+            if candidate.is_symlink() or not candidate.is_file():
+                continue
+            products.append(candidate)
+            if len(products) >= 4096:
+                break
+        return products
+
+    def _assert_native_outputs_absent(
+        self,
+        contract: Gadget2OutputContract,
+    ) -> None:
+        """Prevent staged or stale files from satisfying completion checks."""
+
+        for relative in (contract.energy_file, contract.info_file):
+            path = self._contract_path(relative)
+            if path.exists() or path.is_symlink():
+                raise ValueError(
+                    "Gadget2 required outputs must not exist before execution"
+                )
+        if self._snapshot_products(contract):
+            raise ValueError("Gadget2 snapshots must not exist before execution")
+
+    def _validate_native_completion(
+        self,
+        contract: Gadget2OutputContract,
+    ) -> None:
+        """Require non-empty scientific products after a successful process exit."""
+
+        missing: list[str] = []
+        for label, relative in (
+            ("EnergyFile", contract.energy_file),
+            ("InfoFile", contract.info_file),
+        ):
+            path = self._contract_path(relative)
+            if path.is_symlink() or not path.is_file() or path.stat().st_size <= 0:
+                missing.append(label)
+        snapshots = self._snapshot_products(contract)
+        if not any(snapshot.stat().st_size > 0 for snapshot in snapshots):
+            missing.append("SnapshotFileBase")
+        if missing:
+            raise RuntimeError(
+                "Gadget2 exited without required non-empty products: "
+                + ", ".join(missing)
+            )
 
     def _start_native(self) -> None:
         """Launch the staged scientific input and propagate every rank failure."""
 
-        parameter = self._prepare_native_input()
+        parameter, contract = self._prepare_native_input()
         executable = self.gadget2_bin or self._discover_executable(self.mod_env)
         if executable is None:
             raise RuntimeError("Gadget2 executable is unavailable through PATH")
@@ -437,6 +496,7 @@ class Gadget2(Application):
         failures = {host: code for host, code in result.exit_code.items() if code != 0}
         if failures:
             raise RuntimeError(f"Gadget2 execution failed: {failures}")
+        self._validate_native_completion(contract)
 
     def _configure_legacy(self) -> None:
         """Preserve the historical stock-case/container configuration."""

--- a/builtin/builtin/gadget2/pkg.py
+++ b/builtin/builtin/gadget2/pkg.py
@@ -1,186 +1,533 @@
-"""
-Gadget2 cosmological N-body/SPH simulation. Supports bare-metal and
-container deployments. Container mode builds FFTW 2.1.5 from source (Gadget2
-needs the single-precision, type-prefixed, MPI variant — FFTW3 in the Ubuntu
-archive is ABI-incompatible) and clones lukemartinlogan/gadget2 into
-/opt/gadget2 in build.sh.
-"""
+"""Launch native or containerized Gadget2 simulations."""
+
+from __future__ import annotations
+
 import os
+import shlex
+import shutil
+from pathlib import Path, PurePosixPath
+from typing import Any, cast
 
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo, MpiExecInfo, Mkdir
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ReadinessContract,
+    RuntimeRequirement,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
+from jarvis_cd.shell.process import Mkdir, Rm
 
-
-_TEST_CASES = ['gassphere']
-_GADGET2_PATH_CONTAINER = '/opt/gadget2'
-_BINARY_REL_PATH = 'build/bin/Gadget2'
+_LEGACY_TEST_CASES = (
+    "gassphere",
+    "galaxy",
+    "cluster",
+    "lcdm_gas",
+    "lcdm_gas-ngen",
+)
+_GADGET2_PATH_CONTAINER = "/opt/gadget2"
+_BINARY_REL_PATH = "build/bin/Gadget2"
+_EXECUTABLE_CANDIDATES = ("Gadget2", "gadget2")
 
 
 class Gadget2(Application):
-    """
-    Gadget2 driver.
+    """Run one caller-defined Gadget2 parameter and initial-condition bundle.
+
+    The native profile stages a digest-verified multi-file bundle into one
+    execution-owned directory and launches exactly one declared parameter file.
+    The historical stock-case/container profile remains available for existing
+    pipelines but is not advertised as an agent-facing scientific contract.
     """
 
-    def _configure_menu(self):
+    def _init(self) -> None:
+        self.gadget2_bin: str | None = None
+
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
-            {'name': 'gadget2_path',
-             'msg': ('Absolute path to the Gadget2 source tree (containing '
-                     'ICs/, Gadget2/, build/). In container mode this is '
-                     'baked into the image at /opt/gadget2 and this option '
-                     'is ignored.'),
-             'type': str, 'default': None},
-            {'name': 'test_case', 'msg': 'Predefined test case (paramfile basename)',
-             'type': str, 'default': 'gassphere', 'choices': _TEST_CASES},
-            {'name': 'output', 'msg': 'Output directory (None = under shared_dir)',
-             'type': str, 'default': None},
-            {'name': 'time_max', 'msg': 'Maximum simulation time (internal units)',
-             'type': float, 'default': 0.05},
-            {'name': 'buffer_size', 'msg': 'Communication buffer size in MB',
-             'type': float, 'default': 15},
-            {'name': 'part_alloc_factor',
-             'msg': 'Per-rank particle allocation factor (1.0 - 3.0)',
-             'type': float, 'default': 1.5},
-            {'name': 'tree_alloc_factor', 'msg': 'BH-tree allocation factor',
-             'type': float, 'default': 0.9},
-            {'name': 'nprocs', 'msg': 'Total number of MPI ranks',
-             'type': int, 'default': 2},
-            {'name': 'ppn', 'msg': 'Processes per node',
-             'type': int, 'default': 2},
-            {'name': 'exec_mode', 'msg': 'Multi-node mode: mpi or pssh',
-             'type': str, 'default': 'mpi', 'choices': ['mpi', 'pssh']},
+            {
+                "name": "input_bundle",
+                "msg": (
+                    "Digest-verified JARVIS input bundle containing one Gadget2 "
+                    "parameter file and every referenced initial-condition or "
+                    "support file. The bundle is copied into execution-owned "
+                    "storage before launch."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
+            },
+            {
+                "name": "parameter_path",
+                "msg": (
+                    "Relative manifest member to execute; empty selects the "
+                    "input-bundle entrypoint"
+                ),
+                "type": str,
+                "default": "",
+            },
+            {
+                "name": "out",
+                "msg": (
+                    "Output directory. Relative paths resolve under the JARVIS "
+                    "package shared directory."
+                ),
+                "type": str,
+                "default": "run",
+            },
+            {
+                "name": "nprocs",
+                "msg": "Total number of MPI ranks",
+                "type": int,
+                "default": 2,
+            },
+            {
+                "name": "ppn",
+                "msg": "MPI ranks per node",
+                "type": int,
+                "default": 2,
+            },
+            {
+                "name": "gadget2_path",
+                "msg": "Legacy source-tree path used by stock examples",
+                "type": str,
+                "default": None,
+                "agent_visible": False,
+            },
+            {
+                "name": "test_case",
+                "msg": "Legacy bundled Gadget2 stock-case template",
+                "type": str,
+                "default": "gassphere",
+                "choices": list(_LEGACY_TEST_CASES),
+                "agent_visible": False,
+            },
+            {
+                "name": "output",
+                "msg": "Legacy stock-case output directory",
+                "type": str,
+                "default": None,
+                "agent_visible": False,
+            },
+            {
+                "name": "time_max",
+                "msg": "Legacy stock-case maximum simulation time",
+                "type": float,
+                "default": 0.05,
+                "agent_visible": False,
+            },
+            {
+                "name": "buffer_size",
+                "msg": "Legacy stock-case communication buffer size in MB",
+                "type": float,
+                "default": 15.0,
+                "agent_visible": False,
+            },
+            {
+                "name": "part_alloc_factor",
+                "msg": "Legacy stock-case particle allocation factor",
+                "type": float,
+                "default": 1.5,
+                "agent_visible": False,
+            },
+            {
+                "name": "tree_alloc_factor",
+                "msg": "Legacy stock-case tree allocation factor",
+                "type": float,
+                "default": 0.9,
+                "agent_visible": False,
+            },
+            {
+                "name": "exec_mode",
+                "msg": "Legacy multi-node launch mode",
+                "type": str,
+                "default": "mpi",
+                "choices": ["mpi", "pssh"],
+                "agent_visible": False,
+            },
         ]
 
-    # ------------------------------------------------------------------
-    # Container build/deploy
-    # ------------------------------------------------------------------
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe native Gadget2 runtime, input, and completion semantics."""
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+        environment = self._deployment_environment()
+        program = self._discover_executable(environment)
+        probe = probe_program(
+            program or "Gadget2",
+            environment=environment,
+            accepted_return_codes=(0, 1),
+            timeout_seconds=5,
+        )
+        capabilities = (
+            ("gadget2", "mpi_execution", "particle_simulation")
+            if program is not None and probe.status.usable is True
+            else ()
+        )
+        runtime = RuntimeRequirement(
+            requirement_id="gadget2",
+            description="MPI-enabled Gadget2 runtime available through PATH",
+            required_capabilities=(
+                "gadget2",
+                "mpi_execution",
+                "particle_simulation",
+            ),
+            available_capabilities=capabilities,
+            status=probe.status,
+        )
+        return PackageDeploymentContract(
+            package="builtin.gadget2",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="input_bundle",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    runtime_requirements=("gadget2",),
+                    readiness=ReadinessContract(
+                        mechanism="process_exit", condition="successful_exit"
+                    ),
+                    description=(
+                        "Run one caller-supplied Gadget2 parameter and "
+                        "initial-condition bundle under MPI."
+                    ),
+                ),
+            ),
+            runtime_requirements=(runtime,),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    requires=(ConfigurationCondition("parameter_path", "is_empty"),),
+                    description="parameter_path is valid only with input_bundle.",
+                ),
+            ),
+        )
+
+    def _build_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Build the retained legacy container image when requested."""
+
+        if self.config.get("deploy_mode") != "container":
             return None
-        return self._read_build_script('build.sh', {}), 'default'
+        return self._read_build_script("build.sh", {}), "default"
 
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Create the retained legacy container deployment image."""
+
+        if self.config.get("deploy_mode") != "container":
             return None
-        base = getattr(self.pipeline, 'container_base', 'ubuntu:22.04')
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': base,
-        })
-        return content, ''
+        base = getattr(self.pipeline, "container_base", "ubuntu:22.04")
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {
+                "BUILD_IMAGE": self.build_image_name(),
+                "DEPLOY_BASE": base,
+            },
+        )
+        return content, ""
 
-    # ------------------------------------------------------------------
-    # Configuration
-    # ------------------------------------------------------------------
+    def _configure(self, **kwargs: Any) -> None:
+        """Validate the selected profile and prepare package-owned storage."""
 
-    def _configure(self, **kwargs):
         super()._configure(**kwargs)
+        if self._uses_native_bundle():
+            self._validate_native_configuration()
+            if self.config.get("deploy_mode") == "default":
+                self.gadget2_bin = self._discover_executable(
+                    self._deployment_environment()
+                )
+            self._ensure_output_dir()
+            return
+        self._configure_legacy()
 
-        if self.config.get('deploy_mode') == 'container':
+    def _uses_native_bundle(self) -> bool:
+        """Return whether the explicit scientific input profile is selected."""
+
+        return self.config.get("input_bundle") not in (None, "")
+
+    @staticmethod
+    def _discover_executable(environment: dict[str, str]) -> str | None:
+        """Return the first supported Gadget2 executable available through PATH."""
+
+        for candidate in _EXECUTABLE_CANDIDATES:
+            if shutil.which(candidate, path=environment.get("PATH")) is not None:
+                return candidate
+        return None
+
+    def _validate_native_configuration(self) -> None:
+        """Reject missing bundle, unsafe parameter selection, and invalid MPI sizes."""
+
+        bundle = self.config.get("input_bundle")
+        if not isinstance(bundle, str) or not bundle:
+            raise ValueError("native Gadget2 requires input_bundle")
+        parameter_path = self.config.get("parameter_path")
+        if parameter_path not in (None, "") and not isinstance(parameter_path, str):
+            raise TypeError("parameter_path must be a relative path string")
+        values: dict[str, int] = {}
+        for name in ("nprocs", "ppn"):
+            value = self.config.get(name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+            values[name] = value
+        if values["ppn"] > values["nprocs"]:
+            raise ValueError("ppn cannot exceed nprocs")
+        if self.config.get("deploy_mode") != "default":
+            raise ValueError("input_bundle requires native deploy_mode=default")
+
+    def _output_dir(self) -> Path:
+        """Return the normalized package-owned output root."""
+
+        if self._uses_native_bundle():
+            value = self.config.get("out")
+            return self.resolve_shared_path(value, field="out", default="run")
+        value = self.config.get("output")
+        if value in (None, "") and self.config.get("out") not in (None, "", "run"):
+            value = self.config.get("out")
+        return self.resolve_shared_path(value, field="output", default="gadget2_out")
+
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        """Return local or parallel-SSH execution according to the hostfile."""
+
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
+
+    def _ensure_output_dir(self) -> None:
+        """Create the exact output root on every participating host."""
+
+        output_dir = str(self._output_dir())
+        result = Mkdir(output_dir, self._node_exec_info(env=self.env)).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to create Gadget2 output directory {output_dir}: {failures}"
+            )
+
+    @staticmethod
+    def _resolve_bundle_parameter(
+        bundle: MaterializedInputBundle, requested: object
+    ) -> Path:
+        """Resolve one manifest-declared parameter file without path inference."""
+
+        if requested in (None, ""):
+            selected = bundle.entrypoint
+        else:
+            if not isinstance(requested, str) or "\\" in requested:
+                raise ValueError("parameter_path must be a confined manifest path")
+            relative = PurePosixPath(requested)
+            if relative.is_absolute() or any(
+                part in {"", ".", ".."} for part in relative.parts
+            ):
+                raise ValueError("parameter_path must be a confined manifest path")
+            declared = {item.path for item in bundle.manifest.files}
+            if relative.as_posix() not in declared:
+                raise ValueError("parameter_path is not declared by the input bundle")
+            selected = bundle.root / relative
+        if selected.suffix.casefold() != ".param":
+            raise ValueError("selected Gadget2 parameter_path must end in .param")
+        if selected.is_symlink() or not selected.is_file():
+            raise ValueError("selected Gadget2 parameter_path is not a regular file")
+        return selected
+
+    def _prepare_native_input(self) -> Path:
+        """Verify and copy one complete simulation bundle into owned storage."""
+
+        self._validate_native_configuration()
+        self._ensure_output_dir()
+        configured = self.config.get("input_bundle")
+        assert isinstance(configured, str) and configured
+        if self.shared_dir is None:
+            raise RuntimeError("Gadget2 input bundles require shared storage")
+        bundle = extract_input_bundle(
+            configured, Path(self.shared_dir) / "input-bundles"
+        )
+        selected = self._resolve_bundle_parameter(
+            bundle, self.config.get("parameter_path")
+        )
+        relative = selected.relative_to(bundle.root)
+        stage_input_bundle(bundle, self._output_dir())
+        staged = self._output_dir() / relative
+        if staged.is_symlink() or not staged.is_file():
+            raise RuntimeError("staged Gadget2 parameter file is unavailable")
+        return staged
+
+    def _start_native(self) -> None:
+        """Launch the staged scientific input and propagate every rank failure."""
+
+        parameter = self._prepare_native_input()
+        executable = self.gadget2_bin or self._discover_executable(self.mod_env)
+        if executable is None:
+            raise RuntimeError("Gadget2 executable is unavailable through PATH")
+        command = " ".join((shlex.quote(executable), shlex.quote(parameter.name)))
+        result = Exec(
+            command,
+            MpiExecInfo(
+                nprocs=self.config["nprocs"],
+                ppn=self.config["ppn"],
+                hostfile=self.hostfile,
+                env=self.mod_env,
+                cwd=str(parameter.parent),
+                line_callback=self.runtime_line_callback(),
+            ),
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"Gadget2 execution failed: {failures}")
+
+    def _configure_legacy(self) -> None:
+        """Preserve the historical stock-case/container configuration."""
+
+        config = cast(dict[str, Any], self.config)
+        if config.get("parameter_path") not in (None, ""):
+            raise ValueError("parameter_path requires input_bundle")
+        if config.get("deploy_mode") == "container":
             gadget2_path = _GADGET2_PATH_CONTAINER
         else:
-            gadget2_path = (
-                self.config.get('gadget2_path')
-                or self.env.get('GADGET2_PATH')
-                or os.environ.get('GADGET2_PATH')
+            configured_path = (
+                config.get("gadget2_path")
+                or self.env.get("GADGET2_PATH")
+                or os.environ.get("GADGET2_PATH")
             )
-            if not gadget2_path:
+            if not isinstance(configured_path, str) or not configured_path:
                 raise RuntimeError(
-                    "GADGET2_PATH is not set. Set gadget2_path or export "
-                    "GADGET2_PATH for bare-metal, or use deploy_mode=container."
+                    "GADGET2_PATH is not set. Set gadget2_path for the legacy "
+                    "stock profile or provide input_bundle for the native profile."
                 )
+            gadget2_path = configured_path
             if not os.path.isdir(gadget2_path):
                 raise RuntimeError(
                     f"gadget2_path does not exist on the local node: {gadget2_path}"
                 )
-        self.config['gadget2_path'] = gadget2_path
-        self.setenv('GADGET2_PATH', gadget2_path)
-
-        if self.config.get('output') is None:
-            self.config['output'] = f'{self.shared_dir}/gadget2_out'
-        Mkdir([self.config['output']], LocalExecInfo()).run()
-
-        test_case = self.config.get('test_case', 'gassphere')
-        paramfile_in = os.path.join(self.pkg_dir, 'paramfiles',
-                                    f'{test_case}.param')
-        paramfile_out = os.path.join(self.config['output'],
-                                     f'{test_case}.param')
-        # MaxSizeTimestep is hard-coded in the stock paramfile to 0.02; with
-        # TimeMax much smaller we'd never take a step. The template only
-        # exposes the params Jarvis users tend to tune.
-        self.copy_template_file(paramfile_in, paramfile_out, replacements={
-            'REPO_DIR': gadget2_path,
-            'OUTPUT_DIR': self.config['output'],
-            'TIME_MAX': self.config['time_max'],
-            'BUFFER_SIZE': self.config['buffer_size'],
-            'PART_ALLOC_FACTOR': self.config['part_alloc_factor'],
-            'TREE_ALLOC_FACTOR': self.config['tree_alloc_factor'],
-        })
-        self.config['paramfile'] = paramfile_out
-
+        config["gadget2_path"] = gadget2_path
+        self.setenv("GADGET2_PATH", gadget2_path)
+        self._ensure_output_dir()
+        test_case = config.get("test_case", "gassphere")
+        if not isinstance(test_case, str) or test_case not in _LEGACY_TEST_CASES:
+            raise ValueError(f"unsupported legacy Gadget2 test_case: {test_case!r}")
+        package_dir = self.pkg_dir
+        if not isinstance(package_dir, str) or not package_dir:
+            raise RuntimeError("Gadget2 package directory is unavailable")
+        parameter_input = os.path.join(package_dir, "paramfiles", f"{test_case}.param")
+        parameter_output = self._output_dir() / f"{test_case}.param"
+        self.copy_template_file(
+            parameter_input,
+            str(parameter_output),
+            replacements={
+                "REPO_DIR": gadget2_path,
+                "OUTPUT_DIR": str(self._output_dir()),
+                "TIME_MAX": config["time_max"],
+                "BUFFER_SIZE": config["buffer_size"],
+                "PART_ALLOC_FACTOR": config["part_alloc_factor"],
+                "TREE_ALLOC_FACTOR": config["tree_alloc_factor"],
+            },
+        )
+        config["paramfile"] = str(parameter_output)
         binary = os.path.join(gadget2_path, _BINARY_REL_PATH)
-        if self.config.get('deploy_mode') != 'container' and not os.path.exists(binary):
-            raise RuntimeError(
-                f"Gadget2 binary not found at {binary}. Build it first via "
-                f"`cmake -S {gadget2_path} -B {gadget2_path}/build && "
-                f"cmake --build {gadget2_path}/build`."
-            )
-        self.config['binary'] = binary
+        if config.get("deploy_mode") != "container" and not os.path.isfile(binary):
+            raise RuntimeError(f"Gadget2 binary not found at {binary}")
+        config["binary"] = binary
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
+    def _use_remote(self) -> bool:
+        """Return whether the configured hostfile names remote nodes."""
 
-    def _use_remote(self):
         return self.hostfile is not None and not self.hostfile.is_local()
 
-    def _container_kwargs(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _container_kwargs(self) -> dict[str, Any]:
+        """Return legacy container launch arguments when applicable."""
+
+        if self.config.get("deploy_mode") != "container":
             return {}
-        return dict(
-            container=self._container_engine,
-            container_image=self.deploy_image_name(),
-            shared_dir=self.shared_dir,
-            private_dir=self.private_dir,
-        )
+        return {
+            "container": self._container_engine,
+            "container_image": self.deploy_image_name(),
+            "shared_dir": self.shared_dir,
+            "private_dir": self.private_dir,
+        }
 
-    def _exec_info(self, cwd):
-        nprocs = self.config['nprocs']
-        ppn = self.config['ppn']
-        exec_mode = self.config.get('exec_mode', 'mpi')
-        kwargs = dict(env=self.mod_env, cwd=cwd, **self._container_kwargs())
+    def _legacy_exec_info(self, cwd: str) -> LocalExecInfo | MpiExecInfo | PsshExecInfo:
+        """Return the historical stock-case execution mode."""
 
-        if exec_mode == 'mpi':
-            hostfile = self.hostfile if self._use_remote() else None
+        kwargs: dict[str, Any] = {
+            "env": self.mod_env,
+            "cwd": cwd,
+            **self._container_kwargs(),
+        }
+        if self.config.get("exec_mode", "mpi") == "mpi":
             return MpiExecInfo(
-                nprocs=nprocs, ppn=ppn, hostfile=hostfile,
-                port=self.ssh_port, **kwargs,
+                nprocs=self.config["nprocs"],
+                ppn=self.config["ppn"],
+                hostfile=self.hostfile if self._use_remote() else None,
+                port=self.ssh_port,
+                **kwargs,
             )
-        if exec_mode == 'pssh' and self._use_remote():
+        if self._use_remote():
             return PsshExecInfo(hostfile=self.hostfile, **kwargs)
         return LocalExecInfo(**kwargs)
 
-    def start(self):
-        # Gadget2 reads / writes paths relative to cwd. Run from the output
-        # dir so EnergyFile / InfoFile / snapshots land alongside the
-        # paramfile. Gadget2's MAXLEN_FILENAME is 100 chars — passing the
-        # full absolute path (often >100 under /tmp/...) overflows an early
-        # strcpy on startup ("buffer overflow detected"). We cd into the
-        # output dir and pass just the basename to stay well under the cap.
-        # Also needs a bash -c wrapper: the container exec wrapper doesn't
-        # honor exec_info.cwd, and mpirun takes the first token as the
-        # executable — wrap in `bash -c '...'` so mpirun launches it per-rank.
-        cwd = self.config['output']
-        paramfile_base = os.path.basename(self.config['paramfile'])
-        inner = f'cd {cwd} && {self.config["binary"]} {paramfile_base}'
-        cmd = f"bash -c \"{inner}\""
-        Exec(cmd, self._exec_info(cwd)).run()
+    def _start_legacy(self) -> None:
+        """Run the retained stock-case profile."""
 
-    def stop(self):
-        pass
+        config = cast(dict[str, Any], self.config)
+        cwd = str(self._output_dir())
+        parameter_file = config.get("paramfile")
+        binary = config.get("binary")
+        if not isinstance(parameter_file, str) or not isinstance(binary, str):
+            raise RuntimeError("legacy Gadget2 launch configuration is incomplete")
+        parameter_name = os.path.basename(parameter_file)
+        inner = " ".join(
+            (
+                "cd",
+                shlex.quote(cwd),
+                "&&",
+                shlex.quote(binary),
+                shlex.quote(parameter_name),
+            )
+        )
+        command = f"bash -c {shlex.quote(inner)}"
+        result = Exec(command, self._legacy_exec_info(cwd)).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"Gadget2 execution failed: {failures}")
 
-    def clean(self):
-        pass
+    def start(self) -> None:
+        """Run the explicit native bundle or retained legacy stock profile."""
 
-    def _get_stat(self, stat_dict):
-        stat_dict[f'{self.pkg_id}.runtime'] = self.start_time
+        if self._uses_native_bundle():
+            self._start_native()
+        elif "paramfile" in self.config and "binary" in self.config:
+            self._start_legacy()
+        else:
+            self._validate_native_configuration()
+
+    def stop(self) -> None:
+        """Do nothing because Gadget2 runs to process completion."""
+
+    def clean(self) -> None:
+        """Remove only the exact configured Gadget2 output directory."""
+
+        output_dir = self._output_dir()
+        if output_dir == Path(output_dir.anchor):
+            raise ValueError("refusing to clean a filesystem root as Gadget2 output")
+        result = Rm(
+            str(output_dir),
+            self._node_exec_info(env=self.env),
+            recursive=True,
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to clean Gadget2 output {output_dir}: {failures}"
+            )
+
+    def _get_stat(self, stat_dict: dict[str, Any]) -> None:
+        """Report the package runtime through the legacy statistics surface."""
+
+        stat_dict[f"{self.pkg_id}.runtime"] = getattr(self, "start_time", None)

--- a/builtin/builtin/gadget2/pkg.py
+++ b/builtin/builtin/gadget2/pkg.py
@@ -102,6 +102,7 @@ class Gadget2(Application):
                 "msg": "Legacy source-tree path used by stock examples",
                 "type": str,
                 "default": None,
+                "required": False,
                 "agent_visible": False,
             },
             {
@@ -117,6 +118,7 @@ class Gadget2(Application):
                 "msg": "Legacy stock-case output directory",
                 "type": str,
                 "default": None,
+                "required": False,
                 "agent_visible": False,
             },
             {

--- a/builtin/builtin/gadget2/pkg.py
+++ b/builtin/builtin/gadget2/pkg.py
@@ -359,7 +359,61 @@ class Gadget2(Application):
         staged = self._output_dir() / relative
         if staged.is_symlink() or not staged.is_file():
             raise RuntimeError("staged Gadget2 parameter file is unavailable")
+        self._prepare_native_output_directory(staged)
         return staged
+
+    @staticmethod
+    def _prepare_native_output_directory(parameter: Path) -> Path:
+        """Create the parameter-declared output directory inside owned storage."""
+
+        try:
+            lines = parameter.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeError) as exc:
+            raise ValueError(
+                "Gadget2 parameter file must be readable UTF-8 text"
+            ) from exc
+        values: list[str] = []
+        for raw_line in lines:
+            statement = raw_line.partition("%")[0].partition(";")[0].strip()
+            if not statement:
+                continue
+            tokens = statement.split()
+            if tokens[0] != "OutputDir":
+                continue
+            if len(tokens) != 2:
+                raise ValueError("Gadget2 OutputDir must contain one path token")
+            values.append(tokens[1])
+        if len(values) != 1:
+            raise ValueError(
+                "Gadget2 parameter file must declare OutputDir exactly once"
+            )
+
+        raw_output = values[0]
+        if "\\" in raw_output:
+            raise ValueError("Gadget2 OutputDir must use a confined POSIX path")
+        relative = PurePosixPath(raw_output)
+        if (
+            relative.is_absolute()
+            or ".." in relative.parts
+            or (relative.parts and ":" in relative.parts[0])
+        ):
+            raise ValueError("Gadget2 OutputDir must use a confined POSIX path")
+        lexical_target = parameter.parent.joinpath(*relative.parts)
+        if lexical_target.is_symlink():
+            raise ValueError("Gadget2 OutputDir cannot be a symbolic link")
+        root = parameter.parent.resolve()
+        target = lexical_target.resolve(strict=False)
+        try:
+            target.relative_to(root)
+        except ValueError as exc:
+            raise ValueError("Gadget2 OutputDir escapes staged input storage") from exc
+        try:
+            target.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise RuntimeError("could not create Gadget2 OutputDir") from exc
+        if target.is_symlink() or not target.is_dir():
+            raise ValueError("Gadget2 OutputDir must resolve to a directory")
+        return target
 
     def _start_native(self) -> None:
         """Launch the staged scientific input and propagate every rank failure."""

--- a/builtin/builtin/gadget2/pkg.py
+++ b/builtin/builtin/gadget2/pkg.py
@@ -241,7 +241,7 @@ class Gadget2(Application):
         super()._configure(**kwargs)
         if self._uses_native_bundle():
             self._validate_native_configuration()
-            if self.config.get("deploy_mode") == "default":
+            if self.config.get("deploy_mode", "default") == "default":
                 self.gadget2_bin = self._discover_executable(
                     self._deployment_environment()
                 )
@@ -280,7 +280,7 @@ class Gadget2(Application):
             values[name] = value
         if values["ppn"] > values["nprocs"]:
             raise ValueError("ppn cannot exceed nprocs")
-        if self.config.get("deploy_mode") != "default":
+        if self.config.get("deploy_mode", "default") != "default":
             raise ValueError("input_bundle requires native deploy_mode=default")
 
     def _output_dir(self) -> Path:

--- a/builtin/builtin/lammps/README.md
+++ b/builtin/builtin/lammps/README.md
@@ -15,3 +15,20 @@ custom partitioning (chunks) for binning, and static or dynamic grouping of atom
 
 ## lammps tutorial
 Please refer to this [website](https://docs.lammps.org/) for more details.
+
+## Multi-file inputs
+
+Use `script` for one self-contained input file. Use `input_bundle` when the input refers to
+potentials, included scripts, data files, or other neighboring files:
+
+```bash
+jarvis ppl append builtin.lammps copper \
+  input_bundle=/path/to/copper-inputs.tar \
+  nprocs=4 ppn=4 out=copper-results
+```
+
+The archive must follow the
+[JARVIS package input-bundle contract](../../../docs/input-bundles.md). JARVIS verifies its
+closed manifest, file sizes, and SHA-256 digests, then copies the payload into the
+execution-owned output directory before launching LAMMPS from that directory. `script` and
+`input_bundle` are mutually exclusive.

--- a/builtin/builtin/lammps/artifacts.py
+++ b/builtin/builtin/lammps/artifacts.py
@@ -19,6 +19,7 @@ from jarvis_cd.artifacts import (
     new_artifact_id,
 )
 from jarvis_cd.artifacts.schema import JsonValue
+from jarvis_cd.input_bundle import extract_input_bundle
 
 _MAX_DIRECTORY_ENTRIES = 4096
 _MAX_SCRIPT_BYTES = 1024 * 1024
@@ -303,6 +304,20 @@ def adapter_from_package(package: dict[str, Any]) -> LammpsArtifactAdapter | Non
         else _optional_absolute_path(package.get("runtime_cwd"))
     )
     script_path = _configured_script_path(package.get("script"), script_base)
+    input_bundle = package.get("input_bundle")
+    if isinstance(input_bundle, str) and input_bundle:
+        shared_dir = _optional_absolute_path(package.get("shared_dir"))
+        if shared_dir is None:
+            raise ValueError(
+                "LAMMPS input-bundle artifacts require a package shared directory"
+            )
+        if script_path is not None:
+            raise ValueError("LAMMPS script and input_bundle cannot be combined")
+        materialized = extract_input_bundle(
+            input_bundle,
+            Path(shared_dir.as_posix()) / "input-bundles",
+        )
+        script_path = materialized.entrypoint
     return LammpsArtifactAdapter(output_dir=output_dir, script_path=script_path)
 
 

--- a/builtin/builtin/lammps/pkg.py
+++ b/builtin/builtin/lammps/pkg.py
@@ -24,6 +24,7 @@ from jarvis_cd.deployment import (
     RuntimeStatus,
     probe_program,
 )
+from jarvis_cd.input_bundle import extract_input_bundle, stage_input_bundle
 from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
 
@@ -65,6 +66,21 @@ class Lammps(Application):
                     "commands; for the standard reduced Lennard-Jones single-type "
                     "case, use `mass 1 1.0`. Empty selects the package-owned bounded "
                     "Lennard-Jones workload."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file",
+                    structure="regular_file",
+                ).to_dict(),
+            },
+            {
+                "name": "input_bundle",
+                "msg": (
+                    "Optional digest-verified JARVIS package input bundle. The "
+                    "manifest entrypoint is the LAMMPS input script and every "
+                    "support file is staged into the execution-owned output "
+                    "directory. Cannot be combined with script."
                 ),
                 "type": str,
                 "default": "",
@@ -169,7 +185,10 @@ class Lammps(Application):
                 ExecutionProfile(
                     name="generated_workload",
                     execution_kind="batch",
-                    when=(ConfigurationCondition("script", "is_empty"),),
+                    when=(
+                        ConfigurationCondition("script", "is_empty"),
+                        ConfigurationCondition("input_bundle", "is_empty"),
+                    ),
                     runtime_requirements=("lammps",),
                     readiness=completed,
                     description=(
@@ -180,7 +199,10 @@ class Lammps(Application):
                 ExecutionProfile(
                     name="input_script",
                     execution_kind="batch",
-                    when=(ConfigurationCondition("script", "is_not_empty"),),
+                    when=(
+                        ConfigurationCondition("script", "is_not_empty"),
+                        ConfigurationCondition("input_bundle", "is_empty"),
+                    ),
                     runtime_requirements=("lammps",),
                     readiness=completed,
                     description=(
@@ -193,11 +215,29 @@ class Lammps(Application):
                         "use `mass 1 1.0`."
                     ),
                 ),
+                ExecutionProfile(
+                    name="input_bundle",
+                    execution_kind="batch",
+                    when=(
+                        ConfigurationCondition("script", "is_empty"),
+                        ConfigurationCondition("input_bundle", "is_not_empty"),
+                    ),
+                    runtime_requirements=("lammps",),
+                    readiness=completed,
+                    description=(
+                        "Digest-verified multi-file LAMMPS input set whose "
+                        "manifest entrypoint and support files are staged into "
+                        "one execution-owned working directory."
+                    ),
+                ),
             ),
             runtime_requirements=(runtime,),
             configuration_rules=(
                 ConfigurationRule(
-                    when=(ConfigurationCondition("script", "is_empty"),),
+                    when=(
+                        ConfigurationCondition("script", "is_empty"),
+                        ConfigurationCondition("input_bundle", "is_empty"),
+                    ),
                     requires=(
                         ConfigurationCondition("io_dump_interval", "greater_than", 0),
                         ConfigurationCondition("io_lattice_size", "greater_than", 0),
@@ -291,9 +331,16 @@ class Lammps(Application):
     def _validate_workload_configuration(self) -> None:
         """Ensure every launch selects a real user or generated input."""
         script = self.config.get("script")
+        input_bundle = self.config.get("input_bundle")
+        if script not in (None, "") and input_bundle not in (None, ""):
+            raise ValueError("script and input_bundle cannot be combined")
         if script not in (None, ""):
             if not isinstance(script, str):
                 raise TypeError("script must be a path string")
+            return
+        if input_bundle not in (None, ""):
+            if not isinstance(input_bundle, str):
+                raise TypeError("input_bundle must be a path string")
             return
         raw_values: dict[str, object] = {
             "io_dump_interval": self.config.get("io_dump_interval", 100),
@@ -443,6 +490,25 @@ class Lammps(Application):
                 temporary_path.unlink()
         return str(script_path)
 
+    def _input_script(self) -> str | None:
+        """Resolve a caller script, stage a bundle, or create the default input."""
+
+        self._validate_workload_configuration()
+        configured_bundle: object = self.config.get("input_bundle")
+        if configured_bundle not in (None, ""):
+            if not isinstance(configured_bundle, str):
+                raise TypeError("input_bundle must be a path string")
+            if self.shared_dir is None:
+                raise RuntimeError(
+                    "LAMMPS input bundles require a pipeline shared directory"
+                )
+            bundle = extract_input_bundle(
+                configured_bundle,
+                Path(self.shared_dir) / "input-bundles",
+            )
+            return str(stage_input_bundle(bundle, self._output_dir()))
+        return self._generated_input_script()
+
     def start(self) -> None:
         """
         Launch LAMMPS.
@@ -451,7 +517,7 @@ class Lammps(Application):
         container mode, MpiExecInfo with hostfile for default mode.
         """
         self._validate_legacy_runtime_configuration()
-        script_path = self._generated_input_script()
+        script_path = self._input_script()
         self._ensure_output_dir()
         self._remove_stale_log()
         line_callback = self.progress_line_callback()
@@ -466,7 +532,7 @@ class Lammps(Application):
             lammps_command = " ".join(cmd)
             output_dir = shlex.quote(os.path.dirname(self._log_path()))
             container_command = shlex.quote(
-                f"mkdir -p {output_dir} && exec {lammps_command}"
+                f"mkdir -p {output_dir} && cd {output_dir} && exec {lammps_command}"
             )
             result = Exec(
                 f"bash -c {container_command}",

--- a/builtin/builtin/lbm_cfd/README.md
+++ b/builtin/builtin/lbm_cfd/README.md
@@ -1,0 +1,16 @@
+# LBM-CFD
+
+`builtin.lbm_cfd` is a maintained native application package for the pinned
+LBM-CFD-3D source study. It does not install or evaluate the Coeus system.
+
+The required `input_bundle` follows `jarvis.package-input-bundle.v1` and carries
+the license, build recipe, documentation, and complete source tree. JARVIS
+verifies every member, copies it into an execution-owned working directory,
+builds once with the loaded MPI C++ compiler, and runs the same bounded wake at
+D3Q15, D3Q19, and D3Q27. Each run uses four MPI ranks by default, a 64 x 32 x 32
+domain, and 501 time steps.
+
+Success requires three distinct, finite, nonempty final VTK vorticity fields.
+The package publishes those fields, input provenance, and a closed comparison
+of the mean, RMS, maximum, and RMS ratio to D3Q19. Failed builds or simulations
+publish no finalized study products. The runtime provider hint is `openmpi`.

--- a/builtin/builtin/lbm_cfd/__init__.py
+++ b/builtin/builtin/lbm_cfd/__init__.py
@@ -1,0 +1,1 @@
+"""Native LBM-CFD package."""

--- a/builtin/builtin/lbm_cfd/artifacts.py
+++ b/builtin/builtin/lbm_cfd/artifacts.py
@@ -1,0 +1,172 @@
+"""Generated-artifact semantics for the LBM-CFD stencil comparison."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+)
+
+from builtin.lbm_cfd.contract import (
+    FINAL_STEP,
+    LATTICES,
+    RESULT_NAME,
+    RESULT_SCHEMA,
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(slots=True)
+class LbmStencilArtifactAdapter:
+    """Report only validated bounded products from one LBM-CFD run."""
+
+    output_dir: Path
+    _finalized: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for the comparison to complete before reporting products."""
+
+        del text
+        return []
+
+    def _observation(
+        self,
+        path: Path,
+        *,
+        logical_name: str,
+        kind: str,
+        role: ArtifactRole,
+        media_type: str,
+        format_name: str,
+        metadata: dict[str, Any],
+        maximum_bytes: int,
+    ) -> ArtifactObservation:
+        if path.is_symlink() or not path.is_file():
+            raise RuntimeError(f"LBM-CFD artifact is missing or unsafe: {path.name}")
+        size = path.stat().st_size
+        if size <= 0 or size > maximum_bytes:
+            raise RuntimeError(
+                f"LBM-CFD artifact size is outside its bound: {path.name}"
+            )
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=role,
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.SHARED,
+            state=ArtifactState.FINALIZED,
+            location=ArtifactLocation.cluster_path(PurePosixPath(path.as_posix())),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=size,
+            checksum=f"sha256:{_sha256(path)}",
+            message="Validated LBM-CFD stencil benchmark product",
+            metadata=metadata,
+        )
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Validate and report the result, fields, and input provenance."""
+
+        if self._finalized:
+            return []
+        self._finalized = True
+        result_path = self.output_dir / RESULT_NAME
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        if (
+            not isinstance(result, dict)
+            or result.get("schema_version") != RESULT_SCHEMA
+        ):
+            raise RuntimeError("LBM-CFD result document has the wrong schema")
+        common = {"application": "lbm-cfd", "benchmark_case": "lbm-stencil-response"}
+        observations = [
+            self._observation(
+                result_path,
+                logical_name="lbm-stencil-result",
+                kind="scientific_result",
+                role=ArtifactRole.OUTPUT,
+                media_type="application/json",
+                format_name=RESULT_SCHEMA,
+                metadata={**common, "benchmark_role": "stencil_comparison"},
+                maximum_bytes=1024 * 1024,
+            ),
+            self._observation(
+                self.output_dir / "input-provenance.json",
+                logical_name="lbm-input-provenance",
+                kind="provenance",
+                role=ArtifactRole.PROVENANCE,
+                media_type="application/json",
+                format_name="scientific-benchmark-lbm-input-provenance-v1",
+                metadata=common,
+                maximum_bytes=1024 * 1024,
+            ),
+        ]
+        for lattice in LATTICES:
+            observations.append(
+                self._observation(
+                    self.output_dir
+                    / lattice
+                    / f"simulation_state_t{FINAL_STEP:05d}.vts",
+                    logical_name=f"lbm-{lattice.upper()}-vorticity",
+                    kind="scientific_field",
+                    role=ArtifactRole.OUTPUT,
+                    media_type="application/vnd.vtk",
+                    format_name="vtk-structured-grid",
+                    metadata={
+                        **common,
+                        "lattice": lattice.upper(),
+                        "benchmark_role": "vorticity_field",
+                    },
+                    maximum_bytes=64 * 1024 * 1024,
+                )
+            )
+        return observations
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Publish study products only after a successful process exit."""
+
+        if return_code != 0:
+            self._finalized = True
+            return []
+        return self.finalize_artifacts()
+
+    def reset_artifacts(self) -> None:
+        """Allow a fresh finalization after a JARVIS stream reset."""
+
+        self._finalized = False
+
+
+def adapter_from_package(package: dict[str, Any]) -> LbmStencilArtifactAdapter | None:
+    """Create artifact semantics only for the benchmark LBM-CFD package."""
+
+    if package.get("pkg_type") != "builtin.lbm_cfd":
+        return None
+    configured = package.get("out")
+    if not isinstance(configured, str) or not configured:
+        raise ValueError("LBM-CFD artifact provider requires its output directory")
+    output_dir = Path(configured).resolve(strict=False)
+    shared = package.get("shared_dir")
+    if not isinstance(shared, str) or not shared:
+        raise ValueError("LBM-CFD artifact provider requires its shared root")
+    shared_root = Path(shared).resolve(strict=False)
+    if not output_dir.is_relative_to(shared_root):
+        raise ValueError("LBM-CFD output directory escaped its shared root")
+    return LbmStencilArtifactAdapter(output_dir)

--- a/builtin/builtin/lbm_cfd/contract.py
+++ b/builtin/builtin/lbm_cfd/contract.py
@@ -1,0 +1,280 @@
+"""Pure source, execution-directory, and result contract for LBM-CFD."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import shutil
+import tempfile
+import xml.etree.ElementTree as ET
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+
+from jarvis_cd.input_bundle import InputBundleError, MaterializedInputBundle
+
+LATTICES = ("d3q15", "d3q19", "d3q27")
+DIMENSIONS = (64, 32, 32)
+TIME_STEPS = 501
+FINAL_STEP = 500
+RESULT_NAME = "lbm-stencil-result.json"
+RESULT_SCHEMA = "scientific-benchmark.lbm-stencil-result.v1"
+RESULT_PREFIX = "BENCHMARK_LBM "
+EXPECTED_FILES = {
+    "COPYING",
+    "Makefile",
+    "README.md",
+    "include/lbm_mpi.hpp",
+    "include/paraview_sim.hpp",
+    "src/main.cpp",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class VorticityStatistics:
+    """Validated field statistics for one LBM lattice stencil."""
+
+    lattice: str
+    points: int
+    minimum: float
+    maximum: float
+    mean: float
+    rms: float
+    nonzero_points: int
+    field_sha256: str
+    source: str
+
+
+def validate_lbm_bundle(bundle: MaterializedInputBundle) -> None:
+    """Require the exact pinned, license-bearing LBM-CFD source tree."""
+
+    observed = {item.path for item in bundle.manifest.files}
+    if observed != EXPECTED_FILES:
+        raise InputBundleError("LBM-CFD bundle does not contain the closed source tree")
+    by_path = {item.path: item.role for item in bundle.manifest.files}
+    if by_path.get("COPYING") != "license" or by_path.get("Makefile") != "build_recipe":
+        raise InputBundleError("LBM-CFD bundle omitted its license or build contract")
+    if any(
+        by_path.get(path) != "application_source"
+        for path in ("include/lbm_mpi.hpp", "include/paraview_sim.hpp", "src/main.cpp")
+    ):
+        raise InputBundleError("LBM-CFD bundle source roles are invalid")
+    if bundle.manifest.entrypoint != "Makefile":
+        raise InputBundleError("LBM-CFD bundle entrypoint is not its build recipe")
+
+
+def _safe_execution_id(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or not 1 <= len(value) <= 128
+        or any(
+            character
+            not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+            for character in value
+        )
+    ):
+        raise InputBundleError("JARVIS execution identity is not a safe path token")
+    return value
+
+
+def materialize_run(
+    bundle: MaterializedInputBundle, run_parent: Path, execution_id: object
+) -> Path:
+    """Copy immutable LBM-CFD sources into a new execution-specific directory."""
+
+    validate_lbm_bundle(bundle)
+    token = _safe_execution_id(execution_id)
+    run_parent = run_parent.resolve()
+    run_parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    destination = run_parent / token
+    if destination.exists():
+        raise InputBundleError("LBM-CFD execution working directory already exists")
+    temporary = Path(tempfile.mkdtemp(prefix=f".{token}.", dir=run_parent))
+    try:
+        for item in bundle.manifest.files:
+            source = bundle.root / PurePosixPath(item.path)
+            target = temporary / PurePosixPath(item.path)
+            target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            shutil.copyfile(source, target, follow_symlinks=False)
+            os.chmod(target, 0o600)
+        (temporary / "input-provenance.json").write_text(
+            json.dumps(
+                {
+                    "bundle_sha256": bundle.bundle_sha256,
+                    "dimensions": list(DIMENSIONS),
+                    "lattices": list(LATTICES),
+                    "schema_version": "scientific-benchmark.lbm-stencil-run.v1",
+                    "time_steps": TIME_STEPS,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(temporary / "input-provenance.json", 0o600)
+        os.replace(temporary, destination)
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    return destination
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_vorticity_field(path: Path, *, lattice: str) -> VorticityStatistics:
+    """Parse and validate the bounded ASCII VTK vorticity field."""
+
+    if lattice not in LATTICES:
+        raise ValueError(f"unsupported LBM lattice: {lattice}")
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"LBM-CFD field is missing or unsafe: {path.name}")
+    size = path.stat().st_size
+    if size < 1024 or size > 64 * 1024 * 1024:
+        raise ValueError(f"LBM-CFD field size is outside its bound: {path.name}")
+    prefix = path.read_bytes()[:256]
+    if b"<!DOCTYPE" in prefix.upper() or b"<VTKFile" not in prefix:
+        raise ValueError("LBM-CFD field is not a closed VTK document")
+    root = ET.parse(path).getroot()
+    grid = root.find("StructuredGrid")
+    if grid is None:
+        raise ValueError("LBM-CFD field omitted StructuredGrid")
+    expected_extent = (
+        f"0 {DIMENSIONS[0] - 1} 0 {DIMENSIONS[1] - 1} 0 {DIMENSIONS[2] - 1}"
+    )
+    if grid.get("WholeExtent") != expected_extent:
+        raise ValueError("LBM-CFD field dimensions differ from the benchmark")
+    data = root.find('.//PointData/DataArray[@Name="vorticity"]')
+    if data is None or data.get("format") != "ascii" or data.text is None:
+        raise ValueError("LBM-CFD field omitted its ASCII vorticity values")
+    try:
+        values = [float(token) for token in data.text.split()]
+    except ValueError as error:
+        raise ValueError("LBM-CFD vorticity contains malformed values") from error
+    expected_points = math.prod(DIMENSIONS)
+    if len(values) != expected_points or not all(
+        math.isfinite(value) for value in values
+    ):
+        raise ValueError("LBM-CFD vorticity is incomplete or non-finite")
+    nonzero = sum(value != 0.0 for value in values)
+    rms = math.sqrt(sum(value * value for value in values) / len(values))
+    if nonzero < expected_points // 100 or rms <= 0:
+        raise ValueError("LBM-CFD vorticity field is scientifically empty")
+    return VorticityStatistics(
+        lattice=lattice,
+        points=len(values),
+        minimum=min(values),
+        maximum=max(values),
+        mean=sum(values) / len(values),
+        rms=rms,
+        nonzero_points=nonzero,
+        field_sha256=_sha256(path),
+        source=path.name,
+    )
+
+
+def _result_document(
+    run_root: Path, bundle: MaterializedInputBundle
+) -> dict[str, object]:
+    cases = [
+        parse_vorticity_field(
+            run_root / lattice / f"simulation_state_t{FINAL_STEP:05d}.vts",
+            lattice=lattice,
+        )
+        for lattice in LATTICES
+    ]
+    if len({case.field_sha256 for case in cases}) != len(LATTICES):
+        raise ValueError("LBM-CFD lattice stencils produced indistinguishable fields")
+    baseline = next(case.rms for case in cases if case.lattice == "d3q19")
+    return {
+        "cases": [
+            {**asdict(case), "rms_ratio_to_d3q19": case.rms / baseline}
+            for case in cases
+        ],
+        "dimensions": list(DIMENSIONS),
+        "input_bundle_sha256": bundle.bundle_sha256,
+        "schema_version": RESULT_SCHEMA,
+        "time_steps": TIME_STEPS,
+    }
+
+
+def write_lbm_result(
+    run_root: Path, destination: Path, bundle: MaterializedInputBundle
+) -> dict[str, object]:
+    """Validate the three fields and atomically write their comparison."""
+
+    validate_lbm_bundle(bundle)
+    document = _result_document(run_root, bundle)
+    if destination.exists():
+        raise ValueError("LBM-CFD result destination already exists")
+    handle, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.", dir=destination.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8", newline="\n") as stream:
+            json.dump(document, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, destination)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+    return document
+
+
+def validate_result_document(
+    run_root: Path, result_path: Path, bundle: MaterializedInputBundle
+) -> dict[str, object]:
+    """Require the result document to exactly match all generated fields."""
+
+    if result_path.is_symlink() or not result_path.is_file():
+        raise ValueError("LBM-CFD result document is missing or unsafe")
+    observed = json.loads(result_path.read_text(encoding="utf-8", errors="strict"))
+    expected = _result_document(run_root, bundle)
+    if observed != expected:
+        raise ValueError("LBM-CFD result document does not match generated fields")
+    return expected
+
+
+def result_summary_line(document: dict[str, object]) -> str:
+    """Render the closed terminal summary consumed by JARVIS progress."""
+
+    cases = document.get("cases")
+    if not isinstance(cases, list) or len(cases) != len(LATTICES):
+        raise ValueError("LBM-CFD result cases are missing")
+    summaries: list[str] = []
+    for case in cases:
+        lattice = case.get("lattice") if isinstance(case, dict) else None
+        if lattice not in LATTICES:
+            raise ValueError("LBM-CFD result contains a malformed lattice case")
+        measurements = {
+            "mean": case.get("mean"),
+            "rms": case.get("rms"),
+            "maximum": case.get("maximum"),
+            "rms_ratio_to_d3q19": case.get("rms_ratio_to_d3q19"),
+        }
+        if any(
+            not isinstance(value, (int, float))
+            or isinstance(value, bool)
+            or not math.isfinite(value)
+            for value in measurements.values()
+        ):
+            raise ValueError("LBM-CFD result contains malformed summary measurements")
+        summaries.append(
+            f"lattice={str(lattice).upper()},mean={measurements['mean']:.9g},"
+            f"rms={measurements['rms']:.9g},maximum={measurements['maximum']:.9g},"
+            f"rms_ratio_to_d3q19={measurements['rms_ratio_to_d3q19']:.9g}"
+        )
+    return (
+        f"{RESULT_PREFIX}schema={RESULT_SCHEMA} lattices=D3Q15,D3Q19,D3Q27 "
+        f"dimensions={DIMENSIONS[0]}x{DIMENSIONS[1]}x{DIMENSIONS[2]} step={FINAL_STEP} "
+        f"cases={'|'.join(summaries)}"
+    )

--- a/builtin/builtin/lbm_cfd/pkg.py
+++ b/builtin/builtin/lbm_cfd/pkg.py
@@ -1,0 +1,221 @@
+"""Run a supplied LBM-CFD lattice-stencil comparison."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+from typing import Any, cast
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    probe_program,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo
+
+from jarvis_cd.input_bundle import extract_input_bundle
+from builtin.lbm_cfd.contract import (
+    DIMENSIONS,
+    FINAL_STEP,
+    LATTICES,
+    RESULT_NAME,
+    TIME_STEPS,
+    materialize_run,
+    result_summary_line,
+    validate_lbm_bundle,
+    validate_result_document,
+    write_lbm_result,
+)
+from builtin.lbm_cfd.runtime import DeferredRuntimeCallback
+
+
+class LbmCfd(Application):
+    """Execute the same bounded bluff-body wake with three lattice stencils."""
+
+    def _init(self) -> None:
+        self._run_dir = None
+
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "nprocs",
+                "msg": "Number of MPI processes",
+                "type": int,
+                "default": 4,
+            },
+            {
+                "name": "ppn",
+                "msg": "Number of MPI processes per node",
+                "type": int,
+                "default": 4,
+            },
+            {
+                "name": "input_bundle",
+                "msg": "Immutable pinned LBM-CFD-3D application source bundle",
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
+            },
+        ]
+
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        probe = probe_program(
+            "mpicxx", environment=self._deployment_environment(), arguments=()
+        )
+        capabilities = ("mpi_cxx",) if probe.status.usable is True else ()
+        runtime = RuntimeRequirement(
+            requirement_id="mpi_cxx",
+            description="MPI C++ compiler and launcher",
+            required_capabilities=("mpi_cxx",),
+            available_capabilities=capabilities,
+            status=probe.status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="spack", query_kind="spec", query_value="openmpi"
+                ),
+            ),
+        )
+        return PackageDeploymentContract(
+            package="builtin.lbm_cfd",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="supplied_stencil_comparison",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    runtime_requirements=("mpi_cxx",),
+                    readiness=ReadinessContract(
+                        mechanism="process_exit", condition="successful_exit"
+                    ),
+                    description=(
+                        "Build the pinned LBM-CFD source and compare D3Q15, D3Q19, "
+                        "and D3Q27 vorticity fields for one bounded wake."
+                    ),
+                ),
+            ),
+            runtime_requirements=(runtime,),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    requires=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    description="The stencil comparison requires the immutable source bundle.",
+                ),
+            ),
+        )
+
+    def _configure(self, **kwargs: Any) -> None:
+        super()._configure(**kwargs)
+        config = cast(dict[str, Any], self.config)
+        if config.get("deploy_mode", "default") != "default":
+            raise ValueError("builtin.lbm_cfd supports native execution only")
+        for parameter in ("nprocs", "ppn"):
+            value = config.get(parameter)
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                raise ValueError(f"{parameter} must be positive")
+        configured = config.get("input_bundle")
+        if not isinstance(configured, str) or not configured:
+            raise ValueError("input_bundle is required")
+        bundle = extract_input_bundle(
+            Path(configured),
+            self.resolve_shared_path("input-bundles", field="input bundle root"),
+        )
+        validate_lbm_bundle(bundle)
+
+    @staticmethod
+    def _require_success(result: Any, label: str) -> None:
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"{label} failed: {failures}")
+
+    def start(self) -> None:
+        """Build once, run all three stencils, and finalize their field comparison."""
+
+        config = cast(dict[str, Any], self.config)
+        configured = config.get("input_bundle")
+        if not isinstance(configured, str) or not configured:
+            raise RuntimeError("LBM-CFD source bundle was not persisted")
+        nprocs = config.get("nprocs")
+        ppn = config.get("ppn")
+        if not isinstance(nprocs, int) or isinstance(nprocs, bool) or nprocs <= 0:
+            raise RuntimeError("LBM-CFD nprocs was not persisted")
+        if not isinstance(ppn, int) or isinstance(ppn, bool) or ppn <= 0:
+            raise RuntimeError("LBM-CFD ppn was not persisted")
+        bundle = extract_input_bundle(
+            Path(configured),
+            self.resolve_shared_path("input-bundles", field="input bundle root"),
+        )
+        run_dir = materialize_run(
+            bundle,
+            self.resolve_shared_path("runs", field="run root"),
+            self.mod_env.get("JARVIS_EXECUTION_ID"),
+        )
+        self._run_dir = run_dir
+        config["out"] = str(run_dir)
+        delegate = self.runtime_line_callback()
+        preliminary = DeferredRuntimeCallback(delegate, terminal=False)
+        terminal = DeferredRuntimeCallback(delegate, terminal=True)
+        local_info = LocalExecInfo(
+            env=self.mod_env, cwd=str(run_dir), timeout=900, line_callback=preliminary
+        )
+        self._require_success(
+            Exec("make CXX=mpicxx CXXFLAGS='-std=c++14 -O3'", local_info).run(),
+            "LBM-CFD build",
+        )
+        executable = shlex.quote(str(run_dir / "bin" / "lbmcfd3d"))
+        dimensions = " ".join(str(value) for value in DIMENSIONS)
+        for lattice in LATTICES:
+            output = run_dir / lattice
+            output.mkdir(mode=0o700)
+            mpi_info = MpiExecInfo(
+                nprocs=nprocs,
+                ppn=ppn,
+                hostfile=self.hostfile,
+                env=self.mod_env,
+                cwd=str(run_dir),
+                timeout=1800,
+                line_callback=preliminary,
+            )
+            command = " ".join(
+                (
+                    executable,
+                    f"--{lattice}",
+                    "--dim",
+                    dimensions,
+                    "--steps",
+                    str(TIME_STEPS),
+                    "--output-vorticity",
+                    "--output-dir",
+                    shlex.quote(str(output)),
+                )
+            )
+            self._require_success(
+                Exec(command, mpi_info).run(), f"LBM-CFD {lattice.upper()}"
+            )
+            if not (output / f"simulation_state_t{FINAL_STEP:05d}.vts").is_file():
+                raise RuntimeError(f"LBM-CFD {lattice.upper()} omitted its final field")
+
+        result_path = run_dir / RESULT_NAME
+        document = write_lbm_result(run_dir, result_path, bundle)
+        validate_result_document(run_dir, result_path, bundle)
+        final_info = LocalExecInfo(
+            env=self.mod_env, cwd=str(run_dir), timeout=30, line_callback=terminal
+        )
+        summary = result_summary_line(document)
+        self._require_success(
+            Exec(f"printf '%s\\n' {shlex.quote(summary)}", final_info).run(),
+            "LBM-CFD result finalization",
+        )
+
+    def stop(self) -> None:
+        """Do nothing because the comparison is a bounded batch process."""
+
+    def clean(self) -> None:
+        """Leave immutable inputs and validated outputs for artifact finalization."""

--- a/builtin/builtin/lbm_cfd/pkg.py
+++ b/builtin/builtin/lbm_cfd/pkg.py
@@ -36,6 +36,25 @@ from builtin.lbm_cfd.contract import (
 from builtin.lbm_cfd.runtime import DeferredRuntimeCallback
 
 
+def _lbm_command(executable: Path, lattice: str) -> str:
+    if lattice not in LATTICES:
+        raise ValueError(f"unsupported LBM-CFD lattice: {lattice}")
+    dimensions = " ".join(str(value) for value in DIMENSIONS)
+    return " ".join(
+        (
+            shlex.quote(str(executable)),
+            f"--{lattice}",
+            "--dim",
+            dimensions,
+            "--steps",
+            str(TIME_STEPS),
+            "--output-vorticity",
+            "--output-dir",
+            shlex.quote(lattice),
+        )
+    )
+
+
 class LbmCfd(Application):
     """Execute the same bounded bluff-body wake with three lattice stencils."""
 
@@ -169,8 +188,7 @@ class LbmCfd(Application):
             Exec("make CXX=mpicxx CXXFLAGS='-std=c++14 -O3'", local_info).run(),
             "LBM-CFD build",
         )
-        executable = shlex.quote(str(run_dir / "bin" / "lbmcfd3d"))
-        dimensions = " ".join(str(value) for value in DIMENSIONS)
+        executable = run_dir / "bin" / "lbmcfd3d"
         for lattice in LATTICES:
             output = run_dir / lattice
             output.mkdir(mode=0o700)
@@ -183,19 +201,10 @@ class LbmCfd(Application):
                 timeout=1800,
                 line_callback=preliminary,
             )
-            command = " ".join(
-                (
-                    executable,
-                    f"--{lattice}",
-                    "--dim",
-                    dimensions,
-                    "--steps",
-                    str(TIME_STEPS),
-                    "--output-vorticity",
-                    "--output-dir",
-                    shlex.quote(str(output)),
-                )
-            )
+            # LBM-CFD stores its output directory in a fixed-size native buffer.
+            # Keep the process argument relative to the execution-owned cwd so a
+            # long JARVIS root cannot silently truncate the destination.
+            command = _lbm_command(executable, lattice)
             self._require_success(
                 Exec(command, mpi_info).run(), f"LBM-CFD {lattice.upper()}"
             )

--- a/builtin/builtin/lbm_cfd/runtime.py
+++ b/builtin/builtin/lbm_cfd/runtime.py
@@ -1,0 +1,37 @@
+"""Process-output bridge for the multi-run LBM-CFD package."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+
+class DeferredRuntimeCallback:
+    """Forward lines while deferring success until the terminal command."""
+
+    def __init__(
+        self,
+        delegate: Callable[[str, str], None] | None,
+        *,
+        terminal: bool,
+    ) -> None:
+        self._delegate = delegate
+        self._terminal = terminal
+
+    def __call__(self, stream_name: str, line: str) -> None:
+        if self._delegate is not None:
+            self._delegate(stream_name, line)
+
+    def finalize_process(self, return_code: int) -> None:
+        if self._delegate is not None and (self._terminal or return_code != 0):
+            finalizer = getattr(self._delegate, "finalize_process", None)
+            if callable(finalizer):
+                finalizer(return_code)
+
+    def reconcile_process_exit(self, return_code: int) -> None:
+        if self._delegate is not None:
+            reconciler = getattr(self._delegate, "reconcile_process_exit", None)
+            if callable(reconciler):
+                reconciler(return_code)
+
+
+__all__ = ["DeferredRuntimeCallback"]

--- a/builtin/builtin/montage/README.md
+++ b/builtin/builtin/montage/README.md
@@ -1,60 +1,36 @@
-# montage
+# Montage
 
-NASA/IPAC Montage astronomical mosaic engine — 10-stage pipeline
-(mImgtbl → mProjExec → mImgtbl → mOverlaps → mDiffExec → mFitExec →
-mBgModel → mBgExec → mImgtbl → mAdd). The SIF pre-stages the M17
-J-band 0.2° benchmark; `/opt/run_mosaic.sh` runs the chain.
+`builtin.montage` runs NASA/IPAC Montage mosaics through two explicit profiles.
 
-## Native workflow parameters (`_configure_menu`)
+## Offline three-band profile
 
-| Parameter | Default | Effect on I/O | Effect on compute |
-|---|---|---|---|
-| `region` / `band` / `size` | `M17` / `j` / `0.2` | bigger `size` → more raw FITS tiles → more bytes through mProjExec / mAdd | bigger `size` → quadratic-ish mProjExec compute |
-| `mosaic_replicates` | `1` | runs the full 10-stage pipeline N times into `host-<host>/rep_NNN/` — **linear** I/O | each rep redoes interpolation + add |
-| `scratch_dir` | `${HOME}/montage-scratch` | scratch is the projection working tree; ends up at NFS scratch when `size > 0.2°` | n/a |
-| `out` | `${HOME}/montage_out` | final FITS staging dir | n/a |
+Supply `j_bundle`, `h_bundle`, and `k_bundle` together. Each value is a
+digest-verified `jarvis.package-input-bundle.v1` archive whose manifest:
 
-**Compute-dominated stages**: `mProjExec` (image reprojection
-interpolation) is the wall-time hog at any non-trivial size. `mAdd` and
-`mBgExec` are I/O-heavy. `mImgtbl` and the `*.tbl` index passes are
-metadata-only.
+- selects a `mosaic_header` entrypoint;
+- declares one or more `fits_source` files under a single directory; and
+- contains no undeclared files or links.
 
-## I/O-only benchmark mode (bind-mount override)
+The package stages each bundle into the execution-owned shared directory,
+runs `mExec` and `mExamine` independently for J, H, and K, renders a J/H/K PNG
+with `mViewer`, and validates every product before writing
+`montage-result.json`. It finalizes exactly these durable artifacts:
 
-```yaml
-container_binds:
-  - ${HOME}/jarvis-bench-scripts/montage_io_only.sh:/opt/run_mosaic.sh
-env:
-  MONTAGE_N_TILES:  "20"    # how many projected + corrected tiles to write
-  MONTAGE_TILE_MB:  "512"   # each tile's size
-  MONTAGE_MOSAIC_MB: "512"  # final mosaic.fits size
-```
+- `montage-j.fits`, `montage-h.fits`, and `montage-k.fits`;
+- `montage-jhk.png`; and
+- `montage-result.json` using schema `jarvis.montage-result.v1`.
 
-Writes the same directory layout the real `/opt/run_mosaic.sh`
-produces (`projected/*.fits`, `corrected/*.fits`, `mosaic.fits`, plus
-the seven `.tbl` index files) without running `mProjExec` or `mAdd`.
+Every command failure is propagated. The profile performs no runtime Internet
+discovery or acquisition and supports agent-free replay from the same bundle
+digests.
 
-### Per-rep budget = 2 × N_TILES × TILE_MB + MOSAIC_MB
+## Legacy archive profile
 
-Default = 2 × 20 × 512 + 512 = 20,992 MiB ≈ **20.5 GiB/rep**.
+When all three bundles are empty, Montage retains the earlier single-band
+archive workflow. `region`, `band`, and `size` control the archive request. A
+native execution uses the package-owned `run_mosaic.sh`; a container execution
+uses the built image. If data are not already staged, this profile may access
+IRSA at runtime and is therefore not equivalent to the offline profile.
 
-## Tuning matrix
-
-| Goal | Knob | Rule of thumb |
-|---|---|---|
-| **More I/O per rep (I/O-only)** | bump `MONTAGE_TILE_MB` or `MONTAGE_N_TILES` | linear |
-| **More I/O total (I/O-only)** | bump `mosaic_replicates` | linear |
-| **More I/O (native)** | bump `size` (triggers runtime IRSA fetch); or bump `mosaic_replicates` | size: super-linear data growth |
-| **Less interpolation compute** | use I/O-only bind-mount | wall ≈ I/O bytes ÷ NFS bw |
-| **Different image archive** | tweak `region` + `band`; needs network reach from compute nodes | varies |
-
-## Measured calibration (ares, 4-node SLURM, NFS-backed bind-mount out)
-
-| Variant | mosaic_replicates | per-rep MB | Wall | I/O |
-|---|---|---|---|---|
-| Native (M17 0.2°) | 80 | ~24 | 565 s (9.4 m) | ~1.9 GB |
-| Native (M17 0.2°) | 30 | ~24 | 421 s (7.0 m) | ~720 MB |
-| Native (M17 0.2°) | 20 | ~24 | 260 s (4.3 m) | ~480 MB |
-| **I/O-proxy** | **1** | **20.5 GiB** | **141 s (2.4 m)** | **22 GB** ✓ |
-
-YAML lives at `builtin/pipelines/ares/montage_apptainer_test.yaml`.
+Relative `out` paths resolve below the JARVIS package shared directory. The
+default `.` keeps outputs in the durable execution-owned package root.

--- a/builtin/builtin/montage/artifacts.py
+++ b/builtin/builtin/montage/artifacts.py
@@ -1,0 +1,238 @@
+"""Generated-artifact semantics for the builtin Montage package."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+
+_RESULT_SCHEMA = "jarvis.montage-result.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class _Product:
+    logical_name: str
+    filename: str
+    kind: str
+    role: ArtifactRole
+    media_type: str
+    format_name: str
+
+
+_PRODUCTS = (
+    _Product(
+        "montage-j-mosaic",
+        "montage-j.fits",
+        "scientific_dataset",
+        ArtifactRole.OUTPUT,
+        "image/fits",
+        "fits",
+    ),
+    _Product(
+        "montage-h-mosaic",
+        "montage-h.fits",
+        "scientific_dataset",
+        ArtifactRole.OUTPUT,
+        "image/fits",
+        "fits",
+    ),
+    _Product(
+        "montage-k-mosaic",
+        "montage-k.fits",
+        "scientific_dataset",
+        ArtifactRole.OUTPUT,
+        "image/fits",
+        "fits",
+    ),
+    _Product(
+        "montage-three-band-composite",
+        "montage-jhk.png",
+        "scientific_visualization",
+        ArtifactRole.OUTPUT,
+        "image/png",
+        "png",
+    ),
+    _Product(
+        "montage-result",
+        "montage-result.json",
+        "validation_report",
+        ArtifactRole.VALIDATION,
+        "application/json",
+        _RESULT_SCHEMA,
+    ),
+)
+
+
+@dataclass
+class MontageArtifactAdapter:
+    """Report the exact offline three-band product set at process exit."""
+
+    output_dir: PurePosixPath
+    region: str
+    _finalized: bool = False
+    _artifact_ids: dict[str, str] = field(
+        default_factory=lambda: {
+            product.logical_name: new_artifact_id() for product in _PRODUCTS
+        }
+    )
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Return no provisional records for bounded batch outputs."""
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Finalize products using successful-exit semantics."""
+        return self.finalize_artifacts_for_exit(0)
+
+    def finalize_artifacts_for_exit(
+        self,
+        return_code: int,
+    ) -> list[ArtifactObservation]:
+        """Report present, validated products or explicit incomplete records."""
+        if self._finalized:
+            return []
+        self._finalized = True
+        output = Path(self.output_dir.as_posix())
+        return [
+            self._observation(product, output, return_code) for product in _PRODUCTS
+        ]
+
+    def reset_artifacts(self) -> None:
+        """Allow one later process lifecycle to rediscover the product set."""
+        self._finalized = False
+
+    def _observation(
+        self,
+        product: _Product,
+        output: Path,
+        return_code: int,
+    ) -> ArtifactObservation:
+        path = output / product.filename
+        valid, size_bytes = _validate_product(path, product)
+        finalized = return_code == 0 and valid
+        state = ArtifactState.FINALIZED if finalized else ArtifactState.INCOMPLETE
+        return ArtifactObservation(
+            artifact_id=self._artifact_ids[product.logical_name],
+            logical_name=product.logical_name,
+            kind=product.kind,
+            role=product.role,
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=(
+                ArtifactLocation.cluster_path(self.output_dir / product.filename)
+                if valid
+                else None
+            ),
+            media_type=product.media_type,
+            format=product.format_name,
+            size_bytes=size_bytes,
+            message=(
+                f"{product.logical_name} finalized after successful Montage exit"
+                if finalized
+                else f"{product.logical_name} is missing or incomplete"
+            ),
+            metadata={
+                "application": "montage",
+                "region": self.region,
+                "return_code": return_code,
+            },
+        )
+
+
+def _validate_product(path: Path, product: _Product) -> tuple[bool, int | None]:
+    """Validate one regular product without following symlinks."""
+    try:
+        status = path.lstat()
+        if path.is_symlink() or not path.is_file():
+            return False, None
+        size = status.st_size
+        if product.format_name == "fits":
+            with path.open("rb") as stream:
+                valid = (
+                    2880 <= size <= 512 * 1024 * 1024 and stream.read(8) == b"SIMPLE  "
+                )
+        elif product.format_name == "png":
+            with path.open("rb") as stream:
+                valid = (
+                    1024 < size <= 128 * 1024 * 1024
+                    and stream.read(8) == b"\x89PNG\r\n\x1a\n"
+                )
+        else:
+            valid = False
+            if 0 < size <= 1024 * 1024:
+                payload = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+                valid = (
+                    isinstance(payload, dict)
+                    and payload.get("schema_version") == _RESULT_SCHEMA
+                )
+        return valid, size if valid else None
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return False, None
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> MontageArtifactAdapter | None:
+    """Create artifacts only for the complete offline builtin profile."""
+    if package.get("pkg_type") != "builtin.montage":
+        return None
+    configured = tuple(package.get(f"{band}_bundle") for band in ("j", "h", "k"))
+    if not all(isinstance(value, str) and value for value in configured):
+        return None
+    output_dir = _configured_output_dir(
+        package.get("out"),
+        shared_dir=package.get("shared_dir"),
+        runtime_cwd=package.get("runtime_cwd"),
+    )
+    region = package.get("region", "M17")
+    if not isinstance(region, str) or not region:
+        raise ValueError("Montage artifacts require a region label")
+    return MontageArtifactAdapter(output_dir=output_dir, region=region)
+
+
+def _configured_output_dir(
+    value: object,
+    *,
+    shared_dir: object,
+    runtime_cwd: object,
+) -> PurePosixPath:
+    """Resolve output below JARVIS-owned shared or runtime context."""
+    raw = os.path.expandvars(str(value or "."))
+    path = PurePosixPath(raw)
+    if not path.is_absolute():
+        base = _absolute_path(shared_dir) or _absolute_path(runtime_cwd)
+        if base is None:
+            raise ValueError(
+                "relative Montage output requires a shared directory or runtime cwd"
+            )
+        path = base / path
+    if not path.is_absolute() or ".." in path.parts:
+        raise ValueError("Montage artifact output must be a normalized absolute path")
+    return path
+
+
+def _absolute_path(value: object) -> PurePosixPath | None:
+    """Return one normalized absolute POSIX path when supplied."""
+    if not isinstance(value, str) or not value:
+        return None
+    path = PurePosixPath(value)
+    if not path.is_absolute() or ".." in path.parts:
+        return None
+    return path
+
+
+__all__ = ["MontageArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/montage/pkg.py
+++ b/builtin/builtin/montage/pkg.py
@@ -1,310 +1,710 @@
-"""
-This module provides classes and methods to launch the Montage application.
-Montage is an astronomical image mosaic engine that assembles FITS images
-into custom mosaics. It is developed by the NASA/IPAC Infrared Science
-Archive at Caltech.
-"""
+"""Deploy bounded native or containerized Montage mosaic workflows."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import shlex
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo, LocalExecInfo
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.runtime_callback import RuntimePhaseLineCallback
+from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
+
+_BANDS = ("j", "h", "k")
+_RESULT_SCHEMA = "jarvis.montage-result.v1"
+_RESULT_NAME = "montage-result.json"
+_COMPOSITE_NAME = "montage-jhk.png"
+_STATUS_FIELD = re.compile(r'(\w+)=(?:"([^"]*)"|([^,\]\s]+))')
 
 
 class Montage(Application):
-    """
-    Montage container package supporting both default (bare-metal) and
-    container deployment.
+    """Run Montage with offline supplied inputs or its legacy archive profile."""
 
-    Set deploy_mode='container' to build and run Montage inside a
-    Docker/Podman/Apptainer container.
-    Set deploy_mode='default' to use system-installed Montage binaries.
-    """
-
-    def _init(self):
+    def _init(self) -> None:
         pass
 
-    def _configure_menu(self):
-        return [
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        menu: list[dict[str, Any]] = [
             {
-                'name': 'nprocs',
-                'msg': 'Number of MPI processes',
-                'type': int,
-                'default': 1,
+                "name": "nprocs",
+                "msg": "Number of MPI processes reserved for the workflow",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'ppn',
-                'msg': 'Processes per node',
-                'type': int,
-                'default': 1,
+                "name": "ppn",
+                "msg": "Processes per node reserved for the workflow",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'region',
-                'msg': 'Target region name (e.g., M17, M31)',
-                'type': str,
-                'default': 'M17',
+                "name": "region",
+                "msg": "Printable astronomical target or region label",
+                "type": str,
+                "default": "M17",
             },
             {
-                'name': 'band',
-                'msg': '2MASS band (j, h, k)',
-                'type': str,
-                'default': 'j',
+                "name": "band",
+                "msg": "2MASS band for the legacy archive profile (j, h, or k)",
+                "type": str,
+                "default": "j",
             },
             {
-                'name': 'size',
-                'msg': ('Region size in degrees (square box centered on '
-                        'the region). 0.2° produces tens of MB; 1.0° a '
-                        'few GB; 2.0° tens of GB. Triggers runtime fetch '
-                        'from 2MASS/IRSA when != 0.2 (the default that '
-                        'the SIF pre-stages at build time).'),
-                'type': float,
-                'default': 0.2,
+                "name": "size",
+                "msg": "Square legacy archive region size in degrees",
+                "type": float,
+                "default": 0.2,
             },
             {
-                'name': 'scratch_dir',
-                'msg': ('Scratch dir inside the container for Montage '
-                        'intermediates (projected/diffs/corrected). '
-                        'Default ~/montage-scratch — keep off /tmp '
-                        'because intermediates can be tens of GB.'),
-                'type': str,
-                'default': '${HOME}/montage-scratch',
+                "name": "scratch_dir",
+                "msg": "Legacy container scratch directory",
+                "type": str,
+                "default": "${HOME}/montage-scratch",
             },
             {
-                'name': 'parallel_scratch_root',
-                'msg': ('Root dir for per-rep MONTAGE_SCRATCH_DIR when '
-                        'parallel_reps > 1. Each rep gets '
-                        '`<root>/montage-scratch-<rep>`. Default '
-                        '/dev/shm keeps intermediates on tmpfs (fastest). '
-                        'Point at a FUSE mount (e.g. /mnt/dumbwarp/scratch) '
-                        'when you specifically want every mProjExec / '
-                        'mDiffExec / mAdd read+write to traverse that '
-                        'adapter instead of node-local tmpfs.'),
-                'type': str,
-                'default': '/dev/shm',
+                "name": "parallel_scratch_root",
+                "msg": "Legacy container per-replicate scratch root",
+                "type": str,
+                "default": "/dev/shm",
             },
             {
-                'name': 'out',
-                'msg': 'Output directory for mosaic results',
-                'type': str,
-                'default': '${HOME}/montage_out',
+                "name": "out",
+                "msg": (
+                    "Output directory. Relative paths resolve below the package "
+                    "shared directory; '.' is the durable execution-owned root."
+                ),
+                "type": str,
+                "default": ".",
             },
             {
-                'name': 'mosaic_replicates',
-                'msg': ('Run the full Montage 10-stage mosaic this many '
-                        'times back-to-back in one container exec, each '
-                        'into rep_NNN/ under `out`. Use this to amplify '
-                        'total I/O when the chosen region+size produces '
-                        'a smaller mosaic than the benchmark target.'),
-                'type': int,
-                'default': 1,
+                "name": "mosaic_replicates",
+                "msg": "Legacy container mosaic replicate count",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'parallel_reps',
-                'msg': ('Per-host replicate concurrency. When > 1, the '
-                        'replicates loop fans across hosts via '
-                        'PsshExecInfo and each host runs this many in '
-                        'parallel using `wait -n` batching. Default 1 '
-                        'preserves the original host[0]-only sequential '
-                        'loop.'),
-                'type': int,
-                'default': 1,
+                "name": "parallel_reps",
+                "msg": "Legacy container per-host replicate concurrency",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'omp_threads',
-                'msg': ('OMP_NUM_THREADS for each parallel replicate. Set '
-                        'to roughly cores_per_node / parallel_reps so '
-                        'concurrent mProjExec/mAddExec instances on a '
-                        'single host don\'t oversubscribe. 0 = unset.'),
-                'type': int,
-                'default': 0,
+                "name": "omp_threads",
+                "msg": "Legacy container OpenMP threads per replicate; zero leaves it unset",
+                "type": int,
+                "default": 0,
             },
             {
-                'name': 'base_image',
-                'msg': 'Base Docker image for build container',
-                'type': str,
-                'default': 'sci-hpc-base',
+                "name": "base_image",
+                "msg": "Base image used only by the legacy container profile",
+                "type": str,
+                "default": "sci-hpc-base",
             },
         ]
+        for band in _BANDS:
+            menu.append(
+                {
+                    "name": f"{band}_bundle",
+                    "msg": (
+                        f"Optional digest-verified {band.upper()}-band FITS bundle. "
+                        "The manifest entrypoint is the mosaic header and files "
+                        "with role fits_source form the offline source collection. "
+                        "J, H, and K bundles must be supplied together."
+                    ),
+                    "type": str,
+                    "default": "",
+                    "input_binding": ConfigurationInputBinding(
+                        kind="local_file",
+                        structure="regular_file",
+                    ).to_dict(),
+                }
+            )
+        return menu
 
-    # ------------------------------------------------------------------
-    # Container Dockerfile generators
-    # ------------------------------------------------------------------
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe the offline and legacy Montage execution profiles."""
+        probes = tuple(
+            probe_program(
+                program,
+                environment=self._deployment_environment(),
+                arguments=(),
+            )
+            for program in ("mExec", "mExamine", "mViewer")
+        )
+        usable = all(probe.status.usable is True for probe in probes)
+        unavailable = next(
+            (probe.status for probe in probes if probe.status.usable is False),
+            None,
+        )
+        status = (
+            RuntimeStatus("ready", "all_montage_commands_available")
+            if usable
+            else unavailable
+            or RuntimeStatus("unknown", "montage_commands_not_fully_probed")
+        )
+        runtime = RuntimeRequirement(
+            requirement_id="montage",
+            description="Montage 6 FITS mosaic, statistics, and rendering commands",
+            required_capabilities=(
+                "fits_mosaic",
+                "image_statistics",
+                "three_band_composite",
+            ),
+            available_capabilities=(
+                ("fits_mosaic", "image_statistics", "three_band_composite")
+                if usable
+                else ()
+            ),
+            status=status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="spack",
+                    query_kind="spec",
+                    query_value="montage@6.0",
+                ),
+            ),
+        )
+        completed = ReadinessContract(
+            mechanism="process_exit",
+            condition="successful_exit",
+        )
+        return PackageDeploymentContract(
+            package="builtin.montage",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="legacy_archive",
+                    execution_kind="batch",
+                    when=tuple(
+                        ConfigurationCondition(f"{band}_bundle", "is_empty")
+                        for band in _BANDS
+                    ),
+                    runtime_requirements=("montage",),
+                    readiness=completed,
+                    description=(
+                        "Legacy single-band profile that may acquire archive data at "
+                        "runtime and therefore is not suitable for offline replay."
+                    ),
+                ),
+                ExecutionProfile(
+                    name="offline_three_band",
+                    execution_kind="batch",
+                    when=tuple(
+                        ConfigurationCondition(f"{band}_bundle", "is_not_empty")
+                        for band in _BANDS
+                    ),
+                    runtime_requirements=("montage",),
+                    readiness=completed,
+                    description=(
+                        "Network-independent J/H/K workflow using three immutable "
+                        "FITS collections and one fixed mosaic header per bundle."
+                    ),
+                ),
+            ),
+            runtime_requirements=(runtime,),
+            configuration_rules=tuple(
+                ConfigurationRule(
+                    when=(ConfigurationCondition(f"{band}_bundle", "is_not_empty"),),
+                    requires=tuple(
+                        ConfigurationCondition(f"{other}_bundle", "is_not_empty")
+                        for other in _BANDS
+                        if other != band
+                    ),
+                    description="Offline Montage requires all three J, H, and K bundles.",
+                )
+                for band in _BANDS
+            ),
+        )
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _build_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
             return None
-        base = self.config.get('base_image', 'sci-hpc-base')
-        # Inline run_mosaic.sh into build.sh as base64 so the container
-        # build is self-contained. jarvis's aux-file copy step in
-        # pipeline.py runs `docker cp` with hide_output=True and does not
-        # check exit codes, so a silently-failed copy manifests here as
-        # "cp: cannot stat 'run_mosaic.sh'" deep in the build.
         import base64
-        import os
-        run_mosaic_path = os.path.join(self.pkg_dir, 'run_mosaic.sh')
-        with open(run_mosaic_path, 'rb') as f:
-            run_mosaic_b64 = base64.b64encode(f.read()).decode('ascii')
-        content = self._read_build_script('build.sh', {
-            'BASE_IMAGE': base,
-            'RUN_MOSAIC_B64': run_mosaic_b64,
-        })
-        return content, 'default'
 
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+        package_dir = self.pkg_dir
+        if not isinstance(package_dir, str) or not package_dir:
+            raise RuntimeError("Montage container build requires its package directory")
+        run_mosaic_path = os.path.join(package_dir, "run_mosaic.sh")
+        with open(run_mosaic_path, "rb") as stream:
+            run_mosaic_b64 = base64.b64encode(stream.read()).decode("ascii")
+        content = self._read_build_script(
+            "build.sh",
+            {
+                "BASE_IMAGE": self.config.get("base_image", "sci-hpc-base"),
+                "RUN_MOSAIC_B64": run_mosaic_b64,
+            },
+        )
+        return content, "default"
+
+    def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
             return None
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': 'ubuntu:24.04',
-        })
-        return content, 'default'
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {
+                "BUILD_IMAGE": self.build_image_name(),
+                "DEPLOY_BASE": "ubuntu:24.04",
+            },
+        )
+        return content, "default"
 
-    # ------------------------------------------------------------------
-    # Configuration
-    # ------------------------------------------------------------------
-
-    def _configure(self, **kwargs):
-        """
-        Configure Montage.
-
-        Calls super()._configure() which updates self.config and (when
-        deploy_mode == 'container') triggers build_phase / build_deploy_phase.
-
-        In default mode, also creates the output directory on all nodes.
-        Always propagates MONTAGE_* env vars so the run_mosaic.sh inside
-        the SIF picks up region/band/size/scratch_dir/out overrides
-        without rebuilding the image.
-        """
+    def _configure(self, **kwargs: Any) -> None:
+        """Validate profile selection and prepare the package-owned output."""
         super()._configure(**kwargs)
+        self._validate_configuration()
+        self.setenv("MONTAGE_REGION", str(self.config.get("region", "M17")))
+        self.setenv("MONTAGE_BAND", str(self.config.get("band", "j")).upper())
+        self.setenv("MONTAGE_SIZE", str(self.config.get("size", 0.2)))
+        self.setenv("MONTAGE_OUT", self._output_dir())
+        self.setenv(
+            "MONTAGE_SCRATCH_DIR",
+            str(self.config.get("scratch_dir", "${HOME}/montage-scratch")),
+        )
+        if self.config.get("deploy_mode", "default") == "default":
+            self._ensure_output_dir()
 
-        # Propagate config knobs to run_mosaic.sh via env vars (it reads
-        # MONTAGE_REGION / MONTAGE_BAND / MONTAGE_SIZE / MONTAGE_OUT /
-        # MONTAGE_SCRATCH_DIR; see updated run_mosaic.sh).
-        self.setenv('MONTAGE_REGION', str(self.config.get('region', 'M17')))
-        self.setenv('MONTAGE_BAND', str(self.config.get('band', 'j')).upper())
-        self.setenv('MONTAGE_SIZE', str(self.config.get('size', 0.2)))
-        if self.config.get('out'):
-            self.setenv('MONTAGE_OUT', str(self.config['out']))
-        if self.config.get('scratch_dir'):
-            self.setenv('MONTAGE_SCRATCH_DIR', str(self.config['scratch_dir']))
+    def _configured_bundles(self) -> dict[str, str]:
+        """Return configured offline bundle paths after type validation."""
+        configured: dict[str, str] = {}
+        for band in _BANDS:
+            value = self.config.get(f"{band}_bundle")
+            if value in (None, ""):
+                continue
+            if not isinstance(value, str):
+                raise TypeError(f"{band}_bundle must be a path string")
+            configured[band] = value
+        return configured
 
-        if self.config.get('deploy_mode') == 'default':
-            if self.config['out']:
-                Mkdir(self.config['out'],
-                      PsshExecInfo(hostfile=self.hostfile,
-                                   env=self.env)).run()
+    def _validate_configuration(self) -> None:
+        """Reject ambiguous, unsafe, or unsupported profile combinations."""
+        bundles = self._configured_bundles()
+        if bundles and set(bundles) != set(_BANDS):
+            raise ValueError("offline Montage requires all three J, H, and K bundles")
+        if bundles and self.config.get("deploy_mode", "default") != "default":
+            raise ValueError("offline Montage bundles support native execution only")
+        region = self.config.get("region", "M17")
+        if (
+            not isinstance(region, str)
+            or not region.strip()
+            or len(region) > 128
+            or any(ord(character) < 32 for character in region)
+        ):
+            raise ValueError("region must be a bounded printable label")
+        if not bundles:
+            band = str(self.config.get("band", "j")).casefold()
+            if band not in _BANDS:
+                raise ValueError("band must be j, h, or k")
+            size = self.config.get("size", 0.2)
+            if (
+                isinstance(size, bool)
+                or not isinstance(size, (int, float))
+                or size <= 0
+            ):
+                raise ValueError("size must be positive")
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
+    def _output_dir(self) -> str:
+        """Resolve the durable output directory under package authority."""
+        return str(self.resolve_shared_path(self.config.get("out"), field="out"))
 
-    def start(self):
-        """
-        Launch Montage.
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        """Use local execution for one host and PSSH only for legacy fan-out."""
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
 
-        In container mode, runs /opt/run_mosaic.sh via LocalExecInfo inside
-        the deploy container. In default mode, runs the mosaic script locally.
-        """
-        if self.config.get('deploy_mode') == 'container':
-            replicates = max(
-                int(self.config.get('mosaic_replicates', 1) or 1), 1)
-            parallel = max(
-                int(self.config.get('parallel_reps', 1) or 1), 1)
-            omp = int(self.config.get('omp_threads', 0) or 0)
-            out_root = self.config.get('out')
+    def _ensure_output_dir(self) -> None:
+        """Create the output on each participating host and propagate failures."""
+        result = Mkdir(
+            self._output_dir(),
+            self._node_exec_info(env=self.env),
+        ).run()
+        self._require_success(result, "Montage output directory creation")
 
-            if parallel <= 1:
-                # Single-host sequential path (original).
-                if replicates == 1:
-                    cmd = (
-                        "host_tag=$(hostname -s 2>/dev/null || echo localhost); "
-                        f"/opt/run_mosaic.sh "
-                        f"  /opt/montage-bench/raw_images "
-                        f"  /opt/montage-bench/region.hdr "
-                        f"  '{out_root}/host-'$host_tag"
-                    )
-                else:
-                    cmd = (
-                        "set -e; "
-                        "host_tag=$(hostname -s 2>/dev/null || echo localhost); "
-                        f"for i in $(seq 1 {replicates}); do "
-                        f"  rep=$(printf 'rep_%03d' \"$i\"); "
-                        f"  echo \"=== montage replicate $rep host=$host_tag ($i/{replicates}) ===\"; "
-                        f"  /opt/run_mosaic.sh "
-                        f"    /opt/montage-bench/raw_images "
-                        f"    /opt/montage-bench/region.hdr "
-                        f"    '{out_root}/host-'$host_tag/$rep || exit 1; "
-                        f"done"
-                    )
-                Exec(cmd, LocalExecInfo(
-                    env=self.mod_env,
-                    container=self._container_engine,
-                    container_image=self.deploy_image_name(),
-                    shared_dir=self.shared_dir,
-                    private_dir=self.private_dir,
-                )).run()
-                return
+    @staticmethod
+    def _require_success(result: Any, label: str) -> None:
+        """Raise when any participating host reports command failure."""
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"{label} failed: {failures}")
 
-            # parallel_reps > 1: PsshExecInfo fan-out + per-host parallel
-            # batching. Each host runs ceil(replicates/nhosts) reps; rep
-            # tags include hostname to avoid output collisions on shared
-            # storage. MONTAGE_SCRATCH_DIR is per-rep so concurrent
-            # mProjExec invocations don't trample each other's intermediates.
-            nhosts = max(len(self.hostfile.hosts), 1) if self.hostfile else 1
-            local_reps = (replicates + nhosts - 1) // nhosts
-            scratch_root = (self.config.get('parallel_scratch_root')
-                            or '/dev/shm').rstrip('/')
-            omp_export = (
-                f"export OMP_NUM_THREADS={omp}; " if omp > 0 else ""
+    @staticmethod
+    def _bundle_raw_directory(bundle: MaterializedInputBundle) -> PurePosixPath:
+        """Require one nonempty, single-directory FITS source collection."""
+        fits = tuple(
+            PurePosixPath(item.path)
+            for item in bundle.manifest.files
+            if item.role == "fits_source"
+        )
+        if not fits:
+            raise ValueError("Montage input bundle requires at least one fits_source")
+        parents = {path.parent for path in fits}
+        if len(parents) != 1:
+            raise ValueError("Montage fits_source files must share one directory")
+        entrypoint = next(
+            (
+                item
+                for item in bundle.manifest.files
+                if item.path == bundle.manifest.entrypoint
+            ),
+            None,
+        )
+        if entrypoint is None or entrypoint.role not in {
+            "mosaic_header",
+            "scientific_input",
+        }:
+            raise ValueError("Montage bundle entrypoint must be a mosaic_header")
+        return parents.pop()
+
+    def _prepare_offline_inputs(
+        self,
+    ) -> tuple[dict[str, tuple[Path, Path]], dict[str, str]]:
+        """Extract and stage the exact J/H/K bundle bytes for one execution."""
+        output = Path(self._output_dir())
+        prepared: dict[str, tuple[Path, Path]] = {}
+        digests: dict[str, str] = {}
+        for band, configured in self._configured_bundles().items():
+            bundle = extract_input_bundle(configured, output / "input-bundles")
+            raw_relative = self._bundle_raw_directory(bundle)
+            destination = output / f"inputs-{band}"
+            header = stage_input_bundle(bundle, destination)
+            prepared[band] = (destination / Path(raw_relative.as_posix()), header)
+            digests[band] = bundle.bundle_sha256
+        return prepared, digests
+
+    @staticmethod
+    def _parse_statistics(text: str, *, band: str, mosaic: str) -> dict[str, Any]:
+        """Parse one successful structured mExamine status record."""
+        records = [
+            line.strip()
+            for line in text.splitlines()
+            if line.strip().startswith("[struct")
+        ]
+        if len(records) != 1:
+            raise RuntimeError(
+                f"Montage {band.upper()} statistics require one mExamine record"
             )
-            cmd = (
-                f"set -e; "
-                f"{omp_export}"
-                f"LOCAL={local_reps}; "
-                f"PAR={parallel}; "
-                f"OUT='{out_root}'; "
-                f"H=$(hostname -s); "
-                f"echo \"[montage-parallel] host=$H reps=$LOCAL parallel=$PAR omp=${{OMP_NUM_THREADS:-default}}\"; "
-                f"PIDS=(); "
-                f"for i in $(seq 1 $LOCAL); do "
-                f"  ( "
-                f"    rep=$(printf 'rep_%03d-%s' \"$i\" \"$H\"); "
-                f"    out=\"$OUT/$rep\"; "
-                f"    MONTAGE_SCRATCH_DIR=\"{scratch_root}/montage-scratch-$rep\" "
-                f"    /opt/run_mosaic.sh "
-                f"      /opt/montage-bench/raw_images "
-                f"      /opt/montage-bench/region.hdr "
-                f"      \"$out\" "
-                f"      && echo \"[montage-parallel] host=$H $rep DONE\" "
-                f"      || {{ echo \"[montage-parallel] host=$H $rep FAILED\" >&2; exit 1; }} "
-                f"  ) & "
-                f"  PIDS+=($!); "
-                f"  if [ \"${{#PIDS[@]}}\" -ge $PAR ]; then "
-                f"    wait -n; "
-                f"    PIDS=(\"${{PIDS[@]:1}}\"); "
-                f"  fi; "
-                f"done; "
-                f"wait"
+        fields = {
+            name: quoted if quoted else unquoted
+            for name, quoted, unquoted in _STATUS_FIELD.findall(records[0])
+        }
+        if fields.get("stat") != "OK":
+            raise RuntimeError(f"Montage {band.upper()} mExamine did not succeed")
+        try:
+            npixel = int(fields["npixel"])
+            nnull = int(fields["nnull"])
+            mean_flux = float(fields["aveflux"])
+            rms_flux = float(fields["rmsflux"])
+        except (KeyError, ValueError) as error:
+            raise RuntimeError("Montage mExamine omitted numeric statistics") from error
+        if (
+            npixel <= 0
+            or nnull < 0
+            or nnull >= npixel
+            or not math.isfinite(mean_flux)
+            or not math.isfinite(rms_flux)
+            or rms_flux <= 0
+        ):
+            raise RuntimeError("Montage mExamine statistics are not usable")
+        return {
+            "band": band.upper(),
+            "mean_flux": mean_flux,
+            "mosaic": mosaic,
+            "non_null_pixels": npixel - nnull,
+            "null_pixels": nnull,
+            "pixels": npixel,
+            "rms_flux": rms_flux,
+        }
+
+    @staticmethod
+    def _validate_fits(path: Path) -> None:
+        """Require a bounded regular FITS product with the canonical card prefix."""
+        valid = False
+        if not path.is_symlink() and path.is_file():
+            size = path.stat().st_size
+            if 2880 <= size <= 512 * 1024 * 1024:
+                with path.open("rb") as stream:
+                    valid = stream.read(8) == b"SIMPLE  "
+        if not valid:
+            raise RuntimeError(
+                f"Montage FITS product is missing or invalid: {path.name}"
             )
-            Exec(cmd, PsshExecInfo(
+
+    @staticmethod
+    def _validate_composite(path: Path) -> None:
+        """Require a bounded regular PNG composite."""
+        valid = False
+        if not path.is_symlink() and path.is_file():
+            size = path.stat().st_size
+            if 1024 < size <= 128 * 1024 * 1024:
+                with path.open("rb") as stream:
+                    valid = stream.read(8) == b"\x89PNG\r\n\x1a\n"
+        if not valid:
+            raise RuntimeError("Montage three-band composite is missing or invalid")
+
+    def _write_result(
+        self,
+        output: Path,
+        bundle_digests: dict[str, str],
+    ) -> dict[str, Any]:
+        """Validate products and atomically write the general result document."""
+        bands: list[dict[str, Any]] = []
+        for band in _BANDS:
+            mosaic = output / f"montage-{band}.fits"
+            self._validate_fits(mosaic)
+            statistics = output / f"montage-{band}-statistics.txt"
+            if statistics.is_symlink() or not statistics.is_file():
+                raise RuntimeError(f"Montage {band.upper()} statistics are missing")
+            bands.append(
+                self._parse_statistics(
+                    statistics.read_text(encoding="utf-8", errors="strict"),
+                    band=band,
+                    mosaic=mosaic.name,
+                )
+            )
+        composite = output / _COMPOSITE_NAME
+        self._validate_composite(composite)
+        document: dict[str, Any] = {
+            "bands": bands,
+            "composite": _COMPOSITE_NAME,
+            "input_bundle_sha256": bundle_digests,
+            "region": self.config.get("region", "M17"),
+            "schema_version": _RESULT_SCHEMA,
+        }
+        destination = output / _RESULT_NAME
+        if destination.exists() or destination.is_symlink():
+            raise RuntimeError("Montage result destination already exists")
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{destination.name}.",
+            dir=output,
+        )
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as stream:
+                json.dump(document, stream, indent=2, sort_keys=True)
+                stream.write("\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, destination)
+        finally:
+            temporary.unlink(missing_ok=True)
+        return document
+
+    def _run_offline(self) -> None:
+        """Run the replayable J/H/K mosaic and composite profile."""
+        self._validate_configuration()
+        self._ensure_output_dir()
+        prepared, digests = self._prepare_offline_inputs()
+        output = Path(self._output_dir())
+        callback = self.runtime_line_callback()
+        intermediate = (
+            RuntimePhaseLineCallback(callback, terminal=False)
+            if callback is not None
+            else None
+        )
+        info = LocalExecInfo(
+            env=self.mod_env,
+            cwd=str(output),
+            timeout=1800,
+            line_callback=intermediate,
+        )
+        for band in _BANDS:
+            raw, header = prepared[band]
+            workspace = output / f"work-{band}"
+            workspace.mkdir(mode=0o700)
+            mosaic = output / f"montage-{band}.fits"
+            command = " ".join(
+                (
+                    "mExec",
+                    "-r",
+                    shlex.quote(str(raw)),
+                    "-f",
+                    shlex.quote(str(header)),
+                    "-o",
+                    shlex.quote(str(mosaic)),
+                    "2MASS",
+                    band.upper(),
+                    shlex.quote(str(workspace)),
+                )
+            )
+            self._require_success(
+                Exec(command, info).run(), f"Montage {band.upper()} mosaic"
+            )
+            statistics = output / f"montage-{band}-statistics.txt"
+            examine = (
+                f"mExamine {shlex.quote(str(mosaic))} > {shlex.quote(str(statistics))}"
+            )
+            self._require_success(
+                Exec(examine, info).run(),
+                f"Montage {band.upper()} statistics",
+            )
+        composite = output / _COMPOSITE_NAME
+        viewer = " ".join(
+            (
+                "mViewer",
+                "-blue",
+                shlex.quote(str(output / "montage-j.fits")),
+                "-1s max gaussian-log",
+                "-green",
+                shlex.quote(str(output / "montage-h.fits")),
+                "-1s max gaussian-log",
+                "-red",
+                shlex.quote(str(output / "montage-k.fits")),
+                "-1s max gaussian-log",
+                "-out",
+                shlex.quote(str(composite)),
+            )
+        )
+        self._require_success(Exec(viewer, info).run(), "Montage J/H/K composite")
+        self._write_result(output, digests)
+        terminal = (
+            RuntimePhaseLineCallback(callback, terminal=True)
+            if callback is not None
+            else None
+        )
+        final_info = LocalExecInfo(
+            env=self.mod_env,
+            cwd=str(output),
+            timeout=30,
+            line_callback=terminal,
+        )
+        summary = (
+            f"JARVIS_MONTAGE_RESULT schema={_RESULT_SCHEMA} "
+            f"region={self.config.get('region', 'M17')} bands=J,H,K "
+            f"composite={_COMPOSITE_NAME}"
+        )
+        self._require_success(
+            Exec(f"printf '%s\\n' {shlex.quote(summary)}", final_info).run(),
+            "Montage result finalization",
+        )
+
+    def _run_legacy_native(self) -> None:
+        """Run the network-dependent single-band profile under package storage."""
+        self._ensure_output_dir()
+        output = Path(self._output_dir())
+        raw = output / "archive-input"
+        header = output / "region.hdr"
+        script = Path(str(self.pkg_dir)) / "run_mosaic.sh"
+        command = " ".join(
+            (
+                "bash",
+                shlex.quote(str(script)),
+                shlex.quote(str(raw)),
+                shlex.quote(str(header)),
+                shlex.quote(str(output)),
+            )
+        )
+        result = Exec(
+            command,
+            LocalExecInfo(
+                env=self.mod_env,
+                cwd=str(output),
+                line_callback=self.runtime_line_callback(),
+            ),
+        ).run()
+        self._require_success(result, "Montage legacy archive mosaic")
+
+    def _run_legacy_container(self) -> None:
+        """Preserve the existing container replication workflow."""
+        self._ensure_output_dir()
+        replicates = self._positive_integer("mosaic_replicates", 1)
+        parallel = self._positive_integer("parallel_reps", 1)
+        output = self._output_dir()
+        if parallel <= 1:
+            command = (
+                "set -e; host_tag=$(hostname -s 2>/dev/null || echo localhost); "
+                f"for i in $(seq 1 {replicates}); do "
+                "rep=$(printf 'rep_%03d' \"$i\"); "
+                f"/opt/run_mosaic.sh /opt/montage-bench/raw_images "
+                f"/opt/montage-bench/region.hdr {shlex.quote(output)}/$rep; done"
+            )
+            info: LocalExecInfo | PsshExecInfo = LocalExecInfo(
+                env=self.mod_env,
+                container=self._container_engine,
+                container_image=self.deploy_image_name(),
+                shared_dir=self.shared_dir,
+                private_dir=self.private_dir,
+                line_callback=self.runtime_line_callback(),
+            )
+        else:
+            scratch = str(
+                self.config.get("parallel_scratch_root") or "/dev/shm"
+            ).rstrip("/")
+            raw_omp = self.config.get("omp_threads", 0)
+            if isinstance(raw_omp, bool) or not isinstance(raw_omp, int) or raw_omp < 0:
+                raise ValueError("omp_threads must be a non-negative integer")
+            omp = raw_omp
+            omp_export = f"export OMP_NUM_THREADS={omp}; " if omp > 0 else ""
+            command = (
+                f"set -e; {omp_export}OUT={shlex.quote(output)}; H=$(hostname -s); "
+                f"for i in $(seq 1 {replicates}); do "
+                'rep=$(printf \'rep_%03d-%s\' "$i" "$H"); '
+                f"MONTAGE_SCRATCH_DIR={shlex.quote(scratch)}/montage-scratch-$rep "
+                "/opt/run_mosaic.sh /opt/montage-bench/raw_images "
+                '/opt/montage-bench/region.hdr "$OUT/$rep"; done'
+            )
+            info = PsshExecInfo(
                 hostfile=self.hostfile,
                 container=self._container_engine,
                 container_image=self.deploy_image_name(),
                 shared_dir=self.shared_dir,
                 private_dir=self.private_dir,
                 env=self.mod_env,
-            )).run()
+                line_callback=self.runtime_line_callback(),
+            )
+        self._require_success(Exec(command, info).run(), "Montage container workflow")
+
+    def _positive_integer(self, name: str, default: int) -> int:
+        """Return one positive integer configuration value."""
+        value = self.config.get(name, default)
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{name} must be a positive integer")
+        return value
+
+    def start(self) -> None:
+        """Run exactly one validated Montage profile and propagate failures."""
+        self._validate_configuration()
+        if self._configured_bundles():
+            self._run_offline()
+        elif self.config.get("deploy_mode") == "container":
+            self._run_legacy_container()
         else:
-            cmd = '/opt/run_mosaic.sh'
-            Exec(cmd, LocalExecInfo(
-                env=self.mod_env,
-                cwd=self.config.get('out'),
-            )).run()
+            self._run_legacy_native()
 
-    def stop(self):
-        """Stop Montage (no-op -- runs to completion)."""
-        pass
+    def stop(self) -> None:
+        """Do nothing because every Montage profile is bounded batch work."""
 
-    def clean(self):
-        """Remove Montage output directory."""
-        if self.config['out']:
-            Rm(self.config['out'] + '*',
-               PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+    def clean(self) -> None:
+        """Remove only the resolved package-owned output directory."""
+        output = Path(self._output_dir())
+        if output == Path(output.anchor):
+            raise ValueError("refusing to clean a filesystem root as Montage output")
+        result = Rm(
+            str(output),
+            self._node_exec_info(env=self.env),
+            recursive=True,
+        ).run()
+        self._require_success(result, "Montage output cleanup")

--- a/builtin/builtin/montage/pkg.py
+++ b/builtin/builtin/montage/pkg.py
@@ -7,6 +7,7 @@ import math
 import os
 import re
 import shlex
+import shutil
 import tempfile
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -381,19 +382,71 @@ class Montage(Application):
 
     def _prepare_offline_inputs(
         self,
-    ) -> tuple[dict[str, tuple[Path, Path]], dict[str, str]]:
-        """Extract and stage the exact J/H/K bundle bytes for one execution."""
+    ) -> tuple[
+        dict[str, tuple[MaterializedInputBundle, PurePosixPath]],
+        dict[str, str],
+    ]:
+        """Extract and validate the exact J/H/K bundle bytes for one execution."""
         output = Path(self._output_dir())
-        prepared: dict[str, tuple[Path, Path]] = {}
+        prepared: dict[str, tuple[MaterializedInputBundle, PurePosixPath]] = {}
         digests: dict[str, str] = {}
+        common_header: bytes | None = None
         for band, configured in self._configured_bundles().items():
             bundle = extract_input_bundle(configured, output / "input-bundles")
             raw_relative = self._bundle_raw_directory(bundle)
-            destination = output / f"inputs-{band}"
-            header = stage_input_bundle(bundle, destination)
-            prepared[band] = (destination / Path(raw_relative.as_posix()), header)
+            header_bytes = bundle.entrypoint.read_bytes()
+            if common_header is None:
+                common_header = header_bytes
+            elif header_bytes != common_header:
+                raise ValueError(
+                    "Montage J, H, and K bundles must share one mosaic header"
+                )
+            prepared[band] = (bundle, raw_relative)
             digests[band] = bundle.bundle_sha256
         return prepared, digests
+
+    @staticmethod
+    def _short_scratch_parent() -> Path:
+        """Select a writable real directory for Montage's bounded path workspace."""
+        candidates = (Path("/dev/shm"), Path(tempfile.gettempdir()))
+        for candidate in candidates:
+            try:
+                if (
+                    candidate.is_dir()
+                    and not candidate.is_symlink()
+                    and os.access(candidate, os.W_OK | os.X_OK)
+                ):
+                    return candidate
+            except OSError:
+                continue
+        raise RuntimeError("Montage requires a writable local scratch directory")
+
+    @staticmethod
+    def _publish_scratch_file(source: Path, destination: Path) -> None:
+        """Atomically copy one regular scratch product into durable package storage."""
+        if source.is_symlink() or not source.is_file():
+            raise RuntimeError(f"Montage scratch product is missing: {source.name}")
+        if destination.exists() or destination.is_symlink():
+            raise RuntimeError(
+                f"Montage durable product already exists: {destination.name}"
+            )
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{destination.name}.",
+            dir=destination.parent,
+        )
+        temporary = Path(temporary_name)
+        try:
+            with (
+                source.open("rb") as source_stream,
+                os.fdopen(descriptor, "wb") as destination_stream,
+            ):
+                shutil.copyfileobj(source_stream, destination_stream)
+                destination_stream.flush()
+                os.fsync(destination_stream.fileno())
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, destination)
+        finally:
+            temporary.unlink(missing_ok=True)
 
     @staticmethod
     def _parse_statistics(text: str, *, band: str, mosaic: str) -> dict[str, Any]:
@@ -526,60 +579,99 @@ class Montage(Application):
             if callback is not None
             else None
         )
-        info = LocalExecInfo(
-            env=self.mod_env,
-            cwd=str(output),
-            timeout=1800,
-            line_callback=intermediate,
-        )
-        for band in _BANDS:
-            raw, header = prepared[band]
-            workspace = output / f"work-{band}"
-            workspace.mkdir(mode=0o700)
-            mosaic = output / f"montage-{band}.fits"
-            command = " ".join(
+        scratch_parent = self._short_scratch_parent()
+        with tempfile.TemporaryDirectory(prefix="jm-", dir=scratch_parent) as name:
+            scratch = Path(name)
+            if len(str(scratch)) >= 128:
+                raise RuntimeError(
+                    "Montage local scratch path exceeds its safe execution bound"
+                )
+            for band in _BANDS:
+                bundle, raw_relative = prepared[band]
+                band_scratch = scratch / band
+                band_scratch.mkdir(mode=0o700)
+                staged = band_scratch / "staged"
+                header = stage_input_bundle(bundle, staged)
+                raw_argument = (PurePosixPath("staged") / raw_relative).as_posix()
+                header_argument = header.relative_to(band_scratch).as_posix()
+                if max(len(raw_argument), len(header_argument)) >= 96:
+                    raise RuntimeError(
+                        "Montage bundle paths exceed its safe execution bound"
+                    )
+                info = LocalExecInfo(
+                    env=self.mod_env,
+                    cwd=str(band_scratch),
+                    timeout=1800,
+                    line_callback=intermediate,
+                )
+                command = " ".join(
+                    (
+                        "mExec",
+                        "-r",
+                        shlex.quote(raw_argument),
+                        "-f",
+                        shlex.quote(header_argument),
+                        "-o",
+                        "mosaic.fits",
+                        "2MASS",
+                        band.upper(),
+                        "workspace",
+                    )
+                )
+                self._require_success(
+                    Exec(command, info).run(), f"Montage {band.upper()} mosaic"
+                )
+                scratch_mosaic = band_scratch / "mosaic.fits"
+                self._validate_fits(scratch_mosaic)
+                self._require_success(
+                    Exec("mExamine mosaic.fits > statistics.txt", info).run(),
+                    f"Montage {band.upper()} statistics",
+                )
+                scratch_statistics = band_scratch / "statistics.txt"
+                if scratch_statistics.is_symlink() or not scratch_statistics.is_file():
+                    raise RuntimeError(f"Montage {band.upper()} statistics are missing")
+                self._parse_statistics(
+                    scratch_statistics.read_text(encoding="utf-8", errors="strict"),
+                    band=band,
+                    mosaic=f"montage-{band}.fits",
+                )
+                self._publish_scratch_file(
+                    scratch_mosaic,
+                    output / f"montage-{band}.fits",
+                )
+                self._publish_scratch_file(
+                    scratch_statistics,
+                    output / f"montage-{band}-statistics.txt",
+                )
+
+            composite = scratch / _COMPOSITE_NAME
+            viewer = " ".join(
                 (
-                    "mExec",
-                    "-r",
-                    shlex.quote(str(raw)),
-                    "-f",
-                    shlex.quote(str(header)),
-                    "-o",
-                    shlex.quote(str(mosaic)),
-                    "2MASS",
-                    band.upper(),
-                    shlex.quote(str(workspace)),
+                    "mViewer",
+                    "-blue",
+                    "j/mosaic.fits",
+                    "-1s max gaussian-log",
+                    "-green",
+                    "h/mosaic.fits",
+                    "-1s max gaussian-log",
+                    "-red",
+                    "k/mosaic.fits",
+                    "-1s max gaussian-log",
+                    "-out",
+                    _COMPOSITE_NAME,
                 )
             )
+            viewer_info = LocalExecInfo(
+                env=self.mod_env,
+                cwd=str(scratch),
+                timeout=1800,
+                line_callback=intermediate,
+            )
             self._require_success(
-                Exec(command, info).run(), f"Montage {band.upper()} mosaic"
+                Exec(viewer, viewer_info).run(), "Montage J/H/K composite"
             )
-            statistics = output / f"montage-{band}-statistics.txt"
-            examine = (
-                f"mExamine {shlex.quote(str(mosaic))} > {shlex.quote(str(statistics))}"
-            )
-            self._require_success(
-                Exec(examine, info).run(),
-                f"Montage {band.upper()} statistics",
-            )
-        composite = output / _COMPOSITE_NAME
-        viewer = " ".join(
-            (
-                "mViewer",
-                "-blue",
-                shlex.quote(str(output / "montage-j.fits")),
-                "-1s max gaussian-log",
-                "-green",
-                shlex.quote(str(output / "montage-h.fits")),
-                "-1s max gaussian-log",
-                "-red",
-                shlex.quote(str(output / "montage-k.fits")),
-                "-1s max gaussian-log",
-                "-out",
-                shlex.quote(str(composite)),
-            )
-        )
-        self._require_success(Exec(viewer, info).run(), "Montage J/H/K composite")
+            self._validate_composite(composite)
+            self._publish_scratch_file(composite, output / _COMPOSITE_NAME)
         self._write_result(output, digests)
         terminal = (
             RuntimePhaseLineCallback(callback, terminal=True)

--- a/builtin/builtin/montage/pkg.py
+++ b/builtin/builtin/montage/pkg.py
@@ -151,6 +151,7 @@ class Montage(Application):
                 program,
                 environment=self._deployment_environment(),
                 arguments=(),
+                accepted_return_codes=(0, 1),
             )
             for program in ("mExec", "mExamine", "mViewer")
         )

--- a/builtin/builtin/montage/pkg.py
+++ b/builtin/builtin/montage/pkg.py
@@ -339,10 +339,15 @@ class Montage(Application):
 
     def _ensure_output_dir(self) -> None:
         """Create the output on each participating host and propagate failures."""
-        result = Mkdir(
-            self._output_dir(),
-            self._node_exec_info(env=self.env),
-        ).run()
+        output = Path(self._output_dir())
+        if self.hostfile is None or self.hostfile.is_local():
+            output.mkdir(parents=True, exist_ok=True, mode=0o700)
+            if not output.is_dir():
+                raise RuntimeError(
+                    f"Montage output directory creation failed: {output}"
+                )
+            return
+        result = Mkdir(str(output), self._node_exec_info(env=self.env)).run()
         self._require_success(result, "Montage output directory creation")
 
     @staticmethod

--- a/builtin/builtin/montage/run_mosaic.sh
+++ b/builtin/builtin/montage/run_mosaic.sh
@@ -19,6 +19,9 @@ RAW_DIR="${1:-/opt/montage-bench/raw_images}"
 HDR="${2:-/opt/montage-bench/region.hdr}"
 OUT="${3:-${HOME}/montage_out}"
 HOSTS="${4:-}"
+REGION="${MONTAGE_REGION:-M17}"
+BAND="${MONTAGE_BAND:-J}"
+SIZE="${MONTAGE_SIZE:-0.2}"
 
 mkdir -p "$OUT"/{projected,diffs,corrected}
 
@@ -28,7 +31,7 @@ mkdir -p "$OUT"/{projected,diffs,corrected}
 # reachable now. Bounded so a persistent outage fails fast with a clear
 # message instead of hanging the pipeline start.
 if [ ! -s "$HDR" ] || [ -z "$(ls -A "$RAW_DIR" 2>/dev/null)" ]; then
-    echo "Benchmark region not pre-staged; fetching M17 J-band at runtime..."
+    echo "Archive region not pre-staged; fetching ${REGION} ${BAND}-band at runtime..."
     mkdir -p "$RAW_DIR"
     cd "$(dirname "$HDR")"
     # Montage's homegrown HTTP fetcher (svc/svc.c) can't parse
@@ -38,9 +41,9 @@ if [ ! -s "$HDR" ] || [ -z "$(ls -A "$RAW_DIR" 2>/dev/null)" ]; then
     # mArchiveExec with a curl loop — libcurl handles authenticated
     # proxies, so the FITS pulls work behind a squid with creds.
     env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY \
-        mHdr "M17" 0.2 "$(basename "$HDR")"
+        mHdr "$REGION" "$SIZE" "$(basename "$HDR")"
     env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY \
-        mArchiveList 2mass J "M17" 0.2 0.2 remote.tbl
+        mArchiveList 2mass "$BAND" "$REGION" "$SIZE" "$SIZE" remote.tbl
     fetched=0
     while read -r url; do
         fname=$(basename "$url")

--- a/builtin/builtin/openfoam/README.md
+++ b/builtin/builtin/openfoam/README.md
@@ -1,0 +1,20 @@
+# OpenFOAM
+
+`builtin.openfoam` retains the legacy script and container launcher and adds a
+maintained native supplied-study profile. The supplied profile is selected only
+when `input_bundle` is nonempty.
+
+The archive must implement `jarvis.package-input-bundle.v1` and contain the
+three digest-bound `angle-00`, `angle-06`, and `angle-12` NACA 0012 case trees.
+JARVIS stages the immutable archive into an execution-owned working directory,
+runs `decomposePar`, `simpleFoam -parallel`, and `reconstructPar` for each case,
+and fails on any nonzero process exit. The profile requires exactly four MPI
+ranks because the supplied decomposition is fixed at four subdomains.
+
+The successful profile publishes the closed incidence comparison, input
+provenance, and all three native force-coefficient series. Failed runs publish
+no finalized study products. The runtime may be supplied by the operator or
+resolved through the `openfoam@2312` provider hint.
+
+The legacy `script_location`, `script`, `base_image`, and container settings
+remain available when `input_bundle` is empty.

--- a/builtin/builtin/openfoam/airfoil.py
+++ b/builtin/builtin/openfoam/airfoil.py
@@ -1,0 +1,266 @@
+"""Run a supplied three-angle NACA 0012 OpenFOAM study under MPI."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+from typing import Any, cast
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    probe_program,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo
+
+from jarvis_cd.input_bundle import extract_input_bundle
+from builtin.openfoam.contract import (
+    ANGLES,
+    CASE_NAMES,
+    RESULT_NAME,
+    materialize_run,
+    result_summary_line,
+    validate_airfoil_bundle,
+    validate_result_document,
+    write_incidence_result,
+)
+from builtin.openfoam.runtime import (
+    DeferredRuntimeCallback,
+    resolve_openfoam_environment,
+    resolve_openfoam_executable,
+)
+
+
+class OpenfoamAirfoil(Application):
+    """Execute three digest-bound OpenFOAM airfoil incidence cases."""
+
+    def _init(self) -> None:
+        self._run_dir = None
+
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "nprocs",
+                "msg": "Number of MPI processes; the supplied decomposition requires four",
+                "type": int,
+                "default": 4,
+            },
+            {
+                "name": "ppn",
+                "msg": "MPI processes per node",
+                "type": int,
+                "default": 4,
+            },
+            {
+                "name": "input_bundle",
+                "msg": (
+                    "Immutable OpenFOAM NACA 0012 bundle for 0, 6, and 12 degree "
+                    "incidence cases under jarvis.package-input-bundle.v1"
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file",
+                    structure="regular_file",
+                ).to_dict(),
+            },
+        ]
+
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        probe = probe_program(
+            "simpleFoam",
+            environment=self._deployment_environment(),
+            arguments=("-help",),
+        )
+        capabilities = (
+            ("mpi_execution", "steady_incompressible_cfd", "force_coefficients")
+            if probe.status.usable is True
+            else ()
+        )
+        runtime = RuntimeRequirement(
+            requirement_id="openfoam",
+            description="OpenFOAM simpleFoam runtime under MPI",
+            required_capabilities=(
+                "mpi_execution",
+                "steady_incompressible_cfd",
+                "force_coefficients",
+            ),
+            available_capabilities=capabilities,
+            status=probe.status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="spack",
+                    query_kind="spec",
+                    query_value="openfoam@2312",
+                ),
+            ),
+        )
+        return PackageDeploymentContract(
+            package="builtin.openfoam",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="supplied_airfoil_incidence",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    runtime_requirements=("openfoam",),
+                    readiness=ReadinessContract(
+                        mechanism="process_exit",
+                        condition="successful_exit",
+                    ),
+                    description=(
+                        "Run the three supplied NACA 0012 incidence cases and compare "
+                        "their force coefficients."
+                    ),
+                ),
+                ExecutionProfile(
+                    name="legacy_case_script",
+                    execution_kind="batch",
+                    when=(
+                        ConfigurationCondition("input_bundle", "is_empty"),
+                        ConfigurationCondition("script_location", "is_not_empty"),
+                    ),
+                    runtime_requirements=("openfoam",),
+                    readiness=ReadinessContract(
+                        mechanism="process_exit",
+                        condition="successful_exit",
+                    ),
+                    description="Run an operator-provided OpenFOAM case script.",
+                ),
+            ),
+            runtime_requirements=(runtime,),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    requires=(
+                        ConfigurationCondition("script_location", "is_not_empty"),
+                    ),
+                    description=(
+                        "Without a supplied study bundle, the legacy launcher requires "
+                        "an operator-provided case directory."
+                    ),
+                ),
+            ),
+        )
+
+    def _configure(self, **kwargs: Any) -> None:
+        Application._configure(self, **kwargs)
+        config = cast(dict[str, Any], self.config)
+        if config.get("deploy_mode", "default") != "default":
+            raise ValueError(
+                "builtin.openfoam supplied-input profile supports native execution only"
+            )
+        if config.get("nprocs") != 4:
+            raise ValueError(
+                "the supplied OpenFOAM decomposition requires exactly four ranks"
+            )
+        ppn = config.get("ppn")
+        if not isinstance(ppn, int) or isinstance(ppn, bool) or ppn < 1:
+            raise ValueError("ppn must be a positive integer")
+        configured = config.get("input_bundle")
+        if not isinstance(configured, str) or not configured:
+            raise ValueError("input_bundle is required")
+        extracted = extract_input_bundle(
+            Path(configured),
+            self.resolve_shared_path("input-bundles", field="input bundle root"),
+        )
+        validate_airfoil_bundle(extracted)
+
+    @staticmethod
+    def _require_success(result: Any, label: str) -> None:
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"{label} failed: {failures}")
+
+    def start(self) -> None:
+        """Run all incidence cases and finalize a typed coefficient comparison."""
+
+        config = cast(dict[str, Any], self.config)
+        configured = config.get("input_bundle")
+        if not isinstance(configured, str) or not configured:
+            raise RuntimeError("OpenFOAM airfoil bundle was not persisted")
+        ppn = config.get("ppn")
+        if not isinstance(ppn, int) or isinstance(ppn, bool) or ppn < 1:
+            raise RuntimeError("OpenFOAM ppn was not persisted")
+        bundle = extract_input_bundle(
+            Path(configured),
+            self.resolve_shared_path("input-bundles", field="input bundle root"),
+        )
+        validate_airfoil_bundle(bundle)
+        run_dir = materialize_run(
+            bundle,
+            self.resolve_shared_path("runs", field="run root"),
+            self.mod_env.get("JARVIS_EXECUTION_ID"),
+        )
+        self._run_dir = run_dir
+        config["out"] = str(run_dir)
+        execution_environment = resolve_openfoam_environment(self.mod_env)
+        decompose = shlex.quote(
+            str(resolve_openfoam_executable(execution_environment, "decomposePar"))
+        )
+        solver = shlex.quote(
+            str(resolve_openfoam_executable(execution_environment, "simpleFoam"))
+        )
+        reconstruct = shlex.quote(
+            str(resolve_openfoam_executable(execution_environment, "reconstructPar"))
+        )
+        delegate = self.runtime_line_callback()
+        preliminary = DeferredRuntimeCallback(delegate, terminal=False)
+
+        for angle in ANGLES:
+            case_dir = run_dir / CASE_NAMES[angle]
+            local_info = LocalExecInfo(
+                env=execution_environment,
+                cwd=str(case_dir),
+                timeout=900,
+                line_callback=preliminary,
+            )
+            self._require_success(
+                Exec(f"{decompose} -force", local_info).run(),
+                f"OpenFOAM {angle}-degree decomposition",
+            )
+            mpi_info = MpiExecInfo(
+                nprocs=4,
+                ppn=ppn,
+                hostfile=self.hostfile,
+                env=execution_environment,
+                cwd=str(case_dir),
+                timeout=1800,
+                line_callback=preliminary,
+            )
+            self._require_success(
+                Exec(f"{solver} -parallel", mpi_info).run(),
+                f"OpenFOAM {angle}-degree solve",
+            )
+            self._require_success(
+                Exec(f"{reconstruct} -latestTime", local_info).run(),
+                f"OpenFOAM {angle}-degree reconstruction",
+            )
+
+        result_path = run_dir / RESULT_NAME
+        document = write_incidence_result(run_dir, result_path, bundle)
+        validate_result_document(run_dir, result_path, bundle)
+        summary = result_summary_line(document)
+        terminal = DeferredRuntimeCallback(delegate, terminal=True)
+        final_info = LocalExecInfo(
+            env=execution_environment,
+            cwd=str(run_dir),
+            timeout=30,
+            line_callback=terminal,
+        )
+        self._require_success(
+            Exec(f"printf '%s\\n' {shlex.quote(summary)}", final_info).run(),
+            "OpenFOAM result finalization",
+        )
+
+    def stop(self) -> None:
+        """Do nothing because all OpenFOAM cases are bounded batch processes."""
+
+    def clean(self) -> None:
+        """Leave immutable inputs and validated outputs for artifact finalization."""

--- a/builtin/builtin/openfoam/artifacts.py
+++ b/builtin/builtin/openfoam/artifacts.py
@@ -1,0 +1,181 @@
+"""Generated-artifact semantics for the OpenFOAM airfoil incidence study."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+)
+
+from builtin.openfoam.contract import (
+    ANGLES,
+    CASE_NAMES,
+    RESULT_FILE_SCHEMA,
+    RESULT_NAME,
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(slots=True)
+class OpenfoamAirfoilArtifactAdapter:
+    """Report only validated bounded products from one airfoil run directory."""
+
+    output_dir: Path
+    _finalized: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for all three cases before reporting immutable products."""
+
+        del text
+        return []
+
+    def _observation(
+        self,
+        path: Path,
+        *,
+        logical_name: str,
+        kind: str,
+        role: ArtifactRole,
+        media_type: str,
+        format_name: str,
+        metadata: dict[str, Any],
+    ) -> ArtifactObservation:
+        if path.is_symlink() or not path.is_file():
+            raise RuntimeError(f"OpenFOAM artifact is missing or unsafe: {path.name}")
+        size = path.stat().st_size
+        if size <= 0 or size > 16 * 1024 * 1024:
+            raise RuntimeError(
+                f"OpenFOAM artifact size is outside its bound: {path.name}"
+            )
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=role,
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.SHARED,
+            state=ArtifactState.FINALIZED,
+            location=ArtifactLocation.cluster_path(PurePosixPath(path.as_posix())),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=size,
+            checksum=f"sha256:{_sha256(path)}",
+            message="Validated OpenFOAM airfoil benchmark product",
+            metadata=metadata,
+        )
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Validate and report the result, provenance, and coefficient series."""
+
+        if self._finalized:
+            return []
+        self._finalized = True
+        result_path = self.output_dir / RESULT_NAME
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        if (
+            not isinstance(result, dict)
+            or result.get("schema_version") != RESULT_FILE_SCHEMA
+        ):
+            raise RuntimeError("OpenFOAM result document has the wrong schema")
+        observations = [
+            self._observation(
+                result_path,
+                logical_name="airfoil-incidence-comparison",
+                kind="scientific_result",
+                role=ArtifactRole.OUTPUT,
+                media_type="application/json",
+                format_name=RESULT_FILE_SCHEMA,
+                metadata={
+                    "application": "openfoam",
+                    "benchmark_case": "openfoam-airfoil-incidence",
+                    "benchmark_role": "force_coefficients",
+                },
+            ),
+            self._observation(
+                self.output_dir / "input-provenance.json",
+                logical_name="airfoil-input-provenance",
+                kind="provenance",
+                role=ArtifactRole.PROVENANCE,
+                media_type="application/json",
+                format_name="scientific-benchmark-openfoam-input-provenance-v1",
+                metadata={"application": "openfoam"},
+            ),
+        ]
+        for angle in ANGLES:
+            case_name = CASE_NAMES[angle]
+            matches = list(
+                (self.output_dir / case_name).glob(
+                    "postProcessing/forceCoeffs/*/coefficient.dat"
+                )
+            )
+            if len(matches) != 1:
+                raise RuntimeError(
+                    f"OpenFOAM {angle}-degree coefficient artifact is ambiguous"
+                )
+            observations.append(
+                self._observation(
+                    matches[0],
+                    logical_name=f"airfoil-force-coefficients-{angle:02d}-degrees",
+                    kind="scientific_result",
+                    role=ArtifactRole.OUTPUT,
+                    media_type="text/tab-separated-values",
+                    format_name="openfoam-force-coefficients",
+                    metadata={
+                        "angle_degrees": angle,
+                        "application": "openfoam",
+                        "benchmark_role": "force_coefficients",
+                    },
+                )
+            )
+        return observations
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Publish study products only after a successful process exit."""
+
+        if return_code != 0:
+            self._finalized = True
+            return []
+        return self.finalize_artifacts()
+
+    def reset_artifacts(self) -> None:
+        """Allow a fresh finalization after a JARVIS stream reset."""
+
+        self._finalized = False
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> OpenfoamAirfoilArtifactAdapter | None:
+    """Create artifact semantics only for the benchmark OpenFOAM package."""
+
+    if package.get("pkg_type") != "builtin.openfoam" or not package.get("input_bundle"):
+        return None
+    configured = package.get("out")
+    if not isinstance(configured, str) or not configured:
+        raise ValueError("OpenFOAM artifact provider requires its output directory")
+    output_dir = Path(configured).resolve(strict=False)
+    shared = package.get("shared_dir")
+    if not isinstance(shared, str) or not shared:
+        raise ValueError("OpenFOAM artifact provider requires its shared root")
+    shared_root = Path(shared).resolve(strict=False)
+    if not output_dir.is_relative_to(shared_root):
+        raise ValueError("OpenFOAM output directory escaped its shared root")
+    return OpenfoamAirfoilArtifactAdapter(output_dir)

--- a/builtin/builtin/openfoam/contract.py
+++ b/builtin/builtin/openfoam/contract.py
@@ -1,0 +1,313 @@
+"""Pure input, execution-directory, and result contract for OpenFOAM airfoil."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import shutil
+import statistics
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+
+from jarvis_cd.input_bundle import InputBundleError, MaterializedInputBundle
+
+RESULT_FILE_SCHEMA = "scientific-benchmark.openfoam-airfoil-result.v1"
+RESULT_NAME = "airfoil-incidence.json"
+RESULT_PREFIX = "BENCHMARK_OPENFOAM "
+ANGLES = (0, 6, 12)
+CASE_NAMES = {angle: f"angle-{angle:02d}" for angle in ANGLES}
+CASE_FILES = frozenset(
+    {
+        "0/U",
+        "0/nut",
+        "0/nuTilda",
+        "0/p",
+        "case-metadata.json",
+        "constant/polyMesh/boundary.gz",
+        "constant/polyMesh/cells.gz",
+        "constant/polyMesh/faces.gz",
+        "constant/polyMesh/neighbour.gz",
+        "constant/polyMesh/owner.gz",
+        "constant/polyMesh/points.gz",
+        "constant/transportProperties",
+        "constant/turbulenceProperties",
+        "system/controlDict",
+        "system/decomposeParDict",
+        "system/fvSchemes",
+        "system/fvSolution",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ForceCoefficientSummary:
+    """Terminal and tail-averaged force coefficients for one incidence angle."""
+
+    angle_degrees: int
+    sample_count: int
+    final_time: float
+    final_cd: float
+    final_cl: float
+    tail_mean_cd: float
+    tail_mean_cl: float
+    tail_std_cd: float
+    tail_std_cl: float
+    coefficient_file: str
+
+
+def validate_airfoil_bundle(bundle: MaterializedInputBundle) -> None:
+    """Require exactly three complete, digest-bound OpenFOAM case trees."""
+
+    paths = {item.path for item in bundle.manifest.files}
+    expected = {
+        f"{case_name}/{relative}"
+        for case_name in CASE_NAMES.values()
+        for relative in CASE_FILES
+    }
+    if paths != expected:
+        missing = sorted(expected - paths)
+        unexpected = sorted(paths - expected)
+        raise InputBundleError(
+            f"OpenFOAM airfoil bundle paths differ; missing={missing}, unexpected={unexpected}"
+        )
+    if bundle.manifest.entrypoint != "angle-00/system/controlDict":
+        raise InputBundleError(
+            "OpenFOAM airfoil entrypoint is not the zero-angle control"
+        )
+    for angle, case_name in CASE_NAMES.items():
+        metadata_path = bundle.root / case_name / "case-metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        expected_metadata = {
+            "angle_degrees": angle,
+            "schema_version": "scientific-benchmark.openfoam-airfoil-case.v1",
+            "speed_metres_per_second": 26.0,
+        }
+        if metadata != expected_metadata:
+            raise InputBundleError(f"OpenFOAM metadata differs for {case_name}")
+
+
+def _safe_execution_id(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or not 1 <= len(value) <= 128
+        or any(
+            character
+            not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+            for character in value
+        )
+    ):
+        raise InputBundleError("JARVIS execution identity is not a safe path token")
+    return value
+
+
+def materialize_run(
+    bundle: MaterializedInputBundle, run_parent: Path, execution_id: object
+) -> Path:
+    """Copy immutable OpenFOAM cases into a new execution-specific directory."""
+
+    validate_airfoil_bundle(bundle)
+    token = _safe_execution_id(execution_id)
+    run_parent = run_parent.resolve()
+    run_parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    destination = run_parent / token
+    if destination.exists():
+        raise InputBundleError("OpenFOAM execution working directory already exists")
+    temporary = Path(tempfile.mkdtemp(prefix=f".{token}.", dir=run_parent))
+    try:
+        for item in bundle.manifest.files:
+            source = bundle.root / PurePosixPath(item.path)
+            target = temporary / PurePosixPath(item.path)
+            target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            shutil.copyfile(source, target, follow_symlinks=False)
+            os.chmod(target, 0o600)
+        provenance = {
+            "bundle_sha256": bundle.bundle_sha256,
+            "case_names": [CASE_NAMES[angle] for angle in ANGLES],
+            "schema_version": "scientific-benchmark.openfoam-airfoil-run.v1",
+        }
+        (temporary / "input-provenance.json").write_text(
+            json.dumps(provenance, sort_keys=True, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(temporary / "input-provenance.json", 0o600)
+        os.replace(temporary, destination)
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    return destination
+
+
+def _coefficient_file(case_root: Path) -> Path:
+    matches = [
+        path
+        for path in case_root.glob("postProcessing/forceCoeffs/*/coefficient.dat")
+        if path.is_file() and not path.is_symlink()
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected one OpenFOAM coefficient file below {case_root}, found {len(matches)}"
+        )
+    if matches[0].stat().st_size > 4 * 1024 * 1024:
+        raise ValueError("OpenFOAM coefficient file exceeds the parser bound")
+    return matches[0]
+
+
+def parse_force_coefficients(
+    case_root: Path, angle_degrees: int
+) -> ForceCoefficientSummary:
+    """Parse one complete OpenFOAM coefficient series with named columns."""
+
+    coefficient_path = _coefficient_file(case_root)
+    header: list[str] | None = None
+    rows: list[dict[str, float]] = []
+    for raw_line in coefficient_path.read_text(
+        encoding="utf-8", errors="strict"
+    ).splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            candidate = line.removeprefix("#").strip().split()
+            if {"Time", "Cd", "Cl"}.issubset(candidate):
+                header = candidate
+            continue
+        if header is None:
+            raise ValueError(
+                "OpenFOAM coefficient data appeared before its named header"
+            )
+        fields = line.split()
+        if len(fields) != len(header):
+            raise ValueError("OpenFOAM coefficient row width differs from its header")
+        try:
+            row = {
+                name: float(value) for name, value in zip(header, fields, strict=True)
+            }
+        except ValueError as error:
+            raise ValueError("OpenFOAM coefficient row is not numeric") from error
+        if not all(math.isfinite(value) for value in row.values()):
+            raise ValueError("OpenFOAM coefficient row contains a non-finite value")
+        rows.append(row)
+    if len(rows) < 10:
+        raise ValueError("OpenFOAM coefficient series has fewer than ten samples")
+    if rows[-1]["Time"] < 500:
+        raise ValueError(
+            "OpenFOAM coefficient series did not reach the configured end time"
+        )
+    tail = rows[-10:]
+    cd_values = [row["Cd"] for row in tail]
+    cl_values = [row["Cl"] for row in tail]
+    return ForceCoefficientSummary(
+        angle_degrees=angle_degrees,
+        sample_count=len(rows),
+        final_time=rows[-1]["Time"],
+        final_cd=rows[-1]["Cd"],
+        final_cl=rows[-1]["Cl"],
+        tail_mean_cd=statistics.fmean(cd_values),
+        tail_mean_cl=statistics.fmean(cl_values),
+        tail_std_cd=statistics.pstdev(cd_values),
+        tail_std_cl=statistics.pstdev(cl_values),
+        coefficient_file=coefficient_path.relative_to(case_root).as_posix(),
+    )
+
+
+def _result_document(
+    run_root: Path, bundle: MaterializedInputBundle
+) -> dict[str, object]:
+    summaries = [
+        parse_force_coefficients(run_root / CASE_NAMES[angle], angle)
+        for angle in ANGLES
+    ]
+    by_angle = {summary.angle_degrees: summary for summary in summaries}
+    zero = by_angle[0]
+    six = by_angle[6]
+    twelve = by_angle[12]
+    if six.tail_mean_cl - zero.tail_mean_cl <= 0.01:
+        raise ValueError(
+            "six-degree lift increase is not distinguishable from zero degrees"
+        )
+    if six.tail_mean_cl - twelve.tail_mean_cl <= 0.01:
+        raise ValueError(
+            "the twelve-degree case did not show the expected post-peak lift drop"
+        )
+    if twelve.tail_mean_cl - zero.tail_mean_cl <= 0.01:
+        raise ValueError(
+            "twelve-degree lift remains indistinguishable from zero degrees"
+        )
+    if twelve.tail_mean_cd - six.tail_mean_cd <= 0.001:
+        raise ValueError(
+            "the twelve-degree case did not show the expected drag penalty"
+        )
+    return {
+        "cases": [asdict(summary) for summary in summaries],
+        "input_bundle_sha256": bundle.bundle_sha256,
+        "metrics": {
+            "cd_change_0_to_12": twelve.tail_mean_cd - zero.tail_mean_cd,
+            "drag_increase_6_to_12": twelve.tail_mean_cd - six.tail_mean_cd,
+            "cl_change_0_to_12": twelve.tail_mean_cl - zero.tail_mean_cl,
+            "lift_drop_6_to_12": six.tail_mean_cl - twelve.tail_mean_cl,
+            "peak_lift_angle_degrees": 6,
+        },
+        "schema_version": RESULT_FILE_SCHEMA,
+    }
+
+
+def write_incidence_result(
+    run_root: Path,
+    destination: Path,
+    bundle: MaterializedInputBundle,
+) -> dict[str, object]:
+    """Parse all cases and atomically write the closed incidence result."""
+
+    validate_airfoil_bundle(bundle)
+    document = _result_document(run_root, bundle)
+    payload = json.dumps(document, indent=2, sort_keys=True) + "\n"
+    if destination.exists():
+        raise ValueError("OpenFOAM result destination already exists")
+    handle, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        dir=destination.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8", newline="\n") as stream:
+            stream.write(payload)
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, destination)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+    return document
+
+
+def validate_result_document(
+    run_root: Path,
+    result_path: Path,
+    bundle: MaterializedInputBundle,
+) -> dict[str, object]:
+    """Require the result document to exactly match all coefficient files."""
+
+    if result_path.is_symlink() or not result_path.is_file():
+        raise ValueError("OpenFOAM result document is missing or unsafe")
+    observed = json.loads(result_path.read_text(encoding="utf-8", errors="strict"))
+    expected = _result_document(run_root, bundle)
+    if observed != expected:
+        raise ValueError(
+            "OpenFOAM result document does not match the coefficient series"
+        )
+    return expected
+
+
+def result_summary_line(document: dict[str, object]) -> str:
+    """Render the closed terminal summary consumed by JARVIS progress."""
+
+    metrics = document.get("metrics")
+    if not isinstance(metrics, dict):
+        raise ValueError("OpenFOAM result metrics are missing")
+    return (
+        f"{RESULT_PREFIX}schema={RESULT_FILE_SCHEMA} angles=0,6,12 "
+        f"peak_lift_angle={metrics['peak_lift_angle_degrees']} "
+        f"lift_drop_6_to_12={metrics['lift_drop_6_to_12']:.8g} "
+        f"drag_increase_6_to_12={metrics['drag_increase_6_to_12']:.8g}"
+    )

--- a/builtin/builtin/openfoam/legacy.py
+++ b/builtin/builtin/openfoam/legacy.py
@@ -35,6 +35,7 @@ class OpenfoamLegacy(Application):
                 "msg": "Case directory containing Allrun script",
                 "type": str,
                 "default": None,
+                "required": False,
             },
             {
                 "name": "script",

--- a/builtin/builtin/openfoam/legacy.py
+++ b/builtin/builtin/openfoam/legacy.py
@@ -1,0 +1,125 @@
+"""Legacy script-driven OpenFOAM launcher retained for compatibility."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.shell import Exec, MpiExecInfo
+
+
+class OpenfoamLegacy(Application):
+    """Run an operator-provided OpenFOAM case script natively or in a container."""
+
+    def _init(self) -> None:
+        """Initialize the stateless legacy launcher."""
+
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        """Return the legacy OpenFOAM launch controls."""
+
+        return [
+            {
+                "name": "nprocs",
+                "msg": "Number of MPI processes",
+                "type": int,
+                "default": 1,
+            },
+            {
+                "name": "ppn",
+                "msg": "Processes per node",
+                "type": int,
+                "default": 4,
+            },
+            {
+                "name": "script_location",
+                "msg": "Case directory containing Allrun script",
+                "type": str,
+                "default": None,
+            },
+            {
+                "name": "script",
+                "msg": "Script to execute inside script_location",
+                "type": str,
+                "default": "./Allrun",
+            },
+            {
+                "name": "base_image",
+                "msg": "Base Docker image for build container",
+                "type": str,
+                "default": "sci-hpc-base",
+            },
+        ]
+
+    # Pkg leaves this override point untyped, so Pyright infers a None-only return.
+    def _build_phase(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+    ) -> tuple[str, str] | None:
+        """Return the legacy container build script when explicitly selected."""
+
+        config = cast(dict[str, Any], self.config)
+        if config.get("deploy_mode") != "container":
+            return None
+        content = self._read_build_script(
+            "build.sh",
+            {"BASE_IMAGE": config.get("base_image", "sci-hpc-base")},
+        )
+        return content, "openfoam-dev"
+
+    def _build_deploy_phase(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+    ) -> tuple[str, str] | None:
+        """Return the legacy deploy image recipe when explicitly selected."""
+
+        config = cast(dict[str, Any], self.config)
+        if config.get("deploy_mode") != "container":
+            return None
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {
+                "BUILD_IMAGE": self.build_image_name(),
+                "DEPLOY_BASE": "ubuntu:24.04",
+            },
+        )
+        return content, "openfoam-dev"
+
+    def _configure(self, **kwargs: Any) -> None:
+        """Persist legacy launcher configuration."""
+
+        Application._configure(self, **kwargs)
+
+    def start(self) -> None:
+        """Run the configured case script under MPI."""
+
+        config = cast(dict[str, Any], self.config)
+        script = config.get("script", "./Allrun")
+        cwd = config.get("script_location")
+        if not isinstance(script, str) or not script:
+            raise ValueError("script must be a non-empty string")
+        if cwd is not None and not isinstance(cwd, str):
+            raise ValueError("script_location must be a path string")
+        foam_env = "source /opt/OpenFOAM/OpenFOAM-dev/etc/bashrc"
+        command = f'bash -c "{foam_env} && {script}"'
+        execution = {
+            "nprocs": config["nprocs"],
+            "ppn": config["ppn"],
+            "hostfile": self.hostfile,
+            "env": self.mod_env,
+            "cwd": cwd,
+        }
+        if config.get("deploy_mode") == "container":
+            execution.update(
+                {
+                    "port": self.ssh_port,
+                    "container": self._container_engine,
+                    "container_image": self.deploy_image_name(),
+                    "shared_dir": self.shared_dir,
+                    "private_dir": self.private_dir,
+                }
+            )
+        Exec(command, MpiExecInfo(**execution)).run()
+
+    def stop(self) -> None:
+        """Do nothing because the legacy launcher runs to completion."""
+
+    def clean(self) -> None:
+        """Leave case outputs in the operator-provided script location."""

--- a/builtin/builtin/openfoam/pkg.py
+++ b/builtin/builtin/openfoam/pkg.py
@@ -1,139 +1,68 @@
-"""
-This module provides classes and methods to launch OpenFOAM-dev simulations.
-OpenFOAM (Open Field Operation And Manipulation) is an open-source CFD
-framework from the OpenFOAM Foundation.
-"""
-from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
-from jarvis_cd.shell.process import Mkdir, Rm
+"""Maintained OpenFOAM package with legacy and supplied-study profiles."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from builtin.openfoam.airfoil import OpenfoamAirfoil
+from builtin.openfoam.legacy import OpenfoamLegacy
 
 
-class Openfoam(Application):
-    """
-    OpenFOAM container package supporting both default (bare-metal) and
-    container deployment.
+class Openfoam(OpenfoamAirfoil, OpenfoamLegacy):
+    """Run either the legacy OpenFOAM launcher or a digest-bound airfoil study."""
 
-    Set deploy_mode='container' to build and run OpenFOAM-dev inside a
-    Docker/Podman/Apptainer container with ADIOS2 and system OpenMPI.
-    Set deploy_mode='default' to use a system-installed OpenFOAM via MPI.
+    def _init(self) -> None:
+        OpenfoamAirfoil._init(self)
 
-    ``start`` runs ``./Allrun`` (or a user-specified script) in the case
-    directory under MPI, matching the tutorial case convention.
-    """
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        """Expose one additive menu without duplicate process controls."""
 
-    def _init(self):
-        pass
+        merged: list[dict[str, Any]] = []
+        names: set[str] = set()
+        for item in (
+            *OpenfoamAirfoil._configure_menu(self),
+            *OpenfoamLegacy._configure_menu(self),
+        ):
+            name = str(item["name"])
+            if name not in names:
+                merged.append(item)
+                names.add(name)
+        return merged
 
-    def _configure_menu(self):
-        return [
-            {
-                'name': 'nprocs',
-                'msg': 'Number of MPI processes',
-                'type': int,
-                'default': 1,
-            },
-            {
-                'name': 'ppn',
-                'msg': 'Processes per node',
-                'type': int,
-                'default': 4,
-            },
-            {
-                'name': 'script_location',
-                'msg': 'Case directory containing Allrun script',
-                'type': str,
-                'default': None,
-            },
-            {
-                'name': 'script',
-                'msg': 'Script to execute inside script_location',
-                'type': str,
-                'default': './Allrun',
-            },
-            {
-                'name': 'base_image',
-                'msg': 'Base Docker image for build container',
-                'type': str,
-                'default': 'sci-hpc-base',
-            },
-        ]
+    # Pkg leaves these override points untyped, so Pyright infers None-only returns.
+    def _build_phase(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+    ) -> tuple[str, str] | None:
+        return OpenfoamLegacy._build_phase(self)
 
-    # ------------------------------------------------------------------
-    # Container Dockerfile generators
-    # ------------------------------------------------------------------
+    def _build_deploy_phase(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+    ) -> tuple[str, str] | None:
+        return OpenfoamLegacy._build_deploy_phase(self)
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
-            return None
-        content = self._read_build_script('build.sh', {
-            'BASE_IMAGE': self.config.get('base_image', 'sci-hpc-base'),
-        })
-        return content, 'openfoam-dev'
+    def _configure(self, **kwargs: Any) -> None:
+        """Select the supplied-input profile only when a bundle is explicit."""
 
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
-            return None
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': 'ubuntu:24.04',
-        })
-        return content, 'openfoam-dev'
+        if kwargs.get("input_bundle") or self.config.get("input_bundle"):
+            OpenfoamAirfoil._configure(self, **kwargs)
+            return
+        OpenfoamLegacy._configure(self, **kwargs)
 
-    # ------------------------------------------------------------------
-    # Configuration
-    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Launch the explicitly configured OpenFOAM profile."""
 
-    def _configure(self, **kwargs):
-        """
-        Configure OpenFOAM.
+        if self.config.get("input_bundle"):
+            OpenfoamAirfoil.start(self)
+            return
+        OpenfoamLegacy.start(self)
 
-        Calls super()._configure() which updates self.config and (when
-        deploy_mode == 'container') triggers build_phase / build_deploy_phase.
-        """
-        super()._configure(**kwargs)
+    def stop(self) -> None:
+        """Stop the selected profile when it owns a long-running process."""
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
+        OpenfoamLegacy.stop(self)
 
-    def start(self):
-        """
-        Launch OpenFOAM.
+    def clean(self) -> None:
+        """Preserve supplied-study results and apply legacy cleanup semantics."""
 
-        In container mode, runs the case's Allrun script via MPI inside the
-        deploy container. In default mode, runs from PATH.
-        """
-        script = self.config.get('script', './Allrun')
-        cwd = self.config.get('script_location')
-        foam_env = 'source /opt/OpenFOAM/OpenFOAM-dev/etc/bashrc'
-        cmd = f'bash -c "{foam_env} && {script}"'
-
-        if self.config.get('deploy_mode') == 'container':
-            Exec(cmd, MpiExecInfo(
-                nprocs=self.config['nprocs'],
-                ppn=self.config['ppn'],
-                hostfile=self.hostfile,
-                port=self.ssh_port,
-                container=self._container_engine,
-                container_image=self.deploy_image_name(),
-                shared_dir=self.shared_dir,
-                private_dir=self.private_dir,
-                env=self.mod_env,
-                cwd=cwd,
-            )).run()
-        else:
-            Exec(cmd, MpiExecInfo(
-                nprocs=self.config['nprocs'],
-                ppn=self.config['ppn'],
-                hostfile=self.hostfile,
-                env=self.mod_env,
-                cwd=cwd,
-            )).run()
-
-    def stop(self):
-        """Stop OpenFOAM (no-op — runs to completion)."""
-        pass
-
-    def clean(self):
-        """OpenFOAM leaves case output in script_location; no global cleanup."""
-        pass
+        if not self.config.get("input_bundle"):
+            OpenfoamLegacy.clean(self)

--- a/builtin/builtin/openfoam/runtime.py
+++ b/builtin/builtin/openfoam/runtime.py
@@ -1,0 +1,133 @@
+"""Process-output bridge for the multi-process OpenFOAM package."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+
+def _is_executable_file(path: Path) -> bool:
+    try:
+        if not path.is_file() or path.parent.name != "bin":
+            return False
+        return os.name == "nt" or bool(path.stat().st_mode & 0o111)
+    except OSError:
+        return False
+
+
+def resolve_openfoam_environment(
+    environment: Mapping[str, str],
+    *,
+    executable: Path | None = None,
+) -> dict[str, str]:
+    """Return an OpenFOAM environment with a verified global configuration root."""
+
+    resolved = dict(environment)
+    candidates: list[Path] = []
+    configured_etc = resolved.get("FOAM_ETC")
+    if configured_etc:
+        candidates.append(Path(configured_etc))
+    project_dir = resolved.get("WM_PROJECT_DIR")
+    if project_dir:
+        candidates.append(Path(project_dir) / "etc")
+
+    executable_path = executable
+    if executable_path is None:
+        located = shutil.which("decomposePar", path=resolved.get("PATH"))
+        if located:
+            executable_path = Path(located)
+    if executable_path is not None:
+        canonical = executable_path.resolve()
+        candidates.extend(parent / "etc" for parent in canonical.parents)
+
+    for candidate in candidates:
+        canonical_candidate = candidate.resolve()
+        if (canonical_candidate / "controlDict").is_file():
+            resolved["FOAM_ETC"] = str(canonical_candidate)
+            resolved["WM_PROJECT_DIR"] = str(canonical_candidate.parent)
+            if executable_path is not None:
+                resolved["FOAM_APPBIN"] = str(executable_path.resolve().parent)
+            return resolved
+
+    raise RuntimeError(
+        "OpenFOAM runtime does not expose a global etc/controlDict through "
+        "FOAM_ETC, WM_PROJECT_DIR, or the decomposePar installation prefix"
+    )
+
+
+def resolve_openfoam_executable(environment: Mapping[str, str], name: str) -> Path:
+    """Resolve one OpenFOAM executable from PATH or the verified project tree."""
+
+    located = shutil.which(name, path=environment.get("PATH"))
+    if located:
+        return Path(located).resolve()
+
+    application_bin = environment.get("FOAM_APPBIN")
+    if application_bin:
+        candidate = Path(application_bin) / name
+        if _is_executable_file(candidate):
+            return candidate.resolve()
+
+    project_dir = environment.get("WM_PROJECT_DIR")
+    if project_dir:
+        project = Path(project_dir).resolve()
+        try:
+            matches = sorted(
+                (
+                    path.resolve()
+                    for path in project.rglob(name)
+                    if _is_executable_file(path)
+                ),
+                key=lambda path: path.as_posix(),
+            )
+        except OSError as error:
+            raise RuntimeError(
+                f"OpenFOAM executable search failed for {name}"
+            ) from error
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            options = environment.get("WM_OPTIONS")
+            selected = [path for path in matches if options and options in path.parts]
+            if len(selected) == 1:
+                return selected[0]
+            raise RuntimeError(f"OpenFOAM executable is ambiguous: {name}")
+
+    raise RuntimeError(f"OpenFOAM executable is unavailable: {name}")
+
+
+class DeferredRuntimeCallback:
+    """Forward lines while deferring successful finalization to the final marker."""
+
+    def __init__(
+        self,
+        delegate: Callable[[str, str], None] | None,
+        *,
+        terminal: bool,
+    ) -> None:
+        self._delegate = delegate
+        self._terminal = terminal
+
+    def __call__(self, stream_name: str, line: str) -> None:
+        """Forward captured OpenFOAM output."""
+
+        if self._delegate is not None:
+            self._delegate(stream_name, line)
+
+    def finalize_process(self, return_code: int) -> None:
+        """Finalize only a failure or the declared terminal command."""
+
+        if self._delegate is not None and (self._terminal or return_code != 0):
+            finalizer = getattr(self._delegate, "finalize_process", None)
+            if callable(finalizer):
+                finalizer(return_code)
+
+    def reconcile_process_exit(self, return_code: int) -> None:
+        """Forward effective failure reconciliation unchanged."""
+
+        if self._delegate is not None:
+            reconciler = getattr(self._delegate, "reconcile_process_exit", None)
+            if callable(reconciler):
+                reconciler(return_code)

--- a/builtin/builtin/rna_seq_star_deseq2/artifacts.py
+++ b/builtin/builtin/rna_seq_star_deseq2/artifacts.py
@@ -1,0 +1,276 @@
+"""Generated-artifact semantics for native STAR to DESeq2 workflows."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .result_contract import RnaSeqProduct, load_rnaseq_result
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _optional_absolute_path(value: object) -> PurePosixPath | None:
+    if not isinstance(value, str) or not value:
+        return None
+    path = PurePosixPath(value)
+    return path if path.is_absolute() else None
+
+
+def _configured_output_dir(
+    value: object, *, shared_dir: object, runtime_cwd: object
+) -> PurePosixPath:
+    raw = "run" if value in (None, "") else value
+    if not isinstance(raw, str) or not raw or "\\" in raw:
+        raise ValueError("RNA-seq artifacts require a printable output path")
+    path = PurePosixPath(raw)
+    if not path.is_absolute():
+        base = _optional_absolute_path(shared_dir) or _optional_absolute_path(
+            runtime_cwd
+        )
+        if base is None:
+            raise ValueError(
+                "relative RNA-seq artifact output requires shared_dir or runtime_cwd"
+            )
+        path = base / path
+    if any(part in {"", ".", ".."} for part in path.parts[1:]):
+        raise ValueError("RNA-seq artifact output is not confined")
+    shared = _optional_absolute_path(shared_dir)
+    if shared is not None and not path.is_relative_to(shared):
+        raise ValueError("RNA-seq artifact output escaped its shared root")
+    return path / "results"
+
+
+@dataclass(slots=True)
+class RnaSeqArtifactAdapter:
+    """Publish a closed differential-expression result and its native products."""
+
+    output_dir: PurePosixPath
+    _local_root: Path | None = None
+    _finalized: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for the authoritative process exit before publishing products."""
+
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Finalize products for a successful legacy completion callback."""
+
+        return self._finalize(return_code=0)
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Finalize native products using the authoritative driver exit status."""
+
+        return self._finalize(return_code=return_code)
+
+    def reset_artifacts(self) -> None:
+        """Permit discovery after an execution stream is replaced."""
+
+        self._finalized = False
+
+    def _local_output_path(self) -> Path:
+        if self._local_root is not None:
+            return self._local_root
+        return Path(self.output_dir.as_posix())
+
+    def _file(
+        self,
+        product: RnaSeqProduct,
+        *,
+        logical_name: str,
+        kind: str,
+        role: ArtifactRole,
+        format_name: str,
+        media_type: str,
+        state: ArtifactState,
+        metadata: dict[str, Any],
+    ) -> ArtifactObservation:
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=role,
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(
+                self.output_dir / product.relative_path
+            ),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=product.size_bytes,
+            checksum=f"sha256:{product.sha256}",
+            message="Closed STAR to DESeq2 product",
+            metadata=metadata,
+        )
+
+    def _finalize(self, *, return_code: int) -> list[ArtifactObservation]:
+        if self._finalized:
+            return []
+        self._finalized = True
+        local = self._local_output_path()
+        if return_code != 0 and not (local / "rnaseq-result.json").is_file():
+            return []
+        validated = load_rnaseq_result(local)
+        document = validated.document
+        state = (
+            ArtifactState.FINALIZED if return_code == 0 else ArtifactState.INCOMPLETE
+        )
+        metadata: dict[str, Any] = {
+            "application": "star_deseq2",
+            "comparison_condition": document["comparison_condition"],
+            "reference_condition": document["reference_condition"],
+            "sample_count": document["sample_count"],
+            "significant_gene_count": document["deseq2"]["significant_gene_count"],
+            "tested_gene_count": document["deseq2"]["tested_gene_count"],
+        }
+        products = validated.products
+        result_size = validated.result_path.stat().st_size
+        result_sha = _sha256(validated.result_path)
+        observations = [
+            ArtifactObservation(
+                logical_name="rna-seq-result-tree",
+                kind="scientific_result",
+                role=ArtifactRole.OUTPUT,
+                structure=ArtifactStructure.COLLECTION,
+                ownership=ArtifactOwnership.SHARED,
+                state=state,
+                location=ArtifactLocation.cluster_path(self.output_dir),
+                format="star-deseq2-result-tree",
+                size_bytes=result_size
+                + sum(product.size_bytes for product in products.values()),
+                message="STAR to DESeq2 result tree finalized",
+                metadata={**metadata, "member_count": len(products) + 1},
+            ),
+            ArtifactObservation(
+                logical_name="rna-seq-result",
+                kind="scientific_result",
+                role=ArtifactRole.OUTPUT,
+                structure=ArtifactStructure.FILE,
+                ownership=ArtifactOwnership.SHARED,
+                state=state,
+                location=ArtifactLocation.cluster_path(
+                    self.output_dir / "rnaseq-result.json"
+                ),
+                media_type="application/json",
+                format="jarvis.rnaseq-star-deseq2-result.v1",
+                size_bytes=result_size,
+                checksum=f"sha256:{result_sha}",
+                message="Closed STAR to DESeq2 result summary",
+                metadata=metadata,
+            ),
+        ]
+        file_specs = (
+            (
+                "differential-expression.tsv",
+                "differential-expression",
+                "scientific_table",
+                ArtifactRole.OUTPUT,
+                "deseq2-results-tsv",
+                "text/tab-separated-values",
+            ),
+            (
+                "gene-counts.tsv",
+                "gene-counts",
+                "scientific_table",
+                ArtifactRole.OUTPUT,
+                "star-gene-counts-tsv",
+                "text/tab-separated-values",
+            ),
+            (
+                "normalized-counts.tsv",
+                "normalized-counts",
+                "scientific_table",
+                ArtifactRole.OUTPUT,
+                "deseq2-normalized-counts-tsv",
+                "text/tab-separated-values",
+            ),
+            (
+                "samples.tsv",
+                "rna-seq-sample-design",
+                "configuration",
+                ArtifactRole.PROVENANCE,
+                "sample-design-tsv",
+                "text/tab-separated-values",
+            ),
+            (
+                "deseq2-session-info.txt",
+                "deseq2-session-info",
+                "provenance",
+                ArtifactRole.PROVENANCE,
+                "r-session-info",
+                "text/plain",
+            ),
+        )
+        for path, logical, kind, role, format_name, media_type in file_specs:
+            observations.append(
+                self._file(
+                    products[path],
+                    logical_name=logical,
+                    kind=kind,
+                    role=role,
+                    format_name=format_name,
+                    media_type=media_type,
+                    state=state,
+                    metadata=metadata,
+                )
+            )
+        alignments = [
+            product
+            for path, product in products.items()
+            if path.endswith("/Aligned.sortedByCoord.out.bam")
+        ]
+        observations.append(
+            ArtifactObservation(
+                logical_name="star-alignments",
+                kind="scientific_dataset",
+                role=ArtifactRole.OUTPUT,
+                structure=ArtifactStructure.COLLECTION,
+                ownership=ArtifactOwnership.SHARED,
+                state=state,
+                location=ArtifactLocation.cluster_path(self.output_dir / "star"),
+                media_type="application/octet-stream",
+                format="bam-collection",
+                size_bytes=sum(product.size_bytes for product in alignments),
+                message="Coordinate-sorted STAR alignment collection finalized",
+                metadata={**metadata, "member_count": len(alignments)},
+            )
+        )
+        return observations
+
+
+def adapter_from_package(package: dict[str, Any]) -> RnaSeqArtifactAdapter | None:
+    """Create artifact semantics only for native STAR to DESeq2 packages."""
+
+    if package.get("pkg_type") != "builtin.rna_seq_star_deseq2":
+        return None
+    if str(package.get("effective_deploy_mode") or "default").casefold() == "container":
+        return None
+    output_dir = _configured_output_dir(
+        package.get("out"),
+        shared_dir=package.get("shared_dir"),
+        runtime_cwd=package.get("runtime_cwd"),
+    )
+    return RnaSeqArtifactAdapter(output_dir)
+
+
+__all__ = ["RnaSeqArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/rna_seq_star_deseq2/deseq2_analysis.R
+++ b/builtin/builtin/rna_seq_star_deseq2/deseq2_analysis.R
@@ -1,0 +1,55 @@
+suppressPackageStartupMessages(library("DESeq2"))
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 7) {
+  stop("expected counts, design, reference, comparison, result, normalized, and session paths")
+}
+
+counts_path <- args[[1]]
+design_path <- args[[2]]
+reference_condition <- args[[3]]
+comparison_condition <- args[[4]]
+result_path <- args[[5]]
+normalized_path <- args[[6]]
+session_path <- args[[7]]
+
+counts <- read.delim(counts_path, check.names = FALSE, row.names = 1)
+design <- read.delim(design_path, check.names = FALSE, stringsAsFactors = FALSE)
+if (!identical(colnames(counts), design$sample)) {
+  stop("count columns and sample design differ")
+}
+if (!setequal(unique(design$condition), c(reference_condition, comparison_condition))) {
+  stop("declared conditions differ from sample design")
+}
+design$condition <- relevel(factor(design$condition), ref = reference_condition)
+rownames(design) <- design$sample
+
+dds <- DESeqDataSetFromMatrix(
+  countData = as.matrix(counts),
+  colData = design,
+  design = ~ condition
+)
+dds <- dds[rowSums(counts(dds)) >= 10, ]
+if (nrow(dds) < 10) {
+  stop("fewer than ten expressed genes remain after count filtering")
+}
+dds <- DESeq(dds, quiet = TRUE)
+res <- results(
+  dds,
+  contrast = c("condition", comparison_condition, reference_condition),
+  alpha = 0.05
+)
+result <- data.frame(gene_id = rownames(res), as.data.frame(res), check.names = FALSE)
+result <- result[order(result$padj, -abs(result$log2FoldChange), na.last = TRUE), ]
+write.table(result, result_path, sep = "\t", quote = FALSE, row.names = FALSE)
+
+normalized <- data.frame(
+  gene_id = rownames(dds),
+  as.data.frame(counts(dds, normalized = TRUE)),
+  check.names = FALSE
+)
+write.table(normalized, normalized_path, sep = "\t", quote = FALSE, row.names = FALSE)
+
+sink(session_path)
+sessionInfo()
+sink()

--- a/builtin/builtin/rna_seq_star_deseq2/native_runner.py
+++ b/builtin/builtin/rna_seq_star_deseq2/native_runner.py
@@ -1,0 +1,448 @@
+"""Run a supplied STAR to DESeq2 workflow without runtime installation or network use."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gzip
+import hashlib
+import json
+import math
+import re
+import shutil
+import subprocess
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+
+_SAMPLE_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9_.-]{0,63}")
+_REQUIRED_SAMPLE_COLUMNS = frozenset(
+    {"sample", "condition", "set_id", "accession", "fastq"}
+)
+_RESULT_SCHEMA = "jarvis.rnaseq-star-deseq2-result.v1"
+
+
+class RnaSeqExecutionError(RuntimeError):
+    """Raised when native RNA-seq inputs or products violate their contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class Sample:
+    """One supplied single-end RNA-seq sample."""
+
+    name: str
+    condition: str
+    set_id: int
+    accession: str
+    fastq: Path
+
+
+def _safe_relative(value: str, *, field: str) -> PurePosixPath:
+    if "\\" in value:
+        raise RnaSeqExecutionError(f"{field} must use portable separators")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise RnaSeqExecutionError(f"{field} must be a confined relative path")
+    return path
+
+
+def _resolve_input(root: Path, value: str, *, field: str) -> Path:
+    relative = _safe_relative(value, field=field)
+    candidate = root.joinpath(*relative.parts)
+    try:
+        candidate.resolve(strict=True).relative_to(root.resolve(strict=True))
+    except (OSError, ValueError) as exc:
+        raise RnaSeqExecutionError(f"{field} escapes the supplied input root") from exc
+    if candidate.is_symlink() or not candidate.is_file():
+        raise RnaSeqExecutionError(f"{field} is not a regular supplied file")
+    return candidate
+
+
+def read_samples(path: Path, *, input_root: Path) -> tuple[Sample, ...]:
+    """Read and validate a two-condition, replicated sample design."""
+
+    try:
+        with path.open("r", encoding="utf-8", newline="") as stream:
+            reader = csv.DictReader(stream, delimiter="\t")
+            if (
+                reader.fieldnames is None
+                or set(reader.fieldnames) != _REQUIRED_SAMPLE_COLUMNS
+            ):
+                raise RnaSeqExecutionError("RNA-seq sample table columns differ")
+            rows = tuple(reader)
+    except (OSError, UnicodeError, csv.Error) as exc:
+        raise RnaSeqExecutionError("RNA-seq sample table is unreadable") from exc
+    if not 4 <= len(rows) <= 64:
+        raise RnaSeqExecutionError("RNA-seq sample count must be between 4 and 64")
+    samples: list[Sample] = []
+    for row in rows:
+        name = row["sample"]
+        condition = row["condition"]
+        accession = row["accession"]
+        if _SAMPLE_PATTERN.fullmatch(name) is None:
+            raise RnaSeqExecutionError(f"invalid RNA-seq sample name: {name!r}")
+        if _SAMPLE_PATTERN.fullmatch(condition) is None:
+            raise RnaSeqExecutionError(f"invalid RNA-seq condition: {condition!r}")
+        if _SAMPLE_PATTERN.fullmatch(accession) is None:
+            raise RnaSeqExecutionError(f"invalid RNA-seq accession: {accession!r}")
+        try:
+            set_id = int(row["set_id"])
+        except ValueError as exc:
+            raise RnaSeqExecutionError("RNA-seq set_id must be an integer") from exc
+        if set_id <= 0:
+            raise RnaSeqExecutionError("RNA-seq set_id must be positive")
+        samples.append(
+            Sample(
+                name=name,
+                condition=condition,
+                set_id=set_id,
+                accession=accession,
+                fastq=_resolve_input(input_root, row["fastq"], field="sample fastq"),
+            )
+        )
+    names = [sample.name for sample in samples]
+    accessions = [sample.accession for sample in samples]
+    if len(names) != len(set(names)) or len(accessions) != len(set(accessions)):
+        raise RnaSeqExecutionError("RNA-seq sample names and accessions must be unique")
+    by_condition = Counter(sample.condition for sample in samples)
+    if len(by_condition) != 2 or any(count < 2 for count in by_condition.values()):
+        raise RnaSeqExecutionError("RNA-seq design requires two replicated conditions")
+    paired_sets = {
+        condition: {
+            sample.set_id for sample in samples if sample.condition == condition
+        }
+        for condition in by_condition
+    }
+    if len({frozenset(values) for values in paired_sets.values()}) != 1:
+        raise RnaSeqExecutionError(
+            "RNA-seq conditions must use the same replicate-set IDs"
+        )
+    return tuple(samples)
+
+
+def _read_length(path: Path) -> int:
+    try:
+        with gzip.open(path, "rb") as stream:
+            header = stream.readline()
+            sequence = stream.readline().rstrip(b"\r\n")
+            plus = stream.readline()
+            quality = stream.readline().rstrip(b"\r\n")
+    except (OSError, EOFError) as exc:
+        raise RnaSeqExecutionError(f"cannot read supplied FASTQ: {path.name}") from exc
+    if (
+        not header.startswith(b"@")
+        or not plus.startswith(b"+")
+        or not sequence
+        or len(sequence) != len(quality)
+    ):
+        raise RnaSeqExecutionError(f"supplied FASTQ is malformed: {path.name}")
+    return len(sequence)
+
+
+def _run(command: list[str], *, label: str) -> None:
+    print(f"[rnaseq] {label}: {command[0]}", flush=True)
+    try:
+        completed = subprocess.run(command, check=False)  # noqa: S603
+    except OSError as exc:
+        raise RnaSeqExecutionError(f"could not launch {label}") from exc
+    if completed.returncode != 0:
+        raise RnaSeqExecutionError(f"{label} exited with status {completed.returncode}")
+
+
+def _decompress(source: Path, destination: Path) -> None:
+    try:
+        with gzip.open(source, "rb") as compressed, destination.open("wb") as output:
+            shutil.copyfileobj(compressed, output)
+    except (OSError, EOFError) as exc:
+        raise RnaSeqExecutionError(f"could not decompress {source.name}") from exc
+    if destination.stat().st_size <= 0:
+        raise RnaSeqExecutionError(f"decompressed {source.name} is empty")
+
+
+def _write_counts(samples: tuple[Sample, ...], star_root: Path, output: Path) -> None:
+    genes: list[str] | None = None
+    columns: list[list[int]] = []
+    for sample in samples:
+        path = star_root / sample.name / "ReadsPerGene.out.tab"
+        try:
+            rows = [
+                line.split("\t")
+                for line in path.read_text(encoding="utf-8").splitlines()
+            ]
+        except (OSError, UnicodeError) as exc:
+            raise RnaSeqExecutionError(
+                f"STAR counts are unavailable for {sample.name}"
+            ) from exc
+        if len(rows) <= 4 or any(len(row) != 4 for row in rows):
+            raise RnaSeqExecutionError(f"STAR counts are malformed for {sample.name}")
+        observed_genes = [row[0] for row in rows[4:]]
+        if genes is None:
+            genes = observed_genes
+        elif observed_genes != genes:
+            raise RnaSeqExecutionError("STAR gene order differs across samples")
+        try:
+            columns.append([int(row[1]) for row in rows[4:]])
+        except ValueError as exc:
+            raise RnaSeqExecutionError(
+                f"STAR counts are non-integral for {sample.name}"
+            ) from exc
+    assert genes is not None
+    with output.open("w", encoding="utf-8", newline="\n") as stream:
+        stream.write("gene_id\t" + "\t".join(sample.name for sample in samples) + "\n")
+        for index, gene in enumerate(genes):
+            values = "\t".join(str(column[index]) for column in columns)
+            stream.write(f"{gene}\t{values}\n")
+
+
+def _star_metrics(path: Path) -> dict[str, int | float]:
+    values: dict[str, str] = {}
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if "|" in line:
+                name, value = line.split("|", 1)
+                values[name.strip()] = value.strip()
+    except (OSError, UnicodeError) as exc:
+        raise RnaSeqExecutionError(f"STAR log is unavailable: {path}") from exc
+    try:
+        return {
+            "input_reads": int(values["Number of input reads"]),
+            "uniquely_mapped_reads": int(values["Uniquely mapped reads number"]),
+            "uniquely_mapped_percent": float(
+                values["Uniquely mapped reads %"].rstrip("%")
+            ),
+        }
+    except (KeyError, ValueError) as exc:
+        raise RnaSeqExecutionError(f"STAR log omitted mapping metrics: {path}") from exc
+
+
+def _finite_or_none(value: str) -> float | None:
+    if value in {"", "NA", "NaN", "nan"}:
+        return None
+    parsed = float(value)
+    return parsed if math.isfinite(parsed) else None
+
+
+def _deseq_summary(path: Path) -> tuple[int, int, list[dict[str, Any]]]:
+    try:
+        with path.open("r", encoding="utf-8", newline="") as stream:
+            rows = tuple(csv.DictReader(stream, delimiter="\t"))
+    except (OSError, UnicodeError, csv.Error) as exc:
+        raise RnaSeqExecutionError("DESeq2 result table is unreadable") from exc
+    required = {
+        "gene_id",
+        "baseMean",
+        "log2FoldChange",
+        "lfcSE",
+        "stat",
+        "pvalue",
+        "padj",
+    }
+    if not rows or set(rows[0]) != required:
+        raise RnaSeqExecutionError("DESeq2 result columns differ")
+    significant: list[dict[str, Any]] = []
+    tested = 0
+    for row in rows:
+        padj = _finite_or_none(row["padj"])
+        fold = _finite_or_none(row["log2FoldChange"])
+        if padj is not None:
+            tested += 1
+        if padj is not None and fold is not None and padj <= 0.05 and abs(fold) >= 1.0:
+            significant.append(
+                {
+                    "gene_id": row["gene_id"],
+                    "log2_fold_change": fold,
+                    "adjusted_p_value": padj,
+                }
+            )
+    significant.sort(
+        key=lambda item: (item["adjusted_p_value"], -abs(item["log2_fold_change"]))
+    )
+    return tested, len(significant), significant[:20]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _artifact_records(paths: Iterable[Path], *, root: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for path in sorted(paths):
+        if path.is_symlink() or not path.is_file() or path.stat().st_size <= 0:
+            raise RnaSeqExecutionError(f"required RNA-seq product is missing: {path}")
+        relative = path.relative_to(root).as_posix()
+        records.append(
+            {
+                "path": relative,
+                "sha256": _sha256(path),
+                "size_bytes": path.stat().st_size,
+            }
+        )
+    return records
+
+
+def run_workflow(arguments: argparse.Namespace) -> dict[str, Any]:
+    """Execute STAR and DESeq2 and return the closed result document."""
+
+    input_root = arguments.input_root.resolve(strict=True)
+    samples_path = arguments.samples.resolve(strict=True)
+    samples = read_samples(samples_path, input_root=input_root)
+    conditions = list(dict.fromkeys(sample.condition for sample in samples))
+    reference_condition, comparison_condition = conditions
+    output_root = arguments.output_root.resolve()
+    work_root = arguments.work_root.resolve()
+    if (
+        output_root == work_root
+        or output_root in work_root.parents
+        or work_root in output_root.parents
+    ):
+        raise RnaSeqExecutionError("RNA-seq work and output roots must be separate")
+    for root in (output_root, work_root):
+        if root.exists() or root.is_symlink():
+            raise RnaSeqExecutionError(f"RNA-seq target already exists: {root}")
+        root.mkdir(parents=True)
+    genome = work_root / "genome.fa"
+    annotation = work_root / "genes.gtf"
+    _decompress(arguments.genome.resolve(strict=True), genome)
+    _decompress(arguments.annotation.resolve(strict=True), annotation)
+    index_root = work_root / "star-index"
+    index_root.mkdir()
+    read_length = max(_read_length(sample.fastq) for sample in samples)
+    _run(
+        [
+            arguments.star,
+            "--runMode",
+            "genomeGenerate",
+            "--runThreadN",
+            str(arguments.cores),
+            "--genomeDir",
+            str(index_root),
+            "--genomeFastaFiles",
+            str(genome),
+            "--sjdbGTFfile",
+            str(annotation),
+            "--sjdbOverhang",
+            str(read_length - 1),
+            "--genomeSAindexNbases",
+            "10",
+        ],
+        label="STAR genome generation",
+    )
+    star_root = output_root / "star"
+    star_root.mkdir()
+    for sample in samples:
+        sample_root = star_root / sample.name
+        sample_root.mkdir()
+        _run(
+            [
+                arguments.star,
+                "--runThreadN",
+                str(arguments.cores),
+                "--genomeDir",
+                str(index_root),
+                "--readFilesIn",
+                str(sample.fastq),
+                "--readFilesCommand",
+                "zcat",
+                "--outFileNamePrefix",
+                str(sample_root) + "/",
+                "--outSAMtype",
+                "BAM",
+                "SortedByCoordinate",
+                "--quantMode",
+                "GeneCounts",
+            ],
+            label=f"STAR alignment {sample.name}",
+        )
+    counts = output_root / "gene-counts.tsv"
+    _write_counts(samples, star_root, counts)
+    design = output_root / "samples.tsv"
+    shutil.copyfile(samples_path, design)
+    differential = output_root / "differential-expression.tsv"
+    normalized = output_root / "normalized-counts.tsv"
+    session_info = output_root / "deseq2-session-info.txt"
+    _run(
+        [
+            arguments.rscript,
+            str(arguments.deseq_script.resolve(strict=True)),
+            str(counts),
+            str(design),
+            reference_condition,
+            comparison_condition,
+            str(differential),
+            str(normalized),
+            str(session_info),
+        ],
+        label="DESeq2 differential expression",
+    )
+    tested, significant_count, top = _deseq_summary(differential)
+    mapping = {
+        sample.name: _star_metrics(star_root / sample.name / "Log.final.out")
+        for sample in samples
+    }
+    products = [counts, design, differential, normalized, session_info]
+    for sample in samples:
+        sample_root = star_root / sample.name
+        products.extend(
+            (
+                sample_root / "Aligned.sortedByCoord.out.bam",
+                sample_root / "ReadsPerGene.out.tab",
+                sample_root / "Log.final.out",
+            )
+        )
+    return {
+        "artifacts": _artifact_records(products, root=output_root),
+        "comparison_condition": comparison_condition,
+        "deseq2": {
+            "adjusted_p_value_threshold": 0.05,
+            "absolute_log2_fold_change_threshold": 1.0,
+            "significant_gene_count": significant_count,
+            "tested_gene_count": tested,
+            "top_significant_genes": top,
+        },
+        "mapping": mapping,
+        "reference_condition": reference_condition,
+        "sample_count": len(samples),
+        "schema_version": _RESULT_SCHEMA,
+        "star_read_length": read_length,
+    }
+
+
+def main() -> int:
+    """Parse the confined native execution contract and run it."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-root", required=True, type=Path)
+    parser.add_argument("--samples", required=True, type=Path)
+    parser.add_argument("--genome", required=True, type=Path)
+    parser.add_argument("--annotation", required=True, type=Path)
+    parser.add_argument("--output-root", required=True, type=Path)
+    parser.add_argument("--work-root", required=True, type=Path)
+    parser.add_argument("--deseq-script", required=True, type=Path)
+    parser.add_argument("--star", required=True)
+    parser.add_argument("--rscript", required=True)
+    parser.add_argument("--cores", required=True, type=int)
+    arguments = parser.parse_args()
+    if not 1 <= arguments.cores <= 64:
+        parser.error("--cores must be between 1 and 64")
+    result = run_workflow(arguments)
+    result_path = arguments.output_root / "rnaseq-result.json"
+    temporary = result_path.with_suffix(".json.partial")
+    temporary.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    temporary.replace(result_path)
+    print(
+        "[rnaseq] completed: "
+        f"{result['deseq2']['significant_gene_count']} significant genes",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builtin/builtin/rna_seq_star_deseq2/pkg.py
+++ b/builtin/builtin/rna_seq_star_deseq2/pkg.py
@@ -1,238 +1,427 @@
-"""
-This module provides classes and methods to launch the rna_seq_star_deseq2
-application.  Snakemake workflow for RNA-seq differential expression analysis
-with STAR aligner and DESeq2.
-"""
+"""Launch a supplied STAR to DESeq2 differential-expression workflow."""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+from .result_contract import load_rnaseq_result
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, LocalExecInfo, PsshExecInfo
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ReadinessContract,
+    RuntimeRequirement,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
+
+_EXPECTED_ROLES = {
+    "gene_annotation": 1,
+    "reference_genome": 1,
+    "sample_design": 1,
+}
 
 
 class RnaSeqStarDeseq2(Application):
+    """Align supplied single-end RNA-seq reads and compare two conditions.
+
+    The agent-facing native profile accepts one digest-verified bundle carrying
+    the reads, sample design, reference genome, and gene annotation. It never
+    installs software or accesses the network during scheduled execution. The
+    historical container profile remains available for existing pipelines but
+    is intentionally hidden from the scientific contract.
     """
-    RnaSeqStarDeseq2 class supporting both default (bare-metal) and container
-    deployment.
 
-    Set deploy_mode='container' to build and run the RNA-seq pipeline inside a
-    Docker/Podman/Apptainer container.  Set deploy_mode='default' to use a
-    system-installed environment.
-    """
+    def _init(self) -> None:
+        self.star_bin: str | None = None
+        self.rscript_bin: str | None = None
 
-    def _init(self):
-        pass
-
-    def _configure_menu(self):
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
             {
-                'name': 'nprocs',
-                'msg': 'Number of MPI processes',
-                'type': int,
-                'default': 1,
+                "name": "input_bundle",
+                "msg": (
+                    "Digest-verified bundle containing replicated single-end "
+                    "FASTQ reads, one sample design, one reference genome, and "
+                    "one matching gene annotation"
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                'name': 'cores',
-                'msg': 'Number of Snakemake cores',
-                'type': int,
-                'default': 4,
+                "name": "out",
+                "msg": (
+                    "Output directory. Relative paths resolve under the JARVIS "
+                    "package shared directory."
+                ),
+                "type": str,
+                "default": "run",
             },
             {
-                'name': 'out',
-                'msg': 'Output directory for results',
-                'type': str,
-                'default': '/tmp/rnaseq_out',
+                "name": "cores",
+                "msg": "CPU cores used by STAR for indexing and alignment",
+                "type": int,
+                "default": 4,
             },
             {
-                'name': 'replicates',
-                'msg': ('Run the full snakemake RNA-seq workflow this '
-                        'many times back-to-back in one container exec, '
-                        'each into rep_NNN/ under `out`. Each replicate '
-                        'rebuilds STAR index, aligns FASTQs, and writes '
-                        'BAM + DESeq2 results, so I/O scales linearly.'),
-                'type': int,
-                'default': 1,
+                "name": "nprocs",
+                "msg": "Legacy process count; the native workflow is one batch process",
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
             },
             {
-                'name': 'parallel_reps',
-                'msg': ('Per-host replicate concurrency. When > 1, the '
-                        'replicates loop fans across hosts via PsshExecInfo '
-                        'and each host runs this many in parallel using '
-                        '`wait -n` batching. Default 1 preserves the '
-                        'original host[0]-only sequential loop.'),
-                'type': int,
-                'default': 1,
+                "name": "ppn",
+                "msg": "Legacy processes per node",
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
             },
             {
-                'name': 'parallel_scratch_root',
-                'msg': ('Root dir for per-rep SNAKEMAKE_SCRATCH_DIR when '
-                        'parallel_reps > 1. Each rep gets '
-                        '`<root>/rnaseq-scratch-<rep>`. Default /tmp keeps '
-                        'snakemake/STAR intermediates on node-local '
-                        'disk; point at a FUSE mount (e.g. '
-                        '/mnt/dumbwarp/scratch) to route every '
-                        'STAR-index / BAM / DESeq2 R/W through that '
-                        'adapter.'),
-                'type': str,
-                'default': '/tmp',
+                "name": "replicates",
+                "msg": "Legacy image-baked workflow repetition count",
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
             },
             {
-                'name': 'omp_threads',
-                'msg': ('OMP_NUM_THREADS for each parallel replicate. '
-                        'Snakemake threading is governed separately by '
-                        '`cores`. 0 = unset.'),
-                'type': int,
-                'default': 0,
+                "name": "parallel_reps",
+                "msg": "Legacy image-baked per-host repetition concurrency",
+                "type": int,
+                "default": 1,
+                "agent_visible": False,
             },
             {
-                'name': 'base_image',
-                'msg': 'Base Docker image for build container',
-                'type': str,
-                'default': 'sci-hpc-base',
+                "name": "parallel_scratch_root",
+                "msg": "Legacy image-baked scratch root",
+                "type": str,
+                "default": "/tmp",
+                "agent_visible": False,
+            },
+            {
+                "name": "omp_threads",
+                "msg": "Legacy image-baked OpenMP thread count",
+                "type": int,
+                "default": 0,
+                "agent_visible": False,
+            },
+            {
+                "name": "base_image",
+                "msg": "Legacy container build base image",
+                "type": str,
+                "default": "sci-hpc-base",
+                "agent_visible": False,
             },
         ]
 
-    # ------------------------------------------------------------------
-    # Container Dockerfile generators
-    # ------------------------------------------------------------------
+    @staticmethod
+    def _discover(program: str, environment: dict[str, str]) -> str | None:
+        return program if shutil.which(program, path=environment.get("PATH")) else None
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe the native STAR and DESeq2 runtime and completion contract."""
+
+        environment = self._deployment_environment()
+        star = self._discover("STAR", environment) or "STAR"
+        rscript = self._discover("Rscript", environment) or "Rscript"
+        star_probe = probe_program(
+            star,
+            environment=environment,
+            arguments=("--version",),
+            timeout_seconds=10,
+        )
+        deseq_probe = probe_program(
+            rscript,
+            environment=environment,
+            arguments=(
+                "-e",
+                "suppressPackageStartupMessages(library(DESeq2));cat(as.character(packageVersion('DESeq2')))",
+            ),
+            timeout_seconds=20,
+        )
+        return PackageDeploymentContract(
+            package="builtin.rna_seq_star_deseq2",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="native_supplied_reads",
+                    execution_kind="batch",
+                    when=(
+                        ConfigurationCondition("deploy_mode", "equals", "default"),
+                        ConfigurationCondition("input_bundle", "is_not_empty"),
+                    ),
+                    runtime_requirements=("star", "deseq2"),
+                    readiness=ReadinessContract(
+                        mechanism="process_exit",
+                        condition="successful_exit_with_required_products",
+                    ),
+                    description=(
+                        "Align one supplied replicated two-condition RNA-seq "
+                        "study with STAR and calculate differential expression "
+                        "with DESeq2."
+                    ),
+                ),
+            ),
+            runtime_requirements=(
+                RuntimeRequirement(
+                    requirement_id="star",
+                    description="STAR aligner available through PATH",
+                    required_capabilities=("rna_seq_alignment", "gene_counting"),
+                    available_capabilities=(
+                        ("rna_seq_alignment", "gene_counting")
+                        if star_probe.status.usable is True
+                        else ()
+                    ),
+                    status=star_probe.status,
+                ),
+                RuntimeRequirement(
+                    requirement_id="deseq2",
+                    description="R runtime with the DESeq2 package",
+                    required_capabilities=("differential_expression",),
+                    available_capabilities=(
+                        ("differential_expression",)
+                        if deseq_probe.status.usable is True
+                        else ()
+                    ),
+                    status=deseq_probe.status,
+                ),
+            ),
+        )
+
+    def _build_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Build the retained legacy container image only when requested."""
+
+        if self.config.get("deploy_mode") != "container":
             return None
-        content = self._read_build_script('build.sh', {
-            'BASE_IMAGE': self.config.get('base_image', 'sci-hpc-base'),
-        })
-        return content, 'snakemake'
+        content = self._read_build_script(
+            "build.sh", {"BASE_IMAGE": self.config.get("base_image", "sci-hpc-base")}
+        )
+        return content, "snakemake"
 
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Create the retained legacy deployment image only when requested."""
+
+        if self.config.get("deploy_mode") != "container":
             return None
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': 'ubuntu:24.04',
-        })
-        return content, 'snakemake'
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {"BUILD_IMAGE": self.build_image_name(), "DEPLOY_BASE": "ubuntu:24.04"},
+        )
+        return content, "snakemake"
 
-    # ------------------------------------------------------------------
-    # Configuration
-    # ------------------------------------------------------------------
+    def _configure(self, **kwargs: Any) -> None:
+        """Validate the selected profile and prepare package-owned storage."""
 
-    def _configure(self, **kwargs):
-        """
-        Configure rna_seq_star_deseq2.
-
-        Calls super()._configure() which updates self.config and (when
-        deploy_mode == 'container') triggers build_phase / build_deploy_phase.
-
-        In default mode, also creates the output directory on all nodes.
-        """
         super()._configure(**kwargs)
+        if self.config.get("deploy_mode", "default") == "default":
+            self._validate_native_configuration()
+            environment = self._deployment_environment()
+            self.star_bin = self._discover("STAR", environment)
+            self.rscript_bin = self._discover("Rscript", environment)
+            self._ensure_output_root()
 
-        if self.config.get('deploy_mode') == 'default':
-            if self.config['out']:
-                Mkdir(self.config['out'],
-                      PsshExecInfo(hostfile=self.hostfile,
-                                   env=self.env)).run()
+    def _validate_native_configuration(self) -> None:
+        bundle = self.config.get("input_bundle")
+        if not isinstance(bundle, str) or not bundle:
+            raise ValueError("native STAR to DESeq2 requires input_bundle")
+        cores = self.config.get("cores")
+        if (
+            isinstance(cores, bool)
+            or not isinstance(cores, int)
+            or not 1 <= cores <= 64
+        ):
+            raise ValueError("cores must be an integer between 1 and 64")
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
-
-    def start(self):
-        """
-        Launch rna_seq_star_deseq2.
-
-        run_rnaseq.sh takes the output directory as its first positional
-        argument. Snakemake runs in a /tmp scratch workdir (snakemake
-        uses atomic write-then-rename, which wrp_cte_fuse does not
-        support) and the final results tree is staged into ``out`` via
-        plain cp — which exercises the CTE adapter when ``out`` is on
-        the FUSE mountpoint.
-        """
-        out_root = self.config['out']
-        replicates = max(int(self.config.get('replicates', 1) or 1), 1)
-        parallel = max(int(self.config.get('parallel_reps', 1) or 1), 1)
-        omp = int(self.config.get('omp_threads', 0) or 0)
-
-        if parallel <= 1:
-            # Single-host sequential path (original).
-            if replicates == 1:
-                cmd = f"/opt/run_rnaseq.sh '{out_root}'"
-            else:
-                cmd = (
-                    "set -e; "
-                    f"for i in $(seq 1 {replicates}); do "
-                    f"  rep=$(printf 'rep_%03d' \"$i\"); "
-                    f"  echo \"=== rna_seq replicate $rep ($i/{replicates}) ===\"; "
-                    f"  /opt/run_rnaseq.sh '{out_root}/'$rep || exit 1; "
-                    f"done"
-                )
-            if self.config.get('deploy_mode') == 'container':
-                Exec(cmd, LocalExecInfo(
-                    container=self._container_engine,
-                    container_image=self.deploy_image_name(),
-                    shared_dir=self.shared_dir,
-                    private_dir=self.private_dir,
-                    env=self.mod_env,
-                )).run()
-            else:
-                Exec(cmd, LocalExecInfo(env=self.mod_env)).run()
-            return
-
-        # parallel_reps > 1: PsshExecInfo fan-out + per-host wait -n
-        # batching. Snakemake's /tmp/rnaseq-scratch is wiped at start of
-        # each invocation; concurrent runs on the same host need a per-
-        # rep scratch dir, which the runner script honors via
-        # SNAKEMAKE_SCRATCH_DIR (mirroring biobb/montage's pattern).
-        nhosts = max(len(self.hostfile.hosts), 1) if self.hostfile else 1
-        local_reps = (replicates + nhosts - 1) // nhosts
-        scratch_root = (self.config.get('parallel_scratch_root')
-                        or '/tmp').rstrip('/')
-        omp_export = (
-            f"export OMP_NUM_THREADS={omp}; " if omp > 0 else ""
+    def _output_root(self) -> Path:
+        return self.resolve_shared_path(
+            self.config.get("out"), field="out", default="run"
         )
-        cmd = (
-            f"set -e; "
-            f"{omp_export}"
-            f"LOCAL={local_reps}; "
-            f"PAR={parallel}; "
-            f"OUT='{out_root}'; "
-            f"H=$(hostname -s); "
-            f"echo \"[rnaseq-parallel] host=$H reps=$LOCAL parallel=$PAR omp=${{OMP_NUM_THREADS:-default}}\"; "
-            f"PIDS=(); "
-            f"for i in $(seq 1 $LOCAL); do "
-            f"  ( "
-            f"    rep=$(printf 'rep_%03d-%s' \"$i\" \"$H\"); "
-            f"    RNASEQ_SCRATCH_DIR=\"{scratch_root}/rnaseq-scratch-$rep\" "
-            f"    /opt/run_rnaseq.sh \"$OUT/$rep\" "
-            f"      && echo \"[rnaseq-parallel] host=$H $rep DONE\" "
-            f"      || {{ echo \"[rnaseq-parallel] host=$H $rep FAILED\" >&2; exit 1; }} "
-            f"  ) & "
-            f"  PIDS+=($!); "
-            f"  if [ \"${{#PIDS[@]}}\" -ge $PAR ]; then "
-            f"    wait -n; "
-            f"    PIDS=(\"${{PIDS[@]:1}}\"); "
-            f"  fi; "
-            f"done; "
-            f"wait"
+
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
+
+    def _ensure_output_root(self) -> None:
+        output = str(self._output_root())
+        result = Mkdir(output, self._node_exec_info(env=self.env)).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to create RNA-seq output directory {output}: {failures}"
+            )
+
+    @staticmethod
+    def _bundle_members(
+        bundle: MaterializedInputBundle,
+    ) -> dict[str, Path | tuple[Path, ...]]:
+        by_role: dict[str, list[Path]] = {}
+        for item in bundle.manifest.files:
+            by_role.setdefault(item.role, []).append(bundle.root / item.path)
+        if set(by_role) != {*_EXPECTED_ROLES, "single_end_fastq"}:
+            raise ValueError(
+                "RNA-seq input bundle contains unsupported or missing roles"
+            )
+        for role, expected_count in _EXPECTED_ROLES.items():
+            if len(by_role[role]) != expected_count:
+                raise ValueError(f"RNA-seq input bundle requires exactly one {role}")
+        fastqs = by_role["single_end_fastq"]
+        if not 4 <= len(fastqs) <= 64:
+            raise ValueError("RNA-seq input bundle requires 4 to 64 FASTQ files")
+        design = by_role["sample_design"][0]
+        if design != bundle.entrypoint:
+            raise ValueError(
+                "RNA-seq input bundle entrypoint must be its sample design"
+            )
+        return {
+            "sample_design": design,
+            "reference_genome": by_role["reference_genome"][0],
+            "gene_annotation": by_role["gene_annotation"][0],
+            "single_end_fastq": tuple(fastqs),
+        }
+
+    def _prepare_native_input(self) -> tuple[Path, Path, Path, Path, Path]:
+        """Verify and stage one closed study without accepting stale products."""
+
+        self._validate_native_configuration()
+        self._ensure_output_root()
+        root = self._output_root()
+        for name in ("input", "results", "work"):
+            target = root / name
+            if target.exists() or target.is_symlink():
+                raise ValueError(f"RNA-seq execution target already exists: {name}")
+        configured = self.config.get("input_bundle")
+        assert isinstance(configured, str) and configured
+        if self.shared_dir is None:
+            raise RuntimeError("RNA-seq input bundles require shared storage")
+        bundle = extract_input_bundle(
+            configured, Path(self.shared_dir) / "input-bundles"
         )
-        if self.config.get('deploy_mode') == 'container':
-            Exec(cmd, PsshExecInfo(
-                hostfile=self.hostfile,
+        members = self._bundle_members(bundle)
+        stage_input_bundle(bundle, root / "input")
+
+        def staged(role: str) -> Path:
+            source = members[role]
+            assert isinstance(source, Path)
+            return root / "input" / source.relative_to(bundle.root)
+
+        return (
+            root / "input",
+            staged("sample_design"),
+            staged("reference_genome"),
+            staged("gene_annotation"),
+            root,
+        )
+
+    def _start_native(self) -> None:
+        input_root, samples, genome, annotation, root = self._prepare_native_input()
+        star = self.star_bin or self._discover("STAR", self.mod_env)
+        rscript = self.rscript_bin or self._discover("Rscript", self.mod_env)
+        if star is None:
+            raise RuntimeError("STAR is unavailable through PATH")
+        if rscript is None:
+            raise RuntimeError("Rscript with DESeq2 is unavailable through PATH")
+        runner = Path(__file__).with_name("native_runner.py").resolve()
+        deseq = Path(__file__).with_name("deseq2_analysis.R").resolve()
+        arguments = [
+            sys.executable,
+            str(runner),
+            "--input-root",
+            str(input_root),
+            "--samples",
+            str(samples),
+            "--genome",
+            str(genome),
+            "--annotation",
+            str(annotation),
+            "--output-root",
+            str(root / "results"),
+            "--work-root",
+            str(root / "work"),
+            "--deseq-script",
+            str(deseq),
+            "--star",
+            star,
+            "--rscript",
+            rscript,
+            "--cores",
+            str(self.config["cores"]),
+        ]
+        result = Exec(
+            " ".join(shlex.quote(argument) for argument in arguments),
+            LocalExecInfo(
+                env=self.mod_env,
+                cwd=str(root),
+                line_callback=self.runtime_line_callback(),
+            ),
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"STAR to DESeq2 workflow failed: {failures}")
+        load_rnaseq_result(root / "results")
+
+    def _start_legacy_container(self) -> None:
+        """Retain the historical image-baked workflow for explicit container users."""
+
+        out_root = self.config.get("out")
+        if not isinstance(out_root, str) or not out_root:
+            raise ValueError("legacy RNA-seq output must be a path string")
+        configured_replicates = self.config.get("replicates", 1)
+        if isinstance(configured_replicates, bool) or not isinstance(
+            configured_replicates, int
+        ):
+            raise ValueError("legacy RNA-seq replicates must be an integer")
+        replicates = max(configured_replicates, 1)
+        command = (
+            f"/opt/run_rnaseq.sh {shlex.quote(out_root)}"
+            if replicates == 1
+            else "set -e; "
+            + f"for i in $(seq 1 {replicates}); do "
+            + 'rep=$(printf "rep_%03d" "$i"); '
+            + f"/opt/run_rnaseq.sh {shlex.quote(out_root)}/$rep || exit 1; done"
+        )
+        result = Exec(
+            command,
+            LocalExecInfo(
                 container=self._container_engine,
                 container_image=self.deploy_image_name(),
                 shared_dir=self.shared_dir,
                 private_dir=self.private_dir,
                 env=self.mod_env,
-            )).run()
+            ),
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"Legacy STAR to DESeq2 workflow failed: {failures}")
+
+    def start(self) -> None:
+        """Run the selected native or explicit legacy profile."""
+
+        if self.config.get("deploy_mode", "default") == "container":
+            self._start_legacy_container()
         else:
-            Exec(cmd, PsshExecInfo(
-                hostfile=self.hostfile, env=self.mod_env)).run()
+            self._start_native()
 
-    def stop(self):
-        """Stop rna_seq_star_deseq2 (no-op -- runs to completion)."""
-        pass
+    def stop(self) -> None:
+        """Do nothing because this package is a bounded batch process."""
 
-    def clean(self):
-        """Remove rna_seq_star_deseq2 output directory."""
-        if self.config['out']:
-            Rm(self.config['out'] + '*',
-               PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+    def clean(self) -> None:
+        """Remove the exact package-owned output directory."""
+
+        output = str(self._output_root())
+        Rm(output, self._node_exec_info(env=self.env), recursive=True).run()

--- a/builtin/builtin/rna_seq_star_deseq2/result_contract.py
+++ b/builtin/builtin/rna_seq_star_deseq2/result_contract.py
@@ -1,0 +1,240 @@
+"""Closed result validation shared by RNA-seq lifecycle and artifact semantics."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+RESULT_NAME = "rnaseq-result.json"
+RESULT_SCHEMA = "jarvis.rnaseq-star-deseq2-result.v1"
+_TOP_LEVEL_FIELDS = {
+    "artifacts",
+    "comparison_condition",
+    "deseq2",
+    "mapping",
+    "reference_condition",
+    "sample_count",
+    "schema_version",
+    "star_read_length",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class RnaSeqProduct:
+    """One result-declared, digest-verified RNA-seq product."""
+
+    relative_path: PurePosixPath
+    local_path: Path
+    sha256: str
+    size_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedRnaSeqResult:
+    """A closed RNA-seq result and all of its verified products."""
+
+    result_path: Path
+    document: dict[str, Any]
+    products: dict[str, RnaSeqProduct]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _relative_path(value: object) -> PurePosixPath:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise RuntimeError("RNA-seq result contains an invalid artifact path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise RuntimeError("RNA-seq result artifact path is not confined")
+    return path
+
+
+def _positive_integer(value: object, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise RuntimeError(f"RNA-seq result {field} must be a positive integer")
+    return value
+
+
+def _validate_mapping(
+    document: dict[str, Any], *, sample_count: int
+) -> tuple[str, ...]:
+    mapping = document.get("mapping")
+    if not isinstance(mapping, dict) or len(mapping) != sample_count:
+        raise RuntimeError("RNA-seq result mapping summary differs from sample count")
+    names: list[str] = []
+    for name, raw in mapping.items():
+        if not isinstance(name, str) or not name or not isinstance(raw, dict):
+            raise RuntimeError("RNA-seq result contains an invalid sample mapping")
+        if set(raw) != {
+            "input_reads",
+            "uniquely_mapped_percent",
+            "uniquely_mapped_reads",
+        }:
+            raise RuntimeError("RNA-seq sample mapping fields differ")
+        input_reads = _positive_integer(raw["input_reads"], field="input_reads")
+        mapped_reads = raw["uniquely_mapped_reads"]
+        percent = raw["uniquely_mapped_percent"]
+        if (
+            isinstance(mapped_reads, bool)
+            or not isinstance(mapped_reads, int)
+            or not 0 <= mapped_reads <= input_reads
+            or isinstance(percent, bool)
+            or not isinstance(percent, (int, float))
+            or not 0 <= float(percent) <= 100
+        ):
+            raise RuntimeError("RNA-seq sample mapping metric is outside its bounds")
+        names.append(name)
+    return tuple(names)
+
+
+def _validate_deseq2(document: dict[str, Any]) -> None:
+    summary = document.get("deseq2")
+    if not isinstance(summary, dict) or set(summary) != {
+        "absolute_log2_fold_change_threshold",
+        "adjusted_p_value_threshold",
+        "significant_gene_count",
+        "tested_gene_count",
+        "top_significant_genes",
+    }:
+        raise RuntimeError("RNA-seq DESeq2 summary fields differ")
+    tested = _positive_integer(summary["tested_gene_count"], field="tested_gene_count")
+    significant = summary["significant_gene_count"]
+    top = summary["top_significant_genes"]
+    if (
+        isinstance(significant, bool)
+        or not isinstance(significant, int)
+        or not 0 <= significant <= tested
+        or not isinstance(top, list)
+        or len(top) > min(significant, 20)
+    ):
+        raise RuntimeError("RNA-seq DESeq2 summary values are inconsistent")
+    for item in top:
+        if not isinstance(item, dict) or set(item) != {
+            "adjusted_p_value",
+            "gene_id",
+            "log2_fold_change",
+        }:
+            raise RuntimeError("RNA-seq significant-gene record fields differ")
+
+
+def load_rnaseq_result(output_root: Path) -> ValidatedRnaSeqResult:
+    """Load a result only when its closed document and exact products agree."""
+
+    root = output_root.resolve(strict=True)
+    if root.is_symlink() or not root.is_dir():
+        raise RuntimeError("RNA-seq output root is not a real directory")
+    result_path = root / RESULT_NAME
+    if (
+        result_path.is_symlink()
+        or not result_path.is_file()
+        or not 0 < result_path.stat().st_size <= 2 * 1024 * 1024
+    ):
+        raise RuntimeError("RNA-seq result document is missing, unsafe, or oversized")
+    try:
+        document = json.loads(result_path.read_text(encoding="utf-8", errors="strict"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("RNA-seq result document is not valid JSON") from exc
+    if (
+        not isinstance(document, dict)
+        or set(document) != _TOP_LEVEL_FIELDS
+        or document.get("schema_version") != RESULT_SCHEMA
+    ):
+        raise RuntimeError("RNA-seq result document has the wrong schema")
+    sample_count = _positive_integer(document.get("sample_count"), field="sample_count")
+    if not 4 <= sample_count <= 64:
+        raise RuntimeError("RNA-seq sample count is outside its supported bound")
+    read_length = _positive_integer(
+        document.get("star_read_length"), field="star_read_length"
+    )
+    if read_length > 1000:
+        raise RuntimeError("RNA-seq read length is outside its supported bound")
+    reference = document.get("reference_condition")
+    comparison = document.get("comparison_condition")
+    if (
+        not isinstance(reference, str)
+        or not reference
+        or not isinstance(comparison, str)
+        or not comparison
+        or reference == comparison
+    ):
+        raise RuntimeError("RNA-seq result conditions are invalid")
+    sample_names = _validate_mapping(document, sample_count=sample_count)
+    _validate_deseq2(document)
+
+    raw_products = document.get("artifacts")
+    expected_count = 5 + 3 * sample_count
+    if not isinstance(raw_products, list) or len(raw_products) != expected_count:
+        raise RuntimeError(
+            "RNA-seq result artifact count differs from its sample count"
+        )
+    products: dict[str, RnaSeqProduct] = {}
+    for raw in raw_products:
+        if not isinstance(raw, dict) or set(raw) != {"path", "sha256", "size_bytes"}:
+            raise RuntimeError("RNA-seq result artifact record fields differ")
+        relative = _relative_path(raw["path"])
+        expected_sha = raw["sha256"]
+        expected_size = raw["size_bytes"]
+        if (
+            relative.as_posix() in products
+            or not isinstance(expected_sha, str)
+            or len(expected_sha) != 64
+            or not set(expected_sha).issubset("0123456789abcdef")
+            or isinstance(expected_size, bool)
+            or not isinstance(expected_size, int)
+            or expected_size <= 0
+        ):
+            raise RuntimeError("RNA-seq result artifact identity is invalid")
+        lexical = root.joinpath(*relative.parts)
+        if lexical.is_symlink():
+            raise RuntimeError(f"RNA-seq artifact is a symbolic link: {relative}")
+        candidate = lexical.resolve(strict=True)
+        if (
+            not candidate.is_relative_to(root)
+            or candidate.is_symlink()
+            or not candidate.is_file()
+            or candidate.stat().st_size != expected_size
+            or _sha256(candidate) != expected_sha
+        ):
+            raise RuntimeError(f"RNA-seq artifact differs from result: {relative}")
+        products[relative.as_posix()] = RnaSeqProduct(
+            relative_path=relative,
+            local_path=candidate,
+            sha256=expected_sha,
+            size_bytes=expected_size,
+        )
+    required = {
+        "gene-counts.tsv",
+        "samples.tsv",
+        "differential-expression.tsv",
+        "normalized-counts.tsv",
+        "deseq2-session-info.txt",
+    }
+    for name in sample_names:
+        required.update(
+            {
+                f"star/{name}/Aligned.sortedByCoord.out.bam",
+                f"star/{name}/ReadsPerGene.out.tab",
+                f"star/{name}/Log.final.out",
+            }
+        )
+    if set(products) != required:
+        raise RuntimeError("RNA-seq result does not declare the complete product set")
+    return ValidatedRnaSeqResult(result_path, document, products)
+
+
+__all__ = [
+    "RESULT_NAME",
+    "RESULT_SCHEMA",
+    "RnaSeqProduct",
+    "ValidatedRnaSeqResult",
+    "load_rnaseq_result",
+]

--- a/builtin/builtin/warpx/artifacts.py
+++ b/builtin/builtin/warpx/artifacts.py
@@ -1,0 +1,381 @@
+"""Generated-artifact semantics for the builtin WarpX package."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import posixpath
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+from jarvis_cd.artifacts.schema import JsonValue
+from jarvis_cd.input_bundle import extract_input_bundle
+
+_MAX_DISCOVERED_ENTRIES = 4096
+_MAX_REPORTED_MEMBERS = 256
+_MAX_CHECKSUM_BYTES = 64 * 1024 * 1024
+_DIAGNOSTIC_SUFFIXES = frozenset({".csv", ".h5", ".hdf5", ".json", ".txt"})
+
+
+@dataclass(frozen=True, slots=True)
+class _DiscoveredEntry:
+    """One safe output member below the package-owned WarpX root."""
+
+    relative_path: PurePosixPath
+    is_file: bool
+    is_directory: bool
+    size_bytes: int | None
+
+
+@dataclass
+class WarpxArtifactAdapter:
+    """Discover bounded WarpX plotfiles and reduced diagnostics at exit."""
+
+    output_dir: PurePosixPath
+    input_paths: frozenset[PurePosixPath] = frozenset()
+    _finalized: bool = False
+    _collection_artifact_id: str = field(default_factory=new_artifact_id)
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for process completion before inspecting mutable outputs."""
+
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Report successfully completed WarpX outputs."""
+
+        return self._finalize(return_code=0)
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Report outputs with the authoritative process completion state."""
+
+        return self._finalize(return_code=return_code)
+
+    def reset_artifacts(self) -> None:
+        """Permit discovery after an execution stream is replaced."""
+
+        self._finalized = False
+
+    def _finalize(self, *, return_code: int) -> list[ArtifactObservation]:
+        if self._finalized:
+            return []
+        self._finalized = True
+        entries, truncated = self._discover_entries()
+        outputs = self._output_entries(entries)
+        if not outputs:
+            return []
+        state = (
+            ArtifactState.FINALIZED
+            if return_code == 0 and not truncated
+            else ArtifactState.INCOMPLETE
+        )
+        observations = [
+            self._collection_observation(outputs, state=state, truncated=truncated)
+        ]
+        observations.extend(
+            self._member_observation(entry, state=state)
+            for entry in outputs
+            if self._is_concrete_product(entry)
+        )
+        return observations
+
+    def _discover_entries(self) -> tuple[list[_DiscoveredEntry], bool]:
+        """Walk the owned output tree without following links and with a bound."""
+
+        root = self._local_output_path()
+        if not root.exists():
+            return [], False
+        if root.is_symlink() or not root.is_dir():
+            raise RuntimeError(f"WarpX output root is not a real directory: {root}")
+        discovered: list[_DiscoveredEntry] = []
+        truncated = False
+        try:
+            for current, directory_names, file_names in os.walk(
+                root, topdown=True, followlinks=False
+            ):
+                current_path = Path(current)
+                safe_directories: list[str] = []
+                for name in sorted(directory_names):
+                    path = current_path / name
+                    if path.is_symlink():
+                        continue
+                    if len(discovered) >= _MAX_DISCOVERED_ENTRIES:
+                        truncated = True
+                        break
+                    relative = PurePosixPath(path.relative_to(root).as_posix())
+                    discovered.append(_DiscoveredEntry(relative, False, True, None))
+                    safe_directories.append(name)
+                directory_names[:] = [] if truncated else safe_directories
+                if truncated:
+                    break
+                for name in sorted(file_names):
+                    path = current_path / name
+                    if path.is_symlink() or not path.is_file():
+                        continue
+                    if len(discovered) >= _MAX_DISCOVERED_ENTRIES:
+                        truncated = True
+                        break
+                    relative = PurePosixPath(path.relative_to(root).as_posix())
+                    discovered.append(
+                        _DiscoveredEntry(
+                            relative,
+                            True,
+                            False,
+                            path.stat().st_size,
+                        )
+                    )
+                if truncated:
+                    break
+        except OSError as exc:
+            raise RuntimeError(
+                f"cannot inspect WarpX output directory {root}: {exc}"
+            ) from exc
+        return discovered, truncated
+
+    def _local_output_path(self) -> Path:
+        """Project the declared cluster path into the current host filesystem."""
+
+        return Path(self.output_dir.as_posix())
+
+    def _output_entries(
+        self, entries: list[_DiscoveredEntry]
+    ) -> list[_DiscoveredEntry]:
+        """Exclude exact inputs and directories that contain only staged inputs."""
+
+        files = [
+            entry
+            for entry in entries
+            if entry.is_file and entry.relative_path not in self.input_paths
+        ]
+        concrete_directories = [
+            entry
+            for entry in entries
+            if entry.is_directory and self._is_concrete_product(entry)
+        ]
+        retained_paths = {
+            entry.relative_path for entry in (*files, *concrete_directories)
+        }
+        directories = [
+            entry
+            for entry in entries
+            if entry.is_directory
+            and any(
+                candidate != entry.relative_path
+                and candidate.is_relative_to(entry.relative_path)
+                for candidate in retained_paths
+            )
+        ]
+        selected = {entry.relative_path: entry for entry in files}
+        selected.update({entry.relative_path: entry for entry in concrete_directories})
+        selected.update({entry.relative_path: entry for entry in directories})
+        return [selected[path] for path in sorted(selected)]
+
+    @staticmethod
+    def _is_concrete_product(entry: _DiscoveredEntry) -> bool:
+        """Recognize high-confidence WarpX diagnostics and output collections."""
+
+        name = entry.relative_path.name.casefold()
+        if entry.is_directory:
+            return name.startswith(
+                ("diag", "plt", "chk", "checkpoint")
+            ) or name.endswith(".bp")
+        return PurePosixPath(name).suffix in _DIAGNOSTIC_SUFFIXES
+
+    def _collection_observation(
+        self,
+        outputs: list[_DiscoveredEntry],
+        *,
+        state: ArtifactState,
+        truncated: bool,
+    ) -> ArtifactObservation:
+        """Describe the bounded package-owned WarpX result tree."""
+
+        names: list[JsonValue] = [
+            entry.relative_path.as_posix() for entry in outputs[:_MAX_REPORTED_MEMBERS]
+        ]
+        size_bytes = sum(entry.size_bytes or 0 for entry in outputs if entry.is_file)
+        return ArtifactObservation(
+            artifact_id=self._collection_artifact_id,
+            logical_name="warpx-results",
+            kind="scientific_dataset",
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(self.output_dir),
+            format="warpx-output-tree",
+            size_bytes=size_bytes,
+            message=(
+                "WarpX output discovery reached its safety bound"
+                if truncated
+                else "WarpX output tree finalized"
+            ),
+            metadata={
+                "application": "warpx",
+                "completion_signal": "process_exit",
+                "discovery_truncated": truncated,
+                "member_count_observed": len(outputs),
+                "member_names": names,
+                "member_names_truncated": len(outputs) > len(names),
+            },
+        )
+
+    def _member_observation(
+        self, entry: _DiscoveredEntry, *, state: ArtifactState
+    ) -> ArtifactObservation:
+        """Describe one concrete WarpX plotfile or reduced diagnostic."""
+
+        format_name, media_type = _output_format(entry)
+        checksum = self._checksum(entry)
+        logical_suffix = entry.relative_path.as_posix().replace("/", "-")
+        return ArtifactObservation(
+            logical_name=f"warpx-{logical_suffix}"[:256],
+            kind="scientific_dataset",
+            role=ArtifactRole.OUTPUT,
+            structure=(
+                ArtifactStructure.FILE
+                if entry.is_file
+                else ArtifactStructure.COLLECTION
+            ),
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(
+                self.output_dir / entry.relative_path
+            ),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=entry.size_bytes,
+            checksum=checksum,
+            message="WarpX diagnostic finalized",
+            metadata={"application": "warpx"},
+        )
+
+    def _checksum(self, entry: _DiscoveredEntry) -> str | None:
+        """Hash bounded files while avoiding unbounded finalization work."""
+
+        if (
+            not entry.is_file
+            or entry.size_bytes is None
+            or entry.size_bytes > _MAX_CHECKSUM_BYTES
+        ):
+            return None
+        path = self._local_output_path() / entry.relative_path
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                digest.update(chunk)
+        return f"sha256:{digest.hexdigest()}"
+
+
+def adapter_from_package(package: dict[str, Any]) -> WarpxArtifactAdapter | None:
+    """Create artifact semantics for the builtin WarpX package."""
+
+    if package.get("pkg_type") != "builtin.warpx":
+        return None
+    output_dir = _configured_output_dir(
+        package.get("out"),
+        shared_dir=package.get("shared_dir"),
+        runtime_cwd=package.get("runtime_cwd"),
+    )
+    deploy_mode = str(package.get("effective_deploy_mode") or "default").casefold()
+    if deploy_mode == "container":
+        roots = tuple(
+            root
+            for root in (
+                _optional_absolute_path(package.get("shared_dir")),
+                _optional_absolute_path(package.get("private_dir")),
+            )
+            if root is not None
+        )
+        if not any(output_dir.is_relative_to(root) for root in roots):
+            return None
+    input_paths: set[PurePosixPath] = set()
+    input_bundle = package.get("input_bundle")
+    if isinstance(input_bundle, str) and input_bundle:
+        shared_dir = _optional_absolute_path(package.get("shared_dir"))
+        if shared_dir is None:
+            raise ValueError("WarpX input-bundle artifacts require shared_dir")
+        materialized = extract_input_bundle(
+            input_bundle, Path(shared_dir.as_posix()) / "input-bundles"
+        )
+        input_paths.update(
+            PurePosixPath(item.path) for item in materialized.manifest.files
+        )
+    configured_input = package.get("inputs")
+    if isinstance(configured_input, str) and configured_input:
+        input_paths.add(PurePosixPath(Path(configured_input).name))
+    return WarpxArtifactAdapter(output_dir, frozenset(input_paths))
+
+
+def _configured_output_dir(
+    value: object,
+    *,
+    shared_dir: object,
+    runtime_cwd: object,
+) -> PurePosixPath:
+    """Resolve the normalized absolute output directory used by the package."""
+
+    raw = "run" if value in (None, "") else value
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("WarpX artifacts require a printable output path")
+    path = PurePosixPath(raw)
+    if not path.is_absolute():
+        base = _optional_absolute_path(shared_dir)
+        if base is None:
+            base = _optional_absolute_path(runtime_cwd)
+        if base is None:
+            raise ValueError(
+                "relative WarpX artifact output requires shared_dir or runtime_cwd"
+            )
+        path = base / path
+    normalized = PurePosixPath(posixpath.normpath(path.as_posix()))
+    if not normalized.is_absolute() or ".." in normalized.parts:
+        raise ValueError("WarpX artifacts require a normalized absolute output path")
+    return normalized
+
+
+def _optional_absolute_path(value: object) -> PurePosixPath | None:
+    """Return a normalized absolute POSIX path when one is available."""
+
+    if not isinstance(value, str) or not value:
+        return None
+    path = PurePosixPath(value)
+    if not path.is_absolute() or ".." in path.parts:
+        return None
+    return path
+
+
+def _output_format(entry: _DiscoveredEntry) -> tuple[str, str | None]:
+    """Return a conservative format and media type for one WarpX product."""
+
+    name = entry.relative_path.name.casefold()
+    if entry.is_directory:
+        if name.endswith(".bp"):
+            return "adios2-bp", "application/x-adios2"
+        if name.startswith(("plt", "diag")):
+            return "amrex-plotfile", "application/x-amrex-plotfile"
+        return "warpx-output-collection", None
+    suffix = PurePosixPath(name).suffix
+    if suffix == ".json":
+        return "json", "application/json"
+    if suffix == ".csv":
+        return "csv", "text/csv"
+    if suffix in {".h5", ".hdf5"}:
+        return "hdf5", "application/x-hdf5"
+    return "warpx-reduced-diagnostic", "text/plain"
+
+
+__all__ = ["WarpxArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/warpx/pkg.py
+++ b/builtin/builtin/warpx/pkg.py
@@ -1,251 +1,529 @@
-"""
-WarpX — Exascale Particle-In-Cell plasma accelerator simulation.
-Highly parallel, GPU-optimized PIC code built on AMReX.
-"""
-from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
-from jarvis_cd.shell.process import Mkdir, Rm
+"""Launch native or containerized WarpX particle-in-cell simulations."""
+
+from __future__ import annotations
+
 import os
+import shlex
 import shutil
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
+from jarvis_cd.shell.process import Mkdir, Rm
+
+_EXECUTABLE_CANDIDATES = (
+    "warpx.3d.MPI.NOACC.DP.PDP",
+    "warpx.3d.MPI.CUDA.SP",
+    "warpx.3d",
+    "warpx",
+)
+_MAX_INPUT_BYTES = 16 * 1024 * 1024
 
 
 class Warpx(Application):
+    """Run one WarpX simulation from an example or caller-owned input.
+
+    Caller inputs are copied into a package-owned working directory before
+    launch. Multi-file studies use a digest-verified JARVIS input bundle and
+    may select any manifest-declared member as the WarpX input file. JARVIS
+    owns MPI launch, environment interception, process completion, and output
+    artifact reporting.
     """
-    Merged WarpX class supporting both default (bare-metal) and container deployment.
 
-    Set deploy_mode='container' to build and run WarpX inside a Docker/Podman/Apptainer
-    container with 3D CUDA+MPI+HDF5.  Set deploy_mode='default' to use a
-    system-installed warpx binary via MPI.
-    """
+    def _init(self) -> None:
+        self.warpx_bin: str | None = None
 
-    def _init(self):
-        self.warpx_bin = None
-
-    def _configure_menu(self):
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
             {
-                'name': 'nprocs',
-                'msg': 'Number of MPI processes',
-                'type': int,
-                'default': 2,
+                "name": "nprocs",
+                "msg": "Number of MPI processes",
+                "type": int,
+                "default": 2,
             },
             {
-                'name': 'ppn',
-                'msg': 'Processes per node',
-                'type': int,
-                'default': 2,
+                "name": "ppn",
+                "msg": "Processes per node",
+                "type": int,
+                "default": 2,
             },
             {
-                'name': 'inputs',
-                'msg': 'Path to WarpX inputs file',
-                'type': str,
-                'default': None,
+                "name": "inputs",
+                "msg": (
+                    "Optional single WarpX inputs file. JARVIS copies it into "
+                    "the execution-owned output directory before launch."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                'name': 'example',
-                'msg': 'Built-in example to run (e.g., laser_acceleration, uniform_plasma)',
-                'type': str,
-                'choices': ['laser_acceleration', 'uniform_plasma', 'custom'],
-                'default': 'laser_acceleration',
+                "name": "input_bundle",
+                "msg": (
+                    "Optional digest-verified multi-file JARVIS package input "
+                    "bundle. All manifest files are staged into the execution-"
+                    "owned output directory."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                'name': 'max_step',
-                'msg': 'Total number of time steps',
-                'type': int,
-                'default': 50,
+                "name": "input_path",
+                "msg": (
+                    "Relative manifest member to execute from input_bundle; "
+                    "empty selects the manifest entrypoint"
+                ),
+                "type": str,
+                "default": "",
             },
             {
-                'name': 'n_cell',
-                'msg': 'Base grid cells as "nx ny nz"',
-                'type': str,
-                'default': '64 64 128',
+                "name": "example",
+                "msg": "Installed WarpX example to run when no caller input is supplied",
+                "type": str,
+                "choices": ["laser_acceleration", "uniform_plasma", "custom"],
+                "default": "laser_acceleration",
             },
             {
-                'name': 'out',
-                'msg': 'Output directory for plot files',
-                'type': str,
-                'default': '/tmp/warpx_out',
+                "name": "override_input_parameters",
+                "msg": (
+                    "Apply max_step, n_cell, out, and plot_int command-line "
+                    "overrides to caller-supplied inputs"
+                ),
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'plot_int',
-                'msg': 'Plot output interval (-1 to disable)',
-                'type': int,
-                'default': 10,
+                "name": "max_step",
+                "msg": "Total number of time steps for examples or explicit overrides",
+                "type": int,
+                "default": 50,
             },
             {
-                'name': 'cuda_arch',
-                'msg': 'CUDA architecture code (80=A100, 90=H100, 70=V100)',
-                'type': int,
-                'default': 80,
+                "name": "n_cell",
+                "msg": "Base grid cells as three positive integers: nx ny nz",
+                "type": str,
+                "default": "64 64 128",
             },
             {
-                'name': 'base_image',
-                'msg': 'Base Docker image for build container',
-                'type': str,
-                'default': 'sci-hpc-base',
+                "name": "out",
+                "msg": (
+                    "Output directory. Relative paths resolve under the JARVIS "
+                    "package shared directory."
+                ),
+                "type": str,
+                "default": "run",
             },
             {
-                'name': 'use_gpu',
-                'msg': 'Build with CUDA/GPU backend (WarpX_COMPUTE=CUDA)',
-                'type': bool,
-                'default': False,
+                "name": "plot_int",
+                "msg": "Plot output interval (-1 to disable)",
+                "type": int,
+                "default": 10,
+            },
+            {
+                "name": "cuda_arch",
+                "msg": "CUDA architecture code (80=A100, 90=H100, 70=V100)",
+                "type": int,
+                "default": 80,
+            },
+            {
+                "name": "base_image",
+                "msg": "Base container image for a package-owned container build",
+                "type": str,
+                "default": "sci-hpc-base",
+            },
+            {
+                "name": "use_gpu",
+                "msg": "Build and launch the CUDA/GPU container profile",
+                "type": bool,
+                "default": False,
             },
         ]
 
-    # ------------------------------------------------------------------
-    # Container Dockerfile generators
-    # ------------------------------------------------------------------
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe WarpX runtime, input, and successful-exit semantics."""
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
-            return None
-        base = self.config.get('base_image', 'sci-hpc-base')
-        use_gpu = self.config.get('use_gpu', False) or 'sci-hpc' in base
-        cuda_arch = self.config.get('cuda_arch', 80)
-        if use_gpu:
-            content = self._read_build_script('build.sh', {
-                'BASE_IMAGE': base,
-                'CUDA_ARCH': cuda_arch,
-            })
-            return content, f'3d-cuda-{cuda_arch}'
+        if self.config.get("deploy_mode") == "container":
+            status = RuntimeStatus("unknown", "container_runtime_not_probed")
+            capabilities: tuple[str, ...] = ()
         else:
-            content = self._read_build_script('cpu/build.sh', {
-                'BASE_IMAGE': base,
-            })
-            return content, '3d-cpu'
+            program = self._discover_executable(self._deployment_environment())
+            if program is None:
+                status = RuntimeStatus("unavailable", "software_not_found")
+                capabilities = ()
+            else:
+                probe = probe_program(
+                    program,
+                    environment=self._deployment_environment(),
+                    arguments=("--help",),
+                    accepted_return_codes=(0, 1),
+                )
+                status = probe.status
+                capabilities = (
+                    ("mpi_execution", "particle_in_cell", "warpx_3d")
+                    if status.usable is True
+                    else ()
+                )
+        runtime = RuntimeRequirement(
+            requirement_id="warpx_3d",
+            description="Three-dimensional WarpX runtime available through PATH",
+            required_capabilities=("mpi_execution", "particle_in_cell", "warpx_3d"),
+            available_capabilities=capabilities,
+            status=status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="spack", query_kind="spec", query_value="warpx"
+                ),
+            ),
+        )
+        completed = ReadinessContract(
+            mechanism="process_exit", condition="successful_exit"
+        )
+        return PackageDeploymentContract(
+            package="builtin.warpx",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="installed_example",
+                    execution_kind="batch",
+                    when=(
+                        ConfigurationCondition("inputs", "is_empty"),
+                        ConfigurationCondition("input_bundle", "is_empty"),
+                    ),
+                    runtime_requirements=("warpx_3d",),
+                    readiness=completed,
+                    description="Run one installed WarpX example with explicit bounds.",
+                ),
+                ExecutionProfile(
+                    name="input_file",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("inputs", "is_not_empty"),),
+                    runtime_requirements=("warpx_3d",),
+                    readiness=completed,
+                    description=(
+                        "Run one caller-supplied WarpX input copied into an "
+                        "execution-owned working directory."
+                    ),
+                ),
+                ExecutionProfile(
+                    name="input_bundle",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    runtime_requirements=("warpx_3d",),
+                    readiness=completed,
+                    description=(
+                        "Run one manifest-selected input from a digest-verified "
+                        "multi-file bundle in an execution-owned working directory."
+                    ),
+                ),
+            ),
+            runtime_requirements=(runtime,),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    requires=(ConfigurationCondition("input_path", "is_empty"),),
+                    description="input_path is valid only with input_bundle.",
+                ),
+            ),
+        )
 
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _build_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
             return None
-        base = self.config.get('base_image', 'sci-hpc-base')
-        use_gpu = self.config.get('use_gpu', False) or 'sci-hpc' in base
-        deploy_file = 'Dockerfile.deploy' if use_gpu else 'cpu/Dockerfile.deploy'
-        deploy_base = ('nvidia/cuda:12.6.0-runtime-ubuntu24.04'
-                       if use_gpu else 'ubuntu:24.04')
-        suffix = getattr(self, '_build_suffix', '')
-        content = self._read_dockerfile(deploy_file, {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': deploy_base,
-        })
+        base = self.config.get("base_image", "sci-hpc-base")
+        use_gpu = self.config.get("use_gpu", False) or "sci-hpc" in str(base)
+        cuda_arch = self.config.get("cuda_arch", 80)
+        if use_gpu:
+            content = self._read_build_script(
+                "build.sh", {"BASE_IMAGE": base, "CUDA_ARCH": cuda_arch}
+            )
+            return content, f"3d-cuda-{cuda_arch}"
+        content = self._read_build_script("cpu/build.sh", {"BASE_IMAGE": base})
+        return content, "3d-cpu"
+
+    def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
+            return None
+        base = self.config.get("base_image", "sci-hpc-base")
+        use_gpu = self.config.get("use_gpu", False) or "sci-hpc" in str(base)
+        deploy_file = "Dockerfile.deploy" if use_gpu else "cpu/Dockerfile.deploy"
+        deploy_base = (
+            "nvidia/cuda:12.6.0-runtime-ubuntu24.04" if use_gpu else "ubuntu:24.04"
+        )
+        suffix = str(getattr(self, "_build_suffix", ""))
+        content = self._read_dockerfile(
+            deploy_file,
+            {"BUILD_IMAGE": self.build_image_name(), "DEPLOY_BASE": deploy_base},
+        )
         return content, suffix
 
-    # ------------------------------------------------------------------
-    # Configuration
-    # ------------------------------------------------------------------
+    def _configure(self, **kwargs: Any) -> None:
+        """Validate the selected WarpX profile and prepare owned output."""
 
-    def _configure(self, **kwargs):
-        """
-        Configure WarpX.
-
-        Calls super()._configure() which updates self.config and (when
-        deploy_mode == 'container') triggers build_phase / build_deploy_phase.
-
-        In default mode, also creates the output directory and locates the
-        warpx binary on the system PATH.
-        """
         super()._configure(**kwargs)
+        self._validate_configuration()
+        if self.config.get("deploy_mode") == "default":
+            self.warpx_bin = self._discover_executable(self._deployment_environment())
+            self._ensure_output_dir()
 
-        if self.config.get('deploy_mode') == 'default':
-            Mkdir(self.config['out'],
-                  PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
-            # Find warpx binary (various naming conventions)
-            for name in ['warpx.3d.MPI.CUDA.SP', 'warpx', 'warpx.3d']:
-                if shutil.which(name):
-                    self.warpx_bin = name
-                    break
-            if not self.warpx_bin:
-                self.warpx_bin = 'warpx.3d.MPI.CUDA.SP'
+    def _validate_configuration(self) -> None:
+        """Reject ambiguous inputs and invalid MPI or override settings."""
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
-
-    def start(self):
-        """
-        Launch WarpX.
-
-        Branches on deploy_mode: uses MpiExecInfo with container engine for
-        container mode, MpiExecInfo with hostfile for default mode.
-        """
-        if self.config.get('deploy_mode') == 'container':
-            outdir = self.config.get('out', '/tmp/warpx_out')
-            Mkdir(outdir).run()
-
-            nprocs = self.config.get('nprocs', 2)
-
-            if self.config.get('inputs'):
-                inputs_arg = self.config['inputs']
-            else:
-                example = self.config.get('example', 'laser_acceleration')
-                inputs_arg = (
-                    f'/opt/warpx/Examples/Physics_applications/{example}/inputs_base_3d'
+        for name in ("nprocs", "ppn"):
+            value = self.config.get(name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        inputs = self.config.get("inputs")
+        bundle = self.config.get("input_bundle")
+        if inputs not in (None, "") and bundle not in (None, ""):
+            raise ValueError("inputs and input_bundle cannot be combined")
+        for name, value in (("inputs", inputs), ("input_bundle", bundle)):
+            if value not in (None, "") and not isinstance(value, str):
+                raise TypeError(f"{name} must be a path string")
+        input_path = self.config.get("input_path")
+        if input_path not in (None, "") and not isinstance(input_path, str):
+            raise TypeError("input_path must be a relative path string")
+        if bundle in (None, "") and input_path not in (None, ""):
+            raise ValueError("input_path requires input_bundle")
+        if inputs in (None, "") and bundle in (None, ""):
+            if self.config.get("example") == "custom":
+                raise ValueError(
+                    "custom WarpX execution requires inputs or input_bundle"
                 )
+            self._validate_overrides()
+        elif self.config.get("override_input_parameters"):
+            self._validate_overrides()
 
-            base = self.config.get('base_image', 'sci-hpc-base')
-            use_gpu = self.config.get('use_gpu', False) or 'sci-hpc' in base
-            # WarpX binary name embeds feature flags (MPI/CUDA/SP/PSP/OPMD/EB/QED).
-            # Dockerfile.deploy creates a stable symlink at this path; mpiexec
-            # doesn't invoke a shell per rank, so a glob wouldn't expand here.
-            warpx_bin = '/opt/warpx/build/bin/warpx.3d'
-            diag_args = [
-                'diagnostics.diags_names=diag1',
-                'diag1.diag_type=Full',
-                f'diag1.file_prefix={outdir}/diag1',
-                f'diag1.intervals={self.config["plot_int"]}',
-            ]
-            inner = ' '.join([
-                warpx_bin,
-                inputs_arg,
-                f'max_step={self.config["max_step"]}',
-                f'amr.n_cell={self.config["n_cell"]}',
-                *diag_args,
-            ])
-            Exec(inner, MpiExecInfo(
-                nprocs=nprocs,
-                ppn=self.config.get('ppn'),
-                hostfile=self.hostfile,
-                port=self.ssh_port,
-                container=self._container_engine,
-                container_image=self.deploy_image_name(),
-                shared_dir=self.shared_dir,
-                private_dir=self.private_dir,
-                gpu=use_gpu,
-                env=self.mod_env,
-            )).run()
+    def _validate_overrides(self) -> None:
+        """Validate command-line overrides without interpreting scientific input."""
+
+        max_step = self.config.get("max_step")
+        if isinstance(max_step, bool) or not isinstance(max_step, int) or max_step <= 0:
+            raise ValueError("max_step must be a positive integer")
+        plot_int = self.config.get("plot_int")
+        if (
+            isinstance(plot_int, bool)
+            or not isinstance(plot_int, int)
+            or plot_int == 0
+            or plot_int < -1
+        ):
+            raise ValueError("plot_int must be -1 or a positive integer")
+        n_cell = self.config.get("n_cell")
+        if not isinstance(n_cell, str):
+            raise TypeError("n_cell must contain three positive integers")
+        try:
+            cells = tuple(int(value) for value in n_cell.split())
+        except ValueError as exc:
+            raise ValueError("n_cell must contain three positive integers") from exc
+        if len(cells) != 3 or any(value <= 0 for value in cells):
+            raise ValueError("n_cell must contain three positive integers")
+
+    @staticmethod
+    def _discover_executable(environment: dict[str, str]) -> str | None:
+        """Return the first supported WarpX program name available through PATH."""
+
+        for candidate in _EXECUTABLE_CANDIDATES:
+            if shutil.which(candidate, path=environment.get("PATH")) is not None:
+                return candidate
+        return None
+
+    def _output_dir(self) -> Path:
+        """Return the normalized package-owned output root."""
+
+        return self.resolve_shared_path(
+            self.config.get("out"), field="out", default="run"
+        )
+
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        """Return local or parallel-SSH execution according to the hostfile."""
+
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
+
+    def _ensure_output_dir(self) -> None:
+        """Create the exact output root on every participating host."""
+
+        output_dir = str(self._output_dir())
+        result = Mkdir(output_dir, self._node_exec_info(env=self.env)).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to create WarpX output directory {output_dir}: {failures}"
+            )
+
+    @staticmethod
+    def _resolve_bundle_input(
+        bundle: MaterializedInputBundle, requested: object
+    ) -> Path:
+        """Resolve one manifest-declared WarpX input without path inference."""
+
+        if requested in (None, ""):
+            return bundle.entrypoint
+        if not isinstance(requested, str) or "\\" in requested:
+            raise ValueError("input_path must be a confined manifest path")
+        relative = PurePosixPath(requested)
+        if relative.is_absolute() or any(
+            part in {"", ".", ".."} for part in relative.parts
+        ):
+            raise ValueError("input_path must be a confined manifest path")
+        declared = {item.path for item in bundle.manifest.files}
+        normalized = relative.as_posix()
+        if normalized not in declared:
+            raise ValueError("input_path is not declared by the input bundle")
+        selected = bundle.root / relative
+        if selected.is_symlink() or not selected.is_file():
+            raise ValueError("input_path is not a verified regular file")
+        return selected
+
+    def _stage_single_input(self, configured: str, output_dir: Path) -> Path:
+        """Copy one bounded regular input into package-owned storage."""
+
+        source = Path(
+            os.path.abspath(os.path.expandvars(os.path.expanduser(configured)))
+        )
+        try:
+            status = source.lstat()
+        except OSError as exc:
+            raise ValueError("inputs is not a readable regular file") from exc
+        if (
+            source.is_symlink()
+            or not source.is_file()
+            or status.st_size <= 0
+            or status.st_size > _MAX_INPUT_BYTES
+        ):
+            raise ValueError("inputs is not a bounded regular file")
+        destination = output_dir / source.name
+        if destination.exists() or destination.is_symlink():
+            raise ValueError("WarpX staged input already exists")
+        shutil.copyfile(source, destination)
+        os.chmod(destination, 0o600)
+        return destination
+
+    def _prepare_input(self) -> tuple[Path, Path, bool]:
+        """Materialize the selected input and return input, cwd, and caller flag."""
+
+        self._validate_configuration()
+        self._ensure_output_dir()
+        output_dir = self._output_dir()
+        configured_bundle = self.config.get("input_bundle")
+        if configured_bundle not in (None, ""):
+            assert isinstance(configured_bundle, str)
+            if self.shared_dir is None:
+                raise RuntimeError("WarpX input bundles require package shared storage")
+            bundle = extract_input_bundle(
+                configured_bundle, Path(self.shared_dir) / "input-bundles"
+            )
+            selected = self._resolve_bundle_input(bundle, self.config.get("input_path"))
+            relative = selected.relative_to(bundle.root)
+            stage_input_bundle(bundle, output_dir)
+            staged = output_dir / relative
+            return staged, staged.parent, True
+
+        configured_input = self.config.get("inputs")
+        if configured_input not in (None, ""):
+            assert isinstance(configured_input, str)
+            staged = self._stage_single_input(configured_input, output_dir)
+            return staged, output_dir, True
+
+        example = str(self.config.get("example") or "laser_acceleration")
+        example_dir = Path("/opt/warpx/Examples/Physics_applications") / example
+        return example_dir / "inputs_base_3d", example_dir, False
+
+    def _runtime_arguments(self, *, caller_input: bool) -> list[str]:
+        """Return output-only or explicitly authorized scientific overrides."""
+
+        if caller_input and not self.config.get("override_input_parameters"):
+            return []
+        output_dir = self._output_dir()
+        return [
+            f"max_step={self.config['max_step']}",
+            f"amr.n_cell={self.config['n_cell']}",
+            f"amr.plot_file={output_dir / 'plt'}",
+            f"amr.plot_int={self.config['plot_int']}",
+        ]
+
+    def start(self) -> None:
+        """Launch WarpX and fail the pipeline on any rank failure."""
+
+        input_path, cwd, caller_input = self._prepare_input()
+        if self.config.get("deploy_mode") == "container":
+            executable = "/opt/warpx/build/bin/warpx.3d"
+            exec_kwargs: dict[str, Any] = {
+                "port": self.ssh_port,
+                "container": self._container_engine,
+                "container_image": self.deploy_image_name(),
+                "shared_dir": self.shared_dir,
+                "private_dir": self.private_dir,
+                "gpu": self.config.get("use_gpu", False),
+            }
         else:
-            if self.config['inputs']:
-                inputs_arg = self.config['inputs']
-                cwd = os.path.dirname(self.config['inputs'])
-            elif self.config['example'] != 'custom':
-                example_dir = (
-                    f'/opt/warpx/Examples/Physics_applications/{self.config["example"]}'
-                )
-                inputs_arg = 'inputs_base_3d'
-                cwd = example_dir
-            else:
-                raise ValueError("Either 'inputs' or 'example' must be specified")
+            executable = self.warpx_bin or self._discover_executable(self.mod_env)
+            if executable is None:
+                raise RuntimeError("WarpX executable is unavailable through PATH")
+            exec_kwargs = {}
+        command = " ".join(
+            (
+                shlex.quote(executable),
+                shlex.quote(str(input_path)),
+                *(
+                    shlex.quote(value)
+                    for value in self._runtime_arguments(caller_input=caller_input)
+                ),
+            )
+        )
+        result = Exec(
+            command,
+            MpiExecInfo(
+                nprocs=self.config["nprocs"],
+                ppn=self.config["ppn"],
+                hostfile=self.hostfile,
+                env=self.mod_env,
+                cwd=str(cwd),
+                line_callback=self.runtime_line_callback(),
+                **exec_kwargs,
+            ),
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"WarpX execution failed: {failures}")
 
-            cmd = [
-                self.warpx_bin,
-                inputs_arg,
-                f'max_step={self.config["max_step"]}',
-                f'amr.n_cell={self.config["n_cell"]}',
-                f'amr.plot_file={self.config["out"]}/plt',
-                f'amr.plot_int={self.config["plot_int"]}',
-            ]
+    def stop(self) -> None:
+        """Do nothing because WarpX runs to process completion."""
 
-            Exec(' '.join(cmd),
-                 MpiExecInfo(nprocs=self.config['nprocs'],
-                             ppn=self.config['ppn'],
-                             hostfile=self.hostfile,
-                             env=self.mod_env,
-                             cwd=cwd)).run()
+    def clean(self) -> None:
+        """Remove only the exact configured WarpX output directory."""
 
-    def stop(self):
-        """Stop WarpX (no-op — WarpX runs to completion)."""
-        pass
-
-    def clean(self):
-        """Remove WarpX output directory."""
-        Rm(self.config['out'] + '*',
-           PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+        output_dir = self._output_dir()
+        if output_dir == Path(output_dir.anchor):
+            raise ValueError("refusing to clean a filesystem root as WarpX output")
+        result = Rm(
+            str(output_dir),
+            self._node_exec_info(env=self.env),
+            recursive=True,
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"Failed to clean WarpX output {output_dir}: {failures}")

--- a/builtin/builtin/wfcommons/README.md
+++ b/builtin/builtin/wfcommons/README.md
@@ -1,69 +1,91 @@
 # WfCommons
 
-Generate a synthetic scientific workflow from a [WfCommons](https://wfcommons.org/)
-recipe, translate it into a runnable [WfBench](https://github.com/wfcommons/wfbench)
-benchmark, and execute the tasks locally in topological order.
+`builtin.wfcommons` generates and executes one bounded synthetic workflow cell
+using WfCommons and WfBench. Multiple package aliases compose a parameter grid;
+the package does not hide a benchmark-specific matrix inside one step.
 
-## What it runs
+JARVIS owns the process lifecycle, output root, pinned WfFormat schema, and
+artifact finalization. The scheduled workload never installs Python packages or
+downloads a schema. Operators prepare a WfCommons 1.4 runtime before execution,
+while agents select only scientific and workload dimensions.
 
-1. **Generate** — picks the named recipe (`montage`, `genome`, `cycles`, `blast`,
-   `bwa`, `srasearch`, `epigenomics`, `seismology`, `soykb`) and instantiates a
-   `WorkflowGenerator` with `num_tasks` tasks. Writes the WfFormat JSON to
-   `<out>/workflow.json`.
-2. **Translate** — uses `WfBenchTranslator` to produce an executable benchmark
-   workflow under `<out>/bench/` (per-task `wfbench` commands + I/O stubs).
-3. **Execute** — walks the DAG in topological order with a thread pool of
-   `max_workers` workers, shelling out to each task's `wfbench` command.
+## Configuration menu
 
-## Config
+| Key | Default | Responsibility |
+| --- | ---: | --- |
+| `recipe` | `montage` | WfCommons scientific workflow family. |
+| `num_tasks` | `100` | Requested generated task count. Recipe generators may produce a nearby realizable count, which the result records separately. |
+| `data_footprint_mb` | `0` | Total workflow data footprint in MB. Zero retains recipe defaults. |
+| `seed` | `424200` | Deterministic workflow topology seed. Reuse a seed to compare footprints at fixed topology. |
+| `cpu_work` | `1` | Positive WfBench CPU work units. Zero is rejected because WfBench would not exercise its intended I/O path. |
+| `percent_cpu` | `1.0` | Fraction of WfBench work threads assigned to CPU work. |
+| `drop_page_cache` | `false` | Enables WfBench's per-file `POSIX_FADV_DONTNEED` behavior. It does not claim a privileged system-wide cold cache. |
+| `clio_prefix` | `false` | Prefixes manifest-declared data paths with `clio::` for an explicitly attached storage interceptor. |
+| `out` | `run` | Package-owned result directory under the JARVIS shared root. |
+| `timeout_seconds` | `3600` | Hard cell timeout, bounded to one day. |
+| `nprocs`, `ppn` | `1`, `1` | The workflow driver is single-process. Generated tasks are controlled by WfBench. |
+| `runtime_python` | empty | Hidden operator setting. Empty uses `WFCOMMONS_PYTHON`, then the JARVIS Python executable. |
 
-| Key | Default | Notes |
-| --- | --- | --- |
-| `recipe` | `montage` | One of the 9 wfcommons recipes. |
-| `num_tasks` | `100` | Workflow size. |
-| `cpu_work` | `100` | CPU work units per `wfbench` task. |
-| `data_footprint` | `100M` | Data size per task; passed to translator. |
-| `max_workers` | `4` | Concurrency for the local task pool. |
-| `out` | `$HOME/wfcommons_out` | Output directory (json + bench/ + logs/). |
-| `keep_outputs` | `false` | Retain bulky `bench/data/` after the run. |
-| `venv` | `$HOME/.jarvis-wfcommons-venv` | Bare-metal venv path (default mode only). |
+## Runtime contract
 
-## Deployment modes
+Native execution requires Bash and a prepared Python runtime whose imported
+`wfcommons.__version__` is exactly `1.4`. The package's deployment description
+probes that contract. Configuration never creates a venv, upgrades pip, or
+installs from the network.
 
-- **`base_deploy_mode: container`** — builds a python venv with `wfcommons[bench]`
-  inside the build container and ships it via the deploy image.
-- **`base_deploy_mode: default`** — creates a venv at `venv:` on the local host
-  and `pip install`s wfcommons there (idempotent).
+The optional container build creates that runtime before workload execution,
+pins WfCommons 1.4, and verifies the WfFormat schema against repository digest
+`716e7b625a37a144674afbf8e6a008c21bbd0fd467ccbb7be39deab9fb8f6aab`.
+The built image digest is the deployable runtime identity.
 
-## Example
+## Results and artifacts
+
+Every successful step closes these package-owned artifacts:
+
+- `wfcommons-result.json`, schema `jarvis.wfcommons-result.v1`;
+- the generated WfFormat workflow manifest;
+- the WfBench workflow log;
+- a sorted Python distribution lock from the prepared runtime;
+- the exact staged WfFormat schema.
+
+The result binds the requested and observed task counts, MB footprint, seed,
+elapsed time, DAG edge count, topology hash, runtime versions, return code, and
+SHA-256 digest of every member. Nonzero execution leaves present products
+`incomplete`; it never finalizes them as successful outputs.
+
+## Four-cell example
+
+The following shape compares two task counts and two footprints without a
+benchmark-specific adapter:
 
 ```yaml
-name: wfcommons_container_test
-base_deploy_mode: container
-container_engine: docker
-container_base: ubuntu:24.04
-
+name: wfcommons_epigenomics_grid
 pkgs:
   - pkg_type: builtin.wfcommons
-    pkg_name: wfcommons_container
-    recipe: montage
-    num_tasks: 25
-    cpu_work: 100
-    data_footprint: 100M
-    out: /tmp/wfcommons_out
+    pkg_name: tasks_100_data_8
+    recipe: epigenomics
+    num_tasks: 100
+    data_footprint_mb: 8
+    seed: 424300
+  - pkg_type: builtin.wfcommons
+    pkg_name: tasks_100_data_32
+    recipe: epigenomics
+    num_tasks: 100
+    data_footprint_mb: 32
+    seed: 424300
+  - pkg_type: builtin.wfcommons
+    pkg_name: tasks_500_data_8
+    recipe: epigenomics
+    num_tasks: 500
+    data_footprint_mb: 8
+    seed: 424700
+  - pkg_type: builtin.wfcommons
+    pkg_name: tasks_500_data_32
+    recipe: epigenomics
+    num_tasks: 500
+    data_footprint_mb: 32
+    seed: 424700
 ```
 
-Run with:
-
-```
-jarvis ppl load yaml builtin/pipelines/examples/wfcommons_container_test.yaml
-jarvis ppl run
-```
-
-## Notes
-
-- The runner is single-process; task-level parallelism is governed by
-  `max_workers`, not by MPI. Set `nprocs: 1`, `ppn: 1`.
-- The WfBench tasks fabricate CPU + I/O load; they don't carry the actual
-  scientific kernel of (say) Montage. Use it for scheduler / storage / system
-  benchmarking, not for science.
+WfBench fabricates the CPU and I/O behavior of a workflow family; it does not
+execute the scientific kernels represented by recipe task names.

--- a/builtin/builtin/wfcommons/artifacts.py
+++ b/builtin/builtin/wfcommons/artifacts.py
@@ -1,0 +1,292 @@
+"""Generated-artifact semantics for the builtin WfCommons package."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+)
+
+RESULT_SCHEMA = "jarvis.wfcommons-result.v1"
+RESULT_NAME = "wfcommons-result.json"
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA-256 digest of one bounded artifact."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(slots=True)
+class WfcommonsArtifactAdapter:
+    """Report a closed workflow cell and its exact provenance members."""
+
+    output_dir: PurePosixPath
+    _local_root: Path | None = None
+    _finalized: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for authoritative process completion before reporting files."""
+
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Finalize products for a successful legacy completion callback."""
+
+        return self._finalize(return_code=0)
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Finalize products using the authoritative driver exit status."""
+
+        return self._finalize(return_code=return_code)
+
+    def reset_artifacts(self) -> None:
+        """Permit discovery after an execution stream is replaced."""
+
+        self._finalized = False
+
+    def _result(self) -> tuple[Path, dict[str, Any]]:
+        """Load and minimally validate the package-owned result document."""
+
+        root = self._local_output_path().resolve(strict=True)
+        if root.is_symlink() or not root.is_dir():
+            raise RuntimeError("WfCommons output root is not a real directory")
+        path = root / RESULT_NAME
+        if path.is_symlink() or not path.is_file() or path.stat().st_size > 1024 * 1024:
+            raise RuntimeError("WfCommons result is missing, unsafe, or oversized")
+        try:
+            document = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError("WfCommons result is not valid JSON") from exc
+        if (
+            not isinstance(document, dict)
+            or document.get("schema_version") != RESULT_SCHEMA
+        ):
+            raise RuntimeError("WfCommons result has the wrong schema")
+        return path, document
+
+    def _member(
+        self,
+        document: dict[str, Any],
+        *,
+        path_field: str,
+        hash_field: str,
+        maximum_bytes: int,
+    ) -> tuple[Path, PurePosixPath]:
+        """Resolve and digest-check one result-declared artifact member."""
+
+        relative = document.get(path_field)
+        expected = document.get(hash_field)
+        if (
+            not isinstance(relative, str)
+            or not relative
+            or not isinstance(expected, str)
+            or len(expected) != 64
+        ):
+            raise RuntimeError(f"WfCommons result omitted {path_field}")
+        candidate = Path(relative)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise RuntimeError(
+                f"WfCommons artifact escaped its output root: {relative}"
+            )
+        root = self._local_output_path().resolve(strict=True)
+        path = (root / candidate).resolve(strict=False)
+        if not path.is_relative_to(root):
+            raise RuntimeError(
+                f"WfCommons artifact escaped its output root: {relative}"
+            )
+        if path.is_symlink() or not path.is_file():
+            raise RuntimeError(f"WfCommons artifact is missing or unsafe: {relative}")
+        size = path.stat().st_size
+        if size <= 0 or size > maximum_bytes:
+            raise RuntimeError(
+                f"WfCommons artifact is outside its size bound: {relative}"
+            )
+        if _sha256(path) != expected:
+            raise RuntimeError(f"WfCommons artifact hash differs: {relative}")
+        return path, PurePosixPath(relative)
+
+    def _local_output_path(self) -> Path:
+        """Project the declared cluster directory into this host filesystem."""
+
+        if self._local_root is not None:
+            return self._local_root
+        return Path(self.output_dir.as_posix())
+
+    def _observation(
+        self,
+        path: Path,
+        cluster_path: PurePosixPath,
+        *,
+        logical_name: str,
+        kind: str,
+        role: ArtifactRole,
+        format_name: str,
+        media_type: str,
+        state: ArtifactState,
+        metadata: dict[str, Any],
+    ) -> ArtifactObservation:
+        """Create one exact file observation."""
+
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=role,
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(cluster_path),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=path.stat().st_size,
+            checksum=f"sha256:{_sha256(path)}",
+            message="Closed WfCommons workflow-cell product",
+            metadata=metadata,
+        )
+
+    def _finalize(self, *, return_code: int) -> list[ArtifactObservation]:
+        """Validate and report the exact result-declared files once."""
+
+        if self._finalized:
+            return []
+        self._finalized = True
+        result_path, document = self._result()
+        declared_return_code = document.get("return_code")
+        if not isinstance(declared_return_code, int) or isinstance(
+            declared_return_code, bool
+        ):
+            raise RuntimeError("WfCommons result omitted its process return code")
+        state = (
+            ArtifactState.FINALIZED
+            if return_code == 0 and declared_return_code == 0
+            else ArtifactState.INCOMPLETE
+        )
+        workflow, workflow_relative = self._member(
+            document,
+            path_field="workflow_manifest",
+            hash_field="workflow_sha256",
+            maximum_bytes=64 * 1024 * 1024,
+        )
+        log, log_relative = self._member(
+            document,
+            path_field="workflow_log",
+            hash_field="workflow_log_sha256",
+            maximum_bytes=64 * 1024 * 1024,
+        )
+        lock, lock_relative = self._member(
+            document,
+            path_field="dependency_lock",
+            hash_field="dependency_lock_sha256",
+            maximum_bytes=4 * 1024 * 1024,
+        )
+        schema, schema_relative = self._member(
+            document,
+            path_field="schema_file",
+            hash_field="schema_sha256",
+            maximum_bytes=1024 * 1024,
+        )
+        metadata = {
+            "application": "wfcommons",
+            "data_footprint_mb": document.get("data_footprint_mb"),
+            "observed_task_count": document.get("observed_task_count"),
+            "recipe": document.get("recipe"),
+            "requested_task_count": document.get("requested_task_count"),
+            "seed": document.get("seed"),
+            "topology_sha256": document.get("topology_sha256"),
+        }
+        return [
+            self._observation(
+                result_path,
+                self.output_dir / RESULT_NAME,
+                logical_name="wfcommons-result",
+                kind="scientific_result",
+                role=ArtifactRole.OUTPUT,
+                format_name=RESULT_SCHEMA,
+                media_type="application/json",
+                state=state,
+                metadata=metadata,
+            ),
+            self._observation(
+                workflow,
+                self.output_dir / workflow_relative,
+                logical_name="wfcommons-workflow",
+                kind="workflow_manifest",
+                role=ArtifactRole.OUTPUT,
+                format_name="wfcommons-wfformat-json",
+                media_type="application/json",
+                state=state,
+                metadata=metadata,
+            ),
+            self._observation(
+                log,
+                self.output_dir / log_relative,
+                logical_name="wfcommons-workflow-log",
+                kind="log",
+                role=ArtifactRole.LOG,
+                format_name="text-log",
+                media_type="text/plain",
+                state=state,
+                metadata=metadata,
+            ),
+            self._observation(
+                lock,
+                self.output_dir / lock_relative,
+                logical_name="wfcommons-dependency-lock",
+                kind="provenance",
+                role=ArtifactRole.PROVENANCE,
+                format_name="python-distributions",
+                media_type="text/plain",
+                state=state,
+                metadata=metadata,
+            ),
+            self._observation(
+                schema,
+                self.output_dir / schema_relative,
+                logical_name="wfcommons-schema",
+                kind="configuration",
+                role=ArtifactRole.PROVENANCE,
+                format_name="wfformat-json-schema",
+                media_type="application/schema+json",
+                state=state,
+                metadata=metadata,
+            ),
+        ]
+
+
+def adapter_from_package(package: dict[str, Any]) -> WfcommonsArtifactAdapter | None:
+    """Create artifact semantics only for builtin WfCommons."""
+
+    if package.get("pkg_type") != "builtin.wfcommons":
+        return None
+    configured = package.get("out")
+    if not isinstance(configured, str) or not configured:
+        raise ValueError("WfCommons artifact provider requires its output directory")
+    output_dir = PurePosixPath(configured)
+    if not output_dir.is_absolute() or not configured.startswith("/"):
+        raise ValueError("WfCommons artifact output must be an absolute cluster path")
+    shared = package.get("shared_dir")
+    if isinstance(shared, str) and shared:
+        shared_root = PurePosixPath(shared)
+        if not output_dir.is_relative_to(shared_root):
+            raise ValueError("WfCommons output directory escaped its shared root")
+    return WfcommonsArtifactAdapter(output_dir)
+
+
+__all__ = ["WfcommonsArtifactAdapter", "adapter_from_package"]

--- a/builtin/builtin/wfcommons/build.sh
+++ b/builtin/builtin/wfcommons/build.sh
@@ -29,8 +29,9 @@ printf "StrictHostKeyChecking no\nUserKnownHostsFile /dev/null\n" >> /etc/ssh/ss
 python3 -m venv /opt/wfcommons-env
 /opt/wfcommons-env/bin/pip install --no-cache-dir --upgrade pip wheel setuptools
 
-# Install the wfcommons python library.
-/opt/wfcommons-env/bin/pip install --no-cache-dir wfcommons
+# Install the package-owned WfCommons version. The resulting image digest and
+# runtime dependency lock bind the resolved dependency environment.
+/opt/wfcommons-env/bin/pip install --no-cache-dir 'wfcommons==1.4'
 
 # wfcommons 1.4's wheel build doesn't reliably ship `bin/wfbench` or
 # `bin/cpu-benchmark` (setup.py's scripts= + dynamic data_files don't
@@ -39,7 +40,7 @@ python3 -m venv /opt/wfcommons-env
 # g++, then drop both into the venv's bin/.
 mkdir -p /opt/wfcommons-src
 /opt/wfcommons-env/bin/pip download --no-cache-dir --no-deps \
-    --no-binary=:all: --dest /opt/wfcommons-src wfcommons
+    --no-binary=:all: --dest /opt/wfcommons-src 'wfcommons==1.4'
 tar -xzf /opt/wfcommons-src/wfcommons-*.tar.gz -C /opt/wfcommons-src
 WFC_SRC=$(ls -d /opt/wfcommons-src/wfcommons-*/ | head -1)
 make -C "${WFC_SRC%/}"
@@ -76,3 +77,12 @@ PY
 mkdir -p /opt/wfcommons-driver
 cp run_wfbench.py /opt/wfcommons-driver/run_wfbench.py
 chmod +x /opt/wfcommons-driver/run_wfbench.py
+
+# WfCommons otherwise downloads the latest WfFormat schema during execution.
+# Fetch at image-build time only and fail closed unless the pinned bytes match.
+curl -fsSL \
+    https://raw.githubusercontent.com/wfcommons/wfformat/master/wfcommons-schema.json \
+    -o /opt/wfcommons-driver/wfcommons-schema.json
+printf '%s  %s\n' \
+    '716e7b625a37a144674afbf8e6a008c21bbd0fd467ccbb7be39deab9fb8f6aab' \
+    /opt/wfcommons-driver/wfcommons-schema.json | sha256sum --check --strict

--- a/builtin/builtin/wfcommons/pkg.py
+++ b/builtin/builtin/wfcommons/pkg.py
@@ -1,267 +1,480 @@
-"""
-WfCommons (https://wfcommons.org/) jarvis package.
+"""Generate and execute one bounded WfCommons/WfBench workflow cell."""
 
-Generates a synthetic scientific workflow from a wfcommons recipe
-(Montage, Genome, Cycles, etc.), translates it into a runnable WfBench
-benchmark workflow, and executes the resulting tasks locally in
-topological order via a thread pool.
+from __future__ import annotations
 
-Supports both bare-metal (default) and container deployment modes.
-"""
+import os
+import shlex
+import shutil
+import sys
+import sysconfig
+from pathlib import Path
+from typing import Any
+
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
-from jarvis_cd.shell.process import Mkdir, Rm
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo
+from jarvis_cd.shell.process import Rm
 
-
-RECIPES = [
-    'montage', 'genome', 'cycles', 'blast', 'bwa',
-    'srasearch', 'epigenomics', 'seismology', 'soykb', 'rnaseq',
-]
+RECIPES = (
+    "montage",
+    "genome",
+    "cycles",
+    "blast",
+    "bwa",
+    "srasearch",
+    "epigenomics",
+    "seismology",
+    "soykb",
+    "rnaseq",
+)
+_EXPECTED_WFCOMMONS_VERSION = "1.4"
+_MAX_TASKS = 100_000
+_MAX_DATA_FOOTPRINT_MB = 1_000_000
+_MAX_TIMEOUT_SECONDS = 86_400
 
 
 class Wfcommons(Application):
+    """Run one deterministic synthetic workflow study cell.
+
+    JARVIS owns runtime selection, the pinned WfFormat schema, the output
+    directory, process completion, and artifact reporting. A prepared runtime
+    must already contain the expected WfCommons version. Runtime installation
+    is intentionally outside scheduled scientific execution.
     """
-    Wfcommons workflow benchmark runner.
 
-    Generates a WfFormat workflow from a recipe, translates it with
-    WfBench, and executes the tasks. The translator is invoked locally
-    on a single node; task parallelism is controlled by `max_workers`.
-    """
+    def _init(self) -> None:
+        """Initialize the package without mutable global runtime state."""
 
-    def _init(self):
-        pass
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        """Describe one scientific workflow cell and its execution bounds."""
 
-    def _configure_menu(self):
         return [
             {
-                'name': 'recipe',
-                'msg': 'WfCommons recipe to generate',
-                'type': str,
-                'choices': RECIPES,
-                'default': 'montage',
+                "name": "recipe",
+                "msg": "Synthetic scientific workflow recipe",
+                "type": str,
+                "choices": list(RECIPES),
+                "default": "montage",
             },
             {
-                'name': 'num_tasks',
-                'msg': 'Number of tasks in the generated workflow',
-                'type': int,
-                'default': 100,
+                "name": "num_tasks",
+                "msg": "Requested number of generated workflow tasks",
+                "type": int,
+                "default": 100,
             },
             {
-                'name': 'cpu_work',
-                'msg': ('CPU work units per wfbench task. MUST be > 0; '
-                        'wfbench gates io_alternate on cpu-benchmark progress '
-                        'updates, so cpu_work=0 silently disables ALL '
-                        'reads/writes. Use 1 for minimal CPU + maximal I/O.'),
-                'type': int,
-                'default': 1,
+                "name": "data_footprint_mb",
+                "msg": "Total generated workflow data footprint in MB; 0 uses recipe defaults",
+                "type": int,
+                "default": 0,
             },
             {
-                'name': 'data_footprint',
-                'msg': 'Per-file data size (e.g. 100M, 1G); 0 = recipe defaults',
-                'type': str,
-                'default': '0',
+                "name": "seed",
+                "msg": "Random seed controlling generated workflow topology",
+                "type": int,
+                "default": 424_200,
             },
             {
-                'name': 'percent_cpu',
-                'msg': ('CPU vs memory thread split for the cpu-benchmark '
-                        'process (cpu_threads = 10*percent_cpu, '
-                        'mem_threads = 10 - cpu_threads). Does NOT directly '
-                        'affect I/O volume. mem_threads spawn stress-ng — '
-                        'NOT installed on every system. Default 1.0 (all '
-                        'cpu, no mem threads) so the I/O path runs cleanly '
-                        'on systems without stress-ng.'),
-                'type': float,
-                'default': 1.0,
+                "name": "cpu_work",
+                "msg": "Positive WfBench CPU work units per task",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'drop_page_cache',
-                'msg': ('After each read/write, call '
-                        'posix_fadvise(POSIX_FADV_DONTNEED) so the kernel '
-                        'drops the file from the page cache. Writes also '
-                        'fsync first so dirty pages become drop-eligible. '
-                        'Makes NFS-vs-CTE comparisons apples-to-apples: '
-                        'the CTE adapter has no client-side cache, so '
-                        'letting NFS warm-cache the workflow data '
-                        'biases the comparison. Toggling this sets '
-                        'WFBENCH_DROP_CACHE=1 in the wfbench env.'),
-                'type': bool,
-                'default': False,
+                "name": "percent_cpu",
+                "msg": "Fraction of WfBench work threads assigned to CPU work",
+                "type": float,
+                "default": 1.0,
             },
             {
-                'name': 'out',
-                'msg': 'Output directory (receives bench/ + bench/bash/)',
-                'type': str,
-                'default': '${HOME}/wfcommons_out',
+                "name": "drop_page_cache",
+                "msg": "Request per-file POSIX_FADV_DONTNEED behavior in WfBench",
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'clio_prefix',
-                'msg': 'Rewrite wfbench task paths to begin with "clio::" '
-                       '(opts every read/write into WRP CTE POSIX '
-                       'interception when libwrp_cte_posix.so is LD_PRELOADed)',
-                'type': bool,
-                'default': False,
+                "name": "clio_prefix",
+                "msg": "Prefix translated workflow data paths with clio::",
+                "type": bool,
+                "default": False,
             },
             {
-                'name': 'venv',
-                'msg': 'Path to a wfcommons venv (bare-metal mode only)',
-                'type': str,
-                'default': '${HOME}/.jarvis-wfcommons-venv',
+                "name": "out",
+                "msg": "Package-owned output directory relative to the shared root",
+                "type": str,
+                "default": "run",
             },
             {
-                'name': 'nprocs',
-                'msg': 'MPI ranks (driver runs single-process; tasks use max_workers)',
-                'type': int,
-                'default': 1,
+                "name": "timeout_seconds",
+                "msg": "Maximum elapsed time for this workflow cell",
+                "type": int,
+                "default": 3600,
             },
             {
-                'name': 'ppn',
-                'msg': 'MPI processes per node',
-                'type': int,
-                'default': 1,
+                "name": "nprocs",
+                "msg": "Scheduler process count; WfCommons cell execution is single-process",
+                "type": int,
+                "default": 1,
             },
             {
-                'name': 'base_image',
-                'msg': 'Base image for the build container',
-                'type': str,
-                'default': 'ubuntu:24.04',
+                "name": "ppn",
+                "msg": "Scheduler processes per node; must be one",
+                "type": int,
+                "default": 1,
+            },
+            {
+                "name": "runtime_python",
+                "msg": "Operator-owned Python executable containing WfCommons 1.4",
+                "type": str,
+                "default": "",
+                "agent_visible": False,
+            },
+            {
+                "name": "base_image",
+                "msg": "Base image for an operator-built container runtime",
+                "type": str,
+                "default": "ubuntu:24.04",
+                "agent_visible": False,
             },
         ]
 
-    # ------------------------------------------------------------------
-    # Container build hooks
-    # ------------------------------------------------------------------
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe the prepared runtime and successful-exit contract."""
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+        completed = ReadinessContract(
+            mechanism="process_exit", condition="successful_exit"
+        )
+        if self.config.get("deploy_mode") == "container":
+            wfcommons_status = RuntimeStatus("unknown", "container_runtime_not_probed")
+            bash_status = RuntimeStatus("unknown", "container_runtime_not_probed")
+            wfcommons_capabilities: tuple[str, ...] = ()
+            bash_capabilities: tuple[str, ...] = ()
+        else:
+            environment = self._deployment_environment()
+            python = self._runtime_python()
+            expected = self._expected_version()
+            version_probe = probe_program(
+                python,
+                environment=environment,
+                arguments=(
+                    "-c",
+                    (
+                        "import wfcommons; import sys; "
+                        f"sys.exit(0 if getattr(wfcommons, '__version__', '') == {expected!r} else 3)"
+                    ),
+                ),
+            )
+            bash_probe = probe_program(
+                "bash", environment=environment, arguments=("--version",)
+            )
+            wfcommons_status = version_probe.status
+            bash_status = bash_probe.status
+            wfcommons_capabilities = (
+                ("synthetic_workflow_generation", "wfbench_execution", "wfformat")
+                if wfcommons_status.usable is True
+                else ()
+            )
+            bash_capabilities = (
+                ("bash_workflow_execution",) if bash_status.usable is True else ()
+            )
+        runtime = RuntimeRequirement(
+            requirement_id="wfcommons_runtime",
+            description=(
+                f"Prepared Python runtime containing WfCommons {_EXPECTED_WFCOMMONS_VERSION}"
+            ),
+            required_capabilities=(
+                "synthetic_workflow_generation",
+                "wfbench_execution",
+                "wfformat",
+            ),
+            available_capabilities=wfcommons_capabilities,
+            status=wfcommons_status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="path", query_kind="program", query_value="python3"
+                ),
+            ),
+        )
+        bash = RuntimeRequirement(
+            requirement_id="bash",
+            description="Bash runtime used by the generated WfBench workflow",
+            required_capabilities=("bash_workflow_execution",),
+            available_capabilities=bash_capabilities,
+            status=bash_status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="path", query_kind="program", query_value="bash"
+                ),
+            ),
+        )
+        return PackageDeploymentContract(
+            package="builtin.wfcommons",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="synthetic_workflow_cell",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("recipe", "is_not_empty"),),
+                    runtime_requirements=("bash", "wfcommons_runtime"),
+                    readiness=completed,
+                    description=(
+                        "Generate and execute one deterministic WfBench workflow cell."
+                    ),
+                ),
+            ),
+            runtime_requirements=(bash, runtime),
+        )
+
+    def _build_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Build an operator-owned container runtime when requested."""
+
+        if self.config.get("deploy_mode") != "container":
             return None
-        content = self._read_build_script('build.sh', {
-            'BASE_IMAGE': self.config.get('base_image', 'ubuntu:24.04'),
-        })
-        return content, 'py311'
+        content = self._read_build_script(
+            "build.sh", {"BASE_IMAGE": self.config.get("base_image", "ubuntu:24.04")}
+        )
+        return content, "py311"
 
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
+    def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Create the deploy image containing the prepared runtime."""
+
+        if self.config.get("deploy_mode") != "container":
             return None
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': 'ubuntu:24.04',
-        })
-        return content, 'py311'
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {
+                "BUILD_IMAGE": self.build_image_name(),
+                "DEPLOY_BASE": "ubuntu:24.04",
+            },
+        )
+        return content, "py311"
 
-    # ------------------------------------------------------------------
-    # Configure
-    # ------------------------------------------------------------------
+    def _configure(self, **kwargs: Any) -> None:
+        """Persist a valid cell without installing software or touching outputs."""
 
-    def _configure(self, **kwargs):
         super()._configure(**kwargs)
-
-        if self.config['recipe'] not in RECIPES:
-            raise ValueError(
-                f"recipe '{self.config['recipe']}' not in {RECIPES}"
-            )
-
-        # wfbench main() guards the cpu-benchmark spawn behind
-        # `if args.cpu_work:` (wfbench script line 443). When that block
-        # is skipped, nothing feeds the cpu_queue that io_alternate
-        # blocks on, so the io subprocess hangs until wfbench main kills
-        # it on shutdown — no reads, no writes, just process spawn
-        # overhead. Coerce cpu_work to a minimum of 1 so this path is
-        # always taken.
-        if int(self.config.get('cpu_work', 0)) <= 0:
-            self.log(
-                "cpu_work was 0; coercing to 1 so wfbench actually "
-                "performs I/O (cpu_work=0 silently disables it)"
-            )
-            self.config['cpu_work'] = 1
-
-        # Propagate the drop-page-cache toggle to the wfbench subprocess
-        # (wfbench reads WFBENCH_DROP_CACHE in _drop_page_cache helper).
-        if self.config.get('drop_page_cache', False):
-            self.setenv('WFBENCH_DROP_CACHE', '1')
-
-        if self.config.get('deploy_mode') == 'default':
-            # Output dir on every node so MPI/PSSH topo-execution works.
-            Mkdir(self.config['out'],
-                  PsshExecInfo(hostfile=self.hostfile,
-                               env=self.env)).run()
-            # Bare-metal venv with wfcommons. Idempotent — if the venv
-            # exists and imports wfcommons, skip the (slow) pip install.
-            venv = self.config['venv']
-            ensure = (
-                f"python3 -c 'import sys; sys.exit(0)' && "
-                f"if [ ! -x '{venv}/bin/python3' ]; then "
-                f"  python3 -m venv '{venv}'; "
-                f"fi && "
-                f"'{venv}/bin/pip' install --quiet --upgrade pip && "
-                f"'{venv}/bin/python3' -c 'import wfcommons' 2>/dev/null || "
-                f"'{venv}/bin/pip' install --quiet 'wfcommons[bench]'"
-            )
-            Exec(ensure, LocalExecInfo(env=self.env)).run()
-            self.setenv('WFCOMMONS_PYTHON', f"{venv}/bin/python3")
-
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
+        self._validate_configuration()
 
     @staticmethod
-    def _data_bytes(s):
-        """Parse '100M', '1G', '500k', or a plain integer to bytes."""
-        if s is None:
-            return 0
-        s = str(s).strip()
-        if not s:
-            return 0
-        units = {'k': 1024, 'm': 1024**2, 'g': 1024**3, 't': 1024**4}
-        suffix = s[-1].lower()
-        if suffix in units:
-            return int(float(s[:-1]) * units[suffix])
-        return int(s)
+    def _require_int(value: object, name: str, *, minimum: int, maximum: int) -> int:
+        """Return one bounded integer or fail without coercion."""
 
-    def _driver_args(self):
-        cfg = self.config
-        args = [
-            f"--recipe {cfg['recipe']}",
-            f"--num-tasks {cfg['num_tasks']}",
-            f"--cpu-work {cfg['cpu_work']}",
-            f"--data {self._data_bytes(cfg['data_footprint'])}",
-            f"--percent-cpu {cfg['percent_cpu']}",
-            f"--out '{cfg['out']}'",
-        ]
-        if cfg.get('clio_prefix'):
-            args.append('--clio-prefix')
-        return ' '.join(args)
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or value < minimum
+            or value > maximum
+        ):
+            raise ValueError(f"{name} must be an integer from {minimum} to {maximum}")
+        return value
 
-    def start(self):
-        if self.config.get('deploy_mode') == 'container':
-            cmd = (
-                '/opt/wfcommons-env/bin/python3 '
-                '/opt/wfcommons-driver/run_wfbench.py '
-                + self._driver_args()
+    def _validate_configuration(self) -> None:
+        """Reject ambiguous, unsafe, or unsupported study settings."""
+
+        recipe = self.config.get("recipe")
+        if recipe not in RECIPES:
+            raise ValueError(f"recipe must be one of: {', '.join(RECIPES)}")
+        self._require_int(
+            self.config.get("num_tasks"), "num_tasks", minimum=1, maximum=_MAX_TASKS
+        )
+        self._require_int(
+            self.config.get("data_footprint_mb"),
+            "data_footprint_mb",
+            minimum=0,
+            maximum=_MAX_DATA_FOOTPRINT_MB,
+        )
+        self._require_int(
+            self.config.get("cpu_work"), "cpu_work", minimum=1, maximum=1_000_000
+        )
+        self._require_int(self.config.get("seed"), "seed", minimum=0, maximum=2**32 - 1)
+        self._require_int(
+            self.config.get("timeout_seconds"),
+            "timeout_seconds",
+            minimum=1,
+            maximum=_MAX_TIMEOUT_SECONDS,
+        )
+        percent_cpu = self.config.get("percent_cpu")
+        if (
+            isinstance(percent_cpu, bool)
+            or not isinstance(percent_cpu, (int, float))
+            or not 0 < float(percent_cpu) <= 1
+        ):
+            raise ValueError("percent_cpu must be greater than 0 and at most 1")
+        if self.config.get("nprocs") != 1 or self.config.get("ppn") != 1:
+            raise ValueError(
+                "WfCommons workflow cells require single-process execution"
             )
-            Exec(cmd, LocalExecInfo(
-                env=self.mod_env,
+        runtime_python = self.config.get("runtime_python", "")
+        if not isinstance(runtime_python, str):
+            raise ValueError("runtime_python must be a path string")
+        out = self.config.get("out")
+        if not isinstance(out, str) or not out.strip():
+            raise ValueError("out must be a non-empty path")
+
+    def _expected_version(self) -> str:
+        """Return the package-owned WfCommons version pin."""
+
+        return _EXPECTED_WFCOMMONS_VERSION
+
+    def _runtime_python(self) -> str:
+        """Resolve the operator-prepared Python executable."""
+
+        if self.config.get("deploy_mode") == "container":
+            return "/opt/wfcommons-env/bin/python3"
+        configured = self.config.get("runtime_python")
+        if isinstance(configured, str) and configured:
+            return os.path.expandvars(os.path.expanduser(configured))
+        environment = getattr(self, "mod_env", {})
+        from_environment = environment.get("WFCOMMONS_PYTHON")
+        if from_environment:
+            return from_environment
+        return sys.executable
+
+    def _output_dir(self) -> Path:
+        """Return the package-owned output directory."""
+
+        return self.resolve_shared_path(
+            self.config.get("out"), field="out", default="run"
+        )
+
+    def _schema_source(self) -> Path:
+        """Return the repository-pinned WfFormat schema."""
+
+        package_dir = self._package_dir()
+        package_copy = package_dir / "wfcommons-schema.json"
+        if package_copy.is_file() and not package_copy.is_symlink():
+            return package_copy
+        repository_copy = package_dir.parents[2] / "wfcommons-schema.json"
+        if repository_copy.is_file() and not repository_copy.is_symlink():
+            return repository_copy
+        installed_copy = Path(sysconfig.get_path("data")) / "wfcommons-schema.json"
+        if installed_copy.is_file() and not installed_copy.is_symlink():
+            return installed_copy
+        raise RuntimeError("Pinned WfFormat schema is missing from the package")
+
+    def _package_dir(self) -> Path:
+        """Return the configured package directory as an absolute path."""
+
+        package_dir = self.pkg_dir
+        if not isinstance(package_dir, str) or not package_dir:
+            raise RuntimeError("WfCommons package directory is unavailable")
+        return Path(package_dir).resolve()
+
+    @staticmethod
+    def _failures(result: Any) -> dict[str, int]:
+        """Return all nonzero host exits from one JARVIS shell result."""
+
+        return {host: code for host, code in result.exit_code.items() if code != 0}
+
+    def _driver_arguments(self, *, schema_path: Path) -> list[str]:
+        """Return one shell-safe driver argument vector."""
+
+        arguments = [
+            "--recipe",
+            str(self.config["recipe"]),
+            "--num-tasks",
+            str(self.config["num_tasks"]),
+            "--cpu-work",
+            str(self.config["cpu_work"]),
+            "--data-footprint-mb",
+            str(self.config["data_footprint_mb"]),
+            "--percent-cpu",
+            str(self.config["percent_cpu"]),
+            "--seed",
+            str(self.config["seed"]),
+            "--schema-file",
+            str(schema_path),
+            "--expected-wfcommons-version",
+            self._expected_version(),
+            "--out",
+            str(self._output_dir()),
+        ]
+        if self.config.get("clio_prefix"):
+            arguments.append("--clio-prefix")
+        return arguments
+
+    def start(self) -> None:
+        """Generate and execute one cell and fail on any process error."""
+
+        self._validate_configuration()
+        output_dir = self._output_dir()
+        if output_dir.exists():
+            raise ValueError(f"WfCommons output already exists: {output_dir}")
+        output_dir.mkdir(parents=True, mode=0o700)
+        schema_source = self._schema_source()
+        schema_path = output_dir / "wfcommons-schema.json"
+        shutil.copyfile(schema_source, schema_path, follow_symlinks=False)
+        os.chmod(schema_path, 0o400)
+        self.config["out"] = str(output_dir)  # pyright: ignore[reportArgumentType]
+
+        if self.config.get("deploy_mode") == "container":
+            driver = "/opt/wfcommons-driver/run_wfbench.py"
+            info = LocalExecInfo(
+                env=dict(self.mod_env),
+                cwd=str(output_dir),
+                timeout=self.config["timeout_seconds"],
+                line_callback=self.runtime_line_callback(),
                 container=self._container_engine,
                 container_image=self.deploy_image_name(),
                 shared_dir=self.shared_dir,
                 private_dir=self.private_dir,
-            )).run()
-        else:
-            driver = f"{self.pkg_dir}/run_wfbench.py"
-            cmd = (
-                f"{self.config['venv']}/bin/python3 {driver} "
-                + self._driver_args()
             )
-            Exec(cmd, LocalExecInfo(env=self.mod_env)).run()
+        else:
+            driver = str(self._package_dir() / "run_wfbench.py")
+            environment = dict(self.mod_env)
+            if self.config.get("drop_page_cache"):
+                environment["WFBENCH_DROP_CACHE"] = "1"
+            info = LocalExecInfo(
+                env=environment,
+                cwd=str(output_dir),
+                timeout=self.config["timeout_seconds"],
+                line_callback=self.runtime_line_callback(),
+            )
+        command = " ".join(
+            shlex.quote(value)
+            for value in (
+                self._runtime_python(),
+                driver,
+                *self._driver_arguments(schema_path=schema_path),
+            )
+        )
+        result = Exec(command, info).run()
+        failures = self._failures(result)
+        if failures:
+            rendered = ", ".join(f"{host}={code}" for host, code in failures.items())
+            raise RuntimeError(f"WfCommons execution failed: {rendered}")
 
-    def stop(self):
-        pass
+    def stop(self) -> None:
+        """Do nothing because the workflow cell runs to process completion."""
 
-    def clean(self):
-        if self.config.get('out'):
-            Rm(self.config['out'],
-               PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+    def clean(self) -> None:
+        """Remove only the exact package-owned output directory."""
 
-    def _get_stat(self, stat_dict):
-        stat_dict[f'{self.pkg_id}.recipe'] = self.config['recipe']
-        stat_dict[f'{self.pkg_id}.num_tasks'] = self.config['num_tasks']
-        stat_dict[f'{self.pkg_id}.runtime'] = self.start_time
+        output_dir = self._output_dir()
+        if output_dir == Path(output_dir.anchor):
+            raise ValueError("refusing to clean a filesystem root as WfCommons output")
+        result = Rm(str(output_dir), LocalExecInfo(env=self.env), recursive=True).run()
+        failures = self._failures(result)
+        if failures:
+            raise RuntimeError(
+                f"Failed to clean WfCommons output {output_dir}: {failures}"
+            )
+
+    def _get_stat(self, stat_dict: dict[str, Any]) -> None:
+        """Expose the requested workflow cell in JARVIS statistics."""
+
+        stat_dict[f"{self.pkg_id}.recipe"] = self.config["recipe"]
+        stat_dict[f"{self.pkg_id}.num_tasks"] = self.config["num_tasks"]
+        stat_dict[f"{self.pkg_id}.data_footprint_mb"] = self.config["data_footprint_mb"]
+        stat_dict[f"{self.pkg_id}.runtime"] = getattr(self, "start_time", None)
+
+
+__all__ = ["RECIPES", "Wfcommons"]

--- a/builtin/builtin/wfcommons/pkg.py
+++ b/builtin/builtin/wfcommons/pkg.py
@@ -159,8 +159,14 @@ class Wfcommons(Application):
             wfcommons_capabilities: tuple[str, ...] = ()
             bash_capabilities: tuple[str, ...] = ()
         else:
-            environment = self._deployment_environment()
-            python = self._runtime_python()
+            environment = dict(self._deployment_environment())
+            python_path = Path(self._runtime_python())
+            python = python_path.name
+            if python_path.is_absolute():
+                existing_path = environment.get("PATH", "")
+                environment["PATH"] = os.pathsep.join(
+                    value for value in (str(python_path.parent), existing_path) if value
+                )
             expected = self._expected_version()
             version_probe = probe_program(
                 python,

--- a/builtin/builtin/wfcommons/run_wfbench.py
+++ b/builtin/builtin/wfcommons/run_wfbench.py
@@ -1,38 +1,25 @@
 #!/usr/bin/env python3
-"""
-Driver: generate a wfcommons recipe-based benchmark workflow, translate
-it into a self-contained bash workflow, and execute it.
+"""Generate, translate, execute, and close one WfCommons workflow cell."""
 
-Uses the real wfcommons 1.x API:
+from __future__ import annotations
 
-    WorkflowBenchmark(recipe=<RecipeCls>, num_tasks=N)
-        .create_benchmark(save_dir, cpu_work=..., data=...)   -> path to JSON
-    BashTranslator(workflow=<json_path>).translate(output_folder=...)
-        -> writes run_workflow.sh + bin/{wfbench,cpu-benchmark} + data/
-
-The translator's `bin/wfbench` script picks up its shebang from the
-`wfbench` interpreter on PATH at translation time. Run this driver
-under the same venv that has wfcommons installed so that shebang
-resolves to a python that exists inside this environment.
-"""
 import argparse
+import hashlib
+import importlib.metadata
 import json
 import os
+import random
 import re
-import shutil
 import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
-# Block-buffered stdout hides failures: when the driver fails mid-run,
-# the tail of stderr (Traceback) lands in the log immediately while the
-# trailing stdout prints arrive only when the interpreter exits, which
-# scrambles the apparent ordering. Force line-buffering up front.
-sys.stdout.reconfigure(line_buffering=True)
-sys.stderr.reconfigure(line_buffering=True)
-
-
+RESULT_SCHEMA = "jarvis.wfcommons-result.v1"
+RESULT_NAME = "wfcommons-result.json"
+DEPENDENCY_LOCK_NAME = "dependency-lock.txt"
+WORKFLOW_LOG_NAME = "workflow.log"
 RECIPE_IMPORTS = {
     "montage": "MontageRecipe",
     "genome": "GenomeRecipe",
@@ -47,162 +34,289 @@ RECIPE_IMPORTS = {
 }
 
 
-def load_recipe(name: str):
-    import wfcommons
-    attr = RECIPE_IMPORTS.get(name.lower())
-    if not attr or not hasattr(wfcommons, attr):
-        raise RuntimeError(
-            f"unknown recipe '{name}'. choices: {sorted(RECIPE_IMPORTS)}"
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest of one regular file."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _relative_file(run_root: Path, path: Path, *, label: str) -> str:
+    """Return a confined relative path for one closed result member."""
+
+    root = run_root.resolve(strict=True)
+    resolved = path.resolve(strict=True)
+    if (
+        resolved.is_symlink()
+        or not resolved.is_file()
+        or not resolved.is_relative_to(root)
+    ):
+        raise ValueError(f"{label} is not a confined regular file")
+    return resolved.relative_to(root).as_posix()
+
+
+def workflow_identity(path: Path) -> tuple[int, int, str]:
+    """Return observed tasks, directed edges, and a topology-only hash."""
+
+    raw = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    try:
+        tasks = raw["workflow"]["specification"]["tasks"]
+    except (KeyError, TypeError) as exc:
+        raise ValueError("WfCommons workflow omitted specification tasks") from exc
+    if not isinstance(tasks, list) or not tasks:
+        raise ValueError("WfCommons workflow tasks must be a non-empty list")
+    topology: list[dict[str, Any]] = []
+    edge_count = 0
+    for task in tasks:
+        if not isinstance(task, dict):
+            raise ValueError("WfCommons workflow task is malformed")
+        task_id = task.get("id", task.get("name"))
+        parents = task.get("parents", [])
+        children = task.get("children", [])
+        if (
+            not isinstance(task_id, str)
+            or not task_id
+            or not isinstance(parents, list)
+            or not isinstance(children, list)
+        ):
+            raise ValueError("WfCommons workflow topology is malformed")
+        normalized_parents = sorted(str(value) for value in parents)
+        normalized_children = sorted(str(value) for value in children)
+        edge_count += len(normalized_children)
+        topology.append(
+            {
+                "children": normalized_children,
+                "id": task_id,
+                "parents": normalized_parents,
+            }
         )
-    return getattr(wfcommons, attr)
+    topology.sort(key=lambda item: item["id"])
+    encoded = json.dumps(topology, sort_keys=True, separators=(",", ":")).encode()
+    return len(tasks), edge_count, hashlib.sha256(encoded).hexdigest()
 
 
-def main():
-    p = argparse.ArgumentParser()
-    p.add_argument("--recipe", required=True)
-    p.add_argument("--num-tasks", type=int, required=True)
-    p.add_argument("--cpu-work", type=int, default=100,
-                   help="cpu_work units passed to wfbench tasks")
-    p.add_argument("--data", type=int, default=0,
-                   help="total workflow data footprint in bytes "
-                        "(0 = recipe defaults). Converted to MB internally "
-                        "before being passed to WorkflowBenchmark.create_benchmark, "
-                        "whose `data` arg is documented as 'Total workflow data "
-                        "footprint (in MB)'.")
-    p.add_argument("--percent-cpu", type=float, default=0.6)
-    p.add_argument("--out", type=str, required=True,
-                   help="output dir; receives bench/ and bench/bash/")
-    p.add_argument("--clio-prefix", action="store_true",
-                   help="rewrite every input/output path the translated "
-                        "run_workflow.sh hands to wfbench so it begins "
-                        "with 'clio::'. The WRP CTE POSIX adapter, when "
-                        "LD_PRELOAD'd, only intercepts paths with that "
-                        "prefix; this flag is the opt-in for actually "
-                        "routing wfbench's data I/O through CTE.")
-    args = p.parse_args()
+def write_dependency_lock(destination: Path) -> None:
+    """Write a deterministic snapshot of the prepared Python environment."""
 
-    from wfcommons.wfbench import WorkflowBenchmark, BashTranslator
-
-    out_dir = Path(args.out).resolve()
-    out_dir.mkdir(parents=True, exist_ok=True)
-    bench_dir = out_dir / "bench"
-    bench_dir.mkdir(parents=True, exist_ok=True)
-
-    recipe_cls = load_recipe(args.recipe)
-    # wfcommons.WorkflowBenchmark.create_benchmark expects `data` in MB
-    # (its docstring: "Total workflow data footprint (in MB)"). The
-    # driver accepts bytes for consistency with the pkg.py SizeType
-    # parsing of values like "20G"; convert here.
-    data_mb = (args.data + (1024 * 1024) - 1) // (1024 * 1024) if args.data else 0
-    print(f"[wfbench] recipe={args.recipe} num_tasks={args.num_tasks} "
-          f"cpu_work={args.cpu_work} data={args.data}B (={data_mb} MB)",
-          flush=True)
-
-    bm = WorkflowBenchmark(recipe=recipe_cls, num_tasks=args.num_tasks)
-    create_kwargs = dict(
-        save_dir=bench_dir,
-        cpu_work=args.cpu_work,
-        percent_cpu=args.percent_cpu,
+    packages = sorted(
+        {
+            f"{distribution.metadata['Name']}=={distribution.version}"
+            for distribution in importlib.metadata.distributions()
+            if distribution.metadata.get("Name")
+        },
+        key=str.casefold,
     )
-    if data_mb > 0:
-        create_kwargs["data"] = data_mb
-    json_path = bm.create_benchmark(**create_kwargs)
-    print(f"[wfbench] generated benchmark JSON: {json_path}", flush=True)
+    temporary = destination.with_suffix(destination.suffix + ".tmp")
+    temporary.write_text("\n".join(packages) + "\n", encoding="utf-8")
+    os.replace(temporary, destination)
 
-    bash_dir = bench_dir / "bash"
-    # BashTranslator.translate calls Path.mkdir(parents=True) without
-    # exist_ok, so a leftover bash/ from a prior failed run will fail
-    # the whole pipeline. Clean it up before translating.
-    #
-    # ignore_errors: on NFS, files still held open by a prior wfbench
-    # worker become .nfs* "silly-rename" placeholders that can't be
-    # unlinked until the holder closes them. shutil.rmtree raises on
-    # those, but the directory will be empty enough for the translator
-    # once normal entries are gone — fall back to renaming any
-    # leftover dir out of the way.
-    if bash_dir.exists():
-        print(f"[wfbench] removing stale {bash_dir}", flush=True)
-        shutil.rmtree(bash_dir, ignore_errors=True)
-        if bash_dir.exists():
-            stash = bash_dir.with_name(
-                bash_dir.name + ".stale." + str(int(time.time())))
-            print(f"[wfbench] couldn't fully remove (NFS .nfs* locks?); "
-                  f"renaming to {stash}", flush=True)
-            bash_dir.rename(stash)
 
-    print(f"[wfbench] translating to bash workflow under {bash_dir}", flush=True)
-    BashTranslator(workflow=json_path).translate(output_folder=bash_dir)
+def build_result_document(
+    *,
+    run_root: Path,
+    recipe: str,
+    requested_task_count: int,
+    data_footprint_mb: int,
+    seed: int,
+    elapsed_seconds: float,
+    return_code: int,
+    workflow_path: Path,
+    workflow_log: Path,
+    dependency_lock: Path,
+    schema_path: Path,
+    wfcommons_version: str,
+    python_version: str,
+) -> dict[str, object]:
+    """Build one closed, generic WfCommons result document."""
 
-    runner = bash_dir / "run_workflow.sh"
-    if not runner.exists():
-        raise RuntimeError(f"translator did not produce {runner}")
+    observed_tasks, edge_count, topology_sha256 = workflow_identity(workflow_path)
+    return {
+        "schema_version": RESULT_SCHEMA,
+        "recipe": recipe,
+        "requested_task_count": requested_task_count,
+        "observed_task_count": observed_tasks,
+        "data_footprint_mb": data_footprint_mb,
+        "seed": seed,
+        "elapsed_seconds": elapsed_seconds,
+        "return_code": return_code,
+        "dag_edge_count": edge_count,
+        "topology_sha256": topology_sha256,
+        "workflow_manifest": _relative_file(
+            run_root, workflow_path, label="workflow manifest"
+        ),
+        "workflow_sha256": sha256_file(workflow_path),
+        "workflow_log": _relative_file(run_root, workflow_log, label="workflow log"),
+        "workflow_log_sha256": sha256_file(workflow_log),
+        "dependency_lock": _relative_file(
+            run_root, dependency_lock, label="dependency lock"
+        ),
+        "dependency_lock_sha256": sha256_file(dependency_lock),
+        "schema_file": _relative_file(run_root, schema_path, label="WfFormat schema"),
+        "schema_sha256": sha256_file(schema_path),
+        "wfcommons_version": wfcommons_version,
+        "python_version": python_version,
+    }
 
-    if args.clio_prefix:
-        # Discover the set of paths the workflow actually uses (so we
-        # don't hardcode 'data/'): collect every path the WfFormat JSON
-        # mentions under task `files`, then rewrite each occurrence in
-        # run_workflow.sh's JSON-encoded --input-files / --output-files
-        # args. Sort by length descending so a path that's a prefix of
-        # another doesn't shadow it (e.g. "data/foo" before "data/foo_2").
-        with json_path.open() as fh:
-            workflow_doc = json.load(fh)
-        tasks = (workflow_doc.get("workflow", {}).get("specification", {})
-                              .get("tasks") or
-                 workflow_doc.get("workflow", {}).get("tasks") or
-                 workflow_doc.get("tasks") or [])
-        paths = set()
-        for t in tasks:
-            for f in t.get("inputFiles", []) or t.get("input_files", []) or []:
-                if isinstance(f, dict) and "name" in f:
-                    paths.add(f["name"])
-                elif isinstance(f, str):
-                    paths.add(f)
-            for f in t.get("outputFiles", []) or t.get("output_files", []) or []:
-                if isinstance(f, dict) and "name" in f:
-                    paths.add(f["name"])
-                elif isinstance(f, str):
-                    paths.add(f)
-        # BashTranslator stages all files under bash/data/; the strings
-        # baked into run_workflow.sh are JSON-encoded with that prefix.
-        candidates = sorted(
-            {f"data/{p}" for p in paths} | paths,
-            key=len, reverse=True,
+
+def write_result(destination: Path, document: dict[str, object]) -> None:
+    """Atomically publish one completed result document."""
+
+    temporary = destination.with_suffix(destination.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    os.replace(temporary, destination)
+
+
+def load_recipe(name: str) -> type[Any]:
+    """Resolve one explicitly supported WfCommons recipe class."""
+
+    import wfcommons  # pyright: ignore[reportMissingImports]
+
+    attribute = RECIPE_IMPORTS.get(name.casefold())
+    if attribute is None or not hasattr(wfcommons, attribute):
+        raise RuntimeError(
+            f"unknown recipe {name!r}; choices: {sorted(RECIPE_IMPORTS)}"
         )
-        with runner.open() as fh:
-            text = fh.read()
-        rewritten = 0
-        for raw in candidates:
-            # Paths appear inside escaped JSON: '...\"data/foo\"...'.
-            # Match the literal escaped-quote + path + escaped-quote and
-            # prepend 'clio::' once.
-            pattern = re.compile(r'(\\")' + re.escape(raw) + r'(\\")')
-            text, n = pattern.subn(r'\1clio::' + raw + r'\2', text)
-            rewritten += n
-        with runner.open("w") as fh:
-            fh.write(text)
-        print(f"[wfbench] clio-prefix: rewrote {rewritten} path "
-              f"occurrences in {runner}", flush=True)
+    return getattr(wfcommons, attribute)
 
-    # The translator's bin/wfbench is copied from the python interpreter
-    # that ran the translator. When we run inside an apptainer SIF, its
-    # absolute shebang naturally points at /opt/wfcommons-env/bin/python3,
-    # which exists. Sanity check.
-    wfbench_bin = bash_dir / "bin" / "wfbench"
-    if wfbench_bin.exists():
-        with wfbench_bin.open() as fh:
-            shebang = fh.readline().rstrip()
-        print(f"[wfbench] bin/wfbench shebang: {shebang}", flush=True)
 
-    print(f"[wfbench] executing {runner}", flush=True)
-    rc = subprocess.run(
-        ["bash", "run_workflow.sh"],
-        cwd=str(bash_dir),
-    ).returncode
-    if rc != 0:
-        print(f"[wfbench] run_workflow.sh exited with rc={rc}", file=sys.stderr)
-        sys.exit(rc)
-    print(f"[wfbench] OK", flush=True)
+def _rewrite_clio_paths(workflow_path: Path, runner: Path) -> int:
+    """Prefix only manifest-declared workflow data paths with ``clio::``."""
+
+    workflow = json.loads(workflow_path.read_text(encoding="utf-8", errors="strict"))
+    tasks = workflow["workflow"]["specification"]["tasks"]
+    paths: set[str] = set()
+    for task in tasks:
+        for key in ("inputFiles", "input_files", "outputFiles", "output_files"):
+            for value in task.get(key, []) or []:
+                if isinstance(value, dict) and isinstance(value.get("name"), str):
+                    paths.add(value["name"])
+                elif isinstance(value, str):
+                    paths.add(value)
+    candidates = sorted(
+        {f"data/{path}" for path in paths} | paths, key=len, reverse=True
+    )
+    text = runner.read_text(encoding="utf-8", errors="strict")
+    rewritten = 0
+    for raw in candidates:
+        pattern = re.compile(r'(\\")' + re.escape(raw) + r'(\\")')
+        text, count = pattern.subn(r"\1clio::" + raw + r"\2", text)
+        rewritten += count
+    runner.write_text(text, encoding="utf-8")
+    return rewritten
+
+
+def _parse_arguments() -> argparse.Namespace:
+    """Parse the bounded one-cell driver interface."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--recipe", choices=sorted(RECIPE_IMPORTS), required=True)
+    parser.add_argument("--num-tasks", type=int, required=True)
+    parser.add_argument("--cpu-work", type=int, required=True)
+    parser.add_argument("--data-footprint-mb", type=int, required=True)
+    parser.add_argument("--percent-cpu", type=float, required=True)
+    parser.add_argument("--seed", type=int, required=True)
+    parser.add_argument("--schema-file", type=Path, required=True)
+    parser.add_argument("--expected-wfcommons-version", required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--clio-prefix", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Execute one workflow cell and return its workflow process status."""
+
+    arguments = _parse_arguments()
+    run_root = arguments.out.resolve(strict=True)
+    schema_path = arguments.schema_file.resolve(strict=True)
+    if schema_path.parent != run_root or schema_path.name != "wfcommons-schema.json":
+        raise ValueError("schema file must be the JARVIS-staged output member")
+
+    import numpy as np  # pyright: ignore[reportMissingImports]
+    import wfcommons  # pyright: ignore[reportMissingImports]
+    from wfcommons.wfbench import (  # pyright: ignore[reportMissingImports]
+        BashTranslator,
+        WorkflowBenchmark,
+    )
+
+    version = str(getattr(wfcommons, "__version__", ""))
+    if version != arguments.expected_wfcommons_version:
+        raise RuntimeError(
+            f"WfCommons version differs: expected {arguments.expected_wfcommons_version}, got {version or 'unknown'}"
+        )
+    random.seed(arguments.seed)
+    np.random.seed(arguments.seed)
+    write_dependency_lock(run_root / DEPENDENCY_LOCK_NAME)
+
+    benchmark_root = run_root / "benchmark"
+    recipe = load_recipe(arguments.recipe)
+    generator = WorkflowBenchmark(recipe=recipe, num_tasks=arguments.num_tasks)
+    create_arguments: dict[str, object] = {
+        "save_dir": benchmark_root,
+        "cpu_work": arguments.cpu_work,
+        "percent_cpu": arguments.percent_cpu,
+    }
+    if arguments.data_footprint_mb > 0:
+        create_arguments["data"] = arguments.data_footprint_mb
+    workflow_path = Path(generator.create_benchmark(**create_arguments)).resolve(
+        strict=True
+    )
+    bash_root = run_root / "bash"
+    if bash_root.exists():
+        raise ValueError("WfCommons translator output already exists")
+    BashTranslator(workflow=workflow_path).translate(output_folder=bash_root)
+    runner = bash_root / "run_workflow.sh"
+    if runner.is_symlink() or not runner.is_file():
+        raise RuntimeError("WfCommons translator omitted run_workflow.sh")
+    if arguments.clio_prefix:
+        rewritten = _rewrite_clio_paths(workflow_path, runner)
+        print(f"[wfcommons] clio-prefixed path occurrences={rewritten}", flush=True)
+
+    environment = dict(os.environ)
+    environment["PATH"] = f"{Path(sys.executable).parent}:{environment.get('PATH', '')}"
+    log_path = run_root / WORKFLOW_LOG_NAME
+    started = time.perf_counter()
+    with log_path.open("wb") as log:
+        completed = subprocess.run(
+            ["bash", runner.name],
+            cwd=bash_root,
+            env=environment,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+    elapsed = time.perf_counter() - started
+    document = build_result_document(
+        run_root=run_root,
+        recipe=arguments.recipe,
+        requested_task_count=arguments.num_tasks,
+        data_footprint_mb=arguments.data_footprint_mb,
+        seed=arguments.seed,
+        elapsed_seconds=elapsed,
+        return_code=completed.returncode,
+        workflow_path=workflow_path,
+        workflow_log=log_path,
+        dependency_lock=run_root / DEPENDENCY_LOCK_NAME,
+        schema_path=schema_path,
+        wfcommons_version=version,
+        python_version=sys.version.split()[0],
+    )
+    write_result(run_root / RESULT_NAME, document)
+    print(
+        "WFCOMMONS_RESULT "
+        f"schema={RESULT_SCHEMA} recipe={arguments.recipe} "
+        f"requested_tasks={arguments.num_tasks} "
+        f"observed_tasks={document['observed_task_count']} "
+        f"footprint_mb={arguments.data_footprint_mb} "
+        f"elapsed_s={elapsed:.9g} return_code={completed.returncode}",
+        flush=True,
+    )
+    return completed.returncode
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/builtin/builtin/wrf/README.md
+++ b/builtin/builtin/wrf/README.md
@@ -1,4 +1,21 @@
-# WRF 
+# WRF
+
+## Digest-bound tropical-cyclone comparison
+
+`builtin.wrf` retains its legacy location and ADIOS2 settings and adds a native
+supplied-study profile selected by a nonempty `input_bundle`. The archive uses
+the closed `jarvis.package-input-bundle.v1` contract and carries a WRF v4.6.1
+ideal tropical-cyclone namelist and sounding. `wrf_prefix` names an
+operator-prepared installation containing `main/ideal.exe`, `main/wrf.exe`, and
+the runtime-data directory.
+
+The profile creates independent execution-owned constant-Z0q and Garratt cases,
+runs initialization and the 24-hour forecast for each, and derives bounded
+surface diagnostics with `ncdump`. A successful run publishes both NetCDF
+histories, both diagnostic documents, the closed comparison, and input
+provenance. A failed process cannot finalize those products. The package
+deployment contract exposes the native profile and the provider hint for WRF
+4.6.1 with the ideal tropical-cyclone compile target.
 
 ## what is the WRF application?
 WRF is a state-of-the-art atmospheric modeling system designed for both meteorological research and numerical weather prediction. It offers a host of options for atmospheric processes and can run on a variety of computing platforms. WRF excels in a broad range of applications across scales ranging from tens of meters to thousands of kilometers, including the following.

--- a/builtin/builtin/wrf/artifacts.py
+++ b/builtin/builtin/wrf/artifacts.py
@@ -1,0 +1,173 @@
+"""Generated-artifact semantics for the WRF tropical-cyclone comparison."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+)
+
+from builtin.wrf.contract import (
+    FORMULATIONS,
+    RESULT_NAME,
+    RESULT_SCHEMA,
+    sha256_file,
+)
+
+
+@dataclass(slots=True)
+class WrfTropicalCycloneArtifactAdapter:
+    """Report only closed WRF comparison products."""
+
+    output_dir: Path
+    _finalized: bool = False
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for terminal validation before reporting products."""
+
+        del text
+        return []
+
+    def _file(
+        self,
+        path: Path,
+        *,
+        logical_name: str,
+        kind: str,
+        role: ArtifactRole,
+        media_type: str,
+        format_name: str,
+        metadata: dict[str, Any],
+        maximum_bytes: int,
+    ) -> ArtifactObservation:
+        if path.is_symlink() or not path.is_file():
+            raise RuntimeError(f"WRF artifact is missing or unsafe: {path.name}")
+        size = path.stat().st_size
+        if size <= 0 or size > maximum_bytes:
+            raise RuntimeError(f"WRF artifact size is outside its bound: {path.name}")
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=role,
+            structure=ArtifactStructure.FILE,
+            ownership=ArtifactOwnership.SHARED,
+            state=ArtifactState.FINALIZED,
+            location=ArtifactLocation.cluster_path(PurePosixPath(path.as_posix())),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=size,
+            checksum=f"sha256:{sha256_file(path)}",
+            message="Validated WRF tropical-cyclone product",
+            metadata=metadata,
+        )
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Report the comparison, histories, diagnostics, and input provenance."""
+
+        if self._finalized:
+            return []
+        self._finalized = True
+        result_path = self.output_dir / RESULT_NAME
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        if (
+            not isinstance(result, dict)
+            or result.get("schema_version") != RESULT_SCHEMA
+        ):
+            raise RuntimeError("WRF result document has the wrong schema")
+        common = {"application": "wrf", "benchmark_case": "tc-surface-exchange"}
+        observations = [
+            self._file(
+                result_path,
+                logical_name="wrf-tropical-cyclone-result",
+                kind="scientific_result",
+                role=ArtifactRole.OUTPUT,
+                media_type="application/json",
+                format_name=RESULT_SCHEMA,
+                metadata={**common, "benchmark_role": "surface_exchange_comparison"},
+                maximum_bytes=1024 * 1024,
+            ),
+            self._file(
+                self.output_dir / "input-provenance.json",
+                logical_name="wrf-tropical-cyclone-input-provenance",
+                kind="provenance",
+                role=ArtifactRole.PROVENANCE,
+                media_type="application/json",
+                format_name="scientific-benchmark-wrf-input-provenance-v1",
+                metadata=common,
+                maximum_bytes=1024 * 1024,
+            ),
+        ]
+        for name, option in FORMULATIONS:
+            case_root = self.output_dir / name
+            outputs = sorted(case_root.glob("wrfout_d01_*"))
+            if len(outputs) != 1:
+                raise RuntimeError(f"WRF {name} history artifact is ambiguous")
+            observations.extend(
+                (
+                    self._file(
+                        outputs[0],
+                        logical_name=f"wrf-{name}-history",
+                        kind="scientific_field",
+                        role=ArtifactRole.OUTPUT,
+                        media_type="application/x-netcdf",
+                        format_name="netcdf",
+                        metadata={**common, "formulation": name, "isftcflx": option},
+                        maximum_bytes=4 * 1024 * 1024 * 1024,
+                    ),
+                    self._file(
+                        case_root / "surface-diagnostics.cdl",
+                        logical_name=f"wrf-{name}-surface-diagnostics",
+                        kind="scientific_result",
+                        role=ArtifactRole.OUTPUT,
+                        media_type="text/plain",
+                        format_name="netcdf-cdl",
+                        metadata={**common, "formulation": name, "isftcflx": option},
+                        maximum_bytes=128 * 1024 * 1024,
+                    ),
+                )
+            )
+        return observations
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Publish study products only after a successful process exit."""
+
+        if return_code != 0:
+            self._finalized = True
+            return []
+        return self.finalize_artifacts()
+
+    def reset_artifacts(self) -> None:
+        """Allow a fresh finalization after a JARVIS stream reset."""
+
+        self._finalized = False
+
+
+def adapter_from_package(
+    package: dict[str, Any],
+) -> WrfTropicalCycloneArtifactAdapter | None:
+    """Create artifact semantics only for the benchmark WRF package."""
+
+    if package.get("pkg_type") != "builtin.wrf" or not package.get("input_bundle"):
+        return None
+    configured = package.get("out")
+    if not isinstance(configured, str) or not configured:
+        raise ValueError("WRF artifact provider requires its output directory")
+    output_dir = Path(configured).resolve(strict=False)
+    shared = package.get("shared_dir")
+    if not isinstance(shared, str) or not shared:
+        raise ValueError("WRF artifact provider requires its shared root")
+    shared_root = Path(shared).resolve(strict=False)
+    if not output_dir.is_relative_to(shared_root):
+        raise ValueError("WRF output directory escaped its shared root")
+    return WrfTropicalCycloneArtifactAdapter(output_dir)

--- a/builtin/builtin/wrf/contract.py
+++ b/builtin/builtin/wrf/contract.py
@@ -1,0 +1,341 @@
+"""Pure input, execution-directory, and result contracts for WRF."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path, PurePosixPath
+
+from jarvis_cd.input_bundle import InputBundleError, MaterializedInputBundle
+
+FORMULATIONS = (("constant-z0q", 1), ("garratt", 2))
+RUN_HOURS = 24
+GRID_POINTS = 121
+HISTORY_INTERVAL_MINUTES = 360
+RESULT_NAME = "wrf-tropical-cyclone-result.json"
+RESULT_SCHEMA = "scientific-benchmark.wrf-tropical-cyclone-result.v1"
+RESULT_PREFIX = "BENCHMARK_WRF_TC "
+EXPECTED_FILES = {"input_sounding", "namelist.input"}
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest of one regular file."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_wrf_bundle(bundle: MaterializedInputBundle) -> None:
+    """Require the closed WRF v4.6.1 tropical-cyclone input pair."""
+
+    observed = {item.path for item in bundle.manifest.files}
+    if observed != EXPECTED_FILES:
+        raise InputBundleError("WRF bundle does not contain the closed input pair")
+    roles = {item.path: item.role for item in bundle.manifest.files}
+    if roles != {
+        "input_sounding": "atmospheric_sounding",
+        "namelist.input": "wrf_namelist",
+    }:
+        raise InputBundleError("WRF input roles are invalid")
+    if bundle.manifest.entrypoint != "namelist.input":
+        raise InputBundleError("WRF bundle entrypoint is not namelist.input")
+
+
+def validate_wrf_prefix(prefix: Path) -> Path:
+    """Require a complete native WRF installation with the ideal TC executables."""
+
+    resolved = prefix.resolve(strict=True)
+    required = (
+        resolved / "main" / "ideal.exe",
+        resolved / "main" / "wrf.exe",
+        resolved / "run",
+    )
+    if not all(path.exists() for path in required):
+        raise ValueError("WRF prefix omitted ideal.exe, wrf.exe, or runtime data")
+    if (
+        not required[0].is_file()
+        or not required[1].is_file()
+        or not required[2].is_dir()
+    ):
+        raise ValueError("WRF prefix has invalid runtime object types")
+    return resolved
+
+
+def resolve_runtime_program(name: str, environment: Mapping[str, str]) -> Path:
+    """Resolve one regular executable from JARVIS' loaded runtime environment."""
+
+    configured_path = environment.get("PATH")
+    candidate = shutil.which(name, path=configured_path)
+    if candidate is None:
+        raise ValueError(f"{name} is unavailable in the loaded runtime")
+    resolved = Path(candidate).resolve(strict=True)
+    if not resolved.is_file():
+        raise ValueError(f"{name} did not resolve to a regular file")
+    return resolved
+
+
+def _safe_execution_id(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or not 1 <= len(value) <= 128
+        or any(
+            character
+            not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+            for character in value
+        )
+    ):
+        raise InputBundleError("JARVIS execution identity is not a safe path token")
+    return value
+
+
+def materialize_run(
+    bundle: MaterializedInputBundle, run_parent: Path, execution_id: object
+) -> Path:
+    """Copy immutable inputs into a new execution-specific directory."""
+
+    validate_wrf_bundle(bundle)
+    token = _safe_execution_id(execution_id)
+    run_parent = run_parent.resolve()
+    run_parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    destination = run_parent / token
+    if destination.exists():
+        raise InputBundleError("WRF execution working directory already exists")
+    temporary = Path(tempfile.mkdtemp(prefix=f".{token}.", dir=run_parent))
+    try:
+        for item in bundle.manifest.files:
+            source = bundle.root / PurePosixPath(item.path)
+            target = temporary / PurePosixPath(item.path)
+            shutil.copyfile(source, target, follow_symlinks=False)
+            os.chmod(target, 0o400)
+        (temporary / "input-provenance.json").write_text(
+            json.dumps(
+                {
+                    "bundle_sha256": bundle.bundle_sha256,
+                    "formulations": [name for name, _value in FORMULATIONS],
+                    "grid_points": [GRID_POINTS, GRID_POINTS],
+                    "run_hours": RUN_HOURS,
+                    "schema_version": "scientific-benchmark.wrf-tropical-cyclone-input.v1",
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(temporary / "input-provenance.json", 0o400)
+        os.replace(temporary, destination)
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    return destination
+
+
+def _replace_assignment(text: str, name: str, value: str) -> str:
+    pattern = rf"(?m)^(\s*{re.escape(name)}\s*=\s*)[^,\n]+(,?)\s*$"
+    updated, count = re.subn(pattern, rf"\g<1>{value}\2", text)
+    if count != 1:
+        raise ValueError(f"WRF namelist assignment is not unique: {name}")
+    return updated
+
+
+def prepare_case(
+    run_root: Path,
+    bundle: MaterializedInputBundle,
+    wrf_prefix: Path,
+    *,
+    name: str,
+    isftcflx: int,
+) -> Path:
+    """Create one bounded WRF case without mutating the installed prefix."""
+
+    if (name, isftcflx) not in FORMULATIONS:
+        raise ValueError("unsupported WRF surface-exchange formulation")
+    prefix = validate_wrf_prefix(wrf_prefix)
+    case_root = run_root / name
+    case_root.mkdir(mode=0o700)
+    for source in sorted((prefix / "run").iterdir(), key=lambda item: item.name):
+        if source.name == "namelist.input" or not source.is_file():
+            continue
+        target = case_root / source.name
+        if os.name == "nt":
+            shutil.copyfile(source, target, follow_symlinks=False)
+        else:
+            target.symlink_to(source)
+    shutil.copyfile(bundle.root / "input_sounding", case_root / "input_sounding")
+    base = (bundle.root / "namelist.input").read_text(encoding="utf-8", errors="strict")
+    replacements = {
+        "run_days": "0",
+        "run_hours": str(RUN_HOURS),
+        "end_day": "2",
+        "end_hour": "0",
+        "history_interval": str(HISTORY_INTERVAL_MINUTES),
+        "e_we": str(GRID_POINTS),
+        "e_sn": str(GRID_POINTS),
+        "isftcflx": str(isftcflx),
+    }
+    for setting, value in replacements.items():
+        base = _replace_assignment(base, setting, value)
+    (case_root / "namelist.input").write_text(base, encoding="utf-8", newline="\n")
+    return case_root
+
+
+def _cdl_variable(text: str, name: str) -> list[float]:
+    match = re.search(rf"(?ms)^\s*{re.escape(name)}\s*=\s*(.*?);\s*$", text)
+    if match is None:
+        raise ValueError(f"WRF diagnostics omitted {name}")
+    tokens = re.split(r"[\s,]+", match.group(1).strip())
+    try:
+        values = [
+            float(token.rstrip("fF")) for token in tokens if token and token != "_"
+        ]
+    except ValueError as error:
+        raise ValueError(f"WRF diagnostics contain malformed {name} values") from error
+    if not values or not all(math.isfinite(value) for value in values):
+        raise ValueError(f"WRF diagnostics contain empty or non-finite {name} values")
+    return values
+
+
+def parse_diagnostics(path: Path) -> dict[str, float | int]:
+    """Extract final-time surface wind and pressure metrics from ncdump CDL."""
+
+    if (
+        path.is_symlink()
+        or not path.is_file()
+        or path.stat().st_size > 128 * 1024 * 1024
+    ):
+        raise ValueError("WRF diagnostic CDL is missing, unsafe, or oversized")
+    text = path.read_text(encoding="utf-8", errors="strict")
+    time_match = re.search(r"Time\s*=\s*UNLIMITED\s*;\s*//\s*\((\d+) currently\)", text)
+    if time_match is None:
+        raise ValueError("WRF diagnostics omitted the Time dimension")
+    time_count = int(time_match.group(1))
+    if time_count < 2:
+        raise ValueError("WRF diagnostics did not cover an evolving forecast")
+    u10 = _cdl_variable(text, "U10")
+    v10 = _cdl_variable(text, "V10")
+    psfc = _cdl_variable(text, "PSFC")
+    if len(u10) != len(v10) or len(u10) != len(psfc) or len(u10) % time_count:
+        raise ValueError("WRF surface fields have inconsistent dimensions")
+    points = len(u10) // time_count
+    final_u = u10[-points:]
+    final_v = v10[-points:]
+    final_p = psfc[-points:]
+    maximum_wind = max(math.hypot(u, v) for u, v in zip(final_u, final_v, strict=True))
+    minimum_pressure_hpa = min(final_p) / 100.0
+    if not 0.0 < maximum_wind < 200.0 or not 700.0 < minimum_pressure_hpa < 1100.0:
+        raise ValueError("WRF final surface metrics are physically implausible")
+    return {
+        "final_maximum_ten_meter_wind_m_s": maximum_wind,
+        "final_minimum_surface_pressure_hpa": minimum_pressure_hpa,
+        "surface_point_count": points,
+        "time_count": time_count,
+    }
+
+
+def build_result(run_root: Path, bundle: MaterializedInputBundle) -> dict[str, object]:
+    """Build the closed comparison document from two completed WRF cases."""
+
+    cases: list[dict[str, object]] = []
+    for name, value in FORMULATIONS:
+        case_root = run_root / name
+        outputs = sorted(case_root.glob("wrfout_d01_*"))
+        if len(outputs) != 1 or outputs[0].is_symlink() or not outputs[0].is_file():
+            raise ValueError(f"WRF {name} did not produce one closed history file")
+        diagnostics = case_root / "surface-diagnostics.cdl"
+        cases.append(
+            {
+                "formulation": name,
+                "isftcflx": value,
+                **parse_diagnostics(diagnostics),
+                "diagnostics_sha256": sha256_file(diagnostics),
+                "history_file": outputs[0].name,
+                "history_sha256": sha256_file(outputs[0]),
+                "namelist_sha256": sha256_file(case_root / "namelist.input"),
+            }
+        )
+    by_name = {str(case["formulation"]): case for case in cases}
+    constant = by_name["constant-z0q"]
+    garratt = by_name["garratt"]
+
+    def metric(case: dict[str, object], name: str) -> float:
+        value = case.get(name)
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            raise ValueError(f"WRF result metric is malformed: {name}")
+        return float(value)
+
+    return {
+        "cases": cases,
+        "comparison": {
+            "garratt_minus_constant_final_maximum_ten_meter_wind_m_s": (
+                metric(garratt, "final_maximum_ten_meter_wind_m_s")
+                - metric(constant, "final_maximum_ten_meter_wind_m_s")
+            ),
+            "garratt_minus_constant_final_minimum_surface_pressure_hpa": (
+                metric(garratt, "final_minimum_surface_pressure_hpa")
+                - metric(constant, "final_minimum_surface_pressure_hpa")
+            ),
+        },
+        "grid_points": [GRID_POINTS, GRID_POINTS],
+        "input_bundle_sha256": bundle.bundle_sha256,
+        "run_hours": RUN_HOURS,
+        "schema_version": RESULT_SCHEMA,
+    }
+
+
+def write_result(
+    run_root: Path, destination: Path, bundle: MaterializedInputBundle
+) -> dict[str, object]:
+    """Validate both cases and atomically write their comparison."""
+
+    document = build_result(run_root, bundle)
+    if destination.exists():
+        raise ValueError("WRF result destination already exists")
+    handle, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.", dir=destination.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8", newline="\n") as stream:
+            json.dump(document, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, destination)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+    return document
+
+
+def validate_result_document(
+    run_root: Path, result_path: Path, bundle: MaterializedInputBundle
+) -> dict[str, object]:
+    """Require the result document to exactly match both WRF products."""
+
+    if result_path.is_symlink() or not result_path.is_file():
+        raise ValueError("WRF result document is missing or unsafe")
+    observed = json.loads(result_path.read_text(encoding="utf-8", errors="strict"))
+    expected = build_result(run_root, bundle)
+    if observed != expected:
+        raise ValueError("WRF result document does not match generated fields")
+    return expected
+
+
+def result_summary_line(document: dict[str, object]) -> str:
+    """Render the closed terminal summary consumed by JARVIS progress."""
+
+    cases = document.get("cases")
+    if not isinstance(cases, list) or len(cases) != len(FORMULATIONS):
+        raise ValueError("WRF result cases are missing")
+    return (
+        f"{RESULT_PREFIX}schema={RESULT_SCHEMA} formulations=constant-z0q,garratt "
+        f"hours={RUN_HOURS} grid={GRID_POINTS}x{GRID_POINTS}"
+    )

--- a/builtin/builtin/wrf/legacy.py
+++ b/builtin/builtin/wrf/legacy.py
@@ -36,6 +36,7 @@ class WrfLegacy(Application):
                 "msg": "The location of wrf.exe",
                 "type": str,
                 "default": None,
+                "required": False,
             },
             {
                 "name": "engine",
@@ -49,6 +50,7 @@ class WrfLegacy(Application):
                 "msg": "Path where the bp5 will be stored",
                 "type": str,
                 "default": None,
+                "required": False,
             },
             {
                 "name": "db_path",

--- a/builtin/builtin/wrf/legacy.py
+++ b/builtin/builtin/wrf/legacy.py
@@ -1,0 +1,119 @@
+"""Legacy WRF launcher retained for compatibility."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
+from jarvis_cd.shell.process import Rm
+
+
+class WrfLegacy(Application):
+    """Run WRF from an operator-provided installation directory."""
+
+    def _init(self) -> None:
+        """Initialize the stateless legacy launcher."""
+
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        """Return the legacy WRF launch controls."""
+
+        return [
+            {
+                "name": "nprocs",
+                "msg": "Number of processes",
+                "type": int,
+                "default": 1,
+            },
+            {
+                "name": "ppn",
+                "msg": "The number of processes per node",
+                "type": int,
+                "default": None,
+            },
+            {
+                "name": "wrf_location",
+                "msg": "The location of wrf.exe",
+                "type": str,
+                "default": None,
+            },
+            {
+                "name": "engine",
+                "msg": "Engine to be used",
+                "choices": ["bp5", "hermes"],
+                "type": str,
+                "default": "bp5",
+            },
+            {
+                "name": "Execution_order",
+                "msg": "Path where the bp5 will be stored",
+                "type": str,
+                "default": None,
+            },
+            {
+                "name": "db_path",
+                "msg": "Path where the DB will be stored",
+                "type": str,
+                "default": "benchmark_metadata.db",
+            },
+        ]
+
+    def _configure(self, **kwargs: Any) -> None:
+        """Persist configuration and install the selected ADIOS2 template."""
+
+        Application._configure(self, **kwargs)
+        config = cast(dict[str, Any], self.config)
+        engine = config.get("engine")
+        wrf_location = config.get("wrf_location")
+        if not isinstance(engine, str):
+            raise ValueError("engine must be a string")
+        if not isinstance(wrf_location, str) or not wrf_location:
+            raise ValueError("wrf_location is required")
+        if engine.lower() == "bp5":
+            self.copy_template_file(
+                f"{self.pkg_dir}/config/adios2.xml",
+                f"{wrf_location}/adios2.xml",
+            )
+            return
+        if engine.lower() in {"hermes", "hermes_derived"}:
+            self.copy_template_file(
+                f"{self.pkg_dir}/config/hermes.xml",
+                f"{wrf_location}/adios2.xml",
+                replacements={
+                    "ppn": config["ppn"],
+                    "db_path": config["db_path"],
+                    "Order": config["Execution_order"],
+                },
+            )
+            return
+        raise ValueError("engine is not supported")
+
+    def start(self) -> None:
+        """Launch wrf.exe under MPI from the configured directory."""
+
+        config = cast(dict[str, Any], self.config)
+        wrf_location = config.get("wrf_location")
+        if not isinstance(wrf_location, str) or not wrf_location:
+            raise ValueError("wrf_location is required")
+        Exec(
+            "wrf.exe",
+            MpiExecInfo(
+                nprocs=config["nprocs"],
+                ppn=config["ppn"],
+                hostfile=self.hostfile,
+                env=self.mod_env,
+                cwd=wrf_location,
+            ),
+        ).run()
+
+    def stop(self) -> None:
+        """Do nothing because the legacy launcher runs to completion."""
+
+    def clean(self) -> None:
+        """Remove the configured legacy metadata database."""
+
+        config = cast(dict[str, Any], self.config)
+        db_path = config.get("db_path")
+        if not isinstance(db_path, str) or not db_path:
+            raise ValueError("db_path is required")
+        Rm([db_path], PsshExecInfo(hostfile=self.hostfile)).run()

--- a/builtin/builtin/wrf/pkg.py
+++ b/builtin/builtin/wrf/pkg.py
@@ -1,129 +1,57 @@
-"""
-This module provides classes and methods to launch the Wrf application.
-Wrf is ....
-"""
-from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo
-from jarvis_cd.shell.process import Rm
+"""Maintained WRF package with legacy and supplied-study profiles."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from builtin.wrf.legacy import WrfLegacy
+from builtin.wrf.tropical_cyclone import WrfTropicalCyclone
 
 
-class Wrf(Application):
-    """
-        This class provides methods to launch the Wrf application.
-        """
+class Wrf(WrfTropicalCyclone, WrfLegacy):
+    """Run either the legacy WRF launcher or a digest-bound TC comparison."""
 
-    def _init(self):
-        """
-        Initialize paths
-        """
-        pass
+    def _init(self) -> None:
+        WrfTropicalCyclone._init(self)
 
-    def _configure_menu(self):
-        """
-        Create a CLI menu for the configurator method.
-        For thorough documentation of these parameters, view:
-        https://github.com/scs-lab/jarvis-util/wiki/3.-Argument-Parsing
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        """Expose one additive menu without duplicate process controls."""
 
-        :return: List(dict)
-        """
-        return [
-            {
-                'name': 'nprocs',
-                'msg': 'Number of processes',
-                'type': int,
-                'default': 1,
-            },
-            {
-                'name': 'ppn',
-                'msg': 'The number of processes per node',
-                'type': int,
-                'default': None,
-            },
-            {
-                'name': 'wrf_location',
-                'msg': 'The location of wrf.exe',
-                'type': str,
-                'default': None,
-            },
-            {
-                'name': 'engine',
-                'msg': 'Engine to be used',
-                'choices': ['bp5', 'hermes'],
-                'type': str,
-                'default': 'bp5',
-            },
-            {
-                'name': 'Execution_order',
-                'msg': 'Path where the bp5 will be stored',
-                'type': str,
-                'default': None,
-            },
-            {
-                'name': 'db_path',
-                'msg': 'Path where the DB will be stored',
-                'type': str,
-                'default': 'benchmark_metadata.db',
-            },
+        merged: list[dict[str, Any]] = []
+        names: set[str] = set()
+        for item in (
+            *WrfTropicalCyclone._configure_menu(self),
+            *WrfLegacy._configure_menu(self),
+        ):
+            name = str(item["name"])
+            if name not in names:
+                merged.append(item)
+                names.add(name)
+        return merged
 
+    def _configure(self, **kwargs: Any) -> None:
+        """Select the supplied-input profile only when a bundle is explicit."""
 
-        ]
+        if kwargs.get("input_bundle") or self.config.get("input_bundle"):
+            WrfTropicalCyclone._configure(self, **kwargs)
+            return
+        WrfLegacy._configure(self, **kwargs)
 
-    def _configure(self, **kwargs):
-        """
-        Converts the Jarvis configuration to application-specific configuration.
-        E.g., OrangeFS produces an orangefs.xml file.
+    def start(self) -> None:
+        """Launch the explicitly configured WRF profile."""
 
-        :param kwargs: Configuration parameters for this pkg.
-        :return: None
-        """
-        if self.config['engine'].lower() == 'bp5':
-            self.copy_template_file(f'{self.pkg_dir}/config/adios2.xml',
-                            f'{self.config["wrf_location"]}/adios2.xml')
-        elif self.config['engine'].lower() in ['hermes', 'hermes_derived']:
-                self.copy_template_file(f'{self.pkg_dir}/config/hermes.xml',
-                        f'{self.config["wrf_location"]}/adios2.xml', replacements={
-                    'ppn': self.config['ppn'],
-                    'db_path': self.config['db_path'],
-                    'Order': self.config['Execution_order'],
-                    })
-        else:
-            raise Exception('Engine not defined')
+        if self.config.get("input_bundle"):
+            WrfTropicalCyclone.start(self)
+            return
+        WrfLegacy.start(self)
 
+    def stop(self) -> None:
+        """Stop the selected profile when it owns a long-running process."""
 
+        WrfLegacy.stop(self)
 
-    def start(self):
-        """
-        Launch an application. E.g., OrangeFS will launch the servers, clients,
-        and metadata services on all necessary pkgs.
+    def clean(self) -> None:
+        """Preserve supplied-study results and apply legacy cleanup semantics."""
 
-        :return: None
-        """
-        Exec('wrf.exe',
-             MpiExecInfo(nprocs=self.config['nprocs'],
-                         ppn=self.config['ppn'],
-                         hostfile=self.hostfile,
-                         env=self.mod_env,
-                         cwd=self.config['wrf_location']
-                         )).run()
-
-        pass
-
-    def stop(self):
-        """
-        Stop a running application. E.g., OrangeFS will terminate the servers,
-        clients, and metadata services.
-
-        :return: None
-        """
-        pass
-
-    def clean(self):
-        """
-        Destroy all data for an application. E.g., OrangeFS will delete all
-        metadata and data directories in addition to the orangefs.xml file.
-
-        :return: None
-        """
-        output_file = [self.config['db_path']]
-        Rm(output_file, PsshExecInfo(hostfile=self.hostfile)).run()
-        pass
+        if not self.config.get("input_bundle"):
+            WrfLegacy.clean(self)

--- a/builtin/builtin/wrf/runtime.py
+++ b/builtin/builtin/wrf/runtime.py
@@ -1,0 +1,60 @@
+"""Process-output bridge for the WRF tropical-cyclone package."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+
+class DeferredRuntimeCallback:
+    """Forward lines while deferring success until the terminal command."""
+
+    def __init__(
+        self,
+        delegate: Callable[[str, str], None] | None,
+        *,
+        terminal: bool,
+    ) -> None:
+        self._delegate = delegate
+        self._terminal = terminal
+
+    def __call__(self, stream_name: str, line: str) -> None:
+        if self._delegate is not None:
+            self._delegate(stream_name, line)
+
+    def finalize_process(self, return_code: int) -> None:
+        if self._delegate is not None and (self._terminal or return_code != 0):
+            finalizer = getattr(self._delegate, "finalize_process", None)
+            if callable(finalizer):
+                finalizer(return_code)
+
+    def reconcile_process_exit(self, return_code: int) -> None:
+        if self._delegate is not None:
+            reconciler = getattr(self._delegate, "reconcile_process_exit", None)
+            if callable(reconciler):
+                reconciler(return_code)
+
+
+def read_wrf_diagnostic(case_root: Path, *, max_bytes: int = 8192) -> str:
+    """Read bounded tails of WRF rank-zero diagnostics from one case directory."""
+
+    if not 1 <= max_bytes <= 16384:
+        raise ValueError("max_bytes must be between 1 and 16384")
+    resolved_root = case_root.resolve(strict=True)
+    names = ("rsl.error.0000", "rsl.out.0000")
+    per_file = max(1, max_bytes // len(names))
+    sections: list[str] = []
+    for name in names:
+        path = resolved_root / name
+        if not path.is_file():
+            continue
+        try:
+            payload = path.read_bytes()
+        except OSError as error:
+            raise RuntimeError(f"failed to read WRF diagnostic: {name}") from error
+        tail = payload[-per_file:].decode("utf-8", errors="replace")
+        sections.append(f"[{name}]\n{tail}")
+    return "\n".join(sections)
+
+
+__all__ = ["DeferredRuntimeCallback", "read_wrf_diagnostic"]

--- a/builtin/builtin/wrf/tropical_cyclone.py
+++ b/builtin/builtin/wrf/tropical_cyclone.py
@@ -1,0 +1,289 @@
+"""Run a bounded WRF tropical-cyclone surface-exchange comparison."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+from typing import Any, cast
+
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    probe_program,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo
+
+from jarvis_cd.input_bundle import extract_input_bundle
+from builtin.wrf.contract import (
+    FORMULATIONS,
+    RESULT_NAME,
+    materialize_run,
+    prepare_case,
+    resolve_runtime_program,
+    result_summary_line,
+    validate_result_document,
+    validate_wrf_bundle,
+    validate_wrf_prefix,
+    write_result,
+)
+from builtin.wrf.runtime import (
+    DeferredRuntimeCallback,
+    read_wrf_diagnostic,
+)
+
+
+class WrfTropicalCyclone(Application):
+    """Compare WRF constant-Z0q and Garratt tropical-cyclone surface exchange."""
+
+    def _init(self) -> None:
+        self._run_dir = None
+
+    def _configure_menu(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "nprocs",
+                "msg": "Number of MPI processes",
+                "type": int,
+                "default": 4,
+            },
+            {
+                "name": "ppn",
+                "msg": "Number of MPI processes per node",
+                "type": int,
+                "default": 4,
+            },
+            {
+                "name": "input_bundle",
+                "msg": "Immutable WRF v4.6.1 ideal tropical-cyclone inputs",
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
+            },
+            {
+                "name": "wrf_prefix",
+                "msg": "Resolved native WRF installation prefix",
+                "type": str,
+                "default": "",
+            },
+        ]
+
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        environment = self._deployment_environment()
+        probe = probe_program("ideal.exe", environment=environment, arguments=())
+        ncdump_probe = probe_program("ncdump", environment=environment, arguments=())
+        capabilities = (
+            ("wrf", "netcdf_tools")
+            if probe.status.usable is True and ncdump_probe.status.usable is True
+            else ()
+        )
+        runtime = RuntimeRequirement(
+            requirement_id="wrf",
+            description="Native WRF 4.6.1 ideal-case runtime and NetCDF tools",
+            required_capabilities=("wrf", "netcdf_tools"),
+            available_capabilities=capabilities,
+            status=probe.status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="spack",
+                    query_kind="spec",
+                    query_value="wrf@4.6.1 compile_type=em_tropical_cyclone",
+                ),
+            ),
+        )
+        return PackageDeploymentContract(
+            package="builtin.wrf",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="supplied_surface_exchange_comparison",
+                    execution_kind="batch",
+                    when=(
+                        ConfigurationCondition("input_bundle", "is_not_empty"),
+                        ConfigurationCondition("wrf_prefix", "is_not_empty"),
+                    ),
+                    runtime_requirements=("wrf",),
+                    readiness=ReadinessContract(
+                        mechanism="process_exit", condition="successful_exit"
+                    ),
+                    description=(
+                        "Initialize and run the same bounded idealized tropical cyclone with "
+                        "constant-Z0q and Garratt surface-exchange formulations."
+                    ),
+                ),
+                ExecutionProfile(
+                    name="legacy_wrf_location",
+                    execution_kind="batch",
+                    when=(
+                        ConfigurationCondition("input_bundle", "is_empty"),
+                        ConfigurationCondition("wrf_location", "is_not_empty"),
+                    ),
+                    runtime_requirements=("wrf",),
+                    readiness=ReadinessContract(
+                        mechanism="process_exit", condition="successful_exit"
+                    ),
+                    description="Run wrf.exe from an operator-provided WRF directory.",
+                ),
+            ),
+            runtime_requirements=(runtime,),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    requires=(ConfigurationCondition("wrf_location", "is_not_empty"),),
+                    description=(
+                        "Without a supplied study bundle, the legacy launcher requires "
+                        "an operator-provided WRF directory."
+                    ),
+                ),
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    requires=(ConfigurationCondition("wrf_prefix", "is_not_empty"),),
+                    description="The comparison requires a resolved native WRF prefix.",
+                ),
+            ),
+        )
+
+    def _configure(self, **kwargs: Any) -> None:
+        Application._configure(self, **kwargs)
+        config = cast(dict[str, Any], self.config)
+        if config.get("deploy_mode", "default") != "default":
+            raise ValueError(
+                "builtin.wrf supplied-input profile supports native execution only"
+            )
+        for parameter in ("nprocs", "ppn"):
+            value = config.get(parameter)
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                raise ValueError(f"{parameter} must be positive")
+        configured = config.get("input_bundle")
+        if not isinstance(configured, str) or not configured:
+            raise ValueError("input_bundle is required")
+        bundle = extract_input_bundle(
+            Path(configured),
+            self.resolve_shared_path("input-bundles", field="input bundle root"),
+        )
+        validate_wrf_bundle(bundle)
+        prefix = config.get("wrf_prefix")
+        if not isinstance(prefix, str) or not prefix:
+            raise ValueError("wrf_prefix is required")
+        validate_wrf_prefix(Path(prefix))
+
+    @staticmethod
+    def _require_success(
+        result: Any,
+        label: str,
+        *,
+        diagnostic_root: Path | None = None,
+    ) -> None:
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            diagnostic = (
+                read_wrf_diagnostic(diagnostic_root)
+                if diagnostic_root is not None
+                else ""
+            )
+            if diagnostic:
+                print(f"WRF_RUNTIME_DIAGNOSTIC\n{diagnostic}", flush=True)
+                bounded = " | ".join(diagnostic.splitlines())[-4096:]
+                raise RuntimeError(f"{label} failed: {failures}; {bounded}")
+            raise RuntimeError(
+                f"{label} failed: {failures}; no WRF rank-zero log was produced"
+            )
+
+    def start(self) -> None:
+        """Initialize, execute, and validate both bounded WRF cases."""
+
+        config = cast(dict[str, Any], self.config)
+        configured = config.get("input_bundle")
+        prefix_setting = config.get("wrf_prefix")
+        if not isinstance(configured, str) or not configured:
+            raise RuntimeError("WRF input bundle was not persisted")
+        if not isinstance(prefix_setting, str) or not prefix_setting:
+            raise RuntimeError("WRF prefix was not persisted")
+        nprocs = config.get("nprocs")
+        ppn = config.get("ppn")
+        if not isinstance(nprocs, int) or isinstance(nprocs, bool) or nprocs <= 0:
+            raise RuntimeError("WRF nprocs was not persisted")
+        if not isinstance(ppn, int) or isinstance(ppn, bool) or ppn <= 0:
+            raise RuntimeError("WRF ppn was not persisted")
+        bundle = extract_input_bundle(
+            Path(configured),
+            self.resolve_shared_path("input-bundles", field="input bundle root"),
+        )
+        prefix = validate_wrf_prefix(Path(prefix_setting))
+        run_dir = materialize_run(
+            bundle,
+            self.resolve_shared_path("runs", field="run root"),
+            self.mod_env.get("JARVIS_EXECUTION_ID"),
+        )
+        self._run_dir = run_dir
+        config["out"] = str(run_dir)
+        delegate = self.runtime_line_callback()
+        preliminary = DeferredRuntimeCallback(delegate, terminal=False)
+        terminal = DeferredRuntimeCallback(delegate, terminal=True)
+        ncdump = resolve_runtime_program("ncdump", self.mod_env)
+        for name, option in FORMULATIONS:
+            case_root = prepare_case(
+                run_dir, bundle, prefix, name=name, isftcflx=option
+            )
+            local_info = LocalExecInfo(
+                env=self.mod_env,
+                cwd=str(case_root),
+                timeout=1800,
+                line_callback=preliminary,
+            )
+            self._require_success(
+                Exec(shlex.quote(str(prefix / "main" / "ideal.exe")), local_info).run(),
+                f"WRF {name} initialization",
+                diagnostic_root=case_root,
+            )
+            mpi_info = MpiExecInfo(
+                nprocs=nprocs,
+                ppn=ppn,
+                hostfile=self.hostfile,
+                env=self.mod_env,
+                cwd=str(case_root),
+                timeout=7200,
+                line_callback=preliminary,
+            )
+            self._require_success(
+                Exec(shlex.quote(str(prefix / "main" / "wrf.exe")), mpi_info).run(),
+                f"WRF {name} forecast",
+                diagnostic_root=case_root,
+            )
+            outputs = sorted(case_root.glob("wrfout_d01_*"))
+            if len(outputs) != 1:
+                raise RuntimeError(f"WRF {name} did not produce one history file")
+            command = (
+                f"{shlex.quote(str(ncdump))} -p 15,7 -v U10,V10,PSFC "
+                f"{shlex.quote(outputs[0].name)} > surface-diagnostics.cdl"
+            )
+            self._require_success(
+                Exec(command, local_info).run(), f"WRF {name} diagnostics"
+            )
+
+        result_path = run_dir / RESULT_NAME
+        document = write_result(run_dir, result_path, bundle)
+        validate_result_document(run_dir, result_path, bundle)
+        final_info = LocalExecInfo(
+            env=self.mod_env, cwd=str(run_dir), timeout=30, line_callback=terminal
+        )
+        self._require_success(
+            Exec(
+                f"printf '%s\\n' {shlex.quote(result_summary_line(document))}",
+                final_info,
+            ).run(),
+            "WRF result finalization",
+        )
+
+    def stop(self) -> None:
+        """Do nothing because the comparison is a bounded batch process."""
+
+    def clean(self) -> None:
+        """Leave immutable inputs and validated outputs for artifact finalization."""

--- a/builtin/builtin/xcompact3d/artifacts.py
+++ b/builtin/builtin/xcompact3d/artifacts.py
@@ -1,0 +1,413 @@
+"""Generated-artifact semantics for the builtin Xcompact3D package."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import posixpath
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactLocation,
+    ArtifactObservation,
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    new_artifact_id,
+)
+from jarvis_cd.artifacts.schema import JsonValue
+from jarvis_cd.input_bundle import extract_input_bundle
+
+_MAX_DISCOVERED_ENTRIES = 4096
+_MAX_REPORTED_MEMBERS = 256
+_MAX_CHECKSUM_BYTES = 64 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class _DiscoveredEntry:
+    """One safe output member below the package-owned result root."""
+
+    relative_path: PurePosixPath
+    is_file: bool
+    is_directory: bool
+    size_bytes: int | None
+
+
+@dataclass
+class Xcompact3dArtifactAdapter:
+    """Discover bounded Xcompact3D logs, checkpoints, fields, and statistics."""
+
+    output_dir: PurePosixPath
+    input_paths: frozenset[PurePosixPath] = frozenset()
+    _finalized: bool = False
+    _collection_artifact_id: str = field(default_factory=new_artifact_id)
+
+    def observe_artifacts(self, text: str) -> list[ArtifactObservation]:
+        """Wait for process completion before inspecting mutable outputs."""
+
+        del text
+        return []
+
+    def finalize_artifacts(self) -> list[ArtifactObservation]:
+        """Report outputs after a successful process completion."""
+
+        return self._finalize(return_code=0)
+
+    def finalize_artifacts_for_exit(
+        self, return_code: int
+    ) -> list[ArtifactObservation]:
+        """Report outputs with the authoritative process completion state."""
+
+        return self._finalize(return_code=return_code)
+
+    def reset_artifacts(self) -> None:
+        """Permit discovery after an execution stream is replaced."""
+
+        self._finalized = False
+
+    def _finalize(self, *, return_code: int) -> list[ArtifactObservation]:
+        if self._finalized:
+            return []
+        self._finalized = True
+        entries, truncated = self._discover_entries()
+        outputs = self._output_entries(entries)
+        if not outputs and not truncated:
+            return []
+        state = (
+            ArtifactState.FINALIZED
+            if return_code == 0 and not truncated
+            else ArtifactState.INCOMPLETE
+        )
+        observations = [
+            self._collection_observation(outputs, state=state, truncated=truncated)
+        ]
+        observations.extend(
+            self._member_observation(entry, entries=outputs, state=state)
+            for entry in outputs
+            if self._is_concrete_product(entry)
+        )
+        return observations
+
+    def _discover_entries(self) -> tuple[list[_DiscoveredEntry], bool]:
+        """Walk the owned output tree without following links and with a bound."""
+
+        root = self._local_output_path()
+        if not root.exists():
+            return [], False
+        if root.is_symlink() or not root.is_dir():
+            raise RuntimeError(
+                f"Xcompact3D output root is not a real directory: {root}"
+            )
+        discovered: list[_DiscoveredEntry] = []
+        truncated = False
+        try:
+            for current, directory_names, file_names in os.walk(
+                root, topdown=True, followlinks=False
+            ):
+                current_path = Path(current)
+                safe_directories: list[str] = []
+                for name in sorted(directory_names):
+                    path = current_path / name
+                    if path.is_symlink():
+                        continue
+                    if len(discovered) >= _MAX_DISCOVERED_ENTRIES:
+                        truncated = True
+                        break
+                    discovered.append(
+                        _DiscoveredEntry(
+                            PurePosixPath(path.relative_to(root).as_posix()),
+                            False,
+                            True,
+                            None,
+                        )
+                    )
+                    safe_directories.append(name)
+                directory_names[:] = [] if truncated else safe_directories
+                if truncated:
+                    break
+                for name in sorted(file_names):
+                    path = current_path / name
+                    if path.is_symlink() or not path.is_file():
+                        continue
+                    if len(discovered) >= _MAX_DISCOVERED_ENTRIES:
+                        truncated = True
+                        break
+                    discovered.append(
+                        _DiscoveredEntry(
+                            PurePosixPath(path.relative_to(root).as_posix()),
+                            True,
+                            False,
+                            path.stat().st_size,
+                        )
+                    )
+                if truncated:
+                    break
+        except OSError as exc:
+            raise RuntimeError(
+                f"cannot inspect Xcompact3D output directory {root}: {exc}"
+            ) from exc
+        return discovered, truncated
+
+    def _local_output_path(self) -> Path:
+        """Project the declared cluster path into the current host filesystem."""
+
+        return Path(self.output_dir.as_posix())
+
+    def _output_entries(
+        self, entries: list[_DiscoveredEntry]
+    ) -> list[_DiscoveredEntry]:
+        """Exclude exact inputs and directories that contain only staged inputs."""
+
+        files = [
+            entry
+            for entry in entries
+            if entry.is_file and entry.relative_path not in self.input_paths
+        ]
+        retained_paths = {entry.relative_path for entry in files}
+        directories = [
+            entry
+            for entry in entries
+            if entry.is_directory
+            and any(
+                candidate != entry.relative_path
+                and candidate.is_relative_to(entry.relative_path)
+                for candidate in retained_paths
+            )
+        ]
+        selected = {entry.relative_path: entry for entry in files}
+        selected.update({entry.relative_path: entry for entry in directories})
+        return [selected[path] for path in sorted(selected)]
+
+    @staticmethod
+    def _is_concrete_product(entry: _DiscoveredEntry) -> bool:
+        """Recognize stable, high-confidence Xcompact3D products."""
+
+        name = entry.relative_path.name.casefold()
+        if entry.is_directory:
+            return name in {"data", "statistics"} or name.endswith(".bp")
+        return name in {"checkpoint", "restart.info", "xcompact3d.log"}
+
+    def _collection_observation(
+        self,
+        outputs: list[_DiscoveredEntry],
+        *,
+        state: ArtifactState,
+        truncated: bool,
+    ) -> ArtifactObservation:
+        """Describe the bounded package-owned result tree."""
+
+        names: list[JsonValue] = [
+            entry.relative_path.as_posix() for entry in outputs[:_MAX_REPORTED_MEMBERS]
+        ]
+        size_bytes = sum(entry.size_bytes or 0 for entry in outputs if entry.is_file)
+        return ArtifactObservation(
+            artifact_id=self._collection_artifact_id,
+            logical_name="xcompact3d-results",
+            kind="scientific_dataset",
+            role=ArtifactRole.OUTPUT,
+            structure=ArtifactStructure.COLLECTION,
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(self.output_dir),
+            format="xcompact3d-output-tree",
+            size_bytes=size_bytes,
+            message=(
+                "Xcompact3D output discovery reached its safety bound"
+                if truncated
+                else "Xcompact3D output tree finalized"
+            ),
+            metadata={
+                "application": "xcompact3d",
+                "completion_signal": "process_exit",
+                "discovery_truncated": truncated,
+                "member_count_observed": len(outputs),
+                "member_names": names,
+                "member_names_truncated": len(outputs) > len(names),
+            },
+        )
+
+    def _member_observation(
+        self,
+        entry: _DiscoveredEntry,
+        *,
+        entries: list[_DiscoveredEntry],
+        state: ArtifactState,
+    ) -> ArtifactObservation:
+        """Describe one solver log, checkpoint, field, or statistics product."""
+
+        name = entry.relative_path.name.casefold()
+        logical_name, kind, format_name, media_type = _product_identity(name)
+        size_bytes = entry.size_bytes
+        if entry.is_directory:
+            size_bytes = sum(
+                item.size_bytes or 0
+                for item in entries
+                if item.is_file
+                and item.relative_path.is_relative_to(entry.relative_path)
+            )
+        return ArtifactObservation(
+            logical_name=logical_name,
+            kind=kind,
+            role=ArtifactRole.OUTPUT,
+            structure=(
+                ArtifactStructure.FILE
+                if entry.is_file
+                else ArtifactStructure.COLLECTION
+            ),
+            ownership=ArtifactOwnership.SHARED,
+            state=state,
+            location=ArtifactLocation.cluster_path(
+                self.output_dir / entry.relative_path
+            ),
+            media_type=media_type,
+            format=format_name,
+            size_bytes=size_bytes,
+            checksum=self._checksum(entry),
+            message="Xcompact3D product finalized",
+            metadata={"application": "xcompact3d"},
+        )
+
+    def _checksum(self, entry: _DiscoveredEntry) -> str | None:
+        """Hash bounded files while avoiding unbounded finalization work."""
+
+        if (
+            not entry.is_file
+            or entry.size_bytes is None
+            or entry.size_bytes > _MAX_CHECKSUM_BYTES
+        ):
+            return None
+        path = self._local_output_path() / entry.relative_path
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                digest.update(chunk)
+        return f"sha256:{digest.hexdigest()}"
+
+
+def adapter_from_package(package: dict[str, Any]) -> Xcompact3dArtifactAdapter | None:
+    """Create artifact semantics for the builtin Xcompact3D package."""
+
+    if package.get("pkg_type") != "builtin.xcompact3d":
+        return None
+    output_dir = _configured_output_dir(
+        package.get("out"),
+        shared_dir=package.get("shared_dir"),
+        runtime_cwd=package.get("runtime_cwd"),
+    )
+    deploy_mode = str(package.get("effective_deploy_mode") or "default").casefold()
+    if deploy_mode == "container":
+        roots = tuple(
+            root
+            for root in (
+                _optional_absolute_path(package.get("shared_dir")),
+                _optional_absolute_path(package.get("private_dir")),
+            )
+            if root is not None
+        )
+        if not any(output_dir.is_relative_to(root) for root in roots):
+            return None
+    input_paths: set[PurePosixPath] = set()
+    input_bundle = package.get("input_bundle")
+    if isinstance(input_bundle, str) and input_bundle:
+        shared_dir = _optional_absolute_path(package.get("shared_dir"))
+        if shared_dir is None:
+            raise ValueError("Xcompact3D input-bundle artifacts require shared_dir")
+        materialized = extract_input_bundle(
+            input_bundle, Path(shared_dir.as_posix()) / "input-bundles"
+        )
+        input_paths.update(
+            PurePosixPath(item.path) for item in materialized.manifest.files
+        )
+    configured_input = package.get("inputs")
+    if isinstance(configured_input, str) and configured_input:
+        input_paths.add(PurePosixPath(Path(configured_input).name))
+    return Xcompact3dArtifactAdapter(output_dir, frozenset(input_paths))
+
+
+def _configured_output_dir(
+    value: object,
+    *,
+    shared_dir: object,
+    runtime_cwd: object,
+) -> PurePosixPath:
+    """Resolve the normalized absolute output directory used by the package."""
+
+    raw = "run" if value in (None, "") else value
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("Xcompact3D artifacts require a printable output path")
+    path = PurePosixPath(raw)
+    if not path.is_absolute():
+        base = _optional_absolute_path(shared_dir)
+        if base is None:
+            base = _optional_absolute_path(runtime_cwd)
+        if base is None:
+            raise ValueError(
+                "relative Xcompact3D artifact output requires shared_dir or runtime_cwd"
+            )
+        path = base / path
+    normalized = PurePosixPath(posixpath.normpath(path.as_posix()))
+    if not normalized.is_absolute() or ".." in normalized.parts:
+        raise ValueError(
+            "Xcompact3D artifacts require a normalized absolute output path"
+        )
+    return normalized
+
+
+def _optional_absolute_path(value: object) -> PurePosixPath | None:
+    """Return a normalized absolute POSIX path when one is available."""
+
+    if not isinstance(value, str) or not value:
+        return None
+    path = PurePosixPath(value)
+    if not path.is_absolute() or ".." in path.parts:
+        return None
+    return path
+
+
+def _product_identity(name: str) -> tuple[str, str, str, str | None]:
+    """Return the stable artifact identity for a recognized product name."""
+
+    if name == "xcompact3d.log":
+        return (
+            "xcompact3d-log",
+            "scientific_log",
+            "xcompact3d-runtime-log",
+            "text/plain",
+        )
+    if name == "checkpoint":
+        return (
+            "xcompact3d-checkpoint",
+            "checkpoint",
+            "xcompact3d-checkpoint",
+            "application/octet-stream",
+        )
+    if name == "restart.info":
+        return (
+            "xcompact3d-restart-info",
+            "checkpoint_metadata",
+            "xcompact3d-restart-info",
+            "text/plain",
+        )
+    if name == "data":
+        return (
+            "xcompact3d-data",
+            "scientific_dataset",
+            "xcompact3d-field-output",
+            "application/x-xcompact3d-fields",
+        )
+    if name == "statistics":
+        return (
+            "xcompact3d-statistics",
+            "scientific_dataset",
+            "xcompact3d-statistics",
+            "application/x-xcompact3d-statistics",
+        )
+    return (
+        "xcompact3d-adios2",
+        "scientific_dataset",
+        "adios2-bp",
+        "application/x-adios2",
+    )

--- a/builtin/builtin/xcompact3d/artifacts.py
+++ b/builtin/builtin/xcompact3d/artifacts.py
@@ -24,6 +24,7 @@ from jarvis_cd.input_bundle import extract_input_bundle
 _MAX_DISCOVERED_ENTRIES = 4096
 _MAX_REPORTED_MEMBERS = 256
 _MAX_CHECKSUM_BYTES = 64 * 1024 * 1024
+_RUNTIME_INPUT_NAME = "jarvis-input.i3d"
 
 
 @dataclass(frozen=True, slots=True)
@@ -321,9 +322,19 @@ def adapter_from_package(package: dict[str, Any]) -> Xcompact3dArtifactAdapter |
         input_paths.update(
             PurePosixPath(item.path) for item in materialized.manifest.files
         )
+        requested = package.get("input_path")
+        selected = (
+            PurePosixPath(requested)
+            if isinstance(requested, str) and requested
+            else PurePosixPath(
+                materialized.entrypoint.relative_to(materialized.root).as_posix()
+            )
+        )
+        input_paths.add(selected.parent / _RUNTIME_INPUT_NAME)
     configured_input = package.get("inputs")
     if isinstance(configured_input, str) and configured_input:
         input_paths.add(PurePosixPath(Path(configured_input).name))
+        input_paths.add(PurePosixPath(_RUNTIME_INPUT_NAME))
     return Xcompact3dArtifactAdapter(output_dir, frozenset(input_paths))
 
 

--- a/builtin/builtin/xcompact3d/pkg.py
+++ b/builtin/builtin/xcompact3d/pkg.py
@@ -30,6 +30,7 @@ from jarvis_cd.shell.process import Mkdir, Rm
 
 _EXECUTABLE_CANDIDATES = ("xcompact3d", "incompact3d")
 _MAX_INPUT_BYTES = 64 * 1024 * 1024
+_RUNTIME_INPUT_NAME = "jarvis-input.i3d"
 
 
 class Xcompact3d(Application):
@@ -337,12 +338,25 @@ class Xcompact3d(Application):
             relative = selected.relative_to(bundle.root)
             stage_input_bundle(bundle, output_dir)
             staged = output_dir / relative
-            return staged, staged.parent
+            return self._stage_runtime_input(staged), staged.parent
 
         configured_input = self.config.get("inputs")
         assert isinstance(configured_input, str) and configured_input
         staged = self._stage_single_input(configured_input, output_dir)
-        return staged, output_dir
+        return self._stage_runtime_input(staged), output_dir
+
+    @staticmethod
+    def _stage_runtime_input(selected: Path) -> Path:
+        """Copy the selected input to a short, reserved solver argument."""
+
+        launch_input = selected.parent / _RUNTIME_INPUT_NAME
+        if launch_input == selected:
+            return selected
+        if launch_input.exists() or launch_input.is_symlink():
+            raise ValueError("Xcompact3D runtime input alias already exists")
+        shutil.copyfile(selected, launch_input, follow_symlinks=False)
+        os.chmod(launch_input, 0o600)
+        return launch_input
 
     def start(self) -> None:
         """Launch Xcompact3D and fail the pipeline on any rank failure."""
@@ -363,10 +377,11 @@ class Xcompact3d(Application):
                 raise RuntimeError("Xcompact3D executable is unavailable through PATH")
             exec_kwargs = {}
         log_path = cwd / "xcompact3d.log"
+        input_argument = input_path.name
         command = " ".join(
             (
                 shlex.quote(executable),
-                shlex.quote(str(input_path)),
+                shlex.quote(input_argument),
                 ">",
                 shlex.quote(str(log_path)),
                 "2>&1",

--- a/builtin/builtin/xcompact3d/pkg.py
+++ b/builtin/builtin/xcompact3d/pkg.py
@@ -1,144 +1,409 @@
-"""
-This module provides classes and methods to launch the Xcompact3d application.
-Xcompact3d (Incompact3d) is a high-order finite-difference flow solver for
-DNS and LES of incompressible turbulent flows.
-"""
+"""Launch native or containerized Xcompact3D simulations."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+from pathlib import Path, PurePosixPath
+from typing import Any
+
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo, LocalExecInfo
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ConfigurationInputBinding,
+    ConfigurationRule,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
+from jarvis_cd.input_bundle import (
+    MaterializedInputBundle,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+from jarvis_cd.shell import Exec, LocalExecInfo, MpiExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Mkdir, Rm
+
+_EXECUTABLE_CANDIDATES = ("xcompact3d", "incompact3d")
+_MAX_INPUT_BYTES = 64 * 1024 * 1024
 
 
 class Xcompact3d(Application):
+    """Run one caller-defined Xcompact3D simulation.
+
+    JARVIS copies a single input or a digest-verified multi-file input bundle
+    into package-owned storage, launches the selected input under MPI, records
+    the solver stream in that workspace, and exposes typed output artifacts.
+    Scientific study composition remains a pipeline or benchmark concern.
     """
-    Xcompact3d container package supporting both default (bare-metal) and
-    container deployment.
 
-    Set deploy_mode='container' to build and run Xcompact3d inside a
-    Docker/Podman/Apptainer container with ADIOS2 and 2DECOMP&FFT.
-    Set deploy_mode='default' to use a system-installed xcompact3d via MPI.
-    """
+    def _init(self) -> None:
+        self.xcompact3d_bin: str | None = None
 
-    def _init(self):
-        pass
-
-    def _configure_menu(self):
+    def _configure_menu(self) -> list[dict[str, Any]]:
         return [
             {
-                'name': 'nprocs',
-                'msg': 'Number of MPI processes',
-                'type': int,
-                'default': 4,
+                "name": "nprocs",
+                "msg": "Number of MPI processes",
+                "type": int,
+                "default": 4,
             },
             {
-                'name': 'ppn',
-                'msg': 'Processes per node',
-                'type': int,
-                'default': 4,
+                "name": "ppn",
+                "msg": "MPI processes per node",
+                "type": int,
+                "default": 4,
             },
             {
-                'name': 'case',
-                'msg': 'Xcompact3d test case (e.g., TGV, Channel-Flow)',
-                'type': str,
-                'default': 'TGV',
+                "name": "inputs",
+                "msg": (
+                    "Single Xcompact3D .i3d input file. JARVIS copies it into "
+                    "the execution-owned output directory before launch."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                'name': 'out',
-                'msg': 'Output directory for results',
-                'type': str,
-                'default': '/tmp/xcompact3d_out',
+                "name": "input_bundle",
+                "msg": (
+                    "Digest-verified multi-file JARVIS package input bundle. "
+                    "All manifest files are staged into the execution-owned "
+                    "output directory."
+                ),
+                "type": str,
+                "default": "",
+                "input_binding": ConfigurationInputBinding(
+                    kind="local_file", structure="regular_file"
+                ).to_dict(),
             },
             {
-                'name': 'base_image',
-                'msg': 'Base Docker image for build container',
-                'type': str,
-                'default': 'ubuntu:24.04',
+                "name": "input_path",
+                "msg": (
+                    "Relative manifest member to execute from input_bundle; "
+                    "empty selects the manifest entrypoint"
+                ),
+                "type": str,
+                "default": "",
+            },
+            {
+                "name": "out",
+                "msg": (
+                    "Output directory. Relative paths resolve under the JARVIS "
+                    "package shared directory."
+                ),
+                "type": str,
+                "default": "run",
+            },
+            {
+                "name": "base_image",
+                "msg": "Base image for a package-owned container build",
+                "type": str,
+                "default": "ubuntu:24.04",
             },
         ]
 
-    # ------------------------------------------------------------------
-    # Container Dockerfile generators
-    # ------------------------------------------------------------------
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe Xcompact3D runtime, input, and completion semantics."""
 
-    def _build_phase(self):
-        if self.config.get('deploy_mode') != 'container':
-            return None
-        base = self.config.get('base_image', 'ubuntu:24.04')
-        content = self._read_build_script('build.sh', {
-            'BASE_IMAGE': base,
-        })
-        return content, 'adios2'
-
-    def _build_deploy_phase(self):
-        if self.config.get('deploy_mode') != 'container':
-            return None
-        content = self._read_dockerfile('Dockerfile.deploy', {
-            'BUILD_IMAGE': self.build_image_name(),
-            'DEPLOY_BASE': 'ubuntu:24.04',
-        })
-        return content, 'adios2'
-
-    # ------------------------------------------------------------------
-    # Configuration
-    # ------------------------------------------------------------------
-
-    def _configure(self, **kwargs):
-        """
-        Configure Xcompact3d.
-
-        Calls super()._configure() which updates self.config and (when
-        deploy_mode == 'container') triggers build_phase / build_deploy_phase.
-
-        In default mode, also creates the output directory on all nodes.
-        """
-        super()._configure(**kwargs)
-
-        if self.config.get('deploy_mode') == 'default':
-            if self.config['out']:
-                Mkdir(self.config['out'],
-                      PsshExecInfo(hostfile=self.hostfile,
-                                   env=self.env)).run()
-
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
-
-    def start(self):
-        """
-        Launch Xcompact3d.
-
-        In container mode, runs xcompact3d via MPI inside the deploy
-        container. In default mode, runs xcompact3d from PATH.
-        """
-        if self.config.get('deploy_mode') == 'container':
-            cmd = 'xcompact3d'
-
-            Exec(cmd, MpiExecInfo(
-                nprocs=self.config['nprocs'],
-                ppn=self.config['ppn'],
-                hostfile=self.hostfile,
-                port=self.ssh_port,
-                container=self._container_engine,
-                container_image=self.deploy_image_name(),
-                shared_dir=self.shared_dir,
-                private_dir=self.private_dir,
-                env=self.mod_env,
-            )).run()
+        if self.config.get("deploy_mode") == "container":
+            status = RuntimeStatus("unknown", "container_runtime_not_probed")
+            capabilities: tuple[str, ...] = ()
         else:
-            cmd = 'xcompact3d'
-            Exec(cmd, MpiExecInfo(
-                nprocs=self.config['nprocs'],
-                ppn=self.config['ppn'],
+            program = self._discover_executable(self._deployment_environment())
+            if program is None:
+                status = RuntimeStatus("unavailable", "software_not_found")
+                capabilities = ()
+            else:
+                probe = probe_program(
+                    program,
+                    environment=self._deployment_environment(),
+                    arguments=("--version",),
+                    accepted_return_codes=(0, 1, 2),
+                    timeout_seconds=5,
+                )
+                status = probe.status
+                capabilities = (
+                    ("mpi_execution", "incompressible_flow", "xcompact3d")
+                    if status.usable is True
+                    else ()
+                )
+        runtime = RuntimeRequirement(
+            requirement_id="xcompact3d",
+            description="MPI-enabled Xcompact3D runtime available through PATH",
+            required_capabilities=(
+                "mpi_execution",
+                "incompressible_flow",
+                "xcompact3d",
+            ),
+            available_capabilities=capabilities,
+            status=status,
+        )
+        completed = ReadinessContract(
+            mechanism="process_exit", condition="successful_exit"
+        )
+        return PackageDeploymentContract(
+            package="builtin.xcompact3d",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="input_file",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("inputs", "is_not_empty"),),
+                    runtime_requirements=("xcompact3d",),
+                    readiness=completed,
+                    description=(
+                        "Run one caller-supplied Xcompact3D input copied into an "
+                        "execution-owned working directory."
+                    ),
+                ),
+                ExecutionProfile(
+                    name="input_bundle",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("input_bundle", "is_not_empty"),),
+                    runtime_requirements=("xcompact3d",),
+                    readiness=completed,
+                    description=(
+                        "Run one selected input from a digest-verified multi-file "
+                        "bundle in an execution-owned working directory."
+                    ),
+                ),
+            ),
+            runtime_requirements=(runtime,),
+            configuration_rules=(
+                ConfigurationRule(
+                    when=(ConfigurationCondition("input_bundle", "is_empty"),),
+                    requires=(ConfigurationCondition("input_path", "is_empty"),),
+                    description="input_path is valid only with input_bundle.",
+                ),
+            ),
+        )
+
+    def _build_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
+            return None
+        base = self.config.get("base_image", "ubuntu:24.04")
+        content = self._read_build_script("build.sh", {"BASE_IMAGE": base})
+        return content, "adios2"
+
+    def _build_deploy_phase(self) -> tuple[str, str] | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if self.config.get("deploy_mode") != "container":
+            return None
+        content = self._read_dockerfile(
+            "Dockerfile.deploy",
+            {
+                "BUILD_IMAGE": self.build_image_name(),
+                "DEPLOY_BASE": "ubuntu:24.04",
+            },
+        )
+        return content, "adios2"
+
+    def _configure(self, **kwargs: Any) -> None:
+        """Validate the selected input profile and prepare owned output."""
+
+        super()._configure(**kwargs)
+        self._validate_configuration()
+        if self.config.get("deploy_mode") == "default":
+            self.xcompact3d_bin = self._discover_executable(
+                self._deployment_environment()
+            )
+            self._ensure_output_dir()
+
+    def _validate_configuration(self) -> None:
+        """Reject absent, ambiguous, or malformed input and MPI settings."""
+
+        for name in ("nprocs", "ppn"):
+            value = self.config.get(name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        inputs = self.config.get("inputs")
+        bundle = self.config.get("input_bundle")
+        if inputs not in (None, "") and bundle not in (None, ""):
+            raise ValueError("inputs and input_bundle cannot be combined")
+        for name, value in (("inputs", inputs), ("input_bundle", bundle)):
+            if value not in (None, "") and not isinstance(value, str):
+                raise TypeError(f"{name} must be a path string")
+        if inputs in (None, "") and bundle in (None, ""):
+            raise ValueError("Xcompact3D requires inputs or input_bundle")
+        input_path = self.config.get("input_path")
+        if input_path not in (None, "") and not isinstance(input_path, str):
+            raise TypeError("input_path must be a relative path string")
+        if bundle in (None, "") and input_path not in (None, ""):
+            raise ValueError("input_path requires input_bundle")
+
+    @staticmethod
+    def _discover_executable(environment: dict[str, str]) -> str | None:
+        """Return the first supported executable available through PATH."""
+
+        for candidate in _EXECUTABLE_CANDIDATES:
+            if shutil.which(candidate, path=environment.get("PATH")) is not None:
+                return candidate
+        return None
+
+    def _output_dir(self) -> Path:
+        """Return the normalized package-owned output root."""
+
+        return self.resolve_shared_path(
+            self.config.get("out"), field="out", default="run"
+        )
+
+    def _node_exec_info(self, **kwargs: Any) -> LocalExecInfo | PsshExecInfo:
+        """Return local or parallel-SSH execution according to the hostfile."""
+
+        hostfile = self.hostfile
+        if hostfile is None or hostfile.is_local():
+            return LocalExecInfo(**kwargs)
+        return PsshExecInfo(hostfile=hostfile, **kwargs)
+
+    def _ensure_output_dir(self) -> None:
+        """Create the exact output root on every participating host."""
+
+        output_dir = str(self._output_dir())
+        result = Mkdir(output_dir, self._node_exec_info(env=self.env)).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to create Xcompact3D output directory {output_dir}: {failures}"
+            )
+
+    @staticmethod
+    def _resolve_bundle_input(
+        bundle: MaterializedInputBundle, requested: object
+    ) -> Path:
+        """Resolve one manifest-declared input without path inference."""
+
+        if requested in (None, ""):
+            return bundle.entrypoint
+        if not isinstance(requested, str) or "\\" in requested:
+            raise ValueError("input_path must be a confined manifest path")
+        relative = PurePosixPath(requested)
+        if relative.is_absolute() or any(
+            part in {"", ".", ".."} for part in relative.parts
+        ):
+            raise ValueError("input_path must be a confined manifest path")
+        declared = {item.path for item in bundle.manifest.files}
+        normalized = relative.as_posix()
+        if normalized not in declared:
+            raise ValueError("input_path is not declared by the input bundle")
+        selected = bundle.root / relative
+        if selected.is_symlink() or not selected.is_file():
+            raise ValueError("input_path is not a verified regular file")
+        return selected
+
+    def _stage_single_input(self, configured: str, output_dir: Path) -> Path:
+        """Copy one bounded regular input into package-owned storage."""
+
+        source = Path(
+            os.path.abspath(os.path.expandvars(os.path.expanduser(configured)))
+        )
+        try:
+            status = source.lstat()
+        except OSError as exc:
+            raise ValueError("inputs is not a readable regular file") from exc
+        if (
+            source.is_symlink()
+            or not source.is_file()
+            or status.st_size <= 0
+            or status.st_size > _MAX_INPUT_BYTES
+        ):
+            raise ValueError("inputs is not a bounded regular file")
+        destination = output_dir / source.name
+        if destination.exists() or destination.is_symlink():
+            raise ValueError("Xcompact3D staged input already exists")
+        shutil.copyfile(source, destination)
+        os.chmod(destination, 0o600)
+        return destination
+
+    def _prepare_input(self) -> tuple[Path, Path]:
+        """Materialize the selected input and return its path and working directory."""
+
+        self._validate_configuration()
+        self._ensure_output_dir()
+        output_dir = self._output_dir()
+        configured_bundle = self.config.get("input_bundle")
+        if configured_bundle not in (None, ""):
+            assert isinstance(configured_bundle, str)
+            if self.shared_dir is None:
+                raise RuntimeError("Xcompact3D input bundles require shared storage")
+            bundle = extract_input_bundle(
+                configured_bundle, Path(self.shared_dir) / "input-bundles"
+            )
+            selected = self._resolve_bundle_input(bundle, self.config.get("input_path"))
+            relative = selected.relative_to(bundle.root)
+            stage_input_bundle(bundle, output_dir)
+            staged = output_dir / relative
+            return staged, staged.parent
+
+        configured_input = self.config.get("inputs")
+        assert isinstance(configured_input, str) and configured_input
+        staged = self._stage_single_input(configured_input, output_dir)
+        return staged, output_dir
+
+    def start(self) -> None:
+        """Launch Xcompact3D and fail the pipeline on any rank failure."""
+
+        input_path, cwd = self._prepare_input()
+        if self.config.get("deploy_mode") == "container":
+            executable = "xcompact3d"
+            exec_kwargs: dict[str, Any] = {
+                "port": self.ssh_port,
+                "container": self._container_engine,
+                "container_image": self.deploy_image_name(),
+                "shared_dir": self.shared_dir,
+                "private_dir": self.private_dir,
+            }
+        else:
+            executable = self.xcompact3d_bin or self._discover_executable(self.mod_env)
+            if executable is None:
+                raise RuntimeError("Xcompact3D executable is unavailable through PATH")
+            exec_kwargs = {}
+        log_path = cwd / "xcompact3d.log"
+        command = " ".join(
+            (
+                shlex.quote(executable),
+                shlex.quote(str(input_path)),
+                ">",
+                shlex.quote(str(log_path)),
+                "2>&1",
+            )
+        )
+        result = Exec(
+            command,
+            MpiExecInfo(
+                nprocs=self.config["nprocs"],
+                ppn=self.config["ppn"],
                 hostfile=self.hostfile,
                 env=self.mod_env,
-                cwd=self.config.get('out'),
-            )).run()
+                cwd=str(cwd),
+                line_callback=self.runtime_line_callback(),
+                **exec_kwargs,
+            ),
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"Xcompact3D execution failed: {failures}")
 
-    def stop(self):
-        """Stop Xcompact3d (no-op -- runs to completion)."""
-        pass
+    def stop(self) -> None:
+        """Do nothing because Xcompact3D runs to process completion."""
 
-    def clean(self):
-        """Remove Xcompact3d output directory."""
-        if self.config['out']:
-            Rm(self.config['out'] + '*',
-               PsshExecInfo(hostfile=self.hostfile, env=self.env)).run()
+    def clean(self) -> None:
+        """Remove only the exact configured Xcompact3D output directory."""
+
+        output_dir = self._output_dir()
+        if output_dir == Path(output_dir.anchor):
+            raise ValueError("refusing to clean a filesystem root as Xcompact3D output")
+        result = Rm(
+            str(output_dir),
+            self._node_exec_info(env=self.env),
+            recursive=True,
+        ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(
+                f"Failed to clean Xcompact3D output {output_dir}: {failures}"
+            )

--- a/builtin/pipelines/examples/xcompact3d_container_test.yaml
+++ b/builtin/pipelines/examples/xcompact3d_container_test.yaml
@@ -21,5 +21,9 @@ pkgs:
     pkg_name: xcompact3d_container
     nprocs: 2
     ppn: 2
-    case: TGV
-    out: /tmp/xcompact3d_out
+    # Replace this path with a jarvis.package-input-bundle.v1 archive that is
+    # visible to JARVIS. The bundle should include the selected .i3d file and
+    # support resources such as adios2_config.xml.
+    input_bundle: /path/to/xcompact3d-inputs.tar
+    input_path: channel/input_test_x.i3d
+    out: run

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Jarvis-CD is a unified platform for deploying scientific applications, storage s
 ## Reference
 
 - [Package Deployment Contracts](package-deployment.md) - Versioned execution, runtime resolution, configuration, and readiness metadata
+- [Package Input Bundles](input-bundles.md) - Digest-verified multi-file application inputs and mutable run staging
 - [Pipeline Configuration](pipelines.md) — Full YAML format, install managers (container/spack), environment management, multi-node, devcontainers
 - [Package Development Guide](package_dev_guide.md) — Create new packages, Dockerfile templates, container and spack support
 - [Pipeline Tests](pipeline_tests.md) — Automated testing with grid search and parameter sweeps

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Jarvis-CD is a unified platform for deploying scientific applications, storage s
 
 - [Package Deployment Contracts](package-deployment.md) - Versioned execution, runtime resolution, configuration, and readiness metadata
 - [Package Input Bundles](input-bundles.md) - Digest-verified multi-file application inputs and mutable run staging
+- [WarpX Package](warpx.md) - Execution-owned inputs, runtime controls, and output artifacts
 - [Pipeline Configuration](pipelines.md) — Full YAML format, install managers (container/spack), environment management, multi-node, devcontainers
 - [Package Development Guide](package_dev_guide.md) — Create new packages, Dockerfile templates, container and spack support
 - [Pipeline Tests](pipeline_tests.md) — Automated testing with grid search and parameter sweeps

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Jarvis-CD is a unified platform for deploying scientific applications, storage s
 - [Package Deployment Contracts](package-deployment.md) - Versioned execution, runtime resolution, configuration, and readiness metadata
 - [Package Input Bundles](input-bundles.md) - Digest-verified multi-file application inputs and mutable run staging
 - [WarpX Package](warpx.md) - Execution-owned inputs, runtime controls, and output artifacts
+- [Xcompact3D Package](xcompact3d.md) - Verified multi-file inputs, MPI execution, and output artifacts
 - [Pipeline Configuration](pipelines.md) — Full YAML format, install managers (container/spack), environment management, multi-node, devcontainers
 - [Package Development Guide](package_dev_guide.md) — Create new packages, Dockerfile templates, container and spack support
 - [Pipeline Tests](pipeline_tests.md) — Automated testing with grid search and parameter sweeps

--- a/docs/executions.md
+++ b/docs/executions.md
@@ -37,6 +37,14 @@ record to `running`. The generated scheduler script finalizes it as `completed`
 or `failed`, including failures in pre-run hooks, hostfile construction, and
 post-run hooks.
 
+`Pipeline.get_execution()` reconciles a submitted scheduler record with its
+configured provider. This closes the case where the scheduler accepts an ID
+but rejects the job before the generated script can activate and finalize the
+record, for example when a scheduler log directory is unavailable. The query
+stores a typed provider observation on a state transition. Missing jobs become
+failed only after the startup grace period; an unavailable provider query
+leaves the last durable state intact.
+
 ## Querying records
 
 Python clients can query an exact ID or list a named pipeline's history:

--- a/docs/input-bundles.md
+++ b/docs/input-bundles.md
@@ -1,0 +1,63 @@
+# Package Input Bundles
+
+JARVIS package input bundles carry a caller-supplied multi-file application input as one
+digest-verifiable regular file. They are intended for applications whose entrypoint refers
+to neighboring support files, such as a LAMMPS input script and potential, an OpenFOAM case
+tree, or a WRF namelist and sounding.
+
+The bundle is a tar-compatible archive containing only regular files. It must include
+`jarvis-input-manifest.json` at its root:
+
+```json
+{
+  "schema_version": "jarvis.package-input-bundle.v1",
+  "entrypoint": "in.copper",
+  "files": [
+    {
+      "path": "in.copper",
+      "role": "lammps_input",
+      "sha256": "<64 lowercase hexadecimal characters>",
+      "size_bytes": 1280
+    },
+    {
+      "path": "Cu.eam",
+      "role": "potential",
+      "sha256": "<64 lowercase hexadecimal characters>",
+      "size_bytes": 36588
+    }
+  ]
+}
+```
+
+The manifest is closed: it has exactly `schema_version`, `entrypoint`, and `files`.
+Each file has exactly `path`, `role`, `sha256`, and `size_bytes`. Paths use relative POSIX
+syntax and cannot contain `.` or `..` components. The entrypoint must name one declared
+file. Roles are package-defined semantic labels and may repeat.
+
+JARVIS rejects links, devices, duplicate paths, undeclared archive members, size or digest
+mismatches, unsupported schemas, and configured safety-bound violations. A verified archive
+is extracted atomically below a content-addressed package directory. Applications that need
+a mutable working tree use `stage_input_bundle`; it copies every verified payload without
+overwriting existing paths.
+
+Packages expose a bundle through an ordinary configuration setting with a
+`jarvis.configuration-input-binding.v1` local regular-file descriptor. This lets clients
+materialize the archive itself before the package verifies and expands its contents.
+
+## Python API
+
+```python
+from pathlib import Path
+
+from jarvis_cd.input_bundle import extract_input_bundle, stage_input_bundle
+
+materialized = extract_input_bundle(
+    "/local-or-materialized/inputs.tar",
+    Path(package.shared_dir) / "input-bundles",
+)
+entrypoint = stage_input_bundle(materialized, package_output_directory)
+```
+
+`extract_input_bundle` is idempotent for an unchanged archive and unchanged materialized
+tree. `stage_input_bundle` is intentionally not idempotent: an existing destination file is
+a collision and fails closed rather than reusing or overwriting a prior run.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -825,6 +825,9 @@ Interceptor aliases share the pipeline package namespace. JARVIS verifies that
 every referenced alias exists and derives from `Interceptor` before saving or
 starting the pipeline. Removing an interceptor that is still referenced fails
 instead of silently running the target package without interception.
+The common `interceptors` setting is included in agent-visible package metadata
+for applications and services, while interceptor packages hide it because
+nested interception is invalid.
 
 #### Remove Packages from Pipeline
 ```bash

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -825,6 +825,10 @@ Interceptor aliases share the pipeline package namespace. JARVIS verifies that
 every referenced alias exists and derives from `Interceptor` before saving or
 starting the pipeline. Removing an interceptor that is still referenced fails
 instead of silently running the target package without interception.
+Interceptor configuration does not enter the pipeline-wide environment: each
+instance applies its runtime variables only to the packages that name its alias.
+Consequently, the two Darshan instances above retain distinct log directories
+and job identifiers even when both target packages run in one pipeline.
 The common `interceptors` setting is included in agent-visible package metadata
 for applications and services, while interceptor packages hide it because
 nested interception is invalid.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -802,6 +802,30 @@ jarvis ppl append builtin.ior benchmark_run
 jarvis ppl append my_repo.custom_app my_app
 ```
 
+`ppl append` determines package behavior from the selected class. Classes derived
+from `Interceptor` are stored as named pipeline interceptors. Applications and
+services select interceptor aliases explicitly through their common
+`interceptors` setting:
+
+```bash
+# Configure two independent instances of the same interceptor.
+jarvis ppl append builtin.darshan darshan_ior \
+  log_dir=/tmp/ior_logs job_id=ior
+jarvis ppl append builtin.darshan darshan_clio \
+  log_dir=/tmp/clio_logs job_id=clio
+
+# Apply each instance only to its intended package.
+jarvis ppl append builtin.ior ior \
+  'interceptors=["darshan_ior"]'
+jarvis ppl append my_repo.clio_core clio \
+  'interceptors=["darshan_clio"]'
+```
+
+Interceptor aliases share the pipeline package namespace. JARVIS verifies that
+every referenced alias exists and derives from `Interceptor` before saving or
+starting the pipeline. Removing an interceptor that is still referenced fails
+instead of silently running the target package without interception.
+
 #### Remove Packages from Pipeline
 ```bash
 # Remove package by instance name

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -44,6 +44,14 @@ The pipeline's compatibility `last_submission` record includes the execution ID,
 the execution root, the sealed input and runtime paths, the script and hostfile
 paths, and a SHA-256 digest of the two sealed input documents.
 
+Before invoking the scheduler, JARVIS creates the concrete parent directories
+for `scheduler.output` and `scheduler.error`. Scheduler replacement tokens such
+as SLURM `%j` are supported in the filename, where the provider can resolve
+them after submission, but not in a parent directory whose name is unknown
+before the scheduler accepts the job. A directory preparation failure is a
+terminal pre-submission error, so JARVIS never returns an accepted-looking
+handle for a job that could not open its configured logs.
+
 The pipeline binds `self.hostfile` to that same path at load time, so
 every package in the pipeline that consults `self.hostfile` reads the
 allocation-derived host list with no extra wiring.
@@ -219,6 +227,14 @@ The generated script is written to
 `<pipeline_shared_dir>/executions/<execution-id>/submit.slurm`. A fresh
 execution ID is generated for every CLI submission; API callers may provide a
 bounded path-safe ID for end-to-end correlation.
+
+For a submitted nonterminal record, `Pipeline.get_execution()` also asks the
+selected scheduler provider for current state. The SLURM provider checks the
+live queue and then accounting when available. A provider-reported terminal
+state is committed into the same durable execution record. If SLURM no longer
+recognizes an accepted job and no historical record is available, JARVIS waits
+through a bounded startup grace period before recording failure; generic query
+errors do not silently terminalize the execution.
 
 ## Execution cleanup and pipeline destruction
 

--- a/docs/warpx.md
+++ b/docs/warpx.md
@@ -1,0 +1,77 @@
+# WarpX Package
+
+`builtin.warpx` launches one three-dimensional WarpX particle-in-cell simulation under
+JARVIS-owned MPI execution. The package supports an installed example, one caller-supplied
+input file, or one selected member of a digest-verified package input bundle.
+
+## Input profiles
+
+| Profile | Settings | Behavior |
+|---|---|---|
+| Installed example | `example` | Runs the selected example from the installed WarpX tree and applies the configured bounds. |
+| Single input | `inputs` | Copies the regular input file into the package output root and launches it there. |
+| Input bundle | `input_bundle`, optional `input_path` | Verifies and stages every manifest member, then launches the selected member. An empty `input_path` selects the manifest entrypoint. |
+
+`inputs` and `input_bundle` are mutually exclusive. `input_path` is accepted only with an
+input bundle, must be a confined relative path, and must name a manifest-declared regular
+file. The special `custom` example requires one of the two caller-input forms.
+
+By default, JARVIS does not replace scientific values in caller inputs. Set
+`override_input_parameters=true` to apply `max_step`, `n_cell`, `plot_int`, and the
+package-owned plotfile prefix as WarpX command-line overrides. Installed examples always
+use those bounds.
+
+## Settings
+
+| Setting | Default | Meaning |
+|---|---:|---|
+| `nprocs` | `2` | MPI process count. |
+| `ppn` | `2` | MPI processes per node. |
+| `inputs` | empty | Single caller-supplied WarpX input file. |
+| `input_bundle` | empty | `jarvis.package-input-bundle.v1` archive. |
+| `input_path` | empty | Selected manifest member, or the entrypoint when empty. |
+| `example` | `laser_acceleration` | Installed example used without caller input. |
+| `override_input_parameters` | `false` | Authorize command-line overrides for caller input. |
+| `max_step` | `50` | Step bound for examples or authorized overrides. |
+| `n_cell` | `64 64 128` | Three positive base-grid dimensions. |
+| `out` | `run` | Output root; relative paths resolve below package shared storage. |
+| `plot_int` | `10` | Plot interval; `-1` disables plots. |
+| `use_gpu` | `false` | Select the CUDA container build and launch profile. |
+| `cuda_arch` | `80` | CUDA architecture used by the container build. |
+| `base_image` | `sci-hpc-base` | Base image used by package-owned container builds. |
+
+The native profile resolves a supported WarpX executable through the activated pipeline
+`PATH`. Its deployment contract advertises a provider-neutral `warpx` Spack query. Sites or
+callers may constrain the actual installation through ordinary JARVIS environment and
+installation configuration.
+
+## Outputs and completion
+
+The default `out=run` resolves to a dedicated directory below the execution package's
+durable shared directory. Relative
+diagnostic paths in supplied WarpX inputs therefore remain execution-owned. A nonzero exit
+from any MPI rank fails the package.
+
+At process completion, the package performs a bounded walk without following links. It
+reports the owned WarpX result tree plus high-confidence plotfile, checkpoint, ADIOS2, HDF5,
+JSON, CSV, and text diagnostics. Exact staged input files are excluded from the output
+manifest. A nonzero process exit or a discovery-bound truncation marks reported products
+incomplete.
+
+## Example bundle pipeline
+
+```yaml
+name: plasma-study
+pkgs:
+  - pkg_type: builtin.warpx
+    pkg_name: density_high
+    input_bundle: /data/langmuir-cases.tar
+    input_path: density-high/inputs
+    nprocs: 4
+    ppn: 4
+    out: run
+```
+
+Multiple package instances can select different manifest members without introducing a
+study-specific WarpX package. Downstream analysis remains a separate application or
+pipeline step.

--- a/docs/xcompact3d.md
+++ b/docs/xcompact3d.md
@@ -1,0 +1,71 @@
+# Xcompact3D Package
+
+`builtin.xcompact3d` launches one caller-defined incompressible-flow simulation under
+JARVIS-owned MPI execution. It deliberately does not encode a particular scientific study,
+axis comparison, or benchmark. Multiple package instances can select distinct inputs and a
+separate analysis step can compare their outputs.
+
+## Input profiles
+
+| Profile | Settings | Behavior |
+|---|---|---|
+| Single input | `inputs` | Copies one bounded regular `.i3d` file into package-owned storage and launches it there. |
+| Input bundle | `input_bundle`, optional `input_path` | Verifies and stages every manifest member, then launches the selected member. An empty `input_path` selects the manifest entrypoint. |
+
+`inputs` and `input_bundle` are mutually exclusive, and one is required. `input_path` is
+accepted only with an input bundle. It must be a confined relative path that exactly names a
+manifest member. A bundle is the appropriate profile when an input depends on files such as
+`adios2_config.xml`, geometry, restart data, or other solver resources.
+
+## Settings
+
+| Setting | Default | Meaning |
+|---|---:|---|
+| `nprocs` | `4` | MPI process count. |
+| `ppn` | `4` | MPI processes per node. |
+| `inputs` | empty | Single caller-supplied Xcompact3D input file. |
+| `input_bundle` | empty | `jarvis.package-input-bundle.v1` archive. |
+| `input_path` | empty | Selected manifest member, or the entrypoint when empty. |
+| `out` | `run` | Output root; relative paths resolve below package shared storage. |
+| `base_image` | `ubuntu:24.04` | Base image for the optional package-owned container build. |
+
+The native profile resolves `xcompact3d` or `incompact3d` from the pipeline environment.
+Runtime installation remains an operator or installation-manager responsibility; an agent
+does not provide executable paths.
+
+## Outputs and completion
+
+The selected input and all support files are copied into an execution-owned working tree.
+The solver stream is written to `xcompact3d.log` beside the selected input. A nonzero result
+from any MPI rank fails the package.
+
+At process completion, the package performs a bounded output walk without following links.
+It reports the complete owned result tree and stable high-confidence products for the solver
+log, checkpoint, restart metadata, field-data collection, statistics collection, and ADIOS2
+BP collections. Exact staged inputs are excluded. A nonzero process exit or bounded-walk
+truncation marks discovered products incomplete.
+
+## Multi-input example
+
+```yaml
+name: channel-orientation-study
+pkgs:
+  - pkg_type: builtin.xcompact3d
+    pkg_name: channel_x
+    input_bundle: /data/channel-cases.tar
+    input_path: channel/input_test_x.i3d
+    nprocs: 4
+    ppn: 4
+    out: channel-x
+  - pkg_type: builtin.xcompact3d
+    pkg_name: channel_z
+    input_bundle: /data/channel-cases.tar
+    input_path: channel/input_test_z.i3d
+    nprocs: 4
+    ppn: 4
+    out: channel-z
+```
+
+This pipeline runs two ordinary application instances. Any scientific comparison belongs in
+an explicit downstream package or in the caller's validation layer rather than in the
+Xcompact3D launcher.

--- a/jarvis_cd/configuration_input.py
+++ b/jarvis_cd/configuration_input.py
@@ -7,15 +7,24 @@ import os
 import re
 import stat
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
 
 from jarvis_cd.deployment import ConfigurationInputBinding
 from jarvis_cd.util.private_path import reject_private_path_redirection
 
-MAX_CONFIGURATION_INPUT_BYTES = 16 * 1024 * 1024
+MAX_CONFIGURATION_INPUT_BYTES = 512 * 1024 * 1024
 _PARAMETER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _SAFE_SUFFIX_PATTERN = re.compile(r"^\.[A-Za-z0-9][A-Za-z0-9._-]{0,31}$")
+
+
+@dataclass(frozen=True, slots=True)
+class _FileFingerprint:
+    """Stable size and SHA-256 identity for one bounded regular file."""
+
+    size_bytes: int
+    sha256: str
 
 
 def materialize_configuration_inputs(
@@ -74,13 +83,12 @@ def materialize_configuration_inputs(
                 f"declared configuration input {parameter!r} must be a path string"
             )
         source = _configuration_input_source(value, parameter=parameter)
-        payload, digest = _read_bounded_regular_file(source, parameter=parameter)
+        fingerprint = _fingerprint_bounded_regular_file(source, parameter=parameter)
         target = _materialized_target(
             shared_root,
             parameter=parameter,
             source=source,
-            payload=payload,
-            digest=digest,
+            fingerprint=fingerprint,
         )
         materialized[parameter] = str(target)
     return materialized
@@ -115,7 +123,7 @@ def configuration_input_materialization_matches(
     try:
         ConfigurationInputBinding.from_dict(cast(Mapping[str, object], raw_binding))
         source = _configuration_input_source(requested, parameter=parameter)
-        source_payload, source_digest = _read_bounded_regular_file(
+        source_fingerprint = _fingerprint_bounded_regular_file(
             source,
             parameter=parameter,
         )
@@ -124,17 +132,17 @@ def configuration_input_materialization_matches(
         target = Path(os.path.abspath(os.fspath(materialized)))
         reject_private_path_redirection(target)
         if target.parent != expected_root or target.name != _materialized_name(
-            source, source_digest
+            source, source_fingerprint.sha256
         ):
             return False
-        target_payload, target_digest = _read_bounded_regular_file(
+        target_fingerprint = _fingerprint_bounded_regular_file(
             target,
             parameter=parameter,
             require_single_link=True,
         )
     except (OSError, RuntimeError, TypeError, ValueError):
         return False
-    return source_digest == target_digest and source_payload == target_payload
+    return source_fingerprint == target_fingerprint
 
 
 def _configuration_input_source(
@@ -157,13 +165,52 @@ def _configuration_input_source(
     return source
 
 
-def _read_bounded_regular_file(
+def _fingerprint_bounded_regular_file(
     path: Path,
     *,
     parameter: str,
     require_single_link: bool = False,
-) -> tuple[bytes, str]:
-    """Read one stable regular file through a no-follow descriptor."""
+) -> _FileFingerprint:
+    """Hash one stable bounded file without retaining its payload in memory."""
+
+    descriptor, linked_before, opened_before = _open_bounded_regular_file(
+        path,
+        parameter=parameter,
+        require_single_link=require_single_link,
+    )
+    digest = hashlib.sha256()
+    observed_size = 0
+    try:
+        while chunk := os.read(descriptor, 1024 * 1024):
+            observed_size += len(chunk)
+            if observed_size > MAX_CONFIGURATION_INPUT_BYTES:
+                raise ValueError(
+                    f"declared configuration input {parameter!r} exceeded its bound"
+                )
+            digest.update(chunk)
+        opened_after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    _validate_file_after_read(
+        path,
+        parameter=parameter,
+        linked_before=linked_before,
+        opened_before=opened_before,
+        opened_after=opened_after,
+        observed_size=observed_size,
+        require_single_link=require_single_link,
+    )
+    return _FileFingerprint(observed_size, digest.hexdigest())
+
+
+def _open_bounded_regular_file(
+    path: Path,
+    *,
+    parameter: str,
+    require_single_link: bool,
+) -> tuple[int, os.stat_result, os.stat_result]:
+    """Open one stable bounded regular file without following its final link."""
+
     try:
         linked_before = path.lstat()
     except OSError as exc:
@@ -193,29 +240,32 @@ def _read_bounded_regular_file(
         raise ValueError(
             f"declared configuration input {parameter!r} could not be opened safely"
         ) from exc
-    try:
-        opened_before = os.fstat(descriptor)
-        if (
-            not stat.S_ISREG(opened_before.st_mode)
-            or _is_path_redirection(opened_before)
-            or _file_identity(opened_before) != _file_identity(linked_before)
-            or (require_single_link and opened_before.st_nlink != 1)
-        ):
-            raise ValueError(
-                f"declared configuration input {parameter!r} changed before reading"
-            )
-        chunks: list[bytes] = []
-        remaining = MAX_CONFIGURATION_INPUT_BYTES + 1
-        while remaining:
-            chunk = os.read(descriptor, min(1024 * 1024, remaining))
-            if not chunk:
-                break
-            chunks.append(chunk)
-            remaining -= len(chunk)
-        payload = b"".join(chunks)
-        opened_after = os.fstat(descriptor)
-    finally:
+    opened_before = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(opened_before.st_mode)
+        or _is_path_redirection(opened_before)
+        or _file_identity(opened_before) != _file_identity(linked_before)
+        or (require_single_link and opened_before.st_nlink != 1)
+    ):
         os.close(descriptor)
+        raise ValueError(
+            f"declared configuration input {parameter!r} changed before reading"
+        )
+    return descriptor, linked_before, opened_before
+
+
+def _validate_file_after_read(
+    path: Path,
+    *,
+    parameter: str,
+    linked_before: os.stat_result,
+    opened_before: os.stat_result,
+    opened_after: os.stat_result,
+    observed_size: int,
+    require_single_link: bool,
+) -> None:
+    """Reject a file that changed identity while it was being streamed."""
+
     try:
         linked_after = path.lstat()
     except OSError as exc:
@@ -223,8 +273,8 @@ def _read_bounded_regular_file(
             f"declared configuration input {parameter!r} changed while reading"
         ) from exc
     if (
-        len(payload) > MAX_CONFIGURATION_INPUT_BYTES
-        or len(payload) != opened_before.st_size
+        observed_size > MAX_CONFIGURATION_INPUT_BYTES
+        or observed_size != opened_before.st_size
         or _is_path_redirection(linked_after)
         or (require_single_link and linked_after.st_nlink != 1)
         or _file_identity(opened_after) != _file_identity(opened_before)
@@ -233,7 +283,55 @@ def _read_bounded_regular_file(
         raise ValueError(
             f"declared configuration input {parameter!r} changed while reading"
         )
-    return payload, hashlib.sha256(payload).hexdigest()
+
+
+def _copy_bounded_regular_file(
+    source: Path,
+    destination_descriptor: int,
+    *,
+    parameter: str,
+    expected: _FileFingerprint,
+) -> None:
+    """Stream one stable source into an already-created private destination."""
+
+    source_descriptor, linked_before, opened_before = _open_bounded_regular_file(
+        source,
+        parameter=parameter,
+        require_single_link=False,
+    )
+    digest = hashlib.sha256()
+    observed_size = 0
+    try:
+        while chunk := os.read(source_descriptor, 1024 * 1024):
+            observed_size += len(chunk)
+            if observed_size > MAX_CONFIGURATION_INPUT_BYTES:
+                raise ValueError(
+                    f"declared configuration input {parameter!r} exceeded its bound"
+                )
+            digest.update(chunk)
+            offset = 0
+            while offset < len(chunk):
+                written = os.write(destination_descriptor, chunk[offset:])
+                if written <= 0:
+                    raise OSError("short write while materializing configuration input")
+                offset += written
+        opened_after = os.fstat(source_descriptor)
+    finally:
+        os.close(source_descriptor)
+    _validate_file_after_read(
+        source,
+        parameter=parameter,
+        linked_before=linked_before,
+        opened_before=opened_before,
+        opened_after=opened_after,
+        observed_size=observed_size,
+        require_single_link=False,
+    )
+    observed = _FileFingerprint(observed_size, digest.hexdigest())
+    if observed != expected:
+        raise ValueError(
+            f"declared configuration input {parameter!r} changed before materialization"
+        )
 
 
 def _materialized_target(
@@ -241,8 +339,7 @@ def _materialized_target(
     *,
     parameter: str,
     source: Path,
-    payload: bytes,
-    digest: str,
+    fingerprint: _FileFingerprint,
 ) -> Path:
     bindings_root = shared_root / "configuration-inputs"
     parameter_root = bindings_root / parameter
@@ -253,32 +350,32 @@ def _materialized_target(
         if os.name != "nt":
             directory.chmod(0o700)
 
-    target = parameter_root / _materialized_name(source, digest)
+    target = parameter_root / _materialized_name(source, fingerprint.sha256)
     if target == source:
         return target
     if target.exists():
-        existing, existing_digest = _read_bounded_regular_file(
+        existing = _fingerprint_bounded_regular_file(
             target,
             parameter=parameter,
             require_single_link=True,
         )
-        if existing_digest == digest and existing == payload:
+        if existing == fingerprint:
             return target
 
     descriptor, temporary_name = tempfile.mkstemp(
-        prefix=f".{digest}.",
+        prefix=f".{fingerprint.sha256}.",
         suffix=".tmp",
         dir=parameter_root,
     )
     temporary = Path(temporary_name)
     descriptor_open = True
     try:
-        offset = 0
-        while offset < len(payload):
-            written = os.write(descriptor, payload[offset:])
-            if written <= 0:
-                raise OSError("short write while materializing configuration input")
-            offset += written
+        _copy_bounded_regular_file(
+            source,
+            descriptor,
+            parameter=parameter,
+            expected=fingerprint,
+        )
         os.fsync(descriptor)
         if os.name != "nt":
             descriptor_chmod = cast(Any, getattr(os, "fchmod"))
@@ -294,12 +391,12 @@ def _materialized_target(
             os.close(descriptor)
         if temporary.exists():
             temporary.unlink()
-    persisted, persisted_digest = _read_bounded_regular_file(
+    persisted = _fingerprint_bounded_regular_file(
         target,
         parameter=parameter,
         require_single_link=True,
     )
-    if persisted_digest != digest or persisted != payload:
+    if persisted != fingerprint:
         raise RuntimeError(
             f"materialized configuration input {parameter!r} failed verification"
         )

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -3212,13 +3212,16 @@ class Pipeline:
         print("Reconfiguring pipeline packages with existing configurations...")
         self.configure_all_packages()
 
-    def _configure_package_instance(self, pkg_def: Dict[str, Any], pkg_type_label: str):
+    def _configure_package_instance(
+        self, pkg_def: Dict[str, Any], pkg_type_label: str
+    ) -> None:
         """
         Configure a single package or interceptor instance.
 
         :param pkg_def: Package definition dictionary
         :param pkg_type_label: Label for logging ("package" or "interceptor")
         """
+        from jarvis_cd.core.pkg import Interceptor
         from jarvis_cd.util.logger import logger
 
         try:
@@ -3236,8 +3239,12 @@ class Pipeline:
                 else:
                     pkg_def["config"] = pkg_instance.config.copy()
 
-                # Update the package environment in the pipeline's env
-                self.env.update(pkg_instance.env)
+                # Interceptor runtime mutations belong only to explicitly linked
+                # packages. Configuration may prepare resources using an
+                # interceptor-local environment, but must not leak that state into
+                # every later package through the pipeline-wide environment.
+                if not isinstance(pkg_instance, Interceptor):
+                    self.env.update(pkg_instance.env)
 
             # Print END message
             logger.success(f"[{pkg_def['pkg_type']}] [CONFIGURE] END")

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -2344,6 +2344,8 @@ class Pipeline:
         if not self.name:
             raise ValueError("Pipeline name not set")
 
+        self._validate_interceptor_links()
+
         pipeline_dir = self._pipeline_storage_dir()
         pipeline_dir.mkdir(parents=True, exist_ok=True)
 
@@ -2537,6 +2539,7 @@ class Pipeline:
         """Start all packages in the pipeline"""
         from jarvis_cd.util.logger import logger
 
+        self._validate_interceptor_links()
         logger.pipeline(f"Starting pipeline: {self.name}")
 
         # Store started instances for later access (e.g., _get_stat)
@@ -3280,8 +3283,11 @@ class Pipeline:
         else:
             pkg_id = pkg_name
 
-        # Check for duplicate package IDs
-        existing_ids = [pkg["pkg_id"] for pkg in self.packages]
+        # Package and interceptor aliases share one pipeline namespace.
+        existing_ids = {
+            *(pkg["pkg_id"] for pkg in self.packages),
+            *self.interceptors.keys(),
+        }
         if pkg_id in existing_ids:
             raise ValueError(f"Package ID already exists in pipeline: {pkg_id}")
 
@@ -3297,11 +3303,12 @@ class Pipeline:
             "config": default_config,
         }
 
+        # Load once both to parse package-owned configuration and to identify
+        # whether this definition is an Application, Service, or Interceptor.
+        pkg_instance = self._load_package_instance(package_entry, self.env)
+
         # Apply configuration arguments if provided (before validation)
         if config_args:
-            # Load package instance
-            pkg_instance = self._load_package_instance(package_entry, self.env)
-
             argparse = pkg_instance.get_argparse()
             try:
                 # Use PkgArgParse to parse and convert arguments
@@ -3325,13 +3332,23 @@ class Pipeline:
         # Validate that all required parameters have values (after applying config_args)
         self._validate_required_config(package_spec, package_entry["config"])
 
-        # Add package to pipeline
-        self.packages.append(package_entry)
+        from jarvis_cd.core.pkg import Interceptor
+
+        if isinstance(pkg_instance, Interceptor):
+            nested = package_entry["config"].get("interceptors", [])
+            if nested:
+                raise ValueError("Interceptor packages cannot reference interceptors")
+            self.interceptors[pkg_id] = package_entry
+            added_kind = "interceptor"
+        else:
+            self._validate_package_interceptor_references(package_entry)
+            self.packages.append(package_entry)
+            added_kind = "package"
 
         # Save updated configuration
         self.save()
 
-        print(f"Added package {package_spec} as {pkg_id} to pipeline")
+        print(f"Added {added_kind} {package_spec} as {pkg_id} to pipeline")
 
     def rm(self, package_spec: str):
         """
@@ -3339,18 +3356,31 @@ class Pipeline:
 
         :param package_spec: Package specification to remove (pkg_id)
         """
-        # Find and remove the package
-        package_found = False
-
+        # Find and remove an application/service package.
+        removed_package = None
         for i, pkg_def in enumerate(self.packages):
             if pkg_def["pkg_id"] == package_spec:
                 removed_package = self.packages.pop(i)
-                package_found = True
                 break
 
-        if not package_found:
+        # Interceptors are addressed through the same generic package identity.
+        if removed_package is None and package_spec in self.interceptors:
+            dependents = [
+                pkg["pkg_id"]
+                for pkg in self.packages
+                if package_spec in pkg.get("config", {}).get("interceptors", [])
+            ]
+            if dependents:
+                raise ValueError(
+                    f"Cannot remove interceptor '{package_spec}'; referenced by: "
+                    + ", ".join(dependents)
+                )
+            removed_package = self.interceptors.pop(package_spec)
+
+        if removed_package is None:
             # List available packages to help the user
             available_ids = [pkg["pkg_id"] for pkg in self.packages]
+            available_ids.extend(self.interceptors)
             if available_ids:
                 print(f"Package '{package_spec}' not found in pipeline.")
                 print(f"Available packages: {', '.join(available_ids)}")
@@ -3398,12 +3428,7 @@ class Pipeline:
         :param config_args: Configuration arguments as command-line args (e.g., ['--nprocs', '4', 'block=32m'])
         :raises ValueError: If an argument is unknown or package configuration fails
         """
-        # Find package in pipeline
-        pkg_def = None
-        for pkg in self.packages:
-            if pkg["pkg_id"] == pkg_id:
-                pkg_def = pkg
-                break
+        pkg_def = self._find_package_definition(pkg_id)
 
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
@@ -3461,12 +3486,7 @@ class Pipeline:
 
         :param pkg_id: Package ID to show README for
         """
-        # Find package in pipeline
-        pkg_def = None
-        for pkg in self.packages:
-            if pkg["pkg_id"] == pkg_id:
-                pkg_def = pkg
-                break
+        pkg_def = self._find_package_definition(pkg_id)
 
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
@@ -3480,7 +3500,7 @@ class Pipeline:
 
     def show_package_build_script(self, pkg_id: str):
         """Print the build.sh script for a package within this pipeline."""
-        pkg_def = next((p for p in self.packages if p["pkg_id"] == pkg_id), None)
+        pkg_def = self._find_package_definition(pkg_id)
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
         try:
@@ -3491,7 +3511,7 @@ class Pipeline:
 
     def show_package_deploy_dockerfile(self, pkg_id: str):
         """Print Dockerfile.deploy for a package within this pipeline."""
-        pkg_def = next((p for p in self.packages if p["pkg_id"] == pkg_id), None)
+        pkg_def = self._find_package_definition(pkg_id)
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
         try:
@@ -3507,12 +3527,7 @@ class Pipeline:
         :param pkg_id: Package ID to show paths for
         :param path_flags: Dictionary of path flags to show
         """
-        # Find package in pipeline
-        pkg_def = None
-        for pkg in self.packages:
-            if pkg["pkg_id"] == pkg_id:
-                pkg_def = pkg
-                break
+        pkg_def = self._find_package_definition(pkg_id)
 
         if not pkg_def:
             raise ValueError(f"Package not found: {pkg_id}")
@@ -3647,6 +3662,8 @@ class Pipeline:
                     self.env = {}
         else:
             self.env = {}
+
+        self._validate_interceptor_links()
 
     def _load_from_file(self, load_type: str, pipeline_file: str):
         """Load pipeline from a file"""
@@ -3892,8 +3909,8 @@ class Pipeline:
             package_entry = self._process_package_definition(pkg_def, pkg_id)
             self.packages.append(package_entry)
 
-        # Validate that interceptor and package IDs are unique
-        self._validate_unique_ids()
+        # Validate type-correct interceptor definitions and explicit links.
+        self._validate_interceptor_links()
 
         # Propagate base_deploy_mode -> per-package deploy_mode
         self._propagate_deploy_mode()
@@ -4137,6 +4154,68 @@ class Pipeline:
                 f"Package and interceptor IDs must be unique within the pipeline."
             )
 
+    def _find_package_definition(self, pkg_id: str) -> Optional[Dict[str, Any]]:
+        """Return one application, service, or interceptor definition by alias."""
+        for package in self.packages:
+            if package["pkg_id"] == pkg_id:
+                return package
+        return self.interceptors.get(pkg_id)
+
+    def get_pkg(self, pkg_id: str) -> Optional[Dict[str, Any]]:
+        """Return one pipeline member regardless of its JARVIS package kind.
+
+        Generic clients can use this method after ``append`` without knowing
+        whether JARVIS stored the selected class as an application, service, or
+        interceptor.
+
+        :param pkg_id: Pipeline-local package alias.
+        :return: The stored package definition, or ``None`` when absent.
+        """
+        return self._find_package_definition(pkg_id)
+
+    def _validate_package_interceptor_references(self, package: Dict[str, Any]) -> None:
+        """Validate one package's explicit references to pipeline interceptors."""
+        package_id = str(package.get("pkg_id", "unknown"))
+        references = package.get("config", {}).get("interceptors", [])
+        if not isinstance(references, list):
+            raise ValueError(
+                f"Package '{package_id}' interceptors must be a list of aliases"
+            )
+        if not all(
+            isinstance(reference, str) and reference for reference in references
+        ):
+            raise ValueError(
+                f"Package '{package_id}' interceptor aliases must be non-empty strings"
+            )
+        if len(set(references)) != len(references):
+            raise ValueError(f"Package '{package_id}' repeats an interceptor reference")
+        missing = [
+            reference for reference in references if reference not in self.interceptors
+        ]
+        if missing:
+            raise ValueError(
+                f"Package '{package_id}' references unknown interceptor: {missing[0]}"
+            )
+
+    def _validate_interceptor_links(self) -> None:
+        """Fail closed unless all interceptor definitions and links are valid."""
+        from jarvis_cd.core.pkg import Interceptor
+
+        self._validate_unique_ids()
+        for interceptor_id, definition in self.interceptors.items():
+            instance = self._load_package_instance(definition, self.env)
+            if not isinstance(instance, Interceptor):
+                raise ValueError(
+                    f"Pipeline interceptor '{interceptor_id}' is not an Interceptor package"
+                )
+            nested = definition.get("config", {}).get("interceptors", [])
+            if nested:
+                raise ValueError(
+                    f"Interceptor package '{interceptor_id}' cannot reference interceptors"
+                )
+        for package in self.packages:
+            self._validate_package_interceptor_references(package)
+
     def _validate_required_config(self, package_spec: str, config: Dict[str, Any]):
         """
         Validate that all required configuration parameters have values.
@@ -4206,45 +4285,39 @@ class Pipeline:
         )
 
         for interceptor_name in interceptors_list:
-            try:
-                # Find interceptor in pipeline-level interceptors
-                if interceptor_name not in self.interceptors:
-                    logger.error(
-                        f"Warning: Interceptor '{interceptor_name}' not found in pipeline interceptors"
-                    )
-                    continue
-
-                interceptor_def = self.interceptors[interceptor_name]
-
-                # Print BEGIN message with full interceptor type
-                logger.success(f"[{interceptor_def['pkg_type']}] [MODIFY_ENV] BEGIN")
-
-                # Load interceptor instance
-                interceptor_instance = self._load_package_instance(
-                    interceptor_def, self.env
+            if interceptor_name not in self.interceptors:
+                raise RuntimeError(
+                    f"Package '{pkg_def['pkg_id']}' references unknown interceptor "
+                    f"'{interceptor_name}'"
                 )
 
-                # Verify it's an interceptor and has modify_env method
-                if not hasattr(interceptor_instance, "modify_env"):
-                    logger.error(
-                        f"Warning: Package '{interceptor_name}' does not have modify_env() method"
-                    )
-                    continue
+            interceptor_def = self.interceptors[interceptor_name]
+            logger.success(f"[{interceptor_def['pkg_type']}] [MODIFY_ENV] BEGIN")
 
-                # Share the same mod_env reference between interceptor and package
-                interceptor_instance.mod_env = pkg_instance.mod_env
-                interceptor_instance.env = pkg_instance.env
+            interceptor_instance = self._load_package_instance(
+                interceptor_def, self.env
+            )
+            from jarvis_cd.core.pkg import Interceptor
 
-                # Call modify_env on the interceptor to modify the shared environment
+            if not isinstance(interceptor_instance, Interceptor):
+                raise RuntimeError(
+                    f"Pipeline interceptor '{interceptor_name}' is not an "
+                    "Interceptor package"
+                )
+
+            # The package executor consumes mod_env, so the interceptor mutates
+            # that exact object rather than a pipeline-global environment.
+            interceptor_instance.mod_env = pkg_instance.mod_env
+            interceptor_instance.env = pkg_instance.env
+            try:
                 interceptor_instance.modify_env()
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Interceptor '{interceptor_name}' failed for package "
+                    f"'{pkg_def['pkg_id']}': {exc}"
+                ) from exc
 
-                # The mod_env is shared, so changes are automatically applied to the package
-
-                # Print END message
-                logger.success(f"[{interceptor_def['pkg_type']}] [MODIFY_ENV] END")
-
-            except Exception as e:
-                logger.error(f"Error applying interceptor '{interceptor_name}': {e}")
+            logger.success(f"[{interceptor_def['pkg_type']}] [MODIFY_ENV] END")
 
     def _generate_pipeline_container_yaml(self):
         """

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -4253,10 +4253,17 @@ class Pipeline:
                         name = menu_item.get("name")
                         default_value = menu_item.get("default")
 
-                        # If parameter has no default and is not provided in config, it's required
+                        # Preserve the historical ``default=None`` convention,
+                        # while allowing packages with conditional profiles to
+                        # declare that a nullable-looking legacy setting is not
+                        # unconditionally required. PkgArgParse already treats
+                        # the explicit ``required`` field as authoritative.
+                        required = menu_item.get("required")
+                        if required is None:
+                            required = default_value is None
                         if (
                             name
-                            and default_value is None
+                            and required is True
                             and (name not in config or config[name] is None)
                         ):
                             missing_required.append(name)

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -18,6 +18,7 @@ import tempfile
 import yaml
 from contextlib import ExitStack
 from copy import deepcopy
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Any, List, Mapping, Optional
 from uuid import uuid4
@@ -58,6 +59,7 @@ _EXECUTION_MARKER = RECORD_NAME
 _EXECUTION_MARKER_SCHEMA = LEGACY_RECORD_SCHEMA
 _EXECUTION_CLEANUP_SCHEMA = "jarvis.execution-cleanup.v1"
 _MAX_EXPLICIT_EXECUTION_CLEANUP = 1024
+_SCHEDULER_MISSING_GRACE_SECONDS = 60.0
 
 
 def _absolute_scheduler_log_path(value: object) -> str:
@@ -67,6 +69,26 @@ def _absolute_scheduler_log_path(value: object) -> str:
     if os.name == "nt" and value.startswith("/"):
         return posixpath.normpath(value)
     return os.path.normpath(os.path.abspath(value))
+
+
+def _prepare_scheduler_log_parents(scheduler_spec: Mapping[str, Any]) -> None:
+    """Create concrete scheduler log directories before external submission."""
+    for key in ("output", "error"):
+        configured_path = str(scheduler_spec[key])
+        if os.name == "nt" and configured_path.startswith("/"):
+            # A POSIX scheduler path cannot be materialized by a Windows
+            # controller. This preserves cross-platform rendering/tests; an
+            # actual Windows-local path is still prepared below.
+            continue
+        path = Path(configured_path)
+        parent = path.parent
+        if "%" in str(parent):
+            raise ValueError(
+                f"scheduler.{key} replacement tokens are supported only in filenames"
+            )
+        parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if not parent.is_dir():
+            raise RuntimeError(f"scheduler.{key} parent is not a directory: {parent}")
 
 
 def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> Dict[str, Any]:
@@ -1279,6 +1301,7 @@ class Pipeline:
                 scheduler_spec[scheduler_key] = _absolute_scheduler_log_path(
                     scheduler_spec[scheduler_key]
                 )
+            _prepare_scheduler_log_parents(scheduler_spec)
             snapshot_dir, input_dir, snapshot_sha256 = self._write_execution_snapshot(
                 execution_root,
                 scheduler_spec,
@@ -1589,7 +1612,79 @@ class Pipeline:
 
     def get_execution(self, execution_id: str) -> ExecutionRecord:
         """Return the latest durable state for one exact execution identity."""
-        return self._execution_store().get(execution_id)
+        store = self._execution_store()
+        record = store.get(execution_id)
+        if (
+            record.mode != "scheduler"
+            or record.terminal
+            or not record.submitted
+            or record.scheduler_provider is None
+            or record.scheduler_native_id is None
+        ):
+            return record
+
+        from jarvis_cd.core.scheduler import query_scheduler_execution
+
+        observation = query_scheduler_execution(
+            record.scheduler_provider,
+            record.scheduler_native_id,
+        )
+        if observation.state == "unknown":
+            return record
+        if observation.state == "missing":
+            created = datetime.fromisoformat(record.created_at.replace("Z", "+00:00"))
+            age_seconds = (datetime.now(timezone.utc) - created).total_seconds()
+            if age_seconds < _SCHEDULER_MISSING_GRACE_SECONDS:
+                return record
+            state = "failed"
+            terminal = True
+            return_code = 1
+            error = (
+                f"scheduler {record.scheduler_provider} no longer reports accepted "
+                f"job {record.scheduler_native_id}, and its JARVIS runtime never "
+                "activated within the reconciliation grace period"
+            )
+        else:
+            state = observation.state
+            terminal = observation.terminal
+            return_code = observation.return_code
+            error = (
+                f"scheduler {record.scheduler_provider} reported "
+                f"{observation.provider_state} for job {record.scheduler_native_id}"
+                if state in {"failed", "canceled"}
+                else None
+            )
+        metadata = {
+            "scheduler_observation": {
+                "schema_version": "jarvis.scheduler.observation.v1",
+                "provider": record.scheduler_provider,
+                "native_id": record.scheduler_native_id,
+                "state": observation.state,
+                "provider_state": observation.provider_state,
+                "diagnostic": observation.diagnostic,
+            }
+        }
+        if (
+            state == record.state
+            and terminal == record.terminal
+            and return_code == record.return_code
+            and error == record.error
+        ):
+            return record
+        try:
+            return store.update(
+                execution_id,
+                state=state,
+                terminal=terminal,
+                return_code=return_code,
+                error=error,
+                metadata=metadata,
+            )
+        except ValueError:
+            latest = store.get(execution_id)
+            if latest.terminal:
+                return latest
+            raise
 
     def list_executions(self) -> List[ExecutionRecord]:
         """Return all durable executions owned by this pipeline."""

--- a/jarvis_cd/core/pkg.py
+++ b/jarvis_cd/core/pkg.py
@@ -876,8 +876,13 @@ class Pkg:
         # These controls remain part of the CLI and persisted package config,
         # but generic agents should reason from the package-owned deployment
         # contract instead of choosing installers, paths, or debug machinery.
+        # Explicit interceptor selection is different: it is a semantic edge in
+        # the pipeline graph and therefore must be discoverable for applications
+        # and services. Interceptors cannot themselves reference interceptors.
         for parameter in common_menu:
-            parameter["agent_visible"] = False
+            parameter["agent_visible"] = parameter[
+                "name"
+            ] == "interceptors" and not isinstance(self, Interceptor)
 
         # Combine package-specific and common menus
         return package_menu + common_menu

--- a/jarvis_cd/core/scheduler.py
+++ b/jarvis_cd/core/scheduler.py
@@ -625,6 +625,7 @@ class SlurmScheduler(Scheduler):
                 "--format=%i|%T",
             ]
         )
+        queue_reports_absent = False
         if queue is not None and queue.returncode == 0:
             queue_record = _matching_slurm_status_line(queue.stdout, native_id, 2)
             if queue_record is not None:
@@ -632,6 +633,7 @@ class SlurmScheduler(Scheduler):
                     queue_record[1],
                     return_code=None,
                 )
+            queue_reports_absent = True
 
         accounting, accounting_diagnostic = _run_scheduler_query(
             [
@@ -663,7 +665,7 @@ class SlurmScheduler(Scheduler):
                 return_code=_parse_slurm_exit_code(accounting_record[2]),
             )
 
-        if _slurm_queue_reports_missing(queue):
+        if queue_reports_absent or _slurm_queue_reports_missing(queue):
             return SchedulerExecutionStatus(
                 state="missing",
                 terminal=False,

--- a/jarvis_cd/core/scheduler.py
+++ b/jarvis_cd/core/scheduler.py
@@ -21,11 +21,12 @@ from __future__ import annotations
 import os
 import re
 import shlex
+import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 
 _DIRECTIVE_KEY = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
@@ -43,6 +44,42 @@ class SchedulerArtifactPathResolution:
     path: Optional[str]
     diagnostic_code: Optional[str] = None
     diagnostic: Optional[str] = None
+
+
+SchedulerExecutionState = Literal[
+    "submitted",
+    "running",
+    "completed",
+    "failed",
+    "canceled",
+    "missing",
+    "unknown",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulerExecutionStatus:
+    """One bounded observation of provider-owned execution state."""
+
+    state: SchedulerExecutionState
+    terminal: bool
+    return_code: Optional[int]
+    provider_state: Optional[str]
+    diagnostic: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        """Reject internally inconsistent provider observations."""
+        terminal_states = {"completed", "failed", "canceled"}
+        if self.terminal != (self.state in terminal_states):
+            raise ValueError("scheduler observation terminal state is inconsistent")
+        if self.state == "completed" and self.return_code != 0:
+            raise ValueError("completed scheduler observations require return_code=0")
+        if self.state == "failed" and self.return_code in {None, 0}:
+            raise ValueError("failed scheduler observations require a nonzero code")
+        if self.return_code is not None and (
+            isinstance(self.return_code, bool) or not isinstance(self.return_code, int)
+        ):
+            raise ValueError("scheduler observation return_code is invalid")
 
 
 def _validated_single_line(value: Any, *, field: str, limit: int = 4096) -> str:
@@ -204,6 +241,18 @@ class Scheduler:
         identities from arbitrary application stdout.
         """
         raise NotImplementedError
+
+    @classmethod
+    def query_execution(cls, native_id: str) -> SchedulerExecutionStatus:
+        """Query one provider-native execution identity."""
+        del native_id
+        return SchedulerExecutionStatus(
+            state="unknown",
+            terminal=False,
+            return_code=None,
+            provider_state=None,
+            diagnostic=f"JARVIS cannot query scheduler provider {cls.NAME!r}",
+        )
 
     @property
     def array_requested(self) -> bool:
@@ -561,6 +610,84 @@ class SlurmScheduler(Scheduler):
             "identity_source": "scheduler_submit_api",
         }
 
+    @classmethod
+    def query_execution(cls, native_id: str) -> SchedulerExecutionStatus:
+        """Query live and accounting SLURM state for one exact scalar job."""
+        if _SLURM_NATIVE_ID.fullmatch(native_id) is None:
+            raise ValueError("SLURM execution query requires a numeric job ID")
+
+        queue, queue_diagnostic = _run_scheduler_query(
+            [
+                "squeue",
+                "--noheader",
+                "--jobs",
+                native_id,
+                "--format=%i|%T",
+            ]
+        )
+        if queue is not None and queue.returncode == 0:
+            queue_record = _matching_slurm_status_line(queue.stdout, native_id, 2)
+            if queue_record is not None:
+                return _slurm_execution_status(
+                    queue_record[1],
+                    return_code=None,
+                )
+
+        accounting, accounting_diagnostic = _run_scheduler_query(
+            [
+                "sacct",
+                "--noheader",
+                "--parsable2",
+                "--allocations",
+                "--jobs",
+                native_id,
+                "--format=JobIDRaw,State,ExitCode",
+            ]
+        )
+        if accounting is not None and accounting.returncode == 0:
+            accounting_record = _matching_slurm_status_line(
+                accounting.stdout,
+                native_id,
+                3,
+            )
+            if accounting_record is None:
+                return SchedulerExecutionStatus(
+                    state="missing",
+                    terminal=False,
+                    return_code=None,
+                    provider_state=None,
+                    diagnostic="SLURM accounting has no record for the accepted job",
+                )
+            return _slurm_execution_status(
+                accounting_record[1],
+                return_code=_parse_slurm_exit_code(accounting_record[2]),
+            )
+
+        if _slurm_queue_reports_missing(queue):
+            return SchedulerExecutionStatus(
+                state="missing",
+                terminal=False,
+                return_code=None,
+                provider_state=None,
+                diagnostic=(
+                    "SLURM no longer reports the accepted job; accounting did not "
+                    "provide a historical allocation record"
+                ),
+            )
+
+        diagnostics = [
+            value
+            for value in (queue_diagnostic, accounting_diagnostic)
+            if value is not None
+        ]
+        return SchedulerExecutionStatus(
+            state="unknown",
+            terminal=False,
+            return_code=None,
+            provider_state=None,
+            diagnostic="; ".join(diagnostics) or "SLURM state query was unavailable",
+        )
+
     @property
     def array_requested(self) -> bool:
         """Return whether spec or raw arguments request a SLURM job array."""
@@ -635,6 +762,147 @@ class SlurmScheduler(Scheduler):
 _SCHEDULERS: Dict[str, type[Scheduler]] = {
     SlurmScheduler.NAME: SlurmScheduler,
 }
+
+
+def _run_scheduler_query(
+    argv: list[str],
+) -> tuple[Optional[subprocess.CompletedProcess[str]], Optional[str]]:
+    """Run one bounded scheduler query without invoking a shell."""
+    try:
+        completed = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return None, f"{argv[0]} query failed: {str(exc)[:1024]}"
+    if completed.returncode == 0:
+        return completed, None
+    diagnostic = (completed.stderr or completed.stdout or "").strip()
+    if len(diagnostic) > 1024:
+        diagnostic = "[truncated] " + diagnostic[-1024:]
+    return completed, (
+        f"{argv[0]} query exited {completed.returncode}"
+        + (f": {diagnostic}" if diagnostic else "")
+    )
+
+
+def _matching_slurm_status_line(
+    stdout: str,
+    native_id: str,
+    field_count: int,
+) -> Optional[list[str]]:
+    """Return the exact allocation row while ignoring step records."""
+    for raw_line in stdout.splitlines():
+        fields = [field.strip() for field in raw_line.strip().strip("|").split("|")]
+        if len(fields) == field_count and fields[0] == native_id:
+            return fields
+    return None
+
+
+def _slurm_queue_reports_missing(
+    completed: Optional[subprocess.CompletedProcess[str]],
+) -> bool:
+    """Recognize SLURM's exact absent-job response without broad error guessing."""
+    if completed is None or completed.returncode == 0:
+        return False
+    diagnostic = (completed.stderr or completed.stdout or "").strip().lower()
+    return diagnostic == "slurm_load_jobs error: invalid job id specified"
+
+
+def _parse_slurm_exit_code(value: str) -> Optional[int]:
+    """Parse SLURM's ``exit:signal`` field without guessing malformed data."""
+    match = re.fullmatch(r"([0-9]{1,10}):([0-9]{1,10})", value.strip())
+    if match is None:
+        return None
+    exit_code = int(match.group(1))
+    signal = int(match.group(2))
+    if exit_code != 0:
+        return exit_code
+    if signal != 0:
+        return 128 + signal
+    return 0
+
+
+def _slurm_execution_status(
+    provider_state: str,
+    *,
+    return_code: Optional[int],
+) -> SchedulerExecutionStatus:
+    """Map a SLURM lifecycle value into JARVIS execution semantics."""
+    normalized = provider_state.strip().upper().split(maxsplit=1)[0].rstrip("+")
+    submitted_states = {
+        "PENDING",
+        "CONFIGURING",
+        "REQUEUED",
+        "REQUEUE_FED",
+        "REQUEUE_HOLD",
+        "RESIZING",
+    }
+    running_states = {"RUNNING", "COMPLETING", "SIGNALING", "STAGE_OUT", "SUSPENDED"}
+    failed_states = {
+        "BOOT_FAIL",
+        "DEADLINE",
+        "FAILED",
+        "NODE_FAIL",
+        "OUT_OF_MEMORY",
+        "PREEMPTED",
+        "REVOKED",
+        "SPECIAL_EXIT",
+        "TIMEOUT",
+    }
+    if normalized in submitted_states:
+        state: SchedulerExecutionState = "submitted"
+        terminal = False
+        canonical_return_code = None
+    elif normalized in running_states:
+        state = "running"
+        terminal = False
+        canonical_return_code = None
+    elif normalized == "COMPLETED" and return_code in {None, 0}:
+        state = "completed"
+        terminal = True
+        canonical_return_code = 0
+    elif normalized.startswith("CANCELLED"):
+        state = "canceled"
+        terminal = True
+        canonical_return_code = return_code
+    elif normalized in failed_states or normalized == "COMPLETED":
+        state = "failed"
+        terminal = True
+        canonical_return_code = return_code if return_code not in {None, 0} else 1
+    else:
+        state = "unknown"
+        terminal = False
+        canonical_return_code = None
+    return SchedulerExecutionStatus(
+        state=state,
+        terminal=terminal,
+        return_code=canonical_return_code,
+        provider_state=normalized or None,
+        diagnostic=None,
+    )
+
+
+def query_scheduler_execution(
+    provider: str,
+    native_id: str,
+) -> SchedulerExecutionStatus:
+    """Query execution state through the named scheduler provider."""
+    scheduler_type = _SCHEDULERS.get(provider.strip().lower())
+    if scheduler_type is None:
+        return SchedulerExecutionStatus(
+            state="unknown",
+            terminal=False,
+            return_code=None,
+            provider_state=None,
+            diagnostic=f"JARVIS cannot query scheduler provider {provider!r}",
+        )
+    return scheduler_type.query_execution(native_id)
 
 
 def resolve_scheduler_artifact_path(

--- a/jarvis_cd/deployment.py
+++ b/jarvis_cd/deployment.py
@@ -262,6 +262,7 @@ def probe_program(
     *,
     environment: Mapping[str, str],
     arguments: Sequence[str] = ("--help",),
+    accepted_return_codes: Sequence[int] = (0,),
     timeout_seconds: float = 15,
 ) -> ProgramProbeResult:
     """Probe a program through ``PATH`` without exposing its resolved location.
@@ -273,6 +274,14 @@ def probe_program(
     _validate_text(program, "runtime program")
     if _looks_absolute(program):
         raise ValueError("runtime probes must use a semantic program name")
+    accepted = tuple(accepted_return_codes)
+    if not accepted or any(
+        isinstance(code, bool) or not isinstance(code, int) or not 0 <= code <= 255
+        for code in accepted
+    ):
+        raise ValueError("accepted runtime probe return codes must be bounded integers")
+    if len(set(accepted)) != len(accepted):
+        raise ValueError("accepted runtime probe return codes must be unique")
     if timeout_seconds <= 0:
         raise ValueError("runtime probe timeout must be positive")
     resolved = which(program, path=environment.get("PATH"))
@@ -291,7 +300,7 @@ def probe_program(
         )
     except (OSError, subprocess.SubprocessError):
         return ProgramProbeResult(RuntimeStatus("unavailable", "runtime_probe_failed"))
-    if completed.returncode != 0:
+    if completed.returncode not in accepted:
         return ProgramProbeResult(RuntimeStatus("unavailable", "runtime_probe_failed"))
     return ProgramProbeResult(
         RuntimeStatus("ready", "runtime_probe_succeeded"),

--- a/jarvis_cd/input_bundle.py
+++ b/jarvis_cd/input_bundle.py
@@ -1,0 +1,559 @@
+"""Digest-verified materialization for package-owned multi-file inputs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import stat
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import IO, Mapping, cast
+
+from jarvis_cd.util.private_path import reject_private_path_redirection
+
+INPUT_BUNDLE_SCHEMA_VERSION = "jarvis.package-input-bundle.v1"
+INPUT_BUNDLE_MANIFEST_NAME = "jarvis-input-manifest.json"
+_COMPLETION_MARKER_NAME = ".jarvis-input-bundle.json"
+_SHA256_CHARACTERS = frozenset("0123456789abcdef")
+
+
+class InputBundleError(ValueError):
+    """Raised when a package input bundle is malformed, unsafe, or changed."""
+
+
+@dataclass(frozen=True, slots=True)
+class InputBundleFile:
+    """One digest-bound regular file declared by an input bundle."""
+
+    path: str
+    role: str
+    sha256: str
+    size_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class InputBundleManifest:
+    """The closed, validated manifest carried by an input bundle."""
+
+    entrypoint: str
+    files: tuple[InputBundleFile, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializedInputBundle:
+    """A completely verified input bundle below a package-owned root."""
+
+    root: Path
+    entrypoint: Path
+    manifest: InputBundleManifest
+    bundle_sha256: str
+
+
+def extract_input_bundle(
+    bundle: str | os.PathLike[str],
+    destination_root: str | os.PathLike[str],
+    *,
+    max_archive_bytes: int = 512 * 1024 * 1024,
+    max_total_bytes: int = 4 * 1024 * 1024 * 1024,
+    max_files: int = 4096,
+) -> MaterializedInputBundle:
+    """Validate and atomically extract one package input bundle.
+
+    The archive must contain only regular files and exactly one closed v1
+    manifest. Member paths are relative POSIX paths, links are prohibited, and
+    every declared byte count and SHA-256 digest is verified before publication.
+    Reusing a bundle is idempotent only while the materialized tree remains
+    byte-identical to its manifest.
+
+    :param bundle: Regular tar-compatible archive to materialize.
+    :param destination_root: Package-owned directory for content-addressed trees.
+    :param max_archive_bytes: Maximum compressed archive size.
+    :param max_total_bytes: Maximum declared uncompressed payload size.
+    :param max_files: Maximum declared payload file count.
+    :return: The verified content-addressed materialization.
+    :raises InputBundleError: If any safety, identity, or bound check fails.
+    """
+
+    _validate_positive_bound(max_archive_bytes, "max_archive_bytes")
+    _validate_positive_bound(max_total_bytes, "max_total_bytes")
+    _validate_positive_bound(max_files, "max_files")
+    source = _safe_regular_file(bundle, max_bytes=max_archive_bytes)
+    bundle_sha256 = _sha256_file(source)
+    destination_parent = _safe_destination_root(destination_root)
+    destination = destination_parent / bundle_sha256
+    marker = destination / _COMPLETION_MARKER_NAME
+    if destination.exists():
+        return _load_existing_bundle(
+            destination,
+            source=source,
+            marker=marker,
+            bundle_sha256=bundle_sha256,
+            max_files=max_files,
+            max_total_bytes=max_total_bytes,
+        )
+
+    temporary = Path(
+        tempfile.mkdtemp(prefix=f".{bundle_sha256}.", dir=destination_parent)
+    )
+    try:
+        manifest = _extract_archive(
+            source,
+            temporary,
+            max_files=max_files,
+            max_total_bytes=max_total_bytes,
+        )
+        marker_payload = {
+            "bundle_sha256": bundle_sha256,
+            "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        }
+        marker_path = temporary / _COMPLETION_MARKER_NAME
+        marker_path.write_text(
+            json.dumps(marker_payload, sort_keys=True, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(marker_path, 0o600)
+        try:
+            os.replace(temporary, destination)
+        except OSError:
+            if not destination.exists():
+                raise
+            # Another execution may have published the same digest while this
+            # one was verifying it. Publication is atomic, so reuse only after
+            # validating that winner against the same source and bounds.
+            shutil.rmtree(temporary, ignore_errors=True)
+            return _load_existing_bundle(
+                destination,
+                source=source,
+                marker=marker,
+                bundle_sha256=bundle_sha256,
+                max_files=max_files,
+                max_total_bytes=max_total_bytes,
+            )
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    _validate_materialized(destination, manifest)
+    return MaterializedInputBundle(
+        root=destination,
+        entrypoint=destination / PurePosixPath(manifest.entrypoint),
+        manifest=manifest,
+        bundle_sha256=bundle_sha256,
+    )
+
+
+def stage_input_bundle(
+    bundle: MaterializedInputBundle,
+    destination_root: str | os.PathLike[str],
+) -> Path:
+    """Copy verified bundle payloads into one new mutable run workspace.
+
+    Package inputs remain immutable in their content-addressed materialization.
+    Applications that write beside their inputs receive private copies in the
+    execution-owned output directory. Existing files are never overwritten.
+
+    :param bundle: Previously verified input-bundle materialization.
+    :param destination_root: Package-owned mutable working directory.
+    :return: The staged entrypoint path.
+    :raises InputBundleError: If a destination collides or any source changed.
+    """
+
+    _validate_materialized(bundle.root, bundle.manifest)
+    destination = _safe_destination_root(destination_root)
+    staged: list[Path] = []
+    try:
+        for item in bundle.manifest.files:
+            source = bundle.root / PurePosixPath(item.path)
+            target = destination / PurePosixPath(item.path)
+            if target.exists() or target.is_symlink():
+                raise InputBundleError(
+                    f"input bundle staging destination already exists: {item.path}"
+                )
+            with source.open("rb") as stream:
+                _copy_member(
+                    stream,
+                    target,
+                    expected_size=item.size_bytes,
+                    expected_sha256=item.sha256,
+                )
+            staged.append(target)
+    except Exception:
+        for path in reversed(staged):
+            path.unlink(missing_ok=True)
+        raise
+    return destination / PurePosixPath(bundle.manifest.entrypoint)
+
+
+def _validate_positive_bound(value: int, name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise InputBundleError(f"{name} must be a positive integer")
+
+
+def _safe_regular_file(
+    value: str | os.PathLike[str],
+    *,
+    max_bytes: int,
+) -> Path:
+    raw = os.path.expanduser(os.path.expandvars(os.fspath(value)))
+    if not raw or any(ord(character) < 32 for character in raw):
+        raise InputBundleError("input bundle must be a printable path")
+    path = Path(os.path.abspath(raw))
+    try:
+        reject_private_path_redirection(path)
+        status = path.lstat()
+    except (OSError, RuntimeError) as exc:
+        raise InputBundleError("input bundle is not a readable regular file") from exc
+    if (
+        not stat.S_ISREG(status.st_mode)
+        or path.is_symlink()
+        or status.st_size <= 0
+        or status.st_size > max_bytes
+    ):
+        raise InputBundleError("input bundle archive size or type is invalid")
+    return path
+
+
+def _safe_destination_root(value: str | os.PathLike[str]) -> Path:
+    root = Path(os.path.abspath(Path(value).expanduser()))
+    try:
+        reject_private_path_redirection(root)
+        root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        reject_private_path_redirection(root)
+    except (OSError, RuntimeError) as exc:
+        raise InputBundleError("input bundle destination root is unsafe") from exc
+    if not root.is_dir() or root.is_symlink():
+        raise InputBundleError("input bundle destination root must be a real directory")
+    return root
+
+
+def _sha256_file(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(chunk_size):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_relative_path(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 1024:
+        raise InputBundleError(f"{field} must be a non-empty bounded string")
+    if "\\" in value:
+        raise InputBundleError(f"{field} must use POSIX separators")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise InputBundleError(f"{field} must be a confined relative path")
+    return path.as_posix()
+
+
+def _parse_manifest(payload: bytes, *, max_files: int) -> InputBundleManifest:
+    try:
+        raw = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise InputBundleError("input bundle manifest is not valid UTF-8 JSON") from exc
+    if not isinstance(raw, dict) or set(raw) != {
+        "schema_version",
+        "entrypoint",
+        "files",
+    }:
+        raise InputBundleError(
+            "input bundle manifest fields are not the closed v1 contract"
+        )
+    if raw["schema_version"] != INPUT_BUNDLE_SCHEMA_VERSION:
+        raise InputBundleError("unsupported input bundle manifest schema")
+    raw_files = raw["files"]
+    if not isinstance(raw_files, list) or not 1 <= len(raw_files) <= max_files:
+        raise InputBundleError("input bundle files must be a non-empty bounded list")
+    files: list[InputBundleFile] = []
+    seen: set[str] = set()
+    for index, raw_file in enumerate(raw_files):
+        if not isinstance(raw_file, dict) or set(raw_file) != {
+            "path",
+            "role",
+            "sha256",
+            "size_bytes",
+        }:
+            raise InputBundleError(f"input bundle file {index} fields are invalid")
+        path = _safe_relative_path(raw_file["path"], field=f"files[{index}].path")
+        role = raw_file["role"]
+        sha256 = raw_file["sha256"]
+        size_bytes = raw_file["size_bytes"]
+        if (
+            path in {INPUT_BUNDLE_MANIFEST_NAME, _COMPLETION_MARKER_NAME}
+            or path in seen
+        ):
+            raise InputBundleError(f"duplicate or reserved input bundle path: {path}")
+        if not isinstance(role, str) or not role or len(role) > 128:
+            raise InputBundleError(f"files[{index}].role is invalid")
+        if (
+            not isinstance(sha256, str)
+            or len(sha256) != 64
+            or not set(sha256).issubset(_SHA256_CHARACTERS)
+        ):
+            raise InputBundleError(f"files[{index}].sha256 is invalid")
+        if (
+            not isinstance(size_bytes, int)
+            or isinstance(size_bytes, bool)
+            or size_bytes < 0
+        ):
+            raise InputBundleError(f"files[{index}].size_bytes is invalid")
+        seen.add(path)
+        files.append(
+            InputBundleFile(
+                path=path,
+                role=cast(str, role),
+                sha256=cast(str, sha256),
+                size_bytes=cast(int, size_bytes),
+            )
+        )
+    entrypoint = _safe_relative_path(raw["entrypoint"], field="entrypoint")
+    if entrypoint not in seen:
+        raise InputBundleError("input bundle entrypoint is not a declared file")
+    return InputBundleManifest(entrypoint=entrypoint, files=tuple(files))
+
+
+def _extract_archive(
+    source: Path,
+    temporary: Path,
+    *,
+    max_files: int,
+    max_total_bytes: int,
+) -> InputBundleManifest:
+    try:
+        archive = tarfile.open(source, mode="r:*")
+    except (OSError, tarfile.TarError) as exc:
+        raise InputBundleError("input bundle is not a readable tar archive") from exc
+    with archive:
+        members = _bounded_archive_members(archive, max_files=max_files)
+        by_name: dict[str, tarfile.TarInfo] = {}
+        for member in members:
+            name = _safe_relative_path(member.name, field="archive member")
+            if name in by_name:
+                raise InputBundleError(f"duplicate input bundle member: {name}")
+            if not member.isfile():
+                raise InputBundleError(
+                    f"input bundle member is not a regular file: {name}"
+                )
+            by_name[name] = member
+        manifest_member = by_name.get(INPUT_BUNDLE_MANIFEST_NAME)
+        if manifest_member is None or manifest_member.size > 1024 * 1024:
+            raise InputBundleError("input bundle manifest is missing or oversized")
+        manifest_stream = archive.extractfile(manifest_member)
+        if manifest_stream is None:
+            raise InputBundleError("input bundle manifest could not be read")
+        manifest_payload = manifest_stream.read(1024 * 1024 + 1)
+        manifest = _parse_manifest(manifest_payload, max_files=max_files)
+        declared = {item.path: item for item in manifest.files}
+        if set(by_name) != {INPUT_BUNDLE_MANIFEST_NAME, *declared}:
+            raise InputBundleError(
+                "input bundle members do not exactly match the manifest"
+            )
+        if sum(item.size_bytes for item in manifest.files) > max_total_bytes:
+            raise InputBundleError("input bundle payload exceeds the allowed bound")
+        manifest_path = temporary / INPUT_BUNDLE_MANIFEST_NAME
+        manifest_path.write_bytes(manifest_payload)
+        os.chmod(manifest_path, 0o600)
+        for item in manifest.files:
+            member = by_name[item.path]
+            if member.size != item.size_bytes:
+                raise InputBundleError(
+                    f"input bundle member size differs from manifest: {item.path}"
+                )
+            stream = archive.extractfile(member)
+            if stream is None:
+                raise InputBundleError(
+                    f"input bundle member could not be read: {item.path}"
+                )
+            _copy_member(
+                stream,
+                temporary / PurePosixPath(item.path),
+                expected_size=item.size_bytes,
+                expected_sha256=item.sha256,
+            )
+    return manifest
+
+
+def _bounded_archive_members(
+    archive: tarfile.TarFile,
+    *,
+    max_files: int,
+) -> tuple[tarfile.TarInfo, ...]:
+    """Read at most the permitted number of tar headers.
+
+    ``TarFile.getmembers`` materializes every header before the caller can
+    enforce a bound. Iteration lets malformed archives fail as soon as the
+    manifest plus the maximum payload count has been exceeded.
+    """
+
+    members: list[tarfile.TarInfo] = []
+    try:
+        for member in archive:
+            members.append(member)
+            if len(members) > max_files + 1:
+                raise InputBundleError(
+                    "input bundle member count is outside the allowed bound"
+                )
+    except tarfile.TarError as exc:
+        raise InputBundleError("input bundle archive headers are invalid") from exc
+    if len(members) < 2:
+        raise InputBundleError("input bundle member count is outside the allowed bound")
+    return tuple(members)
+
+
+def _read_archive_manifest(
+    source: Path,
+    *,
+    max_files: int,
+) -> InputBundleManifest:
+    """Read and validate the source archive's closed manifest contract."""
+
+    try:
+        archive = tarfile.open(source, mode="r:*")
+    except (OSError, tarfile.TarError) as exc:
+        raise InputBundleError("input bundle is not a readable tar archive") from exc
+    with archive:
+        members = _bounded_archive_members(archive, max_files=max_files)
+        manifest_member: tarfile.TarInfo | None = None
+        seen: set[str] = set()
+        for member in members:
+            name = _safe_relative_path(member.name, field="archive member")
+            if name in seen:
+                raise InputBundleError(f"duplicate input bundle member: {name}")
+            if not member.isfile():
+                raise InputBundleError(
+                    f"input bundle member is not a regular file: {name}"
+                )
+            seen.add(name)
+            if name == INPUT_BUNDLE_MANIFEST_NAME:
+                manifest_member = member
+        if manifest_member is None or manifest_member.size > 1024 * 1024:
+            raise InputBundleError("input bundle manifest is missing or oversized")
+        stream = archive.extractfile(manifest_member)
+        if stream is None:
+            raise InputBundleError("input bundle manifest could not be read")
+        payload = stream.read(1024 * 1024 + 1)
+    return _parse_manifest(payload, max_files=max_files)
+
+
+def _copy_member(
+    source: IO[bytes],
+    destination: Path,
+    *,
+    expected_size: int,
+    expected_sha256: str,
+) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    digest = hashlib.sha256()
+    written = 0
+    try:
+        with destination.open("xb") as stream:
+            os.chmod(destination, 0o600)
+            while chunk := source.read(1024 * 1024):
+                written += len(chunk)
+                if written > expected_size:
+                    raise InputBundleError(
+                        f"input bundle member exceeds declared size: {destination}"
+                    )
+                digest.update(chunk)
+                stream.write(chunk)
+    except OSError as exc:
+        raise InputBundleError(
+            f"input bundle member could not be materialized: {destination}"
+        ) from exc
+    if written != expected_size or digest.hexdigest() != expected_sha256:
+        raise InputBundleError(
+            f"input bundle member digest or size mismatch: {destination}"
+        )
+
+
+def _load_existing_bundle(
+    destination: Path,
+    *,
+    source: Path,
+    marker: Path,
+    bundle_sha256: str,
+    max_files: int,
+    max_total_bytes: int,
+) -> MaterializedInputBundle:
+    try:
+        reject_private_path_redirection(destination)
+        recorded = json.loads(marker.read_text(encoding="utf-8"))
+        manifest = _parse_manifest(
+            (destination / INPUT_BUNDLE_MANIFEST_NAME).read_bytes(),
+            max_files=max_files,
+        )
+        source_manifest = _read_archive_manifest(source, max_files=max_files)
+    except (InputBundleError, OSError, RuntimeError, json.JSONDecodeError) as exc:
+        raise InputBundleError(
+            "existing input bundle destination is incomplete"
+        ) from exc
+    expected_marker: Mapping[str, str] = {
+        "bundle_sha256": bundle_sha256,
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+    }
+    if recorded != expected_marker:
+        raise InputBundleError(
+            "existing input bundle destination has the wrong identity"
+        )
+    if manifest != source_manifest:
+        raise InputBundleError(
+            "existing input bundle manifest differs from the source archive"
+        )
+    if sum(item.size_bytes for item in manifest.files) > max_total_bytes:
+        raise InputBundleError("input bundle payload exceeds the allowed bound")
+    _validate_materialized(destination, manifest)
+    return MaterializedInputBundle(
+        root=destination,
+        entrypoint=destination / PurePosixPath(manifest.entrypoint),
+        manifest=manifest,
+        bundle_sha256=bundle_sha256,
+    )
+
+
+def _validate_materialized(root: Path, manifest: InputBundleManifest) -> None:
+    expected = {
+        INPUT_BUNDLE_MANIFEST_NAME,
+        _COMPLETION_MARKER_NAME,
+        *(item.path for item in manifest.files),
+    }
+    try:
+        reject_private_path_redirection(root)
+        observed: set[str] = set()
+        for path in root.rglob("*"):
+            if path.is_symlink():
+                raise InputBundleError("materialized input bundle contains a link")
+            if path.is_file():
+                observed.add(path.relative_to(root).as_posix())
+        if observed != expected:
+            raise InputBundleError(
+                "materialized input bundle contains unexpected or missing files"
+            )
+        for item in manifest.files:
+            path = root / PurePosixPath(item.path)
+            status = path.lstat()
+            if (
+                not stat.S_ISREG(status.st_mode)
+                or status.st_size != item.size_bytes
+                or _sha256_file(path) != item.sha256
+            ):
+                raise InputBundleError(
+                    f"materialized input bundle member changed: {item.path}"
+                )
+    except OSError as exc:
+        raise InputBundleError(
+            "materialized input bundle could not be verified"
+        ) from exc
+
+
+__all__ = [
+    "INPUT_BUNDLE_MANIFEST_NAME",
+    "INPUT_BUNDLE_SCHEMA_VERSION",
+    "InputBundleError",
+    "InputBundleFile",
+    "InputBundleManifest",
+    "MaterializedInputBundle",
+    "extract_input_bundle",
+    "stage_input_bundle",
+]

--- a/jarvis_cd/runtime_callback.py
+++ b/jarvis_cd/runtime_callback.py
@@ -1,0 +1,45 @@
+"""Process-output callback ownership for multi-phase JARVIS packages."""
+
+from __future__ import annotations
+
+from typing import Callable, cast
+
+
+class RuntimePhaseLineCallback:
+    """Bind one shared runtime callback to an intermediate or terminal process.
+
+    Multi-process packages must not finalize their package-level progress and
+    artifact providers after each successful process. Intermediate phases keep
+    the shared callback open on success, while any failed phase and the declared
+    terminal phase preserve the normal process-owned finalization semantics.
+    """
+
+    def __init__(
+        self,
+        delegate: Callable[[str, str], None],
+        *,
+        terminal: bool,
+    ) -> None:
+        self._delegate = delegate
+        self._terminal = terminal
+
+    def __call__(self, stream_name: str, line: str) -> None:
+        """Forward one captured process-output line to the shared callback."""
+        self._delegate(stream_name, line)
+
+    def finalize_process(self, return_code: int) -> None:
+        """Finalize only a failed phase or the declared terminal phase."""
+        if not self._terminal and return_code == 0:
+            return
+        process_finalizer = getattr(self._delegate, "finalize_process", None)
+        finalizer = getattr(self._delegate, "finalize", None)
+        if callable(process_finalizer):
+            cast(Callable[[int], None], process_finalizer)(return_code)
+        elif callable(finalizer):
+            cast(Callable[[], None], finalizer)()
+
+    def reconcile_process_exit(self, return_code: int) -> None:
+        """Forward effective nonzero-exit reconciliation to the shared callback."""
+        reconciler = getattr(self._delegate, "reconcile_process_exit", None)
+        if callable(reconciler):
+            cast(Callable[[int], None], reconciler)(return_code)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ jarvis_cd = ["*.yaml", "*.yml"]
 "*" = ["*.py", "*.yaml", "*.yml", "*.md", "*.txt", "*.conf", "*.xml", "*.param", "*.f", "*.input", "*.png", "*.sh"]
 builtin = ["pipelines/**/*.yaml", "pipelines/**/*.yml"]
 
+[tool.setuptools.data-files]
+"." = ["wfcommons-schema.json"]
+
 [project.scripts]
 jarvis = "jarvis_cd.core.cli:main"
 

--- a/test/unit/core/test_adios2_gray_scott_analysis.py
+++ b/test/unit/core/test_adios2_gray_scott_analysis.py
@@ -1,0 +1,319 @@
+"""Tests for reusable paired Gray-Scott morphology analysis."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+    extract_input_bundle,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "adios2_gray_scott_analysis"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_adios2_gray_scott_analysis_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load package: {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _configuration(*, feed: float, kill: float, output: str) -> bytes:
+    return json.dumps(
+        {
+            "Du": 0.2,
+            "Dv": 0.1,
+            "F": feed,
+            "L": 64,
+            "adios_config": "adios2.xml",
+            "adios_memory_selection": False,
+            "adios_span": False,
+            "checkpoint": False,
+            "checkpoint_freq": 2000,
+            "checkpoint_output": f"checkpoint-{output}",
+            "dt": 2.0,
+            "k": kill,
+            "mesh_type": "image",
+            "noise": 0.0,
+            "output": output,
+            "plotgap": 100,
+            "steps": 1000,
+        },
+        sort_keys=True,
+    ).encode()
+
+
+def _write_bundle(destination: Path, *, analysis_role: str = "analysis_source") -> Path:
+    files = {
+        "CMakeLists.txt": (
+            "build_spec",
+            b"project(gray_scott_analysis)\nadd_executable(gray-scott-analyze analysis.cpp)\n",
+        ),
+        "analysis.cpp": (analysis_role, b"int main() { return 0; }\n"),
+        "config/high.json": (
+            "scientific_input",
+            _configuration(feed=0.03, kill=0.0545, output="high.bp"),
+        ),
+        "config/low.json": (
+            "scientific_input",
+            _configuration(feed=0.02, kill=0.048, output="low.bp"),
+        ),
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "config/low.json",
+        "files": [
+            {
+                "path": name,
+                "role": role,
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, (role, payload) in sorted(files.items())
+        ],
+    }
+    manifest_payload = json.dumps(manifest, sort_keys=True).encode()
+    with tarfile.open(destination, mode="w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(manifest_payload)
+        archive.addfile(info, io.BytesIO(manifest_payload))
+        for name, (_role, payload) in sorted(files.items()):
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def _metrics(threshold: float) -> dict[str, float | int]:
+    return {
+        "active_fraction": 0.2,
+        "active_threshold": threshold,
+        "component_count": 3,
+        "interface_density": 0.12,
+        "largest_component_fraction_of_active": 0.8,
+        "max": 0.7,
+        "mean": 0.2,
+        "min": 0.0,
+        "standard_deviation": 0.15,
+        "surface_to_active": 1.2,
+    }
+
+
+def _result(
+    low: dict[str, Any], high: dict[str, Any], threshold: float
+) -> dict[str, Any]:
+    return {
+        "cases": {
+            "feed_high": {
+                "configuration": high,
+                "element_count": 64**3,
+                "final_simulation_step": 1000,
+                "output_steps": 10,
+                "shape": [64, 64, 64],
+                "u": _metrics(threshold),
+                "v": _metrics(threshold),
+            },
+            "feed_low": {
+                "configuration": low,
+                "element_count": 64**3,
+                "final_simulation_step": 1000,
+                "output_steps": 10,
+                "shape": [64, 64, 64],
+                "u": _metrics(threshold),
+                "v": _metrics(threshold),
+            },
+        },
+        "comparison": {
+            "max_absolute_v_difference": 0.5,
+            "pearson_v_correlation": 0.25,
+            "relative_v_l2_difference": 0.8,
+            "v_rms_difference": 0.2,
+        },
+        "schema_version": "jarvis.gray-scott-morphology.v1",
+    }
+
+
+def test_analysis_bundle_resolves_declared_source_and_configuration(
+    tmp_path: Path,
+) -> None:
+    """The build and paired configurations come only from declared bundle roles."""
+    module = _module()
+    archive = _write_bundle(tmp_path / "gray-scott.tar")
+    bundle = extract_input_bundle(archive, tmp_path / "materialized")
+
+    selected = module.resolve_analysis_bundle(
+        bundle,
+        "config/low.json",
+        "config/high.json",
+    )
+
+    assert selected.build_spec == bundle.root / "CMakeLists.txt"
+    assert selected.analysis_source == bundle.root / "analysis.cpp"
+    assert selected.low.values["F"] == 0.02
+    assert selected.high.values["F"] == 0.03
+
+    mistyped = _write_bundle(tmp_path / "mistyped.tar", analysis_role="upstream_source")
+    invalid = extract_input_bundle(mistyped, tmp_path / "invalid")
+    with pytest.raises(ValueError, match="one analysis_source"):
+        module.resolve_analysis_bundle(invalid, "config/low.json", "config/high.json")
+
+
+def test_analysis_result_is_closed_and_bound_to_inputs(tmp_path: Path) -> None:
+    """Result validation binds both configuration documents and the threshold."""
+    module = _module()
+    low = json.loads(_configuration(feed=0.02, kill=0.048, output="low.bp"))
+    high = json.loads(_configuration(feed=0.03, kill=0.0545, output="high.bp"))
+    result_path = tmp_path / "result.json"
+    result_path.write_text(json.dumps(_result(low, high, 0.1)), encoding="utf-8")
+
+    result = module.validate_result_document(
+        result_path,
+        low,
+        high,
+        active_threshold=0.1,
+    )
+
+    assert result["comparison"]["v_rms_difference"] == 0.2
+    changed = _result(low, high, 0.2)
+    result_path.write_text(json.dumps(changed), encoding="utf-8")
+    with pytest.raises(ValueError, match="threshold"):
+        module.validate_result_document(
+            result_path,
+            low,
+            high,
+            active_threshold=0.1,
+        )
+
+
+def test_analysis_menu_and_deployment_expose_source_bundle_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agents see paired data, paired configurations, threshold, and result output."""
+    module = _module()
+    package = object.__new__(module.Adios2GrayScottAnalysis)
+    package.config = {"input_bundle": "/inputs/gray-scott.tar"}
+    package.env = {}
+    package.mod_env = {}
+    monkeypatch.setattr(
+        module,
+        "probe_program",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            status=module.RuntimeStatus("ready", "runtime_probe_succeeded")
+        ),
+    )
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    document = package.describe_deployment()
+
+    assert menu["input_bundle"]["input_binding"]["kind"] == "local_file"
+    assert menu["active_threshold"]["default"] == 0.1
+    assert menu["low_input"]["default"] is None
+    assert menu["high_input"]["default"] is None
+    assert document is not None
+    assert {profile["name"] for profile in document["execution_profiles"]} == {
+        "installed_executable",
+        "source_bundle",
+    }
+
+
+class _SuccessfulExec:
+    calls: list[tuple[str, Any]] = []
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.calls.append((command, exec_info))
+        self.exit_code = {"ares": 0}
+
+    def run(self) -> "_SuccessfulExec":
+        return self
+
+
+class _FailedExec:
+    def __init__(self, _command: str, _exec_info: Any) -> None:
+        self.exit_code = {"ares": 7}
+
+    def run(self) -> "_FailedExec":
+        return self
+
+
+def test_analysis_bundle_builds_only_the_declared_analysis_target(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Source builds are confined to one staged tree and one analysis target."""
+    module = _module()
+    archive = _write_bundle(tmp_path / "gray-scott.tar")
+    package = object.__new__(module.Adios2GrayScottAnalysis)
+    package.shared_dir = str(tmp_path / "shared")
+    package.mod_env = {}
+    package.config = {
+        "input_bundle": str(archive),
+        "low_configuration": "config/low.json",
+        "high_configuration": "config/high.json",
+    }
+    _SuccessfulExec.calls = []
+    monkeypatch.setattr(module, "Exec", _SuccessfulExec)
+
+    executable, low, high, cwd = package._prepare_bundle_run()
+
+    run = (tmp_path / "shared" / "run").resolve()
+    assert executable == str(run / "build" / "bin" / "gray-scott-analyze")
+    assert low == run / "config" / "low.json"
+    assert high == run / "config" / "high.json"
+    assert cwd == run
+    assert _SuccessfulExec.calls[-1][0].endswith(
+        "--parallel 4 --target gray-scott-analyze"
+    )
+
+
+def test_analysis_propagates_native_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A failed analyzer cannot be converted into a successful package execution."""
+    module = _module()
+    low_input = tmp_path / "low.bp"
+    high_input = tmp_path / "high.bp"
+    low_input.mkdir()
+    high_input.mkdir()
+    low_config = tmp_path / "low.json"
+    high_config = tmp_path / "high.json"
+    low_config.write_bytes(_configuration(feed=0.02, kill=0.048, output="low.bp"))
+    high_config.write_bytes(_configuration(feed=0.03, kill=0.0545, output="high.bp"))
+    package = object.__new__(module.Adios2GrayScottAnalysis)
+    package.config = {
+        "active_threshold": 0.1,
+        "executable": "gray-scott-analyze",
+        "high_configuration": str(high_config),
+        "high_input": str(high_input),
+        "input_bundle": "",
+        "low_configuration": str(low_config),
+        "low_input": str(low_input),
+        "nprocs": 1,
+        "output_file": str(tmp_path / "result.json"),
+        "ppn": 1,
+    }
+    package.mod_env = {}
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: None)
+    package.runtime_line_callback = lambda: None
+    monkeypatch.setattr(module, "Exec", _FailedExec)
+
+    with pytest.raises(RuntimeError, match="Gray-Scott analysis.*ares=7"):
+        package.start()

--- a/test/unit/core/test_adios2_gray_scott_analysis.py
+++ b/test/unit/core/test_adios2_gray_scott_analysis.py
@@ -234,6 +234,40 @@ def test_analysis_menu_and_deployment_expose_source_bundle_profile(
     }
 
 
+def test_analysis_configuration_preserves_agent_supplied_output_value(
+    tmp_path: Path,
+) -> None:
+    """Configuration persistence retains the value verified by the MCP client."""
+    module = _module()
+    low_input = tmp_path / "low.bp"
+    high_input = tmp_path / "high.bp"
+    low_input.mkdir()
+    high_input.mkdir()
+    low_config = tmp_path / "low.json"
+    high_config = tmp_path / "high.json"
+    low_config.write_bytes(_configuration(feed=0.02, kill=0.048, output="low.bp"))
+    high_config.write_bytes(_configuration(feed=0.03, kill=0.0545, output="high.bp"))
+    package = object.__new__(module.Adios2GrayScottAnalysis)
+    package.shared_dir = str(tmp_path / "shared")
+    package.config = {
+        "active_threshold": 0.1,
+        "executable": "gray-scott-analyze",
+        "high_configuration": str(high_config),
+        "high_input": str(high_input),
+        "input_bundle": "",
+        "low_configuration": str(low_config),
+        "low_input": str(low_input),
+        "nprocs": 1,
+        "output_file": "result.json",
+        "ppn": 1,
+    }
+
+    package._configure(**package.config)
+
+    assert package.config["output_file"] == "result.json"
+    assert package._output_path() == (tmp_path / "shared" / "result.json").resolve()
+
+
 class _SuccessfulExec:
     calls: list[tuple[str, Any]] = []
 

--- a/test/unit/core/test_adios2_gray_scott_analysis_artifacts.py
+++ b/test/unit/core/test_adios2_gray_scott_analysis_artifacts.py
@@ -1,0 +1,158 @@
+"""Tests for paired Gray-Scott analysis artifact semantics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import (
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "adios2_gray_scott_analysis"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def _result(path: Path, schema: str = "jarvis.gray-scott-morphology.v1") -> None:
+    metrics = {
+        "active_fraction": 0.2,
+        "active_threshold": 0.1,
+        "component_count": 2,
+        "interface_density": 0.1,
+        "largest_component_fraction_of_active": 0.8,
+        "max": 0.7,
+        "mean": 0.2,
+        "min": 0.0,
+        "standard_deviation": 0.1,
+        "surface_to_active": 1.0,
+    }
+    case = {
+        "configuration": {"F": 0.02},
+        "element_count": 8,
+        "final_simulation_step": 100,
+        "output_steps": 10,
+        "shape": [2, 2, 2],
+        "u": metrics,
+        "v": metrics,
+    }
+    path.write_text(
+        json.dumps(
+            {
+                "cases": {"feed_high": case, "feed_low": case},
+                "comparison": {
+                    "max_absolute_v_difference": 0.5,
+                    "pearson_v_correlation": 0.2,
+                    "relative_v_l2_difference": 0.8,
+                    "v_rms_difference": 0.3,
+                },
+                "schema_version": schema,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_analysis_finalizes_one_typed_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Successful exit exposes the validated JSON result as scientific analysis."""
+    output = tmp_path / "result.json"
+    _result(output)
+    module = _module()
+    assert module._valid_result(output, 0.1) == (True, output.stat().st_size)
+    monkeypatch.setattr(
+        module,
+        "_valid_result",
+        lambda _path, _threshold: (True, output.stat().st_size),
+    )
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_gray_scott_analysis",
+            "output_file": "/execution/shared/result.json",
+            "active_threshold": 0.1,
+            "low_input": "/datasets/low.bp",
+            "high_input": "/datasets/high.bp",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert len(observations) == 1
+    result = observations[0]
+    assert result.state is ArtifactState.FINALIZED
+    assert result.logical_name == "gray-scott-morphology-comparison"
+    assert result.role is ArtifactRole.VALIDATION
+    assert result.structure is ArtifactStructure.FILE
+    assert result.ownership is ArtifactOwnership.SHARED
+    assert result.location is not None
+    assert result.location.value == "/execution/shared/result.json"
+    assert result.format == "jarvis.gray-scott-morphology.v1"
+    assert result.metadata["active_threshold"] == 0.1
+
+
+def test_analysis_rejects_missing_or_wrong_schema_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Missing, malformed, or wrong-schema bytes remain explicitly incomplete."""
+    output = tmp_path / "result.json"
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_gray_scott_analysis",
+            "output_file": "/execution/shared/result.json",
+            "active_threshold": 0.1,
+            "low_input": "/datasets/low.bp",
+            "high_input": "/datasets/high.bp",
+        }
+    )
+    assert adapter is not None
+    assert module._valid_result(output, 0.1) == (False, None)
+
+    _result(output, schema="wrong")
+    assert module._valid_result(output, 0.1) == (False, None)
+    _result(output)
+    changed = json.loads(output.read_text(encoding="utf-8"))
+    changed["cases"]["feed_high"]["v"]["active_threshold"] = 0.2
+    output.write_text(json.dumps(changed), encoding="utf-8")
+    assert module._valid_result(output, 0.1) == (False, None)
+    monkeypatch.setattr(
+        module, "_valid_result", lambda _path, _threshold: (False, None)
+    )
+    assert adapter.finalize_artifacts_for_exit(0)[0].state is ArtifactState.INCOMPLETE
+
+
+def test_analysis_factory_is_package_local_and_requires_absolute_output() -> None:
+    """Artifact authority is exact and never inferred from another package."""
+    module = _module()
+    assert (
+        module.adapter_from_package({"pkg_type": "builtin.adios2_gray_scott"}) is None
+    )
+    try:
+        module.adapter_from_package(
+            {
+                "pkg_type": "builtin.adios2_gray_scott_analysis",
+                "output_file": "relative.json",
+            }
+        )
+    except ValueError as error:
+        assert "absolute" in str(error)
+    else:
+        raise AssertionError("relative analysis output was accepted")

--- a/test/unit/core/test_adios2_gray_scott_inputs.py
+++ b/test/unit/core/test_adios2_gray_scott_inputs.py
@@ -171,6 +171,7 @@ def test_gray_scott_menu_and_deployment_expose_portable_bundle_profile(
         "structure": "regular_file",
     }
     assert menu["configuration_path"]["default"] == ""
+    assert menu["out_file"]["default"] == ""
     assert document is not None
     assert {profile["name"] for profile in document["execution_profiles"]} == {
         "installed_executable",

--- a/test/unit/core/test_adios2_gray_scott_inputs.py
+++ b/test/unit/core/test_adios2_gray_scott_inputs.py
@@ -1,0 +1,280 @@
+"""Tests for portable ADIOS2 Gray-Scott source and configuration bundles."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+    extract_input_bundle,
+)
+
+
+def _package_module(package: str) -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3] / "builtin" / "builtin" / package / "pkg.py"
+    )
+    spec = spec_from_file_location(f"test_{package}_input_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load package: {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _configuration(*, output: str = "fields.bp") -> bytes:
+    return json.dumps(
+        {
+            "Du": 0.2,
+            "Dv": 0.1,
+            "F": 0.02,
+            "L": 64,
+            "adios_config": "adios2.xml",
+            "adios_memory_selection": False,
+            "adios_span": False,
+            "checkpoint": False,
+            "checkpoint_freq": 100,
+            "checkpoint_output": "checkpoint.bp",
+            "dt": 2.0,
+            "k": 0.048,
+            "mesh_type": "image",
+            "noise": 0.0,
+            "output": output,
+            "plotgap": 10,
+            "restart": False,
+            "restart_input": "checkpoint.bp",
+            "steps": 100,
+        },
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _write_bundle(
+    destination: Path,
+    *,
+    output: str = "fields.bp",
+    selected_role: str = "scientific_input",
+) -> Path:
+    files = {
+        "CMakeLists.txt": ("build_spec", b"project(gray_scott)\n"),
+        "adios2.xml": ("adios2_configuration", b"<adios-config/>\n"),
+        "config/high.json": (selected_role, _configuration(output=output)),
+        "config/low.json": ("scientific_input", _configuration()),
+        "src/main.cpp": ("upstream_source", b"int main() { return 0; }\n"),
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "config/low.json",
+        "files": [
+            {
+                "path": name,
+                "role": role,
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, (role, payload) in sorted(files.items())
+        ],
+    }
+    manifest_payload = json.dumps(manifest, sort_keys=True).encode("utf-8")
+    with tarfile.open(destination, mode="w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(manifest_payload)
+        archive.addfile(info, io.BytesIO(manifest_payload))
+        for name, (_role, payload) in sorted(files.items()):
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def test_gray_scott_selects_only_manifest_declared_scientific_configuration(
+    tmp_path: Path,
+) -> None:
+    """A selected regime is a verified bundle member, never a free path."""
+    module = _package_module("adios2_gray_scott")
+    archive = _write_bundle(tmp_path / "gray-scott.tar")
+    bundle = extract_input_bundle(archive, tmp_path / "materialized")
+
+    selected = module.resolve_bundle_configuration(bundle, "config/high.json")
+
+    assert selected.path == bundle.root / "config" / "high.json"
+    assert selected.values["F"] == 0.02
+    assert selected.values["output"] == "fields.bp"
+    assert selected.build_spec == bundle.root / "CMakeLists.txt"
+    assert selected.adios_config == bundle.root / "adios2.xml"
+
+    with pytest.raises(ValueError, match="declared scientific_input"):
+        module.resolve_bundle_configuration(bundle, "CMakeLists.txt")
+    with pytest.raises(ValueError, match="declared scientific_input"):
+        module.resolve_bundle_configuration(bundle, "../outside.json")
+
+
+@pytest.mark.parametrize(
+    ("output", "selected_role", "message"),
+    [
+        ("/tmp/foreign.bp", "scientific_input", "relative bundle path"),
+        ("fields.bp", "upstream_source", "declared scientific_input"),
+    ],
+)
+def test_gray_scott_rejects_unsafe_or_mistyped_configuration_bundle(
+    tmp_path: Path,
+    output: str,
+    selected_role: str,
+    message: str,
+) -> None:
+    """Bundle data cannot redirect output or masquerade as scientific input."""
+    module = _package_module("adios2_gray_scott")
+    archive = _write_bundle(
+        tmp_path / "gray-scott.tar",
+        output=output,
+        selected_role=selected_role,
+    )
+    bundle = extract_input_bundle(archive, tmp_path / "materialized")
+
+    with pytest.raises(ValueError, match=message):
+        module.resolve_bundle_configuration(bundle, "config/high.json")
+
+
+def test_gray_scott_menu_and_deployment_expose_portable_bundle_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agents see one staged bundle and a confined member selector."""
+    module = _package_module("adios2_gray_scott")
+    package = object.__new__(module.Adios2GrayScott)
+    package.config = {"input_bundle": "/inputs/gray-scott.tar"}
+    package.env = {}
+    package.mod_env = {}
+    monkeypatch.setattr(
+        module,
+        "probe_program",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            status=module.RuntimeStatus("ready", "runtime_probe_succeeded")
+        ),
+    )
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    document = package.describe_deployment()
+
+    assert menu["input_bundle"]["input_binding"] == {
+        "schema_version": "jarvis.configuration-input-binding.v1",
+        "kind": "local_file",
+        "structure": "regular_file",
+    }
+    assert menu["configuration_path"]["default"] == ""
+    assert document is not None
+    assert {profile["name"] for profile in document["execution_profiles"]} == {
+        "installed_executable",
+        "source_bundle",
+    }
+    bundle_profile = next(
+        profile
+        for profile in document["execution_profiles"]
+        if profile["name"] == "source_bundle"
+    )
+    assert bundle_profile["runtime_requirements"] == ["gray_scott_source_build"]
+
+
+class _FailedExec:
+    def __init__(self, _command: str, _exec_info: Any) -> None:
+        self.exit_code = {"ares": 9}
+
+    def run(self) -> "_FailedExec":
+        return self
+
+
+class _SuccessfulExec:
+    calls: list[tuple[str, Any]] = []
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.calls.append((command, exec_info))
+        self.exit_code = {"ares": 0}
+
+    def run(self) -> "_SuccessfulExec":
+        return self
+
+
+def test_gray_scott_bundle_materializes_one_execution_owned_run(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Build and scientific paths derive only from the verified staged tree."""
+    module = _package_module("adios2_gray_scott")
+    archive = _write_bundle(tmp_path / "gray-scott.tar")
+    shared = tmp_path / "shared"
+    package = object.__new__(module.Adios2GrayScott)
+    package.shared_dir = str(shared)
+    package.mod_env = {}
+    package.config = {
+        "input_bundle": str(archive),
+        "configuration_path": "config/high.json",
+    }
+    _SuccessfulExec.calls = []
+    monkeypatch.setattr(module, "Exec", _SuccessfulExec)
+
+    executable, cwd = package._prepare_bundle_run()
+
+    run = shared / "run"
+    assert executable == str(run / "build" / "bin" / "gray-scott")
+    assert cwd == str(run.resolve())
+    assert [call[0] for call in _SuccessfulExec.calls] == [
+        (
+            f"cmake -S {module.shlex.quote(str(run.resolve()))} "
+            f"-B {module.shlex.quote(str(run.resolve() / 'build'))} "
+            "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=mpicc "
+            "-DCMAKE_CXX_COMPILER=mpic++"
+        ),
+        (
+            "cmake --build "
+            f"{module.shlex.quote(str(run.resolve() / 'build'))} "
+            "--parallel 4 --target gray-scott"
+        ),
+    ]
+    settings = json.loads((run / "config" / "high.json").read_text(encoding="utf-8"))
+    assert settings["F"] == 0.02
+    assert settings["output"] == str(run.resolve() / "fields.bp")
+    assert settings["adios_config"] == str(run.resolve() / "adios2.xml")
+    assert package.config["out_file"] == str(run.resolve() / "fields.bp")
+
+
+def test_pdf_calc_uses_explicit_executable_and_propagates_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """PDF Calc has no developer checkout path and cannot hide a failed run."""
+    module = _package_module("adios2_pdf_calc")
+    package = object.__new__(module.Adios2PdfCalc)
+    package.config = {
+        "engine": "bp5",
+        "executable": "pdf_calc",
+        "input_file": str(tmp_path / "fields.bp"),
+        "output_file": str(tmp_path / "pdf.bp"),
+        "nbins": 128,
+        "nprocs": 1,
+        "ppn": 1,
+        "output_inputdata": "NO",
+        "wait_for_producer": False,
+    }
+    package.adios2_xml_path = str(tmp_path / "adios2.xml")
+    package.shared_dir = str(tmp_path)
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: object())
+    package.mod_env = {}
+    package.runtime_line_callback = lambda: None
+    monkeypatch.setattr(module.shutil, "copyfile", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "Exec", _FailedExec)
+
+    with pytest.raises(RuntimeError, match="PDF Calc.*ares=9"):
+        package.start()
+
+    assert module.__file__ is not None
+    source = Path(module.__file__).read_text(encoding="utf-8")
+    assert "/workspace/external" not in source

--- a/test/unit/core/test_adios2_pdf_calc_artifacts.py
+++ b/test/unit/core/test_adios2_pdf_calc_artifacts.py
@@ -1,0 +1,98 @@
+"""Tests for builtin ADIOS2 PDF Calc artifact semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+from jarvis_cd.artifacts import (
+    ArtifactOwnership,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "adios2_pdf_calc"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def test_pdf_calc_finalizes_one_typed_analysis_dataset() -> None:
+    """Successful process exit promotes the declared BP output to finalized."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_pdf_calc",
+            "output_file": "/scratch/run/feed-low-pdf.bp",
+            "engine": "bp5",
+            "nbins": 128,
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts(
+        "PDF analysis writes using engine type: BP5\n"
+    )
+    observations += adapter.finalize_artifacts_for_exit(0)
+
+    assert [item.state for item in observations] == [
+        ArtifactState.PRODUCING,
+        ArtifactState.FINALIZED,
+    ]
+    final = observations[-1]
+    assert final.logical_name == "gray-scott-pdf-analysis"
+    assert final.role is ArtifactRole.OUTPUT
+    assert final.structure is ArtifactStructure.COLLECTION
+    assert final.ownership is ArtifactOwnership.SHARED
+    assert final.location is not None
+    assert final.location.value == "/scratch/run/feed-low-pdf.bp"
+    assert final.media_type == "application/x-adios2-bp"
+    assert final.format == "adios2-bp5-pdf"
+    assert final.metadata["bins"] == 128
+
+
+def test_pdf_calc_nonzero_exit_is_incomplete_and_idempotent() -> None:
+    """A process failure cannot leave a finalized analysis claim."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.adios2_pdf_calc",
+            "output_file": "/scratch/run/pdf.bp",
+            "engine": "bp5",
+            "nbins": 64,
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.finalize_artifacts_for_exit(7)
+
+    assert len(observations) == 1
+    assert observations[0].state is ArtifactState.INCOMPLETE
+    assert observations[0].metadata["return_code"] == 7
+    assert adapter.finalize_artifacts_for_exit(7) == []
+
+
+def test_pdf_calc_factory_is_package_local_and_requires_absolute_output() -> None:
+    """Artifact authority is exact and cannot be inferred from a relative path."""
+    module = _module()
+
+    assert (
+        module.adapter_from_package({"pkg_type": "builtin.adios2_gray_scott"}) is None
+    )
+    try:
+        module.adapter_from_package(
+            {
+                "pkg_type": "builtin.adios2_pdf_calc",
+                "output_file": "relative.bp",
+            }
+        )
+    except ValueError as exc:
+        assert "absolute" in str(exc)
+    else:
+        raise AssertionError("relative PDF Calc output was accepted")

--- a/test/unit/core/test_biobb_wf_md_setup_artifacts.py
+++ b/test/unit/core/test_biobb_wf_md_setup_artifacts.py
@@ -1,0 +1,178 @@
+"""Generated-artifact tests for the builtin BioBB MD-setup package."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import ArtifactRole, ArtifactState, load_artifacts_module
+
+
+def _load_artifacts() -> ModuleType:
+    """Load BioBB artifact semantics directly from the builtin package."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "biobb_wf_md_setup"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _closed_result(root: Path, *, status: str = "completed") -> None:
+    products = [
+        ("fixed.pdb", "pdb"),
+        ("processed.gro", "gromacs-gro"),
+        ("processed_topology.zip", "gromacs-topology-zip"),
+        ("boxed.gro", "gromacs-gro"),
+        ("solvated.gro", "gromacs-gro"),
+        ("solvated_topology.zip", "gromacs-topology-zip"),
+    ]
+    artifacts = []
+    for name, format_name in products:
+        path = root / name
+        path.write_bytes(f"product:{name}\n".encode())
+        artifacts.append(
+            {
+                "path": name,
+                "format": format_name,
+                "size_bytes": path.stat().st_size,
+                "sha256": _sha(path),
+            }
+        )
+    result = {
+        "schema_version": "jarvis.biobb-md-setup-result.v1",
+        "status": status,
+        "return_code": 0 if status == "completed" else 1,
+        "parameters": {
+            "force_field": "amber99sb-ildn",
+            "water_type": "tip3p",
+            "box_type": "cubic",
+            "distance_to_molecule": 1.0,
+            "ignore_input_hydrogens": True,
+            "merge_chains": False,
+        },
+        "input": {"path": "input.pdb", "size_bytes": 5, "sha256": "0" * 64},
+        "stages": [{"name": "solvate", "status": status}],
+        "metrics": {
+            "boxed_volume_nm3": 24.0,
+            "solvated_atom_count": 8,
+            "solvent_molecule_count": 2,
+        },
+        "artifacts": artifacts,
+    }
+    (root / "biobb-result.json").write_text(json.dumps(result), encoding="utf-8")
+
+
+def test_success_reports_result_and_all_exact_products(tmp_path: Path) -> None:
+    """A closed successful cell exposes hashes and semantic metrics."""
+
+    _closed_result(tmp_path)
+    module = _load_artifacts()
+    adapter = module.BiobbMdSetupArtifactAdapter(
+        module.PurePosixPath("/execution/shared/biobb"), tmp_path
+    )
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert [item.logical_name for item in observations] == [
+        "biobb-md-setup-result",
+        "biobb-fixed-structure",
+        "biobb-processed-coordinates",
+        "biobb-processed-topology",
+        "biobb-boxed-coordinates",
+        "biobb-solvated-coordinates",
+        "biobb-solvated-topology",
+    ]
+    assert all(item.state is ArtifactState.FINALIZED for item in observations)
+    assert observations[0].role is ArtifactRole.OUTPUT
+    assert observations[0].metadata["solvent_molecule_count"] == 2
+    assert adapter.finalize_artifacts_for_exit(0) == []
+
+
+def test_nonzero_process_or_failed_document_never_finalizes(tmp_path: Path) -> None:
+    """Filesystem presence cannot conceal process or driver failure."""
+
+    _closed_result(tmp_path, status="failed")
+    module = _load_artifacts()
+    adapter = module.BiobbMdSetupArtifactAdapter(
+        module.PurePosixPath("/execution/shared/biobb"), tmp_path
+    )
+
+    observations = adapter.finalize_artifacts_for_exit(7)
+
+    assert observations
+    assert all(item.state is ArtifactState.INCOMPLETE for item in observations)
+
+
+def test_declared_product_hash_and_root_confinement_are_enforced(
+    tmp_path: Path,
+) -> None:
+    """A result cannot redirect artifact ownership or silently change a file."""
+
+    _closed_result(tmp_path)
+    module = _load_artifacts()
+    document = json.loads((tmp_path / "biobb-result.json").read_text())
+    document["artifacts"][0]["sha256"] = "f" * 64
+    (tmp_path / "biobb-result.json").write_text(json.dumps(document))
+    adapter = module.BiobbMdSetupArtifactAdapter(
+        module.PurePosixPath("/execution/shared/biobb"), tmp_path
+    )
+    with pytest.raises(RuntimeError, match="hash differs"):
+        adapter.finalize_artifacts_for_exit(0)
+
+    _closed_result(tmp_path)
+    document = json.loads((tmp_path / "biobb-result.json").read_text())
+    document["artifacts"][0]["path"] = "../outside.pdb"
+    (tmp_path / "biobb-result.json").write_text(json.dumps(document))
+    adapter = module.BiobbMdSetupArtifactAdapter(
+        module.PurePosixPath("/execution/shared/biobb"), tmp_path
+    )
+    with pytest.raises(RuntimeError, match="escaped"):
+        adapter.finalize_artifacts_for_exit(0)
+
+
+def test_factory_resolves_relative_output_and_ignores_unrelated_packages() -> None:
+    """Artifact discovery uses the same package-owned root as native launch."""
+
+    module = _load_artifacts()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.biobb_wf_md_setup",
+            "out": "run",
+            "shared_dir": "/execution/shared/biobb",
+            "runtime_cwd": "/execution/runtime",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.output_dir.as_posix() == "/execution/shared/biobb/run"
+    assert module.adapter_from_package({"pkg_type": "builtin.ior"}) is None
+
+
+def test_container_private_output_is_not_claimed() -> None:
+    """A host cannot report artifacts from an unmounted container path."""
+
+    module = _load_artifacts()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.biobb_wf_md_setup",
+            "out": "/tmp/biobb",
+            "effective_deploy_mode": "container",
+            "shared_dir": "/execution/shared",
+            "private_dir": "/execution/private",
+            "runtime_cwd": "/execution/runtime",
+        }
+    )
+
+    assert adapter is None

--- a/test/unit/core/test_biobb_wf_md_setup_driver.py
+++ b/test/unit/core/test_biobb_wf_md_setup_driver.py
@@ -1,0 +1,234 @@
+"""Tests for the package-owned BioBB MD-setup driver."""
+
+from __future__ import annotations
+
+import json
+import sys
+import zipfile
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+
+def _load_driver() -> ModuleType:
+    """Load the standalone driver without requiring BioBB at test time."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "biobb_wf_md_setup"
+        / "run_md_setup.py"
+    )
+    name = "test_biobb_md_setup_driver_module"
+    spec = spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load BioBB driver from {path}")
+    module = module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+driver = _load_driver()
+
+
+def _gro(path: Path, atom_count: int, box: str = "2.0 3.0 4.0") -> None:
+    lines = ["generated", str(atom_count)]
+    lines.extend(
+        f"    1SOL     OW{index:5d}   0.000   0.000   0.000"
+        for index in range(1, atom_count + 1)
+    )
+    lines.append(box)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _topology(path: Path, *, solvent: int) -> None:
+    with zipfile.ZipFile(path, mode="w") as archive:
+        archive.writestr(
+            "topol.top",
+            f"[ system ]\nProtein\n\n[ molecules ]\nProtein 1\nSOL {solvent}\n",
+        )
+
+
+def _functions(calls: dict[str, dict[str, Any]]) -> Any:
+    def fix_side_chain(**kwargs: Any) -> int:
+        calls["fix_side_chain"] = kwargs
+        Path(kwargs["output_pdb_path"]).write_text(
+            Path(kwargs["input_pdb_path"]).read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        return 0
+
+    def pdb2gmx(**kwargs: Any) -> int:
+        calls["pdb2gmx"] = kwargs
+        _gro(Path(kwargs["output_gro_path"]), 2)
+        _topology(Path(kwargs["output_top_zip_path"]), solvent=0)
+        return 0
+
+    def editconf(**kwargs: Any) -> int:
+        calls["editconf"] = kwargs
+        _gro(Path(kwargs["output_gro_path"]), 2)
+        return 0
+
+    def solvate(**kwargs: Any) -> int:
+        calls["solvate"] = kwargs
+        _gro(Path(kwargs["output_gro_path"]), 8)
+        _topology(Path(kwargs["output_top_zip_path"]), solvent=2)
+        return 0
+
+    return driver.BioBBFunctions(fix_side_chain, pdb2gmx, editconf, solvate)
+
+
+def _config(root: Path) -> Any:
+    input_path = root / "input.pdb"
+    input_path.write_text(
+        "ATOM      1  N   ALA A   1\nHETATM    2  O   HOH A   2\nEND\n",
+        encoding="utf-8",
+    )
+    return driver.RunConfiguration(
+        input_pdb=input_path,
+        output_dir=root,
+        force_field="charmm27",
+        water_type="spce",
+        box_type="dodecahedron",
+        distance_to_molecule=1.25,
+        ignore_input_hydrogens=True,
+        merge_chains=False,
+        gmx="gmx",
+    )
+
+
+def test_successful_driver_records_semantics_metrics_and_exact_outputs(
+    tmp_path: Path,
+) -> None:
+    """A real five-stage cell closes with scientific values and file hashes."""
+
+    calls: dict[str, dict[str, Any]] = {}
+
+    return_code = driver.run(_config(tmp_path), functions=_functions(calls))
+
+    assert return_code == 0
+    result = json.loads((tmp_path / driver.RESULT_NAME).read_text(encoding="utf-8"))
+    assert result["schema_version"] == driver.RESULT_SCHEMA
+    assert result["status"] == "completed"
+    assert result["parameters"] == {
+        "box_type": "dodecahedron",
+        "distance_to_molecule": 1.25,
+        "force_field": "charmm27",
+        "ignore_input_hydrogens": True,
+        "merge_chains": False,
+        "water_type": "spce",
+    }
+    assert result["metrics"]["input_pdb_atom_count"] == 2
+    assert result["metrics"]["boxed_volume_nm3"] == pytest.approx(24.0)
+    assert result["metrics"]["solvent_molecule_count"] == 2
+    assert [stage["name"] for stage in result["stages"]] == [
+        "stage_input",
+        "fix_side_chain",
+        "pdb2gmx",
+        "editconf",
+        "solvate",
+    ]
+    assert len(result["artifacts"]) == 6
+    assert all(len(item["sha256"]) == 64 for item in result["artifacts"])
+    assert calls["pdb2gmx"]["properties"] == {
+        "force_field": "charmm27",
+        "water_type": "spce",
+        "ignh": True,
+        "merge": False,
+        "gmx_path": "gmx",
+    }
+    assert calls["editconf"]["properties"]["box_type"] == "dodecahedron"
+
+
+def test_failed_stage_writes_a_nonzero_closed_partial_result(tmp_path: Path) -> None:
+    """A BioBB exception remains inspectable without becoming a successful run."""
+
+    calls: dict[str, dict[str, Any]] = {}
+    functions = _functions(calls)
+
+    def fail_pdb2gmx(**kwargs: Any) -> int:
+        del kwargs
+        return 9
+
+    failed = driver.BioBBFunctions(
+        functions.fix_side_chain,
+        fail_pdb2gmx,
+        functions.editconf,
+        functions.solvate,
+    )
+
+    return_code = driver.run(_config(tmp_path), functions=failed)
+
+    assert return_code == 1
+    result = json.loads((tmp_path / driver.RESULT_NAME).read_text(encoding="utf-8"))
+    assert result["status"] == "failed"
+    assert result["return_code"] == 1
+    assert result["error"]["type"] == "RuntimeError"
+    assert [item["path"] for item in result["artifacts"]] == ["fixed.pdb"]
+
+
+def test_malformed_scientific_output_is_a_recorded_failure(tmp_path: Path) -> None:
+    """A nominal block return cannot bypass semantic output validation."""
+
+    calls: dict[str, dict[str, Any]] = {}
+    functions = _functions(calls)
+
+    def malformed_solvate(**kwargs: Any) -> int:
+        Path(kwargs["output_gro_path"]).write_text("not a GRO\n", encoding="utf-8")
+        _topology(Path(kwargs["output_top_zip_path"]), solvent=2)
+        return 0
+
+    malformed = driver.BioBBFunctions(
+        functions.fix_side_chain,
+        functions.pdb2gmx,
+        functions.editconf,
+        malformed_solvate,
+    )
+
+    return_code = driver.run(_config(tmp_path), functions=malformed)
+
+    assert return_code == 1
+    result = json.loads((tmp_path / driver.RESULT_NAME).read_text(encoding="utf-8"))
+    assert result["status"] == "failed"
+    assert result["stages"][-1]["name"] == "validate_outputs"
+    assert result["error"]["message"].startswith("GRO output is truncated")
+
+
+def test_gro_parser_handles_triclinic_box_vectors(tmp_path: Path) -> None:
+    """Nine-value GROMACS boxes use the documented vector ordering."""
+
+    path = tmp_path / "triclinic.gro"
+    _gro(path, 1, "2.0 3.0 4.0 0.0 0.0 0.5 0.0 0.0 0.25")
+
+    metrics = driver._gro_metrics(path)
+
+    assert metrics["atom_count"] == 1
+    assert metrics["box_volume_nm3"] == pytest.approx(24.0)
+
+
+def test_input_must_be_inside_the_package_owned_output(tmp_path: Path) -> None:
+    """The driver cannot claim or mutate a caller-owned source path."""
+
+    root = tmp_path / "out"
+    root.mkdir()
+    outside = tmp_path / "outside.pdb"
+    outside.write_text("ATOM\n", encoding="utf-8")
+    config = driver.RunConfiguration(
+        input_pdb=outside,
+        output_dir=root,
+        force_field="amber99sb-ildn",
+        water_type="tip3p",
+        box_type="cubic",
+        distance_to_molecule=1.0,
+        ignore_input_hydrogens=True,
+        merge_chains=False,
+        gmx="gmx",
+    )
+
+    with pytest.raises(ValueError, match="output directory"):
+        driver.run(config, functions=_functions({}))

--- a/test/unit/core/test_biobb_wf_md_setup_driver.py
+++ b/test/unit/core/test_biobb_wf_md_setup_driver.py
@@ -98,7 +98,7 @@ def _config(root: Path) -> Any:
         distance_to_molecule=1.25,
         ignore_input_hydrogens=True,
         merge_chains=False,
-        gmx="gmx",
+        gmx="gmx_mpi",
     )
 
 
@@ -140,8 +140,10 @@ def test_successful_driver_records_semantics_metrics_and_exact_outputs(
         "water_type": "spce",
         "ignh": True,
         "merge": False,
-        "gmx_path": "gmx",
+        "binary_path": "gmx_mpi",
     }
+    assert calls["editconf"]["properties"]["binary_path"] == "gmx_mpi"
+    assert calls["solvate"]["properties"]["binary_path"] == "gmx_mpi"
     assert calls["editconf"]["properties"]["box_type"] == "dodecahedron"
 
 

--- a/test/unit/core/test_biobb_wf_md_setup_package_runtime.py
+++ b/test/unit/core/test_biobb_wf_md_setup_package_runtime.py
@@ -128,6 +128,7 @@ def _package(tmp_path: Path, config: dict[str, Any]) -> Any:
     package.env = {}
     package.mod_env = {"PATH": "/runtime/bin"}
     package.python_bin = "python3"
+    package.gmx_bin = "gmx_mpi"
     package.pipeline = SimpleNamespace(get_hostfile=lambda: Hostfile(find_ips=False))
     package.runtime_line_callback = lambda: None
     return package
@@ -214,8 +215,30 @@ def test_native_run_copies_input_and_launches_package_owned_driver(
     assert "--water-type spce" in command
     assert "--box-type dodecahedron" in command
     assert "--distance-to-molecule 1.25" in command
+    assert "--gmx gmx_mpi" in command
     assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
     assert isinstance(_CapturedExec.infos[-1], LocalExecInfo)
+
+
+def test_gromacs_discovery_supports_mpi_named_spack_builds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid ``gmx_mpi`` installation satisfies the GROMACS runtime."""
+
+    monkeypatch.setattr(
+        biobb_package.shutil,
+        "which",
+        lambda program, *, path: (
+            "/spack/gromacs/bin/gmx_mpi"
+            if program == "gmx_mpi" and path == "/spack/bin"
+            else None
+        ),
+    )
+
+    assert (
+        biobb_package.BiobbWfMdSetup._discover_gromacs({"PATH": "/spack/bin"})
+        == "gmx_mpi"
+    )
 
 
 def test_native_run_rejects_missing_unsafe_or_colliding_input(tmp_path: Path) -> None:

--- a/test/unit/core/test_biobb_wf_md_setup_package_runtime.py
+++ b/test/unit/core/test_biobb_wf_md_setup_package_runtime.py
@@ -1,0 +1,294 @@
+"""Runtime-contract tests for the builtin BioBB MD-setup package."""
+
+from __future__ import annotations
+
+import shlex
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.deployment import ProgramProbeResult, RuntimeStatus
+from jarvis_cd.shell import LocalExecInfo
+from jarvis_cd.util.hostfile import Hostfile
+
+
+def _load_package() -> ModuleType:
+    """Load the builtin package without changing repository imports."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "biobb_wf_md_setup"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_biobb_md_setup_runtime_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load BioBB package from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+biobb_package = _load_package()
+
+
+class _CapturedExec:
+    """Capture launches and expose a configurable process result."""
+
+    commands: list[str] = []
+    infos: list[Any] = []
+    return_code = 0
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": self.return_code}
+        self.commands.append(command)
+        self.infos.append(exec_info)
+
+    def run(self) -> _CapturedExec:
+        """Return the captured result."""
+
+        return self
+
+
+class _CapturedMkdir:
+    """Create the requested test directory."""
+
+    def __init__(self, path: str, exec_info: Any) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedMkdir:
+        """Materialize the directory and report success."""
+
+        Path(self.path).mkdir(parents=True, exist_ok=True)
+        return self
+
+
+class _CapturedRm:
+    """Capture exact cleanup authority without deleting files."""
+
+    calls: list[tuple[str, bool]] = []
+
+    def __init__(self, path: str, exec_info: Any, *, recursive: bool = False) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.recursive = recursive
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedRm:
+        """Record the requested cleanup."""
+
+        self.calls.append((self.path, self.recursive))
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _capture_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep package tests free of process and remote-host side effects."""
+
+    _CapturedExec.commands = []
+    _CapturedExec.infos = []
+    _CapturedExec.return_code = 0
+    _CapturedRm.calls = []
+    monkeypatch.setattr(biobb_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(biobb_package, "Mkdir", _CapturedMkdir)
+    monkeypatch.setattr(biobb_package, "Rm", _CapturedRm)
+
+
+def _base_config(**overrides: Any) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "deploy_mode": "default",
+        "pdb_file": "",
+        "out": "run",
+        "force_field": "amber99sb-ildn",
+        "water_type": "tip3p",
+        "box_type": "cubic",
+        "distance_to_molecule": 1.0,
+        "ignore_input_hydrogens": True,
+        "merge_chains": False,
+        "nprocs": 1,
+        "ppn": 1,
+    }
+    config.update(overrides)
+    return config
+
+
+def _package(tmp_path: Path, config: dict[str, Any]) -> Any:
+    package = object.__new__(biobb_package.BiobbWfMdSetup)
+    package.config = config
+    package.shared_dir = tmp_path / "shared"
+    package.private_dir = tmp_path / "private"
+    package.env = {}
+    package.mod_env = {"PATH": "/runtime/bin"}
+    package.python_bin = "python3"
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: Hostfile(find_ips=False))
+    package.runtime_line_callback = lambda: None
+    return package
+
+
+def test_agent_contract_exposes_real_scientific_inputs_and_hides_benchmark_knobs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agents see the scientific cell instead of container benchmark controls."""
+
+    monkeypatch.setattr(
+        biobb_package,
+        "probe_program",
+        lambda *_args, **_kwargs: ProgramProbeResult(
+            RuntimeStatus("ready", "runtime_probe_succeeded")
+        ),
+    )
+    package = object.__new__(biobb_package.BiobbWfMdSetup)
+    package.config = _base_config()
+    package.env = {}
+    package.mod_env = {}
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    contract = package._deployment_contract().to_dict()
+
+    assert menu["pdb_file"]["default"] == ""
+    assert menu["pdb_file"]["input_binding"] == {
+        "schema_version": "jarvis.configuration-input-binding.v1",
+        "kind": "local_file",
+        "structure": "regular_file",
+    }
+    assert menu["out"]["default"] == "run"
+    assert menu["force_field"]["default"] == "amber99sb-ildn"
+    assert menu["box_type"]["default"] == "cubic"
+    assert all(
+        menu[name]["agent_visible"] is False
+        for name in {
+            "replicates",
+            "parallel_scratch_root",
+            "parallel_reps",
+            "omp_threads",
+            "md_steps",
+            "md_nstxout",
+            "md_extend_script",
+            "base_image",
+        }
+    )
+    assert [profile["name"] for profile in contract["execution_profiles"]] == [
+        "native_md_setup"
+    ]
+    assert {item["id"] for item in contract["runtime_requirements"]} == {
+        "biobb_python",
+        "gromacs",
+    }
+
+
+def test_native_run_copies_input_and_launches_package_owned_driver(
+    tmp_path: Path,
+) -> None:
+    """The caller PDB is immutable and all generated files share one owned root."""
+
+    source = tmp_path / "caller" / "protein with space.pdb"
+    source.parent.mkdir()
+    source.write_text("ATOM      1  N   ALA A   1\nEND\n", encoding="utf-8")
+    package = _package(
+        tmp_path,
+        _base_config(
+            pdb_file=str(source),
+            force_field="charmm27",
+            water_type="spce",
+            box_type="dodecahedron",
+            distance_to_molecule=1.25,
+        ),
+    )
+
+    package.start()
+
+    staged = tmp_path / "shared" / "run" / "input.pdb"
+    assert staged.read_bytes() == source.read_bytes()
+    command = _CapturedExec.commands[-1]
+    assert shlex.quote(str(staged.resolve())) in command
+    assert "run_md_setup.py" in command
+    assert "--force-field charmm27" in command
+    assert "--water-type spce" in command
+    assert "--box-type dodecahedron" in command
+    assert "--distance-to-molecule 1.25" in command
+    assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
+    assert isinstance(_CapturedExec.infos[-1], LocalExecInfo)
+
+
+def test_native_run_rejects_missing_unsafe_or_colliding_input(tmp_path: Path) -> None:
+    """Malformed input and staged-name collisions fail before process launch."""
+
+    package = _package(tmp_path, _base_config())
+    with pytest.raises(ValueError, match="requires pdb_file"):
+        package.start()
+
+    empty = tmp_path / "empty.pdb"
+    empty.touch()
+    package.config = _base_config(pdb_file=str(empty))
+    with pytest.raises(ValueError, match="bounded regular PDB"):
+        package.start()
+
+    source = tmp_path / "protein.pdb"
+    source.write_text("ATOM\n", encoding="utf-8")
+    collision = tmp_path / "shared" / "run" / "input.pdb"
+    collision.parent.mkdir(parents=True, exist_ok=True)
+    collision.write_text("unrelated\n", encoding="utf-8")
+    package.config = _base_config(pdb_file=str(source))
+    with pytest.raises(ValueError, match="staged input already exists"):
+        package.start()
+
+    assert collision.read_text(encoding="utf-8") == "unrelated\n"
+    assert _CapturedExec.commands == []
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"force_field": "unknown"}, "force_field"),
+        ({"water_type": "unknown"}, "water_type"),
+        ({"box_type": "sphere"}, "box_type"),
+        ({"distance_to_molecule": 0.0}, "distance_to_molecule"),
+        ({"distance_to_molecule": 10.1}, "distance_to_molecule"),
+    ],
+)
+def test_native_scientific_parameters_are_closed_and_bounded(
+    tmp_path: Path, overrides: dict[str, Any], message: str
+) -> None:
+    """The package rejects unsupported scientific configurations locally."""
+
+    source = tmp_path / "protein.pdb"
+    source.write_text("ATOM\n", encoding="utf-8")
+    package = _package(tmp_path, _base_config(pdb_file=str(source), **overrides))
+
+    with pytest.raises(ValueError, match=message):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
+def test_native_process_failure_fails_the_package_lifecycle(tmp_path: Path) -> None:
+    """A failed BioBB stage cannot be represented as a successful pipeline."""
+
+    source = tmp_path / "protein.pdb"
+    source.write_text("ATOM\n", encoding="utf-8")
+    package = _package(tmp_path, _base_config(pdb_file=str(source)))
+    _CapturedExec.return_code = 7
+
+    with pytest.raises(RuntimeError, match="BioBB MD setup failed"):
+        package.start()
+
+
+def test_clean_uses_one_exact_recursive_output_without_wildcard(tmp_path: Path) -> None:
+    """Cleanup cannot erase prefix-matching sibling directories."""
+
+    package = _package(tmp_path, _base_config(out="results"))
+
+    package.clean()
+
+    assert _CapturedRm.calls == [
+        (str((tmp_path / "shared" / "results").resolve()), True)
+    ]
+    assert "*" not in _CapturedRm.calls[0][0]

--- a/test/unit/core/test_configuration_input_materialization.py
+++ b/test/unit/core/test_configuration_input_materialization.py
@@ -11,6 +11,7 @@ from typing import Any
 import pytest
 
 from jarvis_cd.configuration_input import (
+    MAX_CONFIGURATION_INPUT_BYTES,
     configuration_input_materialization_matches,
     materialize_configuration_inputs,
 )
@@ -194,6 +195,66 @@ def test_malformed_declared_input_binding_fails_closed(tmp_path: Path) -> None:
                 }
             ],
             config={"script": str(source)},
+            shared_dir=(tmp_path / "shared").resolve(),
+        )
+
+
+def test_scientific_bundle_above_legacy_limit_is_streamed(tmp_path: Path) -> None:
+    """Large bounded inputs materialize without the obsolete 16 MiB ceiling."""
+
+    source = tmp_path / "study.tar"
+    chunk = b"bounded-scientific-input\n" * 4096
+    with source.open("wb") as stream:
+        while stream.tell() <= 17 * 1024 * 1024:
+            stream.write(chunk)
+    shared_dir = (tmp_path / "shared").resolve()
+    shared_dir.mkdir()
+
+    configured = materialize_configuration_inputs(
+        menu=[
+            {
+                "name": "input_bundle",
+                "input_binding": dict(_INPUT_BINDING),
+            }
+        ],
+        config={"input_bundle": str(source)},
+        shared_dir=shared_dir,
+    )
+
+    target = Path(configured["input_bundle"])
+    assert target.stat().st_size == source.stat().st_size
+    assert configuration_input_materialization_matches(
+        menu=[
+            {
+                "name": "input_bundle",
+                "input_binding": dict(_INPUT_BINDING),
+            }
+        ],
+        parameter="input_bundle",
+        requested=source,
+        materialized=target,
+        shared_dir=shared_dir,
+    )
+
+
+def test_configuration_input_still_rejects_files_above_global_bound(
+    tmp_path: Path,
+) -> None:
+    """Streaming does not remove the global denial-of-service size bound."""
+
+    source = tmp_path / "oversized.tar"
+    with source.open("wb") as stream:
+        stream.truncate(MAX_CONFIGURATION_INPUT_BYTES + 1)
+
+    with pytest.raises(ValueError, match="must be one bounded regular file"):
+        materialize_configuration_inputs(
+            menu=[
+                {
+                    "name": "input_bundle",
+                    "input_binding": dict(_INPUT_BINDING),
+                }
+            ],
+            config={"input_bundle": str(source)},
             shared_dir=(tmp_path / "shared").resolve(),
         )
 

--- a/test/unit/core/test_dlio_benchmark_artifacts.py
+++ b/test/unit/core/test_dlio_benchmark_artifacts.py
@@ -1,0 +1,111 @@
+"""Artifact lifecycle tests for builtin DLIO Benchmark."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+from jarvis_cd.artifacts import (
+    ArtifactObservation,
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "dlio_benchmark"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def test_dlio_outputs_and_checkpoints_follow_process_lifecycle() -> None:
+    """Native output groups retain identity through successful completion."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.dlio_benchmark",
+            "workload": "resnet50_v100",
+            "generate_data": True,
+            "checkpoint_supported": True,
+            "checkpoint": True,
+            "data_path": "/scratch/run/dataset",
+            "output_path": "/scratch/run/output",
+            "checkpoint_path": "/scratch/run/checkpoints",
+            "cache_policy": "sync",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.observe_artifacts("Starting DLIO benchmark\n")
+    observations += adapter.finalize_artifacts_for_exit(0)
+
+    assert {item.role for item in observations[:3]} == {
+        ArtifactRole.INTERMEDIATE,
+        ArtifactRole.OUTPUT,
+        ArtifactRole.CHECKPOINT,
+    }
+    assert all(item.state is ArtifactState.PRODUCING for item in observations[:3])
+    assert all(item.state is ArtifactState.FINALIZED for item in observations[-3:])
+    assert all(item.structure is ArtifactStructure.COLLECTION for item in observations)
+    by_role: dict[ArtifactRole, list[ArtifactObservation]] = {}
+    for item in observations:
+        by_role.setdefault(item.role, []).append(item)
+    assert all(
+        len({item.artifact_id for item in items}) == 1 for items in by_role.values()
+    )
+    output = next(
+        item for item in observations[-3:] if item.role is ArtifactRole.OUTPUT
+    )
+    assert output.location is not None
+    assert output.location.value == "/scratch/run/output"
+    assert output.metadata["cache_policy"] == "sync"
+
+
+def test_dlio_failure_marks_every_declared_product_incomplete() -> None:
+    """A nonzero owned process cannot leave finalized DLIO artifacts."""
+    adapter = _module().adapter_from_package(
+        {
+            "pkg_type": "builtin.dlio_benchmark",
+            "workload": "unet3d_a100",
+            "generate_data": False,
+            "checkpoint_supported": True,
+            "checkpoint": True,
+            "output_path": "/scratch/run/output",
+            "checkpoint_path": "/scratch/run/checkpoints",
+            "cache_policy": "none",
+        }
+    )
+    assert adapter is not None
+
+    observations = adapter.finalize_artifacts_for_exit(17)
+
+    assert {item.role for item in observations} == {
+        ArtifactRole.OUTPUT,
+        ArtifactRole.CHECKPOINT,
+    }
+    assert all(item.state is ArtifactState.INCOMPLETE for item in observations)
+    assert all(item.metadata["return_code"] == 17 for item in observations)
+
+
+def test_dlio_artifacts_reject_relative_or_unsafe_paths() -> None:
+    """Artifact providers cannot turn relative settings into cluster authority."""
+    module = _module()
+
+    try:
+        module.adapter_from_package(
+            {
+                "pkg_type": "builtin.dlio_benchmark",
+                "workload": "unet3d_a100",
+                "output_path": "relative/output",
+            }
+        )
+    except ValueError as error:
+        assert "absolute" in str(error)
+    else:
+        raise AssertionError("relative DLIO output path was accepted")

--- a/test/unit/core/test_dlio_benchmark_package.py
+++ b/test/unit/core/test_dlio_benchmark_package.py
@@ -1,0 +1,280 @@
+"""Runtime-contract tests for the builtin DLIO Benchmark package."""
+
+from __future__ import annotations
+
+import shlex
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def _load_package() -> ModuleType:
+    """Load builtin DLIO without relying on repository registration."""
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "dlio_benchmark"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_builtin_dlio_benchmark", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load the DLIO package from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+dlio_package = _load_package()
+
+
+class _CapturedExec:
+    """Capture exact package commands and configurable process results."""
+
+    commands: list[str] = []
+    exec_infos: list[Any] = []
+    failures: dict[str, dict[str, object]] = {}
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = self.failures.get(command, {"localhost": 0})
+        self.commands.append(command)
+        self.exec_infos.append(exec_info)
+
+    def run(self) -> _CapturedExec:
+        """Return the captured process result."""
+        callback = getattr(self.exec_info, "line_callback", None)
+        if callback is not None:
+            callback("stdout", f"running {self.command}\n")
+            return_code = next(
+                (code for code in self.exit_code.values() if code != 0),
+                0,
+            )
+            callback.finalize_process(return_code)
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _reset_exec_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep command-level package tests independent."""
+    _CapturedExec.commands = []
+    _CapturedExec.exec_infos = []
+    _CapturedExec.failures = {}
+    monkeypatch.setattr(dlio_package, "Exec", _CapturedExec)
+
+
+def _package(tmp_path: Path, **updates: object) -> Any:
+    """Build a minimally configured package without invoking JARVIS discovery."""
+    package = object.__new__(dlio_package.DlioBenchmark)
+    package.shared_dir = str(tmp_path / "shared")
+    package.get_hostfile = lambda: None
+    package.env = {"PATH": "/runtime/bin"}
+    package.mod_env = dict(package.env)
+    package.config = {
+        "workload": "resnet50_v100",
+        "generate_data": False,
+        "evaluation": False,
+        "checkpoint_supported": True,
+        "checkpoint": True,
+        "data_path": "dataset",
+        "output_path": "output",
+        "checkpoint_path": "checkpoints",
+        "num_files_train": 32,
+        "num_samples_per_file": 2,
+        "record_length_bytes": 114660,
+        "record_length_bytes_resize": 114660,
+        "batch_size": 8,
+        "read_threads": 4,
+        "epochs": 3,
+        "train_computation_time": 0.05,
+        "checkpoint_size_bytes": 104857600,
+        "checkpoint_fsync": True,
+        "checkpoint_after_epoch": 2,
+        "epochs_between_checkpoints": 4,
+        "nprocs": 4,
+        "ppn": 4,
+        "timeout_seconds": 3600,
+        "tracing": False,
+        "cache_policy": "none",
+        "deploy_mode": "default",
+    }
+    package.config.update(updates)
+    package.runtime_line_callback = lambda: None
+    return package
+
+
+def test_agent_contract_has_safe_cache_and_runtime_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Describe a bounded runtime without silently claiming cold-cache IO."""
+    package = object.__new__(dlio_package.DlioBenchmark)
+    package.config = {"generate_data": False}
+    package.mod_env = {"PATH": "/runtime/bin"}
+    package.env = dict(package.mod_env)
+    package._deployment_environment = lambda: package.mod_env
+    monkeypatch.setattr(
+        dlio_package,
+        "probe_program",
+        lambda *args, **kwargs: SimpleNamespace(
+            status=dlio_package.RuntimeStatus("ready", "runtime_probe_succeeded")
+        ),
+    )
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    assert menu["cache_policy"]["default"] == "none"
+    assert menu["cache_policy"]["choices"] == ["none", "sync", "drop_caches"]
+    assert menu["output_path"]["default"] == "output"
+
+    contract = package._deployment_contract().to_dict()
+    assert contract["package"] == "builtin.dlio_benchmark"
+    assert contract["execution_profiles"][0]["readiness"] == {
+        "mechanism": "process_exit",
+        "condition": "successful_exit",
+    }
+    runtime = contract["runtime_requirements"][0]
+    assert runtime["id"] == "dlio"
+    assert runtime["status"]["usable"] is True
+    assert runtime["provider_resolutions"] == [
+        {
+            "provider": "path",
+            "query": {"kind": "program", "value": "dlio_benchmark"},
+        }
+    ]
+
+
+def test_command_quotes_paths_and_exposes_typed_workload_controls(
+    tmp_path: Path,
+) -> None:
+    """Build one native DLIO invocation without a shell-injection surface."""
+    package = _package(tmp_path)
+    command = package._command(generate_only=False, output_path=tmp_path / "result dir")
+
+    assert shlex.quote("workload=resnet50_v100") in command
+    assert (
+        shlex.quote(f"++workload.dataset.data_folder={tmp_path / 'shared' / 'dataset'}")
+        in command
+    )
+    assert shlex.quote(f"++workload.output.folder={tmp_path / 'result dir'}") in command
+    assert "++workload.reader.read_threads=4" in command
+    assert "++workload.dataset.num_samples_per_file=2" in command
+    assert "++workload.dataset.record_length_bytes=114660" in command
+    assert "++workload.dataset.record_length_bytes_resize=114660" in command
+    assert "++workload.workflow.evaluation=false" in command
+    assert "++workload.dataset.num_files_eval=0" in command
+    assert "++workload.workflow.train=true" in command
+    assert "++workload.train.computation_time=0.05" in command
+    assert "++workload.workflow.checkpoint=true" in command
+    assert "++workload.model.model_size_bytes=104857600" in command
+    assert "++workload.checkpoint.fsync=true" in command
+    assert "++workload.checkpoint.checkpoint_after_epoch=2" in command
+    assert "++workload.checkpoint.epochs_between_checkpoints=4" in command
+
+
+@pytest.mark.parametrize("policy, expected", [("none", []), ("sync", ["sync"])])
+def test_non_privileged_cache_policies_never_call_sudo(
+    tmp_path: Path,
+    policy: str,
+    expected: list[str],
+) -> None:
+    """The safe policies are explicit and cannot perform privileged eviction."""
+    package = _package(tmp_path, cache_policy=policy)
+
+    package._apply_cache_policy()
+
+    assert _CapturedExec.commands == expected
+    assert all("sudo" not in command for command in _CapturedExec.commands)
+
+
+def test_privileged_cache_eviction_is_explicit_and_noninteractive(
+    tmp_path: Path,
+) -> None:
+    """Cold-cache requests fail rather than hanging on an interactive password."""
+    package = _package(tmp_path, cache_policy="drop_caches")
+
+    package._apply_cache_policy()
+
+    assert _CapturedExec.commands == [
+        "sync && sudo -n sh -c 'echo 3 > /proc/sys/vm/drop_caches'"
+    ]
+
+
+def test_start_propagates_native_dlio_failure(tmp_path: Path) -> None:
+    """A failed rank makes the package fail instead of reporting completion."""
+    package = _package(tmp_path)
+    command = package._command(
+        generate_only=False,
+        output_path=package._output_path() / "training",
+    )
+    _CapturedExec.failures[command] = {"node-a": 9}
+
+    with pytest.raises(RuntimeError, match="DLIO workload.*node-a=9"):
+        package.start()
+
+    assert _CapturedExec.exec_infos[-1].timeout == 3600
+
+
+class _StrictRuntimeCallback:
+    """Reject output after package-level semantic finalization."""
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+        self.finalized: list[int] = []
+        self.closed = False
+
+    def __call__(self, stream_name: str, line: str) -> None:
+        """Record output only while the package callback remains open."""
+        if self.closed:
+            raise RuntimeError("runtime callback already finalized")
+        self.lines.append(f"{stream_name}:{line}")
+
+    def finalize_process(self, return_code: int) -> None:
+        """Close package semantics after the terminal process."""
+        self.finalized.append(return_code)
+        self.closed = True
+
+    def reconcile_process_exit(self, return_code: int) -> None:
+        """Expose the process callback protocol used by JARVIS."""
+
+
+def test_generate_and_train_share_one_callback_until_terminal_phase(
+    tmp_path: Path,
+) -> None:
+    """Data generation must not close semantics before training starts."""
+    package = _package(tmp_path, generate_data=True)
+    callback = _StrictRuntimeCallback()
+    package.runtime_line_callback = lambda: callback
+
+    package.start()
+
+    assert len(callback.lines) == 2
+    assert callback.finalized == [0]
+    assert callback.closed is True
+    assert _CapturedExec.exec_infos[0].line_callback is not callback
+    assert _CapturedExec.exec_infos[1].line_callback is not callback
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("workload", "bad workload"),
+        ("nprocs", 0),
+        ("ppn", True),
+        ("read_threads", -1),
+        ("cache_policy", "pretend-cold"),
+        ("timeout_seconds", 0),
+    ],
+)
+def test_configuration_rejects_ambiguous_or_unsafe_values(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    """Invalid scientific and execution controls fail before submission."""
+    package = _package(tmp_path, **{field: value})
+
+    with pytest.raises((TypeError, ValueError)):
+        package._validate_configuration()

--- a/test/unit/core/test_gadget2_artifacts.py
+++ b/test/unit/core/test_gadget2_artifacts.py
@@ -1,0 +1,198 @@
+"""Artifact-contract tests for the builtin Gadget2 package."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from jarvis_cd.artifacts import (
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+)
+
+
+def _load_artifacts() -> ModuleType:
+    """Load the package-local artifact module."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "gadget2"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def _write_bundle(destination: Path) -> Path:
+    files = {
+        "galaxy/galaxy.param": b"InitCondFile ICs/galaxy.dat\n",
+        "galaxy/ICs/galaxy.dat": b"initial-condition\x00\x01",
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "galaxy/galaxy.param",
+        "files": [
+            {
+                "path": name,
+                "role": "gadget2_input",
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, payload in files.items()
+        ],
+    }
+    encoded = json.dumps(manifest, sort_keys=True).encode()
+    with tarfile.open(destination, "w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(encoded)
+        archive.addfile(info, io.BytesIO(encoded))
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def _adapter(module: ModuleType, tmp_path: Path) -> Any:
+    adapter = module.Gadget2ArtifactAdapter(
+        module.PurePosixPath("/scratch/gadget2/run"),
+        frozenset(
+            {
+                module.PurePosixPath("galaxy/galaxy.param"),
+                module.PurePosixPath("galaxy/ICs/galaxy.dat"),
+            }
+        ),
+    )
+    adapter._local_root = tmp_path / "run"
+    return adapter
+
+
+def _write_products(root: Path) -> None:
+    (root / "galaxy" / "ICs").mkdir(parents=True)
+    (root / "galaxy" / "galaxy.param").write_text(
+        "InitCondFile ICs/galaxy.dat\n", encoding="utf-8"
+    )
+    (root / "galaxy" / "ICs" / "galaxy.dat").write_bytes(b"initial-condition\x00\x01")
+    products = root / "galaxy" / "output"
+    products.mkdir()
+    (products / "energy.txt").write_text(
+        "0 0 -10 4\n0.1 0 -9.99 3.99\n", encoding="utf-8"
+    )
+    (products / "info.txt").write_text("Begin Step 1\n", encoding="utf-8")
+    (products / "cpu.txt").write_text("Step 1\n", encoding="utf-8")
+    (products / "timings.txt").write_text("Step=1\n", encoding="utf-8")
+    (products / "snapshot_000").write_bytes(b"snapshot-zero")
+    (products / "snapshot_001").write_bytes(b"snapshot-one")
+    (products / "restart.0").write_bytes(b"rank-zero")
+    (products / "restart.1").write_bytes(b"rank-one")
+
+
+def test_success_finalizes_closed_logs_snapshots_and_restart_sets(
+    tmp_path: Path,
+) -> None:
+    """A successful run reports outputs but never republishes staged inputs."""
+
+    module = _load_artifacts()
+    adapter = _adapter(module, tmp_path)
+    _write_products(tmp_path / "run")
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    by_name = {item.logical_name: item for item in observations}
+    assert set(by_name) == {
+        "gadget2-results",
+        "gadget2-energy",
+        "gadget2-info",
+        "gadget2-cpu",
+        "gadget2-timings",
+        "gadget2-snapshots",
+        "gadget2-restarts",
+    }
+    assert all(item.state is ArtifactState.FINALIZED for item in observations)
+    assert by_name["gadget2-snapshots"].structure is ArtifactStructure.COLLECTION
+    assert by_name["gadget2-restarts"].structure is ArtifactStructure.COLLECTION
+    members = by_name["gadget2-results"].metadata["member_names"]
+    assert "galaxy/galaxy.param" not in members
+    assert "galaxy/ICs/galaxy.dat" not in members
+    assert "galaxy/output/energy.txt" in members
+    assert adapter.finalize_artifacts_for_exit(0) == []
+
+
+def test_missing_scientific_products_cannot_be_finalized(tmp_path: Path) -> None:
+    """Process exit alone is weaker than a Gadget2 result contract."""
+
+    module = _load_artifacts()
+    adapter = _adapter(module, tmp_path)
+    root = tmp_path / "run" / "galaxy" / "output"
+    root.mkdir(parents=True)
+    (root / "info.txt").write_text("started\n", encoding="utf-8")
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert observations
+    assert all(item.state is ArtifactState.INCOMPLETE for item in observations)
+    assert "missing" in observations[0].message.casefold()
+
+
+def test_nonzero_exit_marks_observed_products_incomplete(tmp_path: Path) -> None:
+    """Native files cannot conceal an authoritative process failure."""
+
+    module = _load_artifacts()
+    adapter = _adapter(module, tmp_path)
+    _write_products(tmp_path / "run")
+
+    observations = adapter.finalize_artifacts_for_exit(7)
+
+    assert observations
+    assert all(item.state is ArtifactState.INCOMPLETE for item in observations)
+
+
+def test_factory_resolves_relative_output_and_ignores_unrelated_packages(
+    tmp_path: Path,
+) -> None:
+    """Artifact authority remains exact to one package-owned output root."""
+
+    module = _load_artifacts()
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.gadget2",
+            "input_bundle": str(bundle),
+            "out": "run",
+            "shared_dir": "/execution/shared/gadget2",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.output_dir.as_posix() == "/execution/shared/gadget2/run"
+    assert module.adapter_from_package({"pkg_type": "builtin.ior"}) is None
+
+
+def test_container_private_output_is_not_claimed(tmp_path: Path) -> None:
+    """A host cannot report files that exist only in a private container path."""
+
+    module = _load_artifacts()
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.gadget2",
+            "input_bundle": str(bundle),
+            "out": "/tmp/gadget2",
+            "effective_deploy_mode": "container",
+            "shared_dir": "/execution/shared",
+            "private_dir": "/execution/private",
+        }
+    )
+
+    assert adapter is None

--- a/test/unit/core/test_gadget2_artifacts.py
+++ b/test/unit/core/test_gadget2_artifacts.py
@@ -36,7 +36,11 @@ def _load_artifacts() -> ModuleType:
 
 def _write_bundle(destination: Path) -> Path:
     files = {
-        "galaxy/galaxy.param": b"InitCondFile ICs/galaxy.dat\n",
+        "galaxy/galaxy.param": (
+            b"InitCondFile ICs/galaxy.dat\nOutputDir output/\n"
+            b"EnergyFile energy.txt\nInfoFile info.txt\nCpuFile cpu.txt\n"
+            b"TimingsFile timings.txt\nSnapshotFileBase snapshot\n"
+        ),
         "galaxy/ICs/galaxy.dat": b"initial-condition\x00\x01",
     }
     manifest = {
@@ -65,6 +69,14 @@ def _write_bundle(destination: Path) -> Path:
 
 
 def _adapter(module: ModuleType, tmp_path: Path) -> Any:
+    declared = module.parse_gadget2_output_contract(
+        (
+            "OutputDir output/\nEnergyFile energy.txt\nInfoFile info.txt\n"
+            "CpuFile cpu.txt\nTimingsFile timings.txt\n"
+            "SnapshotFileBase snapshot\n"
+        ),
+        parameter_path=module.PurePosixPath("galaxy/galaxy.param"),
+    )
     adapter = module.Gadget2ArtifactAdapter(
         module.PurePosixPath("/scratch/gadget2/run"),
         frozenset(
@@ -73,6 +85,7 @@ def _adapter(module: ModuleType, tmp_path: Path) -> Any:
                 module.PurePosixPath("galaxy/ICs/galaxy.dat"),
             }
         ),
+        declared,
     )
     adapter._local_root = tmp_path / "run"
     return adapter
@@ -81,7 +94,12 @@ def _adapter(module: ModuleType, tmp_path: Path) -> Any:
 def _write_products(root: Path) -> None:
     (root / "galaxy" / "ICs").mkdir(parents=True)
     (root / "galaxy" / "galaxy.param").write_text(
-        "InitCondFile ICs/galaxy.dat\n", encoding="utf-8"
+        (
+            "InitCondFile ICs/galaxy.dat\nOutputDir output/\n"
+            "EnergyFile energy.txt\nInfoFile info.txt\nCpuFile cpu.txt\n"
+            "TimingsFile timings.txt\nSnapshotFileBase snapshot\n"
+        ),
+        encoding="utf-8",
     )
     (root / "galaxy" / "ICs" / "galaxy.dat").write_bytes(b"initial-condition\x00\x01")
     products = root / "galaxy" / "output"
@@ -143,6 +161,57 @@ def test_missing_scientific_products_cannot_be_finalized(tmp_path: Path) -> None
     assert observations
     assert all(item.state is ArtifactState.INCOMPLETE for item in observations)
     assert "missing" in observations[0].message.casefold()
+
+
+def test_zero_byte_declared_products_cannot_be_finalized(tmp_path: Path) -> None:
+    """Names alone cannot turn an aborted zero-status run into valid artifacts."""
+
+    module = _load_artifacts()
+    adapter = _adapter(module, tmp_path)
+    root = tmp_path / "run" / "galaxy" / "output"
+    root.mkdir(parents=True)
+    (root / "energy.txt").write_bytes(b"")
+    (root / "info.txt").write_bytes(b"")
+    (root / "snapshot_000").write_bytes(b"")
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert observations
+    assert all(item.state is ArtifactState.INCOMPLETE for item in observations)
+
+
+def test_parameter_declared_names_drive_artifact_discovery(tmp_path: Path) -> None:
+    """Custom scientific filenames are discovered without stock-name guesses."""
+
+    module = _load_artifacts()
+    declared = module.parse_gadget2_output_contract(
+        (
+            "OutputDir products/\nEnergyFile conserved.dat\n"
+            "InfoFile progress.log\nSnapshotFileBase states/galaxy\n"
+        ),
+        parameter_path=module.PurePosixPath("galaxy/custom.param"),
+    )
+    adapter = module.Gadget2ArtifactAdapter(
+        module.PurePosixPath("/scratch/gadget2/run"),
+        frozenset(),
+        declared,
+    )
+    adapter._local_root = tmp_path / "run"
+    products = tmp_path / "run" / "galaxy" / "products"
+    (products / "states").mkdir(parents=True)
+    (products / "conserved.dat").write_text("0 -1\n", encoding="utf-8")
+    (products / "progress.log").write_text("Step 1\n", encoding="utf-8")
+    (products / "states" / "galaxy_000").write_bytes(b"snapshot")
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    by_name = {item.logical_name: item for item in observations}
+    assert all(item.state is ArtifactState.FINALIZED for item in observations)
+    assert by_name["gadget2-energy"].location.value.endswith("conserved.dat")
+    assert by_name["gadget2-info"].location.value.endswith("progress.log")
+    assert by_name["gadget2-snapshots"].metadata["member_names"] == [
+        "galaxy/products/states/galaxy_000"
+    ]
 
 
 def test_nonzero_exit_marks_observed_products_incomplete(tmp_path: Path) -> None:

--- a/test/unit/core/test_gadget2_artifacts.py
+++ b/test/unit/core/test_gadget2_artifacts.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
+import pytest
+
 from jarvis_cd.artifacts import (
     ArtifactState,
     ArtifactStructure,
@@ -228,12 +230,22 @@ def test_nonzero_exit_marks_observed_products_incomplete(tmp_path: Path) -> None
 
 
 def test_factory_resolves_relative_output_and_ignores_unrelated_packages(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """Artifact authority remains exact to one package-owned output root."""
 
     module = _load_artifacts()
     bundle = _write_bundle(tmp_path / "galaxy.tar")
+    materialized = module.extract_input_bundle(
+        bundle,
+        tmp_path / "materialized-input",
+    )
+    monkeypatch.setattr(
+        module,
+        "extract_input_bundle",
+        lambda *_args, **_kwargs: materialized,
+    )
     adapter = module.adapter_from_package(
         {
             "pkg_type": "builtin.gadget2",

--- a/test/unit/core/test_gadget2_package_runtime.py
+++ b/test/unit/core/test_gadget2_package_runtime.py
@@ -146,11 +146,15 @@ def _package(tmp_path: Path, config: dict[str, Any]) -> Any:
     return package
 
 
-def _write_bundle(destination: Path) -> Path:
+def _write_bundle(
+    destination: Path,
+    *,
+    parameter: bytes = (
+        b"InitCondFile ICs/galaxy.dat\nOutputDir output/\nEnergyFile energy.txt\n"
+    ),
+) -> Path:
     files = {
-        "galaxy/galaxy.param": (
-            b"InitCondFile ICs/galaxy.dat\nOutputDir output/\nEnergyFile energy.txt\n"
-        ),
+        "galaxy/galaxy.param": parameter,
         "galaxy/ICs/galaxy.dat": b"gadget2-initial-condition\x00\x01",
     }
     manifest = {
@@ -246,11 +250,43 @@ def test_bundle_is_verified_and_staged_before_native_launch(tmp_path: Path) -> N
     staged_ic = workdir / "ICs" / "galaxy.dat"
     assert staged_parameter.read_bytes().startswith(b"InitCondFile")
     assert staged_ic.read_bytes() == b"gadget2-initial-condition\x00\x01"
+    assert (workdir / "output").is_dir()
     assert bundle.read_bytes() == source_bytes
     command = _CapturedExec.commands[-1]
     assert command == "Gadget2 galaxy.param"
     assert _CapturedExec.infos[-1].cwd == str(workdir.resolve())
     assert isinstance(_CapturedExec.infos[-1], gadget2_package.MpiExecInfo)
+
+
+@pytest.mark.parametrize(
+    ("parameter", "message"),
+    [
+        (b"InitCondFile ICs/galaxy.dat\n", "declare OutputDir exactly once"),
+        (
+            b"OutputDir output/\nOutputDir other/\n",
+            "declare OutputDir exactly once",
+        ),
+        (b"OutputDir ../escape/\n", "confined POSIX path"),
+        (b"OutputDir /tmp/escape/\n", "confined POSIX path"),
+        (b"OutputDir C:/escape/\n", "confined POSIX path"),
+        (b"OutputDir output\\escape\n", "confined POSIX path"),
+        (b"OutputDir output path\n", "one path token"),
+    ],
+)
+def test_native_output_directory_is_single_and_confined(
+    tmp_path: Path,
+    parameter: bytes,
+    message: str,
+) -> None:
+    """A supplied parameter cannot direct Gadget2 outside staged storage."""
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar", parameter=parameter)
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+
+    with pytest.raises(ValueError, match=message):
+        package.start()
+
+    assert _CapturedExec.commands == []
 
 
 def test_parameter_override_must_name_a_declared_bundle_file(tmp_path: Path) -> None:

--- a/test/unit/core/test_gadget2_package_runtime.py
+++ b/test/unit/core/test_gadget2_package_runtime.py
@@ -1,0 +1,354 @@
+"""Runtime-contract tests for the builtin Gadget2 package."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import shlex
+import tarfile
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+)
+from jarvis_cd.shell import LocalExecInfo
+from jarvis_cd.util.hostfile import Hostfile
+
+
+def _load_package() -> ModuleType:
+    """Load the builtin package without changing repository imports."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "gadget2"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_gadget2_runtime_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load Gadget2 package from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gadget2_package = _load_package()
+
+
+class _CapturedExec:
+    """Capture launches and expose a configurable process result."""
+
+    commands: list[str] = []
+    infos: list[Any] = []
+    return_code = 0
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": self.return_code}
+        self.commands.append(command)
+        self.infos.append(exec_info)
+
+    def run(self) -> _CapturedExec:
+        """Return the captured result."""
+
+        return self
+
+
+class _CapturedMkdir:
+    """Create the requested test directory."""
+
+    def __init__(self, path: str, exec_info: Any) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedMkdir:
+        """Materialize the directory and report success."""
+
+        Path(self.path).mkdir(parents=True, exist_ok=True)
+        return self
+
+
+class _CapturedRm:
+    """Capture exact cleanup authority without deleting files."""
+
+    calls: list[tuple[str, bool]] = []
+
+    def __init__(self, path: str, exec_info: Any, *, recursive: bool = False) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.recursive = recursive
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedRm:
+        """Record the requested cleanup."""
+
+        self.calls.append((self.path, self.recursive))
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _capture_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep package tests free of process and remote-host side effects."""
+
+    _CapturedExec.commands = []
+    _CapturedExec.infos = []
+    _CapturedExec.return_code = 0
+    _CapturedRm.calls = []
+    monkeypatch.setattr(gadget2_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(gadget2_package, "Mkdir", _CapturedMkdir)
+    monkeypatch.setattr(gadget2_package, "Rm", _CapturedRm)
+
+
+def _base_config(**overrides: Any) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "deploy_mode": "default",
+        "input_bundle": "",
+        "parameter_path": "",
+        "out": "run",
+        "nprocs": 2,
+        "ppn": 2,
+        "exec_mode": "mpi",
+        "gadget2_path": None,
+        "test_case": "gassphere",
+        "output": None,
+        "time_max": 0.05,
+        "buffer_size": 15.0,
+        "part_alloc_factor": 1.5,
+        "tree_alloc_factor": 0.9,
+    }
+    config.update(overrides)
+    return config
+
+
+def _package(tmp_path: Path, config: dict[str, Any]) -> Any:
+    package = object.__new__(gadget2_package.Gadget2)
+    package.config = config
+    package.shared_dir = tmp_path / "shared"
+    package.private_dir = tmp_path / "private"
+    package.env = {}
+    package.mod_env = {"PATH": "/runtime/bin"}
+    package.gadget2_bin = "Gadget2"
+    package.pipeline = SimpleNamespace(
+        get_hostfile=lambda: Hostfile(find_ips=False),
+        _has_containerized_packages=lambda: False,
+    )
+    package.runtime_line_callback = lambda: None
+    return package
+
+
+def _write_bundle(destination: Path) -> Path:
+    files = {
+        "galaxy/galaxy.param": (
+            b"InitCondFile ICs/galaxy.dat\nOutputDir output/\nEnergyFile energy.txt\n"
+        ),
+        "galaxy/ICs/galaxy.dat": b"gadget2-initial-condition\x00\x01",
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "galaxy/galaxy.param",
+        "files": [
+            {
+                "path": name,
+                "role": (
+                    "gadget2_parameter_file"
+                    if name.endswith(".param")
+                    else "gadget2_initial_condition"
+                ),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, payload in files.items()
+        ],
+    }
+    manifest_bytes = json.dumps(manifest, sort_keys=True).encode()
+    with tarfile.open(destination, mode="w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(manifest_bytes)
+        archive.addfile(info, io.BytesIO(manifest_bytes))
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def test_agent_contract_exposes_bundle_profile_and_hides_legacy_defaults() -> None:
+    """Agents receive a scientific input contract rather than stock demos."""
+
+    package = object.__new__(gadget2_package.Gadget2)
+    package.config = _base_config()
+    package.env = {}
+    package.mod_env = {}
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    contract = package._deployment_contract().to_dict()
+
+    assert menu["input_bundle"]["input_binding"] == {
+        "schema_version": "jarvis.configuration-input-binding.v1",
+        "kind": "local_file",
+        "structure": "regular_file",
+    }
+    assert menu["parameter_path"]["default"] == ""
+    assert menu["out"]["default"] == "run"
+    assert all(
+        menu[name]["agent_visible"] is False
+        for name in {
+            "gadget2_path",
+            "test_case",
+            "output",
+            "time_max",
+            "buffer_size",
+            "part_alloc_factor",
+            "tree_alloc_factor",
+            "exec_mode",
+        }
+    )
+    assert [profile["name"] for profile in contract["execution_profiles"]] == [
+        "input_bundle"
+    ]
+    assert [item["id"] for item in contract["runtime_requirements"]] == ["gadget2"]
+
+
+def test_bundle_is_verified_and_staged_before_native_launch(tmp_path: Path) -> None:
+    """The solver runs from an owned copy while caller bytes remain immutable."""
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    source_bytes = bundle.read_bytes()
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+
+    package.start()
+
+    workdir = tmp_path / "shared" / "run" / "galaxy"
+    staged_parameter = workdir / "galaxy.param"
+    staged_ic = workdir / "ICs" / "galaxy.dat"
+    assert staged_parameter.read_bytes().startswith(b"InitCondFile")
+    assert staged_ic.read_bytes() == b"gadget2-initial-condition\x00\x01"
+    assert bundle.read_bytes() == source_bytes
+    command = _CapturedExec.commands[-1]
+    assert command == "Gadget2 galaxy.param"
+    assert _CapturedExec.infos[-1].cwd == str(workdir.resolve())
+    assert isinstance(_CapturedExec.infos[-1], gadget2_package.MpiExecInfo)
+
+
+def test_parameter_override_must_name_a_declared_bundle_file(tmp_path: Path) -> None:
+    """Alternate parameter selection cannot escape or guess outside the manifest."""
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    package = _package(
+        tmp_path,
+        _base_config(input_bundle=str(bundle), parameter_path="../galaxy.param"),
+    )
+
+    with pytest.raises(ValueError, match="confined manifest path"):
+        package.start()
+
+    package.config["parameter_path"] = "galaxy/missing.param"
+    with pytest.raises(ValueError, match="not declared by the input bundle"):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
+def test_native_configuration_fails_before_launch(tmp_path: Path) -> None:
+    """Missing input and invalid MPI resources are local configuration errors."""
+
+    package = _package(tmp_path, _base_config())
+    with pytest.raises(ValueError, match="requires input_bundle"):
+        package.start()
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    package.config = _base_config(input_bundle=str(bundle), nprocs=0)
+    with pytest.raises(ValueError, match="nprocs must be a positive integer"):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
+def test_native_process_failure_fails_the_package_lifecycle(tmp_path: Path) -> None:
+    """A failing Gadget2 rank cannot become a successful JARVIS execution."""
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+    _CapturedExec.return_code = 9
+
+    with pytest.raises(RuntimeError, match="Gadget2 execution failed"):
+        package.start()
+
+
+def test_legacy_stock_profile_retains_its_existing_launch_shape(tmp_path: Path) -> None:
+    """Existing configured stock pipelines still run their generated parameter."""
+
+    output = tmp_path / "legacy output"
+    output.mkdir()
+    parameter = output / "gassphere.param"
+    parameter.write_text("TimeMax 0.05\n", encoding="utf-8")
+    binary = tmp_path / "Gadget2 runtime"
+    binary.write_bytes(b"runtime-placeholder")
+    package = _package(
+        tmp_path,
+        _base_config(
+            output=str(output),
+            paramfile=str(parameter),
+            binary=str(binary),
+        ),
+    )
+
+    package.start()
+
+    inner = " ".join(
+        (
+            "cd",
+            shlex.quote(str(output.resolve())),
+            "&&",
+            shlex.quote(str(binary)),
+            "gassphere.param",
+        )
+    )
+    assert _CapturedExec.commands[-1] == f"bash -c {shlex.quote(inner)}"
+    assert _CapturedExec.infos[-1].cwd == str(output.resolve())
+    assert isinstance(_CapturedExec.infos[-1], gadget2_package.MpiExecInfo)
+
+
+def test_native_command_quotes_runtime_and_parameter_names(tmp_path: Path) -> None:
+    """Runtime discovery cannot turn a valid path into shell syntax."""
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+    package.gadget2_bin = "/runtime with space/Gadget2"
+
+    package.start()
+
+    assert _CapturedExec.commands[-1] == (
+        f"{shlex.quote('/runtime with space/Gadget2')} galaxy.param"
+    )
+
+
+def test_clean_uses_one_exact_recursive_output_without_wildcard(tmp_path: Path) -> None:
+    """Cleanup cannot erase prefix-matching sibling directories."""
+
+    package = _package(tmp_path, _base_config(out="results"))
+
+    package.clean()
+
+    assert _CapturedRm.calls == [
+        (str((tmp_path / "shared" / "results").resolve()), True)
+    ]
+    assert "*" not in _CapturedRm.calls[0][0]
+
+
+def test_default_hostfile_uses_local_output_lifecycle(tmp_path: Path) -> None:
+    """Local output preparation does not require SSH."""
+
+    package = _package(tmp_path, _base_config())
+
+    assert isinstance(package._node_exec_info(), LocalExecInfo)

--- a/test/unit/core/test_gadget2_package_runtime.py
+++ b/test/unit/core/test_gadget2_package_runtime.py
@@ -223,6 +223,15 @@ def test_agent_contract_exposes_bundle_profile_and_hides_legacy_defaults() -> No
     assert [item["id"] for item in contract["runtime_requirements"]] == ["gadget2"]
 
 
+def test_native_validation_treats_absent_deploy_mode_as_default() -> None:
+    """New pipeline members resolve an omitted deploy mode to native execution."""
+    package = object.__new__(gadget2_package.Gadget2)
+    package.config = _base_config(input_bundle="galaxy.tar")
+    del package.config["deploy_mode"]
+
+    package._validate_native_configuration()
+
+
 def test_bundle_is_verified_and_staged_before_native_launch(tmp_path: Path) -> None:
     """The solver runs from an owned copy while caller bytes remain immutable."""
 

--- a/test/unit/core/test_gadget2_package_runtime.py
+++ b/test/unit/core/test_gadget2_package_runtime.py
@@ -6,9 +6,10 @@ import hashlib
 import io
 import json
 import shlex
+import sys
 import tarfile
-from importlib.util import module_from_spec, spec_from_file_location
-from pathlib import Path
+from importlib import import_module
+from pathlib import Path, PurePosixPath
 from types import ModuleType, SimpleNamespace
 from typing import Any
 
@@ -25,19 +26,12 @@ from jarvis_cd.util.hostfile import Hostfile
 def _load_package() -> ModuleType:
     """Load the builtin package without changing repository imports."""
 
-    path = (
-        Path(__file__).resolve().parents[3]
-        / "builtin"
-        / "builtin"
-        / "gadget2"
-        / "pkg.py"
-    )
-    spec = spec_from_file_location("test_gadget2_runtime_package", path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"Could not load Gadget2 package from {path}")
-    module = module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    repository_root = Path(__file__).resolve().parents[3] / "builtin"
+    sys.path.insert(0, str(repository_root))
+    try:
+        return import_module("builtin.gadget2.pkg")
+    finally:
+        sys.path.remove(str(repository_root))
 
 
 gadget2_package = _load_package()
@@ -49,6 +43,8 @@ class _CapturedExec:
     commands: list[str] = []
     infos: list[Any] = []
     return_code = 0
+    emit_products = True
+    product_bytes = b"scientific-product\n"
 
     def __init__(self, command: str, exec_info: Any) -> None:
         self.command = command
@@ -58,8 +54,30 @@ class _CapturedExec:
         self.infos.append(exec_info)
 
     def run(self) -> _CapturedExec:
-        """Return the captured result."""
+        """Materialize parameter-declared products and return the result."""
 
+        if (
+            self.return_code == 0
+            and self.emit_products
+            and not self.command.startswith("bash -c ")
+        ):
+            cwd = Path(self.exec_info.cwd)
+            parameter_name = shlex.split(self.command)[-1]
+            parameter = cwd / parameter_name
+            contract = gadget2_package.parse_gadget2_output_contract(
+                parameter.read_text(encoding="utf-8"),
+                parameter_path=PurePosixPath(cwd.name) / parameter_name,
+            )
+            run_root = cwd.parent
+            for relative in (contract.energy_file, contract.info_file):
+                product = run_root.joinpath(*relative.parts)
+                product.parent.mkdir(parents=True, exist_ok=True)
+                product.write_bytes(self.product_bytes)
+            snapshot_base = run_root.joinpath(*contract.snapshot_file_base.parts)
+            snapshot_base.parent.mkdir(parents=True, exist_ok=True)
+            snapshot_base.with_name(f"{snapshot_base.name}_000").write_bytes(
+                self.product_bytes
+            )
         return self
 
 
@@ -103,6 +121,8 @@ def _capture_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     _CapturedExec.commands = []
     _CapturedExec.infos = []
     _CapturedExec.return_code = 0
+    _CapturedExec.emit_products = True
+    _CapturedExec.product_bytes = b"scientific-product\n"
     _CapturedRm.calls = []
     monkeypatch.setattr(gadget2_package, "Exec", _CapturedExec)
     monkeypatch.setattr(gadget2_package, "Mkdir", _CapturedMkdir)
@@ -150,7 +170,8 @@ def _write_bundle(
     destination: Path,
     *,
     parameter: bytes = (
-        b"InitCondFile ICs/galaxy.dat\nOutputDir output/\nEnergyFile energy.txt\n"
+        b"InitCondFile ICs/galaxy.dat\nOutputDir output/\n"
+        b"EnergyFile energy.txt\nInfoFile info.txt\nSnapshotFileBase snapshot\n"
     ),
 ) -> Path:
     files = {
@@ -225,6 +246,10 @@ def test_agent_contract_exposes_bundle_profile_and_hides_legacy_defaults() -> No
         "input_bundle"
     ]
     assert [item["id"] for item in contract["runtime_requirements"]] == ["gadget2"]
+    assert contract["execution_profiles"][0]["readiness"] == {
+        "mechanism": "process_exit",
+        "condition": "successful_exit_with_required_products",
+    }
 
 
 def test_native_validation_treats_absent_deploy_mode_as_default() -> None:
@@ -261,16 +286,40 @@ def test_bundle_is_verified_and_staged_before_native_launch(tmp_path: Path) -> N
 @pytest.mark.parametrize(
     ("parameter", "message"),
     [
-        (b"InitCondFile ICs/galaxy.dat\n", "declare OutputDir exactly once"),
         (
-            b"OutputDir output/\nOutputDir other/\n",
+            b"EnergyFile energy.txt\nInfoFile info.txt\nSnapshotFileBase snapshot\n",
             "declare OutputDir exactly once",
         ),
-        (b"OutputDir ../escape/\n", "confined POSIX path"),
-        (b"OutputDir /tmp/escape/\n", "confined POSIX path"),
-        (b"OutputDir C:/escape/\n", "confined POSIX path"),
-        (b"OutputDir output\\escape\n", "confined POSIX path"),
-        (b"OutputDir output path\n", "one path token"),
+        (
+            b"OutputDir output/\nOutputDir other/\nEnergyFile energy.txt\n"
+            b"InfoFile info.txt\nSnapshotFileBase snapshot\n",
+            "declare OutputDir exactly once",
+        ),
+        (
+            b"OutputDir ../escape/\nEnergyFile energy.txt\nInfoFile info.txt\n"
+            b"SnapshotFileBase snapshot\n",
+            "confined POSIX path",
+        ),
+        (
+            b"OutputDir /tmp/escape/\nEnergyFile energy.txt\nInfoFile info.txt\n"
+            b"SnapshotFileBase snapshot\n",
+            "confined POSIX path",
+        ),
+        (
+            b"OutputDir C:/escape/\nEnergyFile energy.txt\nInfoFile info.txt\n"
+            b"SnapshotFileBase snapshot\n",
+            "confined POSIX path",
+        ),
+        (
+            b"OutputDir output\\escape\nEnergyFile energy.txt\nInfoFile info.txt\n"
+            b"SnapshotFileBase snapshot\n",
+            "confined POSIX path",
+        ),
+        (
+            b"OutputDir output path\nEnergyFile energy.txt\nInfoFile info.txt\n"
+            b"SnapshotFileBase snapshot\n",
+            "one path token",
+        ),
     ],
 )
 def test_native_output_directory_is_single_and_confined(
@@ -332,6 +381,47 @@ def test_native_process_failure_fails_the_package_lifecycle(tmp_path: Path) -> N
 
     with pytest.raises(RuntimeError, match="Gadget2 execution failed"):
         package.start()
+
+
+def test_zero_exit_without_scientific_products_fails_lifecycle(tmp_path: Path) -> None:
+    """Gadget2's zero-status fatal paths cannot become successful executions."""
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+    _CapturedExec.emit_products = False
+
+    with pytest.raises(RuntimeError, match="without required non-empty products"):
+        package.start()
+
+
+def test_zero_byte_scientific_products_fail_lifecycle(tmp_path: Path) -> None:
+    """Placeholder files do not satisfy the native completion contract."""
+
+    bundle = _write_bundle(tmp_path / "galaxy.tar")
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+    _CapturedExec.product_bytes = b""
+
+    with pytest.raises(RuntimeError, match="EnergyFile, InfoFile, SnapshotFileBase"):
+        package.start()
+
+
+def test_completion_uses_parameter_declared_product_names(tmp_path: Path) -> None:
+    """The native lifecycle does not guess stock Gadget2 filenames."""
+
+    parameter = (
+        b"InitCondFile ICs/galaxy.dat\nOutputDir products/\n"
+        b"EnergyFile conserved.dat\nInfoFile progress.log\n"
+        b"SnapshotFileBase states/galaxy\n"
+    )
+    bundle = _write_bundle(tmp_path / "galaxy.tar", parameter=parameter)
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+
+    package.start()
+
+    root = tmp_path / "shared" / "run" / "galaxy" / "products"
+    assert (root / "conserved.dat").stat().st_size > 0
+    assert (root / "progress.log").stat().st_size > 0
+    assert (root / "states" / "galaxy_000").stat().st_size > 0
 
 
 def test_legacy_stock_profile_retains_its_existing_launch_shape(tmp_path: Path) -> None:

--- a/test/unit/core/test_gadget2_package_runtime.py
+++ b/test/unit/core/test_gadget2_package_runtime.py
@@ -200,6 +200,10 @@ def test_agent_contract_exposes_bundle_profile_and_hides_legacy_defaults() -> No
     }
     assert menu["parameter_path"]["default"] == ""
     assert menu["out"]["default"] == "run"
+    assert menu["gadget2_path"]["default"] is None
+    assert menu["gadget2_path"]["required"] is False
+    assert menu["output"]["default"] is None
+    assert menu["output"]["required"] is False
     assert all(
         menu[name]["agent_visible"] is False
         for name in {

--- a/test/unit/core/test_input_bundle.py
+++ b/test/unit/core/test_input_bundle.py
@@ -1,0 +1,247 @@
+"""Security and identity tests for package input-bundle materialization."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import shutil
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+    InputBundleError,
+    extract_input_bundle,
+    stage_input_bundle,
+)
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _write_bundle(
+    destination: Path,
+    files: dict[str, bytes],
+    *,
+    entrypoint: str,
+    mutate_manifest: object | None = None,
+    extra_member: tuple[tarfile.TarInfo, bytes] | None = None,
+) -> Path:
+    manifest: object = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": entrypoint,
+        "files": [
+            {
+                "path": name,
+                "role": "package_input",
+                "sha256": _sha256(payload),
+                "size_bytes": len(payload),
+            }
+            for name, payload in sorted(files.items())
+        ],
+    }
+    if mutate_manifest is not None:
+        manifest = mutate_manifest
+    manifest_payload = json.dumps(manifest, sort_keys=True).encode("utf-8")
+    with tarfile.open(destination, mode="w") as archive:
+        manifest_info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        manifest_info.size = len(manifest_payload)
+        archive.addfile(manifest_info, io.BytesIO(manifest_payload))
+        for name, payload in sorted(files.items()):
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+        if extra_member is not None:
+            info, payload = extra_member
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def test_extract_input_bundle_is_digest_bound_and_idempotent(tmp_path: Path) -> None:
+    archive = _write_bundle(
+        tmp_path / "inputs.tar",
+        {
+            "in/run.lmp": b"include support/potential.eam\n",
+            "support/potential.eam": b"EAM",
+        },
+        entrypoint="in/run.lmp",
+    )
+
+    first = extract_input_bundle(archive, tmp_path / "materialized")
+    second = extract_input_bundle(archive, tmp_path / "materialized")
+
+    assert first == second
+    assert first.root.name == _sha256(archive.read_bytes())
+    assert first.entrypoint.read_bytes() == b"include support/potential.eam\n"
+    assert (first.root / "support" / "potential.eam").read_bytes() == b"EAM"
+    assert first.manifest.entrypoint == "in/run.lmp"
+
+
+def test_extract_input_bundle_rejects_links_and_path_traversal(tmp_path: Path) -> None:
+    link = tarfile.TarInfo("linked")
+    link.type = tarfile.SYMTYPE
+    link.linkname = "entrypoint"
+    archive = _write_bundle(
+        tmp_path / "link.tar",
+        {"entrypoint": b"run"},
+        entrypoint="entrypoint",
+        extra_member=(link, b""),
+    )
+    with pytest.raises(InputBundleError, match="not a regular file"):
+        extract_input_bundle(archive, tmp_path / "linked-output")
+
+    traversal = tarfile.TarInfo("../escape")
+    traversal.size = 1
+    archive = _write_bundle(
+        tmp_path / "traversal.tar",
+        {"entrypoint": b"run"},
+        entrypoint="entrypoint",
+        extra_member=(traversal, b"x"),
+    )
+    with pytest.raises(InputBundleError, match="confined relative path"):
+        extract_input_bundle(archive, tmp_path / "traversal-output")
+
+
+def test_extract_input_bundle_rejects_manifest_and_payload_mismatch(
+    tmp_path: Path,
+) -> None:
+    malformed = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "entrypoint",
+        "files": [
+            {
+                "path": "entrypoint",
+                "role": "package_input",
+                "sha256": "0" * 64,
+                "size_bytes": 3,
+            }
+        ],
+    }
+    archive = _write_bundle(
+        tmp_path / "mismatch.tar",
+        {"entrypoint": b"run"},
+        entrypoint="entrypoint",
+        mutate_manifest=malformed,
+    )
+
+    with pytest.raises(InputBundleError, match="digest or size mismatch"):
+        extract_input_bundle(archive, tmp_path / "output")
+
+
+def test_extract_input_bundle_detects_changed_materialization(tmp_path: Path) -> None:
+    archive = _write_bundle(
+        tmp_path / "inputs.tar",
+        {"entrypoint": b"run"},
+        entrypoint="entrypoint",
+    )
+    materialized = extract_input_bundle(archive, tmp_path / "output")
+    materialized.entrypoint.write_bytes(b"changed")
+
+    with pytest.raises(InputBundleError, match="member changed"):
+        extract_input_bundle(archive, tmp_path / "output")
+
+
+def test_extract_input_bundle_rejects_coordinated_materialization_rewrite(
+    tmp_path: Path,
+) -> None:
+    archive = _write_bundle(
+        tmp_path / "inputs.tar",
+        {"entrypoint": b"run"},
+        entrypoint="entrypoint",
+    )
+    materialized = extract_input_bundle(archive, tmp_path / "output")
+    changed = b"changed"
+    materialized.entrypoint.write_bytes(changed)
+    rewritten_manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "entrypoint",
+        "files": [
+            {
+                "path": "entrypoint",
+                "role": "package_input",
+                "sha256": _sha256(changed),
+                "size_bytes": len(changed),
+            }
+        ],
+    }
+    (materialized.root / INPUT_BUNDLE_MANIFEST_NAME).write_text(
+        json.dumps(rewritten_manifest, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(InputBundleError, match="differs from the source archive"):
+        extract_input_bundle(archive, tmp_path / "output")
+
+
+def test_extract_input_bundle_reapplies_bounds_when_reusing(tmp_path: Path) -> None:
+    archive = _write_bundle(
+        tmp_path / "inputs.tar",
+        {"entrypoint": b"run"},
+        entrypoint="entrypoint",
+    )
+    extract_input_bundle(archive, tmp_path / "output")
+
+    with pytest.raises(InputBundleError, match="payload exceeds"):
+        extract_input_bundle(archive, tmp_path / "output", max_total_bytes=1)
+
+
+def test_extract_input_bundle_reuses_concurrent_atomic_publication(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = _write_bundle(
+        tmp_path / "inputs.tar",
+        {"entrypoint": b"run"},
+        entrypoint="entrypoint",
+    )
+
+    def publish_competitor(source: Path, destination: Path) -> None:
+        shutil.copytree(source, destination)
+        raise FileExistsError("concurrent publication")
+
+    monkeypatch.setattr("jarvis_cd.input_bundle.os.replace", publish_competitor)
+
+    materialized = extract_input_bundle(archive, tmp_path / "output")
+
+    assert materialized.entrypoint.read_bytes() == b"run"
+    assert not any(
+        path.name.startswith(f".{materialized.bundle_sha256}.")
+        for path in (tmp_path / "output").iterdir()
+    )
+
+
+def test_stage_input_bundle_copies_payload_without_overwriting(tmp_path: Path) -> None:
+    archive = _write_bundle(
+        tmp_path / "inputs.tar",
+        {"in/run.lmp": b"run 1\n", "potential.eam": b"EAM"},
+        entrypoint="in/run.lmp",
+    )
+    materialized = extract_input_bundle(archive, tmp_path / "materialized")
+
+    entrypoint = stage_input_bundle(materialized, tmp_path / "run")
+
+    assert entrypoint == tmp_path / "run" / "in" / "run.lmp"
+    assert entrypoint.read_bytes() == b"run 1\n"
+    assert (tmp_path / "run" / "potential.eam").read_bytes() == b"EAM"
+    with pytest.raises(InputBundleError, match="already exists"):
+        stage_input_bundle(materialized, tmp_path / "run")
+
+
+def test_extract_input_bundle_enforces_declared_bounds(tmp_path: Path) -> None:
+    archive = _write_bundle(
+        tmp_path / "inputs.tar",
+        {"entrypoint": b"run", "second": b"file"},
+        entrypoint="entrypoint",
+    )
+
+    with pytest.raises(InputBundleError, match="member count"):
+        extract_input_bundle(archive, tmp_path / "file-bound", max_files=1)
+    with pytest.raises(InputBundleError, match="payload exceeds"):
+        extract_input_bundle(archive, tmp_path / "byte-bound", max_total_bytes=1)
+    with pytest.raises(InputBundleError, match="archive size or type"):
+        extract_input_bundle(archive, tmp_path / "archive-bound", max_archive_bytes=1)

--- a/test/unit/core/test_lammps_artifacts.py
+++ b/test/unit/core/test_lammps_artifacts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -162,6 +162,35 @@ def test_lammps_default_artifacts_resolve_to_execution_package_shared_root() -> 
 
     assert adapter is not None
     assert adapter.output_dir.as_posix() == "/execution/shared/lammps"
+
+
+def test_lammps_bundle_entrypoint_drives_declared_output_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Artifact semantics inspect the same manifest entrypoint LAMMPS executes."""
+
+    script = tmp_path / "materialized" / "in.copper"
+    script.parent.mkdir()
+    script.write_text("write_data copper.data\n", encoding="utf-8")
+    module = _module()
+    monkeypatch.setattr(
+        module,
+        "extract_input_bundle",
+        lambda _bundle, _destination: SimpleNamespace(entrypoint=script),
+    )
+
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.lammps",
+            "input_bundle": "/staged/copper.tar",
+            "out": "/execution/shared/lammps",
+            "shared_dir": "/execution/shared/lammps",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.script_path == script
 
 
 def test_container_lammps_reports_only_host_visible_output() -> None:

--- a/test/unit/core/test_lammps_package_runtime.py
+++ b/test/unit/core/test_lammps_package_runtime.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
+import io
+import json
 import shlex
+import tarfile
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -10,6 +14,10 @@ from typing import Any
 
 import pytest
 
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+)
 from jarvis_cd.shell import LocalExecInfo, PsshExecInfo
 from jarvis_cd.util.hostfile import Hostfile
 
@@ -38,12 +46,14 @@ class _CapturedExec:
     """Capture a package launch without executing the application."""
 
     commands: list[str] = []
+    exec_infos: list[Any] = []
 
     def __init__(self, command: str, exec_info: Any) -> None:
         self.command = command
         self.exec_info = exec_info
         self.exit_code = {"localhost": 0}
         self.commands.append(command)
+        self.exec_infos.append(exec_info)
 
     def run(self) -> _CapturedExec:
         """Record the launch only."""
@@ -105,6 +115,7 @@ def _capture_output_directory_creation(
     """Keep package launch tests isolated from PSSH output creation."""
     _CapturedMkdir.paths = []
     _CapturedRm.calls = []
+    _CapturedExec.exec_infos = []
     monkeypatch.setattr(lammps_package, "Mkdir", _CapturedMkdir)
     monkeypatch.setattr(lammps_package, "Rm", _CapturedRm)
 
@@ -117,6 +128,41 @@ def test_portable_defaults_use_package_shared_output_and_cpu() -> None:
     assert menu["out"]["default"] == "."
     assert "JARVIS package shared directory" in menu["out"]["msg"]
     assert menu["kokkos_gpu"]["default"] is False
+    assert menu["input_bundle"]["default"] == ""
+    assert menu["input_bundle"]["input_binding"]["kind"] == "local_file"
+
+
+def _write_lammps_input_bundle(destination: Path) -> Path:
+    files = {
+        "in.copper": b"pair_style eam\npair_coeff * * Cu.eam\nrun 0\n",
+        "Cu.eam": b"potential\n",
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "in.copper",
+        "files": [
+            {
+                "path": name,
+                "role": role,
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, role, payload in (
+                ("in.copper", "lammps_input", files["in.copper"]),
+                ("Cu.eam", "potential", files["Cu.eam"]),
+            )
+        ],
+    }
+    manifest_payload = json.dumps(manifest, sort_keys=True).encode("utf-8")
+    with tarfile.open(destination, mode="w") as archive:
+        manifest_info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        manifest_info.size = len(manifest_payload)
+        archive.addfile(manifest_info, io.BytesIO(manifest_payload))
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
 
 
 def test_default_output_resolves_inside_execution_package_shared_root(
@@ -278,6 +324,60 @@ def test_default_launch_generates_package_owned_lennard_jones_input(
     assert f"-in {shlex.quote(str(generated))}" in _CapturedExec.commands[1]
 
 
+def test_default_launch_stages_multi_file_input_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """LAMMPS receives its entrypoint and support files in one owned cwd."""
+
+    output_dir = tmp_path / "output"
+    bundle = _write_lammps_input_bundle(tmp_path / "copper.tar")
+    package = object.__new__(lammps_package.Lammps)
+    package.config = {
+        "input_bundle": str(bundle),
+        "kokkos_gpu": False,
+        "nprocs": 2,
+        "out": str(output_dir),
+        "ppn": 2,
+        "script": "",
+    }
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: None)
+    package.env = {}
+    package.mod_env = {}
+    package.shared_dir = tmp_path / "shared"
+    _CapturedExec.commands = []
+    monkeypatch.setattr(lammps_package, "Exec", _CapturedExec)
+
+    package.start()
+
+    staged_script = output_dir / "in.copper"
+    assert staged_script.read_bytes().startswith(b"pair_style eam")
+    assert (output_dir / "Cu.eam").read_bytes() == b"potential\n"
+    assert f"-in {shlex.quote(str(staged_script))}" in _CapturedExec.commands[1]
+    assert _CapturedExec.exec_infos[-1].cwd == str(output_dir.resolve())
+
+
+def test_input_bundle_is_mutually_exclusive_with_script(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Ambiguous caller inputs fail before directory or process side effects."""
+
+    package = object.__new__(lammps_package.Lammps)
+    package.config = {
+        "input_bundle": str(tmp_path / "inputs.tar"),
+        "script": str(tmp_path / "in.lmp"),
+    }
+    package.shared_dir = tmp_path / "shared"
+    _CapturedExec.commands = []
+    monkeypatch.setattr(lammps_package, "Exec", _CapturedExec)
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
 def test_generated_inputs_are_content_addressed_for_concurrent_executions(
     tmp_path: Path,
 ) -> None:
@@ -381,8 +481,9 @@ def test_container_launch_creates_log_directory_before_lammps(
     assert _CapturedExec.commands[0] == f"rm -f {shlex.quote(str(expected_log))}"
     argv = shlex.split(_CapturedExec.commands[1])
     assert argv[:2] == ["bash", "-c"]
+    output = shlex.quote(str(output_dir.resolve()))
     expected_prefix = (
-        f"mkdir -p {shlex.quote(str(output_dir.resolve()))} "
+        f"mkdir -p {output} && cd {output} "
         f"&& exec /usr/local/bin/lmp -log {shlex.quote(str(expected_log))}"
     )
     assert argv[2].startswith(expected_prefix + " -in ")

--- a/test/unit/core/test_montage_artifacts.py
+++ b/test/unit/core/test_montage_artifacts.py
@@ -1,0 +1,126 @@
+"""Generated-artifact tests for the builtin Montage package."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import (
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "montage"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def _products(root: Path) -> None:
+    for band in ("j", "h", "k"):
+        (root / f"montage-{band}.fits").write_bytes(b"SIMPLE  " + bytes(4096))
+    (root / "montage-jhk.png").write_bytes(b"\x89PNG\r\n\x1a\n" + bytes(2048))
+    (root / "montage-result.json").write_text(
+        json.dumps({"schema_version": "jarvis.montage-result.v1"}) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_montage_success_finalizes_only_declared_products(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The provider reports FITS, composite, and result products without crawling."""
+    _products(tmp_path)
+    (tmp_path / "unrelated.txt").write_text("ignore\n", encoding="utf-8")
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.montage",
+            "out": "/execution/shared/montage",
+            "j_bundle": "/inputs/j.tar",
+            "h_bundle": "/inputs/h.tar",
+            "k_bundle": "/inputs/k.tar",
+            "region": "M31",
+        }
+    )
+    monkeypatch.setattr(module, "Path", lambda _value: tmp_path)
+
+    assert adapter is not None
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert adapter.finalize_artifacts_for_exit(0) == []
+    assert {item.logical_name for item in observations} == {
+        "montage-j-mosaic",
+        "montage-h-mosaic",
+        "montage-k-mosaic",
+        "montage-three-band-composite",
+        "montage-result",
+    }
+    assert {item.state for item in observations} == {ArtifactState.FINALIZED}
+    assert sum(item.role is ArtifactRole.OUTPUT for item in observations) == 4
+    result = next(
+        item for item in observations if item.logical_name == "montage-result"
+    )
+    assert result.role is ArtifactRole.VALIDATION
+    assert result.structure is ArtifactStructure.FILE
+
+
+def test_montage_missing_product_is_incomplete_even_after_zero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Process exit alone cannot claim a complete three-band product set."""
+    _products(tmp_path)
+    (tmp_path / "montage-k.fits").unlink()
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.montage",
+            "out": "/execution/shared/montage",
+            "j_bundle": "/inputs/j.tar",
+            "h_bundle": "/inputs/h.tar",
+            "k_bundle": "/inputs/k.tar",
+            "region": "M31",
+        }
+    )
+    monkeypatch.setattr(module, "Path", lambda _value: tmp_path)
+
+    assert adapter is not None
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    missing = next(
+        item for item in observations if item.logical_name == "montage-k-mosaic"
+    )
+    assert missing.state is ArtifactState.INCOMPLETE
+    assert missing.location is None
+
+
+def test_montage_factory_confines_relative_output_to_shared_root() -> None:
+    """Artifacts cannot escape the package-owned shared output namespace."""
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.montage",
+            "out": ".",
+            "shared_dir": "/execution/shared/montage",
+            "j_bundle": "/inputs/j.tar",
+            "h_bundle": "/inputs/h.tar",
+            "k_bundle": "/inputs/k.tar",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.output_dir.as_posix() == "/execution/shared/montage"
+    assert module.adapter_from_package({"pkg_type": "builtin.lammps"}) is None

--- a/test/unit/core/test_montage_package.py
+++ b/test/unit/core/test_montage_package.py
@@ -1,0 +1,285 @@
+"""Runtime-contract tests for the builtin Montage package."""
+
+from __future__ import annotations
+
+import shlex
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def _load_package() -> ModuleType:
+    """Load builtin Montage without repository registration."""
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "montage"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_builtin_montage", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load the Montage package from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+montage_package = _load_package()
+
+
+class _RuntimeCallback:
+    """Capture the one terminal process finalization."""
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+        self.finalizations: list[int] = []
+
+    def __call__(self, _stream: str, line: str) -> None:
+        self.lines.append(line)
+
+    def finalize_process(self, return_code: int) -> None:
+        self.finalizations.append(return_code)
+
+
+class _CapturedExec:
+    """Execute no external programs while materializing expected products."""
+
+    commands: list[str] = []
+    failures: dict[str, int] = {}
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": self.failures.get(command, 0)}
+        self.commands.append(command)
+
+    def run(self) -> _CapturedExec:
+        """Materialize products corresponding to a successful Montage command."""
+        return_code = self.exit_code["localhost"]
+        if return_code == 0:
+            tokens = shlex.split(self.command)
+            if tokens and tokens[0] == "mExec":
+                output = Path(tokens[tokens.index("-o") + 1])
+                output.write_bytes(b"SIMPLE  " + bytes(4096))
+            elif tokens and tokens[0] == "mExamine":
+                stats = Path(tokens[tokens.index(">") + 1])
+                stats.write_text(
+                    '[struct stat="OK", npixel=4096, nnull=32, '
+                    "aveflux=1.25, rmsflux=0.50]\n",
+                    encoding="utf-8",
+                )
+            elif tokens and tokens[0] == "mViewer":
+                composite = Path(tokens[tokens.index("-out") + 1])
+                composite.write_bytes(b"\x89PNG\r\n\x1a\n" + bytes(2048))
+        callback = getattr(self.exec_info, "line_callback", None)
+        if callback is not None:
+            callback("stdout", f"{self.command}\n")
+            callback.finalize_process(return_code)
+        return self
+
+
+def _bundle(tmp_path: Path, band: str) -> SimpleNamespace:
+    """Create one verified-bundle-shaped test object."""
+    root = tmp_path / f"materialized-{band}"
+    source = root / band / f"source-{band}.fits"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"SIMPLE  " + bytes(4096))
+    header = root / "region.hdr"
+    header.write_text("SIMPLE mosaic header\n", encoding="utf-8")
+    return SimpleNamespace(
+        band=band,
+        bundle_sha256=band * 64,
+        entrypoint=header,
+        manifest=SimpleNamespace(
+            entrypoint="region.hdr",
+            files=(
+                SimpleNamespace(path=f"{band}/source-{band}.fits", role="fits_source"),
+                SimpleNamespace(path="region.hdr", role="mosaic_header"),
+            ),
+        ),
+        root=root,
+    )
+
+
+def _package(tmp_path: Path, **updates: object) -> Any:
+    """Build a minimally configured Montage package."""
+    package = object.__new__(montage_package.Montage)
+    package.shared_dir = str(tmp_path / "shared")
+    package.private_dir = str(tmp_path / "private")
+    package.get_hostfile = lambda: None
+    package.env = {"PATH": "/runtime/bin"}
+    package.mod_env = dict(package.env)
+    package.config = {
+        "deploy_mode": "default",
+        "region": "M31",
+        "band": "j",
+        "size": 0.2,
+        "out": ".",
+        "j_bundle": "/inputs/j.tar",
+        "h_bundle": "/inputs/h.tar",
+        "k_bundle": "/inputs/k.tar",
+        "nprocs": 1,
+        "ppn": 1,
+    }
+    package.config.update(updates)
+    return package
+
+
+def test_montage_contract_discloses_offline_three_band_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agents can discover a network-independent supplied-input profile."""
+    package = object.__new__(montage_package.Montage)
+    package.config = {"deploy_mode": "default"}
+    package.mod_env = {"PATH": "/runtime/bin"}
+    package.env = dict(package.mod_env)
+    package._deployment_environment = lambda: package.mod_env
+    monkeypatch.setattr(
+        montage_package,
+        "probe_program",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            status=montage_package.RuntimeStatus("ready", "test")
+        ),
+    )
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    contract = package._deployment_contract().to_dict()
+
+    for band in ("j", "h", "k"):
+        assert menu[f"{band}_bundle"]["input_binding"]["kind"] == "local_file"
+    profiles = {item["name"]: item for item in contract["execution_profiles"]}
+    offline = profiles["offline_three_band"]
+    assert offline["execution_kind"] == "batch"
+    assert {item["parameter"] for item in offline["when"]} == {
+        "j_bundle",
+        "h_bundle",
+        "k_bundle",
+    }
+    runtime = contract["runtime_requirements"][0]
+    assert runtime["provider_resolutions"][0]["query"]["value"] == "montage@6.0"
+
+
+def test_montage_rejects_partial_offline_and_container_configuration(
+    tmp_path: Path,
+) -> None:
+    """Offline inputs are all-or-none and never trigger a container build."""
+    partial = _package(tmp_path, h_bundle="", k_bundle="")
+    with pytest.raises(ValueError, match="all three"):
+        partial._validate_configuration()
+    container = _package(tmp_path, deploy_mode="container")
+    with pytest.raises(ValueError, match="native execution"):
+        container._validate_configuration()
+
+
+def test_legacy_script_uses_configured_archive_coordinates() -> None:
+    """Legacy acquisition cannot silently fall back to fixed M17/J coordinates."""
+    script = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "montage"
+        / "run_mosaic.sh"
+    ).read_text(encoding="utf-8")
+
+    assert 'REGION="${MONTAGE_REGION:-M17}"' in script
+    assert 'BAND="${MONTAGE_BAND:-J}"' in script
+    assert 'SIZE="${MONTAGE_SIZE:-0.2}"' in script
+    assert 'mHdr "$REGION" "$SIZE"' in script
+    assert 'mArchiveList 2mass "$BAND" "$REGION" "$SIZE" "$SIZE"' in script
+
+
+def test_montage_offline_profile_runs_three_bands_and_finalizes_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The maintained profile stages inputs, validates outputs, and closes once."""
+    package = _package(tmp_path)
+    callback = _RuntimeCallback()
+    package.runtime_line_callback = lambda: callback
+    bundles = {
+        f"/inputs/{band}.tar": _bundle(tmp_path, band) for band in ("j", "h", "k")
+    }
+
+    def stage(bundle: SimpleNamespace, destination: Path) -> Path:
+        destination.mkdir(parents=True, exist_ok=True)
+        source = destination / bundle.band / f"source-{bundle.band}.fits"
+        source.parent.mkdir(parents=True)
+        source.write_bytes(b"SIMPLE  " + bytes(4096))
+        header = destination / "region.hdr"
+        header.write_text("SIMPLE mosaic header\n", encoding="utf-8")
+        return header
+
+    _CapturedExec.commands = []
+    _CapturedExec.failures = {}
+    monkeypatch.setattr(montage_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(
+        montage_package,
+        "extract_input_bundle",
+        lambda path, _destination: bundles[path],
+    )
+    monkeypatch.setattr(montage_package, "stage_input_bundle", stage)
+
+    package.start()
+
+    assert sum(command.startswith("mExec ") for command in _CapturedExec.commands) == 3
+    assert (
+        sum(command.startswith("mExamine ") for command in _CapturedExec.commands) == 3
+    )
+    assert (
+        sum(command.startswith("mViewer ") for command in _CapturedExec.commands) == 1
+    )
+    assert callback.finalizations == [0]
+    output = Path(package.shared_dir)
+    assert (output / "montage-j.fits").is_file()
+    assert (output / "montage-h.fits").is_file()
+    assert (output / "montage-k.fits").is_file()
+    assert (output / "montage-jhk.png").is_file()
+    assert (output / "montage-result.json").is_file()
+
+
+def test_montage_propagates_the_first_command_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A failed Montage command cannot become scheduler success."""
+    package = _package(tmp_path)
+    package.runtime_line_callback = _RuntimeCallback
+    bundles = {
+        f"/inputs/{band}.tar": _bundle(tmp_path, band) for band in ("j", "h", "k")
+    }
+    monkeypatch.setattr(montage_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(
+        montage_package,
+        "extract_input_bundle",
+        lambda path, _destination: bundles[path],
+    )
+    monkeypatch.setattr(
+        montage_package,
+        "stage_input_bundle",
+        lambda bundle, destination: destination / bundle.manifest.entrypoint,
+    )
+    _CapturedExec.commands = []
+    _CapturedExec.failures = {}
+    output = Path(package.shared_dir)
+    failed_command = " ".join(
+        (
+            "mExec",
+            "-r",
+            shlex.quote(str(output / "inputs-j" / "j")),
+            "-f",
+            shlex.quote(str(output / "inputs-j" / "region.hdr")),
+            "-o",
+            shlex.quote(str(output / "montage-j.fits")),
+            "2MASS",
+            "J",
+            shlex.quote(str(output / "work-j")),
+        )
+    )
+    _CapturedExec.failures[failed_command] = 7
+
+    with pytest.raises(RuntimeError, match="Montage J mosaic failed"):
+        package.start()

--- a/test/unit/core/test_montage_package.py
+++ b/test/unit/core/test_montage_package.py
@@ -49,6 +49,7 @@ class _CapturedExec:
     """Execute no external programs while materializing expected products."""
 
     commands: list[str] = []
+    working_directories: list[str] = []
     failures: dict[str, int] = {}
 
     def __init__(self, command: str, exec_info: Any) -> None:
@@ -56,24 +57,30 @@ class _CapturedExec:
         self.exec_info = exec_info
         self.exit_code = {"localhost": self.failures.get(command, 0)}
         self.commands.append(command)
+        self.working_directories.append(str(exec_info.cwd))
 
     def run(self) -> _CapturedExec:
         """Materialize products corresponding to a successful Montage command."""
         return_code = self.exit_code["localhost"]
         if return_code == 0:
             tokens = shlex.split(self.command)
+
+            def resolve(value: str) -> Path:
+                path = Path(value)
+                return path if path.is_absolute() else Path(self.exec_info.cwd) / path
+
             if tokens and tokens[0] == "mExec":
-                output = Path(tokens[tokens.index("-o") + 1])
+                output = resolve(tokens[tokens.index("-o") + 1])
                 output.write_bytes(b"SIMPLE  " + bytes(4096))
             elif tokens and tokens[0] == "mExamine":
-                stats = Path(tokens[tokens.index(">") + 1])
+                stats = resolve(tokens[tokens.index(">") + 1])
                 stats.write_text(
                     '[struct stat="OK", npixel=4096, nnull=32, '
                     "aveflux=1.25, rmsflux=0.50]\n",
                     encoding="utf-8",
                 )
             elif tokens and tokens[0] == "mViewer":
-                composite = Path(tokens[tokens.index("-out") + 1])
+                composite = resolve(tokens[tokens.index("-out") + 1])
                 composite.write_bytes(b"\x89PNG\r\n\x1a\n" + bytes(2048))
         callback = getattr(self.exec_info, "line_callback", None)
         if callback is not None:
@@ -103,6 +110,17 @@ def _bundle(tmp_path: Path, band: str) -> SimpleNamespace:
         ),
         root=root,
     )
+
+
+def _stage_bundle(bundle: SimpleNamespace, destination: Path) -> Path:
+    """Stage one bundle-shaped fixture into a mutable scratch directory."""
+    destination.mkdir(parents=True, exist_ok=True)
+    source = destination / bundle.band / f"source-{bundle.band}.fits"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"SIMPLE  " + bytes(4096))
+    header = destination / "region.hdr"
+    header.write_text("SIMPLE mosaic header\n", encoding="utf-8")
+    return header
 
 
 def _package(tmp_path: Path, **updates: object) -> Any:
@@ -204,16 +222,8 @@ def test_montage_offline_profile_runs_three_bands_and_finalizes_once(
         f"/inputs/{band}.tar": _bundle(tmp_path, band) for band in ("j", "h", "k")
     }
 
-    def stage(bundle: SimpleNamespace, destination: Path) -> Path:
-        destination.mkdir(parents=True, exist_ok=True)
-        source = destination / bundle.band / f"source-{bundle.band}.fits"
-        source.parent.mkdir(parents=True)
-        source.write_bytes(b"SIMPLE  " + bytes(4096))
-        header = destination / "region.hdr"
-        header.write_text("SIMPLE mosaic header\n", encoding="utf-8")
-        return header
-
     _CapturedExec.commands = []
+    _CapturedExec.working_directories = []
     _CapturedExec.failures = {}
     monkeypatch.setattr(montage_package, "Exec", _CapturedExec)
     monkeypatch.setattr(
@@ -221,8 +231,7 @@ def test_montage_offline_profile_runs_three_bands_and_finalizes_once(
         "extract_input_bundle",
         lambda path, _destination: bundles[path],
     )
-    monkeypatch.setattr(montage_package, "stage_input_bundle", stage)
-
+    monkeypatch.setattr(montage_package, "stage_input_bundle", _stage_bundle)
     package.start()
 
     assert sum(command.startswith("mExec ") for command in _CapturedExec.commands) == 3
@@ -233,6 +242,26 @@ def test_montage_offline_profile_runs_three_bands_and_finalizes_once(
         sum(command.startswith("mViewer ") for command in _CapturedExec.commands) == 1
     )
     assert callback.finalizations == [0]
+    mexec_invocations = [
+        (command, Path(cwd))
+        for command, cwd in zip(
+            _CapturedExec.commands,
+            _CapturedExec.working_directories,
+            strict=True,
+        )
+        if command.startswith("mExec ")
+    ]
+    assert {
+        shlex.split(command)[shlex.split(command).index("-r") + 1]
+        for command, _ in mexec_invocations
+    } == {"staged/j", "staged/h", "staged/k"}
+    assert all(
+        "-f staged/region.hdr -o mosaic.fits" in command
+        for command, _ in mexec_invocations
+    )
+    assert all(cwd != Path(package.shared_dir) for _, cwd in mexec_invocations)
+    assert all(len(str(cwd)) < 128 for _, cwd in mexec_invocations)
+    assert all(not cwd.exists() for _, cwd in mexec_invocations)
     output = Path(package.shared_dir)
     assert (output / "montage-j.fits").is_file()
     assert (output / "montage-h.fits").is_file()
@@ -257,29 +286,42 @@ def test_montage_propagates_the_first_command_failure(
         "extract_input_bundle",
         lambda path, _destination: bundles[path],
     )
-    monkeypatch.setattr(
-        montage_package,
-        "stage_input_bundle",
-        lambda bundle, destination: destination / bundle.manifest.entrypoint,
-    )
+    monkeypatch.setattr(montage_package, "stage_input_bundle", _stage_bundle)
     _CapturedExec.commands = []
+    _CapturedExec.working_directories = []
     _CapturedExec.failures = {}
-    output = Path(package.shared_dir)
-    failed_command = " ".join(
-        (
-            "mExec",
-            "-r",
-            shlex.quote(str(output / "inputs-j" / "j")),
-            "-f",
-            shlex.quote(str(output / "inputs-j" / "region.hdr")),
-            "-o",
-            shlex.quote(str(output / "montage-j.fits")),
-            "2MASS",
-            "J",
-            shlex.quote(str(output / "work-j")),
-        )
+    failed_command = (
+        "mExec -r staged/j -f staged/region.hdr -o mosaic.fits 2MASS J workspace"
     )
     _CapturedExec.failures[failed_command] = 7
 
     with pytest.raises(RuntimeError, match="Montage J mosaic failed"):
         package.start()
+    assert _CapturedExec.working_directories
+    assert all(
+        not Path(directory).exists() for directory in _CapturedExec.working_directories
+    )
+
+
+def test_montage_rejects_different_band_headers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A three-band run cannot silently combine different mosaic regions."""
+    package = _package(tmp_path)
+    Path(package.shared_dir).mkdir(parents=True)
+    bundles = {
+        f"/inputs/{band}.tar": _bundle(tmp_path, band) for band in ("j", "h", "k")
+    }
+    bundles["/inputs/h.tar"].entrypoint.write_text(
+        "different mosaic header\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        montage_package,
+        "extract_input_bundle",
+        lambda path, _destination: bundles[path],
+    )
+
+    with pytest.raises(ValueError, match="share one mosaic header"):
+        package._prepare_offline_inputs()

--- a/test/unit/core/test_package_deployment_contract.py
+++ b/test/unit/core/test_package_deployment_contract.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import pytest
 
-from jarvis_cd.core.pkg import Pkg
+from jarvis_cd.core.pkg import Interceptor, Pkg
 from jarvis_cd.deployment import (
     ConfigurationCondition,
     ConfigurationInputBinding,
@@ -43,21 +43,36 @@ def test_legacy_package_has_no_inferred_deployment_contract() -> None:
     assert package.describe_deployment() is None
 
 
-def test_common_implementation_controls_are_not_agent_visible() -> None:
-    """Generic agents see semantic package inputs, not JARVIS admin controls."""
+def test_only_explicit_interceptor_links_are_agent_visible_common_settings() -> None:
+    """Generic agents see graph edges but not JARVIS administration controls."""
     package = object.__new__(Pkg)
 
     parameters = package.configure_menu()
+    by_name = {parameter["name"]: parameter for parameter in parameters}
 
     assert parameters
-    assert all(parameter["agent_visible"] is False for parameter in parameters)
-    assert {parameter["name"] for parameter in parameters} >= {
+    assert by_name["interceptors"]["agent_visible"] is True
+    assert all(
+        parameter["agent_visible"] is False
+        for parameter in parameters
+        if parameter["name"] != "interceptors"
+    )
+    assert set(by_name) >= {
         "install_method",
         "install_query",
         "install",
         "hostfile",
         "timeout",
     }
+
+
+def test_interceptor_packages_do_not_advertise_nested_interceptor_links() -> None:
+    """An interceptor never invites an invalid nested-interceptor configuration."""
+    package = object.__new__(Interceptor)
+
+    parameters = {item["name"]: item for item in package.configure_menu()}
+
+    assert parameters["interceptors"]["agent_visible"] is False
 
 
 def test_standalone_descriptor_preserves_canonical_package_identity(

--- a/test/unit/core/test_package_deployment_contract.py
+++ b/test/unit/core/test_package_deployment_contract.py
@@ -161,6 +161,12 @@ def test_lammps_contract_defaults_to_generated_batch_and_spack_resolution(
         "kind": "local_file",
         "structure": "regular_file",
     }
+    assert menu["input_bundle"]["default"] == ""
+    assert menu["input_bundle"]["input_binding"] == {
+        "schema_version": "jarvis.configuration-input-binding.v1",
+        "kind": "local_file",
+        "structure": "regular_file",
+    }
     assert "`lattice fcc <density>`" in menu["script"]["msg"]
     assert "`region ... units lattice`" in menu["script"]["msg"]
     assert (
@@ -175,7 +181,11 @@ def test_lammps_contract_defaults_to_generated_batch_and_spack_resolution(
     assert {
         (profile["name"], profile["execution_kind"])
         for profile in document["execution_profiles"]
-    } == {("generated_workload", "batch"), ("input_script", "batch")}
+    } == {
+        ("generated_workload", "batch"),
+        ("input_script", "batch"),
+        ("input_bundle", "batch"),
+    }
     profiles = {profile["name"]: profile for profile in document["execution_profiles"]}
     assert profiles["generated_workload"]["description"] == (
         "Built-in bounded Lennard-Jones smoke workload with a package-generated "
@@ -187,6 +197,7 @@ def test_lammps_contract_defaults_to_generated_batch_and_spack_resolution(
         in profiles["input_script"]["description"]
     )
     assert "`mass 1 1.0`" in profiles["input_script"]["description"]
+    assert "Digest-verified multi-file" in profiles["input_bundle"]["description"]
     runtime = document["runtime_requirements"][0]
     assert runtime["status"] == {
         "state": "ready",

--- a/test/unit/core/test_package_deployment_contract.py
+++ b/test/unit/core/test_package_deployment_contract.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import pytest
 
+import jarvis_cd.deployment as deployment_module
 from jarvis_cd.core.pkg import Interceptor, Pkg
 from jarvis_cd.deployment import (
     ConfigurationCondition,
@@ -21,13 +22,14 @@ from jarvis_cd.deployment import (
     ReadinessContract,
     RuntimeRequirement,
     RuntimeStatus,
+    probe_program,
 )
 
 _BUILTIN_REPOSITORY_ROOT = Path(__file__).resolve().parents[3] / "builtin"
 sys.path.insert(0, str(_BUILTIN_REPOSITORY_ROOT))
 
-from builtin.lammps import pkg as lammps_module  # noqa: E402
-from builtin.paraview import pkg as paraview_module  # noqa: E402
+from builtin.lammps import pkg as lammps_module  # pyright: ignore[reportMissingImports]  # noqa: E402
+from builtin.paraview import pkg as paraview_module  # pyright: ignore[reportMissingImports]  # noqa: E402
 from jarvis_cd.core.config import Jarvis  # noqa: E402
 
 
@@ -150,6 +152,48 @@ def test_configuration_input_binding_is_closed_and_machine_readable() -> None:
             kind="local_file",
             structure="regular_file",
             schema_version="jarvis.configuration-input-binding.v2",
+        )
+
+
+def test_program_probe_can_accept_a_documented_usage_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI tools that use exit 1 for side-effect-free usage remain probeable."""
+    monkeypatch.setattr(
+        deployment_module,
+        "which",
+        lambda _program, *, path: "/runtime/bin/mExec" if path else None,
+    )
+    monkeypatch.setattr(
+        deployment_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=1,
+            stdout='[struct stat="ERROR", msg="Usage: mExec ..."]\n',
+            stderr="",
+        ),
+    )
+
+    accepted = probe_program(
+        "mExec",
+        environment={"PATH": "/runtime/bin"},
+        arguments=(),
+        accepted_return_codes=(0, 1),
+    )
+    strict = probe_program(
+        "mExec",
+        environment={"PATH": "/runtime/bin"},
+        arguments=(),
+    )
+
+    assert accepted.status.usable is True
+    assert "Usage: mExec" in accepted.output
+    assert strict.status.usable is False
+    with pytest.raises(ValueError, match="bounded integers"):
+        probe_program(
+            "mExec",
+            environment={"PATH": "/runtime/bin"},
+            accepted_return_codes=(),
         )
 
 

--- a/test/unit/core/test_pipeline_coverage.py
+++ b/test/unit/core/test_pipeline_coverage.py
@@ -147,6 +147,22 @@ class TestPipelineCoverage(unittest.TestCase):
         except Exception as e:
             self.fail(f"rm() raised unexpectedly: {e}")
 
+    def test_rm_rejects_referenced_interceptor(self):
+        """An interceptor cannot be removed while a package still references it."""
+        pipeline = self._make_pipeline("rm_interceptor_in_use")
+        pipeline.append("builtin.example_interceptor", package_alias="monitor")
+        pipeline.append(
+            "builtin.echo",
+            package_alias="workload",
+            config_args=['interceptors=["monitor"]'],
+        )
+
+        with self.assertRaisesRegex(ValueError, "referenced by: workload"):
+            pipeline.rm("monitor")
+
+        reloaded = Pipeline("rm_interceptor_in_use")
+        self.assertIn("monitor", reloaded.interceptors)
+
     # ------------------------------------------------------------------
     # status()
     # ------------------------------------------------------------------
@@ -238,6 +254,129 @@ class TestPipelineCoverage(unittest.TestCase):
         reloaded = Pipeline("append_valid")
         self.assertEqual(reloaded.packages[0]["config"]["retry_count"], 4)
 
+    def test_append_routes_interceptor_without_implicit_attachment(self):
+        """Appending an Interceptor stores it separately without changing applications."""
+        pipeline = self._make_pipeline("append_interceptor")
+
+        pipeline.append(
+            "builtin.example_interceptor",
+            package_alias="monitor",
+            config_args=["debug_mode=false"],
+        )
+        pipeline.append("builtin.echo", package_alias="workload")
+
+        self.assertEqual(pipeline.packages[0]["pkg_id"], "workload")
+        self.assertEqual(pipeline.packages[0]["config"]["interceptors"], [])
+        self.assertEqual(
+            pipeline.interceptors["monitor"]["pkg_type"],
+            "builtin.example_interceptor",
+        )
+        self.assertIs(pipeline.get_pkg("monitor"), pipeline.interceptors["monitor"])
+
+        reloaded = Pipeline("append_interceptor")
+        self.assertEqual(reloaded.packages[0]["config"]["interceptors"], [])
+        self.assertEqual(
+            reloaded.interceptors["monitor"]["config"]["debug_mode"], False
+        )
+
+    def test_append_supports_selective_named_interceptor_instances(self):
+        """Applications can select independently configured interceptor aliases."""
+        pipeline = self._make_pipeline("append_interceptor_selection")
+
+        pipeline.append(
+            "builtin.darshan",
+            package_alias="darshan_ior",
+            config_args=["log_dir=/tmp/ior_logs", "job_id=ior"],
+        )
+        pipeline.append(
+            "builtin.darshan",
+            package_alias="darshan_clio",
+            config_args=["log_dir=/tmp/clio_logs", "job_id=clio"],
+        )
+        pipeline.append(
+            "builtin.ior",
+            package_alias="ior",
+            config_args=['interceptors=["darshan_ior"]'],
+        )
+        pipeline.append(
+            "builtin.echo",
+            package_alias="clio",
+            config_args=['interceptors=["darshan_clio"]'],
+        )
+
+        self.assertEqual(
+            pipeline.interceptors["darshan_ior"]["config"]["log_dir"],
+            "/tmp/ior_logs",
+        )
+        self.assertEqual(
+            pipeline.interceptors["darshan_clio"]["config"]["log_dir"],
+            "/tmp/clio_logs",
+        )
+        self.assertEqual(
+            pipeline.packages[0]["config"]["interceptors"], ["darshan_ior"]
+        )
+        self.assertEqual(
+            pipeline.packages[1]["config"]["interceptors"], ["darshan_clio"]
+        )
+
+    def test_append_rejects_unknown_interceptor_reference_atomically(self):
+        """An application cannot reference an interceptor absent from the pipeline."""
+        pipeline = self._make_pipeline("append_interceptor_missing")
+
+        with self.assertRaisesRegex(ValueError, "unknown interceptor"):
+            pipeline.append(
+                "builtin.echo",
+                package_alias="workload",
+                config_args=['interceptors=["missing"]'],
+            )
+
+        self.assertEqual(pipeline.packages, [])
+
+    def test_save_rejects_non_interceptor_in_interceptor_section(self):
+        """A top-level interceptor definition must derive from Interceptor."""
+        pipeline = self._make_pipeline("invalid_interceptor_type")
+        pipeline.interceptors["not_an_interceptor"] = {
+            "pkg_type": "builtin.echo",
+            "pkg_id": "not_an_interceptor",
+            "pkg_name": "echo",
+            "global_id": "invalid_interceptor_type.not_an_interceptor",
+            "config": pipeline._get_package_default_config("builtin.echo"),
+        }
+
+        with self.assertRaisesRegex(ValueError, "is not an Interceptor package"):
+            pipeline.save()
+
+    def test_interceptor_modifies_only_the_explicitly_linked_package(self):
+        """Runtime environment mutation follows explicit package references."""
+        pipeline = self._make_pipeline("interceptor_runtime_link")
+        pipeline.append(
+            "builtin.example_interceptor",
+            package_alias="monitor",
+            config_args=["library_path=/tmp/libmonitor.so"],
+        )
+        pipeline.append("builtin.echo", package_alias="plain")
+        pipeline.append(
+            "builtin.echo",
+            package_alias="observed",
+            config_args=['interceptors=["monitor"]'],
+        )
+
+        plain = pipeline._load_package_instance(pipeline.packages[0], pipeline.env)
+        observed = pipeline._load_package_instance(pipeline.packages[1], pipeline.env)
+        pipeline._apply_interceptors_to_package(plain, pipeline.packages[0])
+        pipeline._apply_interceptors_to_package(observed, pipeline.packages[1])
+
+        self.assertNotIn("LD_PRELOAD", plain.mod_env)
+        self.assertEqual(observed.mod_env["LD_PRELOAD"], "/tmp/libmonitor.so")
+
+    def test_append_rejects_cross_kind_alias_collision(self):
+        """Package and interceptor IDs share one pipeline namespace."""
+        pipeline = self._make_pipeline("append_interceptor_collision")
+        pipeline.append("builtin.example_interceptor", package_alias="shared")
+
+        with self.assertRaisesRegex(ValueError, "already exists"):
+            pipeline.append("builtin.echo", package_alias="shared")
+
     # ------------------------------------------------------------------
     # configure_package()
     # ------------------------------------------------------------------
@@ -256,6 +395,16 @@ class TestPipelineCoverage(unittest.TestCase):
         # Reload pipeline and confirm nprocs was persisted
         pipeline2 = Pipeline("cfgpkg_test")
         self.assertEqual(pipeline2.packages[0]["config"].get("nprocs"), 8)
+
+    def test_configure_package_updates_interceptor_config(self):
+        """Generic package configuration also addresses Interceptor instances."""
+        pipeline = self._make_pipeline("cfg_interceptor")
+        pipeline.append("builtin.example_interceptor", package_alias="monitor")
+
+        pipeline.configure_package("monitor", ["debug_mode=false"])
+
+        reloaded = Pipeline("cfg_interceptor")
+        self.assertIs(reloaded.interceptors["monitor"]["config"]["debug_mode"], False)
 
     def test_configure_package_can_reset_a_value_to_its_default(self):
         """Explicit default values replace an earlier non-default value."""

--- a/test/unit/core/test_pipeline_coverage.py
+++ b/test/unit/core/test_pipeline_coverage.py
@@ -319,6 +319,27 @@ class TestPipelineCoverage(unittest.TestCase):
             pipeline.packages[1]["config"]["interceptors"], ["darshan_clio"]
         )
 
+    def test_append_accepts_native_gadget2_without_hidden_legacy_paths(self):
+        """The advertised native profile does not require stock-case controls."""
+        pipeline = self._make_pipeline("append_gadget2_native")
+
+        pipeline.append(
+            "builtin.gadget2",
+            package_alias="galaxy",
+            config_args=[
+                "input_bundle=/tmp/galaxy.tar",
+                "parameter_path=galaxy/galaxy.param",
+                "out=galaxy-run",
+                "nprocs=4",
+                "ppn=4",
+            ],
+        )
+
+        config = pipeline.packages[0]["config"]
+        self.assertEqual(config["input_bundle"], "/tmp/galaxy.tar")
+        self.assertIsNone(config["gadget2_path"])
+        self.assertIsNone(config["output"])
+
     def test_append_rejects_unknown_interceptor_reference_atomically(self):
         """An application cannot reference an interceptor absent from the pipeline."""
         pipeline = self._make_pipeline("append_interceptor_missing")
@@ -826,6 +847,24 @@ class TestPipelineCoverage(unittest.TestCase):
             with self.assertRaises(ValueError) as ctx:
                 pipeline._validate_required_config("builtin.ior", {})
         self.assertIn("Missing required", str(ctx.exception))
+
+    def test_validate_required_honors_explicit_conditional_override(self):
+        """A package may defer a conditionally required field to configuration."""
+        pipeline = self._make_pipeline("vrc_conditional")
+
+        from unittest.mock import MagicMock, patch
+
+        mock_pkg = MagicMock()
+        mock_pkg.configure_menu.return_value = [
+            {
+                "name": "legacy_profile_path",
+                "default": None,
+                "required": False,
+            },
+        ]
+
+        with patch.object(pipeline, "_load_package_instance", return_value=mock_pkg):
+            pipeline._validate_required_config("builtin.ior", {})
 
 
 if __name__ == "__main__":

--- a/test/unit/core/test_pipeline_coverage.py
+++ b/test/unit/core/test_pipeline_coverage.py
@@ -320,14 +320,20 @@ class TestPipelineCoverage(unittest.TestCase):
         )
 
     def test_append_accepts_native_gadget2_without_hidden_legacy_paths(self):
-        """The advertised native profile does not require stock-case controls."""
+        """The MCP-shaped native profile needs no stock-case or deploy controls."""
         pipeline = self._make_pipeline("append_gadget2_native")
+        bundle = os.path.join(self.test_dir, "galaxy.tar")
+        with open(bundle, "wb") as stream:
+            stream.write(b"immutable-gadget2-input")
 
         pipeline.append(
             "builtin.gadget2",
             package_alias="galaxy",
-            config_args=[
-                "input_bundle=/tmp/galaxy.tar",
+        )
+        pipeline.configure_package(
+            "galaxy",
+            [
+                f"input_bundle={bundle}",
                 "parameter_path=galaxy/galaxy.param",
                 "out=galaxy-run",
                 "nprocs=4",
@@ -336,7 +342,9 @@ class TestPipelineCoverage(unittest.TestCase):
         )
 
         config = pipeline.packages[0]["config"]
-        self.assertEqual(config["input_bundle"], "/tmp/galaxy.tar")
+        self.assertNotEqual(config["input_bundle"], bundle)
+        self.assertTrue(os.path.isfile(config["input_bundle"]))
+        self.assertNotIn("deploy_mode", config)
         self.assertIsNone(config["gadget2_path"])
         self.assertIsNone(config["output"])
 

--- a/test/unit/core/test_pipeline_coverage.py
+++ b/test/unit/core/test_pipeline_coverage.py
@@ -369,6 +369,68 @@ class TestPipelineCoverage(unittest.TestCase):
         self.assertNotIn("LD_PRELOAD", plain.mod_env)
         self.assertEqual(observed.mod_env["LD_PRELOAD"], "/tmp/libmonitor.so")
 
+    def test_configured_interceptor_environments_remain_package_local(self) -> None:
+        """Two configured Darshan aliases retain independent runtime settings."""
+        pipeline = self._make_pipeline("interceptor_runtime_isolation")
+        pipeline.append(
+            "builtin.darshan",
+            package_alias="darshan_ior",
+            config_args=[
+                "log_dir=/tmp/ior_logs",
+                "job_id=ior",
+            ],
+        )
+        pipeline.append(
+            "builtin.darshan",
+            package_alias="darshan_clio",
+            config_args=[
+                "log_dir=/tmp/clio_logs",
+                "job_id=clio",
+            ],
+        )
+        pipeline.append(
+            "builtin.echo",
+            package_alias="ior",
+            config_args=['interceptors=["darshan_ior"]'],
+        )
+        pipeline.append(
+            "builtin.echo",
+            package_alias="clio",
+            config_args=['interceptors=["darshan_clio"]'],
+        )
+        pipeline.append("builtin.echo", package_alias="plain")
+
+        pipeline.interceptors["darshan_ior"]["config"]["deploy_mode"] = "container"
+        pipeline.interceptors["darshan_clio"]["config"]["deploy_mode"] = "container"
+
+        with patch("builtin.darshan.pkg.Mkdir.run"):
+            pipeline._configure_package_instance(
+                pipeline.interceptors["darshan_ior"], "interceptor"
+            )
+            pipeline._configure_package_instance(
+                pipeline.interceptors["darshan_clio"], "interceptor"
+            )
+
+        self.assertNotIn("DARSHAN_LOG_DIR", pipeline.env)
+        self.assertNotIn("PBS_JOBID", pipeline.env)
+
+        ior = pipeline._load_package_instance(pipeline.packages[0], pipeline.env)
+        clio = pipeline._load_package_instance(pipeline.packages[1], pipeline.env)
+        plain = pipeline._load_package_instance(pipeline.packages[2], pipeline.env)
+        pipeline._apply_interceptors_to_package(ior, pipeline.packages[0])
+        pipeline._apply_interceptors_to_package(clio, pipeline.packages[1])
+        pipeline._apply_interceptors_to_package(plain, pipeline.packages[2])
+
+        self.assertEqual(ior.env["DARSHAN_LOG_DIR"], "/tmp/ior_logs")
+        self.assertEqual(ior.env["PBS_JOBID"], "ior")
+        self.assertEqual(ior.mod_env["LD_PRELOAD"], "/opt/darshan/lib/libdarshan.so")
+        self.assertEqual(clio.env["DARSHAN_LOG_DIR"], "/tmp/clio_logs")
+        self.assertEqual(clio.env["PBS_JOBID"], "clio")
+        self.assertEqual(clio.mod_env["LD_PRELOAD"], "/opt/darshan/lib/libdarshan.so")
+        self.assertNotIn("DARSHAN_LOG_DIR", plain.env)
+        self.assertNotIn("PBS_JOBID", plain.env)
+        self.assertNotIn("LD_PRELOAD", plain.mod_env)
+
     def test_append_rejects_cross_kind_alias_collision(self):
         """Package and interceptor IDs share one pipeline namespace."""
         pipeline = self._make_pipeline("append_interceptor_collision")

--- a/test/unit/core/test_rnaseq_native_artifacts.py
+++ b/test/unit/core/test_rnaseq_native_artifacts.py
@@ -1,0 +1,221 @@
+"""Native runner and closed-artifact tests for STAR to DESeq2."""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import hashlib
+import json
+import sys
+from importlib import import_module
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_module(name: str) -> ModuleType:
+    repository_root = Path(__file__).resolve().parents[3] / "builtin"
+    sys.path.insert(0, str(repository_root))
+    try:
+        return import_module(name)
+    finally:
+        sys.path.remove(str(repository_root))
+
+
+runner = _load_module("builtin.rna_seq_star_deseq2.native_runner")
+contract = _load_module("builtin.rna_seq_star_deseq2.result_contract")
+artifacts = _load_module("builtin.rna_seq_star_deseq2.artifacts")
+
+
+def _write_fastq(path: Path, *, sequence: str = "ACGT") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(path, "wt", encoding="ascii", newline="\n") as stream:
+        stream.write(f"@read\n{sequence}\n+\n{'I' * len(sequence)}\n")
+
+
+def _write_samples(root: Path, *, second_set: int = 2) -> Path:
+    rows = (
+        ("a1", "control", 1, "SRR1", "reads/a1.fastq.gz"),
+        ("a2", "control", second_set, "SRR2", "reads/a2.fastq.gz"),
+        ("b1", "treated", 1, "SRR3", "reads/b1.fastq.gz"),
+        ("b2", "treated", 2, "SRR4", "reads/b2.fastq.gz"),
+    )
+    for row in rows:
+        _write_fastq(root / row[4])
+    path = root / "samples.tsv"
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.writer(stream, delimiter="\t", lineterminator="\n")
+        writer.writerow(("sample", "condition", "set_id", "accession", "fastq"))
+        writer.writerows(rows)
+    return path
+
+
+def test_sample_design_requires_paired_replicates_and_confined_reads(
+    tmp_path: Path,
+) -> None:
+    samples = _write_samples(tmp_path)
+
+    observed = runner.read_samples(samples, input_root=tmp_path)
+
+    assert [sample.name for sample in observed] == ["a1", "a2", "b1", "b2"]
+    assert {sample.condition for sample in observed} == {"control", "treated"}
+
+    unpaired_root = tmp_path / "unpaired"
+    unpaired_root.mkdir()
+    unpaired = _write_samples(unpaired_root, second_set=3)
+    with pytest.raises(runner.RnaSeqExecutionError, match="same replicate-set IDs"):
+        runner.read_samples(unpaired, input_root=unpaired_root)
+
+    text = samples.read_text(encoding="utf-8").replace(
+        "reads/a1.fastq.gz", "../a1.fastq.gz"
+    )
+    samples.write_text(text, encoding="utf-8")
+    with pytest.raises(runner.RnaSeqExecutionError, match="confined relative path"):
+        runner.read_samples(samples, input_root=tmp_path)
+
+
+def test_star_gene_counts_require_identical_gene_order(tmp_path: Path) -> None:
+    sample_path = _write_samples(tmp_path)
+    samples = runner.read_samples(sample_path, input_root=tmp_path)
+    star = tmp_path / "star"
+    for index, sample in enumerate(samples):
+        sample_root = star / sample.name
+        sample_root.mkdir(parents=True)
+        genes = ("gene1", "gene2") if index != 3 else ("gene2", "gene1")
+        (sample_root / "ReadsPerGene.out.tab").write_text(
+            "N_unmapped\t0\t0\t0\n"
+            "N_multimapping\t0\t0\t0\n"
+            "N_noFeature\t0\t0\t0\n"
+            "N_ambiguous\t0\t0\t0\n"
+            + "".join(f"{gene}\t{index + 1}\t0\t0\n" for gene in genes),
+            encoding="utf-8",
+        )
+
+    with pytest.raises(runner.RnaSeqExecutionError, match="gene order differs"):
+        runner._write_counts(samples, star, tmp_path / "counts.tsv")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_closed_result(root: Path) -> dict[str, object]:
+    root.mkdir(parents=True, exist_ok=True)
+    samples = ("a1", "a2", "b1", "b2")
+    paths = [
+        "gene-counts.tsv",
+        "samples.tsv",
+        "differential-expression.tsv",
+        "normalized-counts.tsv",
+        "deseq2-session-info.txt",
+    ]
+    for sample in samples:
+        paths.extend(
+            (
+                f"star/{sample}/Aligned.sortedByCoord.out.bam",
+                f"star/{sample}/ReadsPerGene.out.tab",
+                f"star/{sample}/Log.final.out",
+            )
+        )
+    records: list[dict[str, object]] = []
+    for relative in paths:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(f"product:{relative}\n".encode())
+        records.append(
+            {
+                "path": relative,
+                "sha256": _sha256(path),
+                "size_bytes": path.stat().st_size,
+            }
+        )
+    document: dict[str, object] = {
+        "artifacts": records,
+        "comparison_condition": "treated",
+        "deseq2": {
+            "adjusted_p_value_threshold": 0.05,
+            "absolute_log2_fold_change_threshold": 1.0,
+            "significant_gene_count": 0,
+            "tested_gene_count": 10,
+            "top_significant_genes": [],
+        },
+        "mapping": {
+            sample: {
+                "input_reads": 100,
+                "uniquely_mapped_reads": 80,
+                "uniquely_mapped_percent": 80.0,
+            }
+            for sample in samples
+        },
+        "reference_condition": "control",
+        "sample_count": 4,
+        "schema_version": contract.RESULT_SCHEMA,
+        "star_read_length": 100,
+    }
+    (root / contract.RESULT_NAME).write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return document
+
+
+def test_closed_result_rejects_changed_products(tmp_path: Path) -> None:
+    _write_closed_result(tmp_path)
+
+    validated = contract.load_rnaseq_result(tmp_path)
+    assert len(validated.products) == 17
+
+    (tmp_path / "gene-counts.tsv").write_text("changed\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="differs from result"):
+        contract.load_rnaseq_result(tmp_path)
+
+
+def test_artifact_adapter_finalizes_result_tables_and_alignment_collection(
+    tmp_path: Path,
+) -> None:
+    _write_closed_result(tmp_path)
+    adapter = artifacts.RnaSeqArtifactAdapter(
+        artifacts.PurePosixPath("/cluster/run/results"),
+        _local_root=tmp_path,
+    )
+
+    observed = adapter.finalize_artifacts_for_exit(0)
+
+    by_name = {item.logical_name: item for item in observed}
+    assert set(by_name) == {
+        "rna-seq-result-tree",
+        "rna-seq-result",
+        "differential-expression",
+        "gene-counts",
+        "normalized-counts",
+        "rna-seq-sample-design",
+        "deseq2-session-info",
+        "star-alignments",
+    }
+    assert all(item.state.value == "finalized" for item in observed)
+    assert by_name["star-alignments"].metadata["member_count"] == 4
+    assert by_name["rna-seq-result"].checksum.startswith("sha256:")
+    assert adapter.finalize_artifacts_for_exit(0) == []
+
+
+def test_failed_process_without_closed_result_publishes_nothing(tmp_path: Path) -> None:
+    adapter = artifacts.RnaSeqArtifactAdapter(
+        artifacts.PurePosixPath("/cluster/run/results"),
+        _local_root=tmp_path,
+    )
+
+    assert adapter.finalize_artifacts_for_exit(2) == []
+
+
+def test_adapter_resolves_relative_output_below_shared_storage() -> None:
+    adapter = artifacts.adapter_from_package(
+        {
+            "pkg_type": "builtin.rna_seq_star_deseq2",
+            "effective_deploy_mode": "default",
+            "out": "study",
+            "shared_dir": "/cluster/shared",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.output_dir.as_posix() == "/cluster/shared/study/results"

--- a/test/unit/core/test_rnaseq_package_runtime.py
+++ b/test/unit/core/test_rnaseq_package_runtime.py
@@ -1,0 +1,295 @@
+"""Runtime-contract tests for the builtin STAR to DESeq2 package."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import sys
+import tarfile
+from importlib import import_module
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+)
+from jarvis_cd.util.hostfile import Hostfile
+
+
+def _load_package() -> ModuleType:
+    repository_root = Path(__file__).resolve().parents[3] / "builtin"
+    sys.path.insert(0, str(repository_root))
+    try:
+        return import_module("builtin.rna_seq_star_deseq2.pkg")
+    finally:
+        sys.path.remove(str(repository_root))
+
+
+rnaseq_package = _load_package()
+
+
+class _CapturedExec:
+    commands: list[str] = []
+    infos: list[Any] = []
+    return_code = 0
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": self.return_code}
+        self.commands.append(command)
+        self.infos.append(exec_info)
+
+    def run(self) -> _CapturedExec:
+        return self
+
+
+class _CapturedMkdir:
+    def __init__(self, path: str, exec_info: Any) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedMkdir:
+        Path(self.path).mkdir(parents=True, exist_ok=True)
+        return self
+
+
+class _CapturedRm:
+    calls: list[tuple[str, bool]] = []
+
+    def __init__(self, path: str, exec_info: Any, *, recursive: bool = False) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.recursive = recursive
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedRm:
+        self.calls.append((self.path, self.recursive))
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _capture_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    _CapturedExec.commands = []
+    _CapturedExec.infos = []
+    _CapturedExec.return_code = 0
+    _CapturedRm.calls = []
+    monkeypatch.setattr(rnaseq_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(rnaseq_package, "Mkdir", _CapturedMkdir)
+    monkeypatch.setattr(rnaseq_package, "Rm", _CapturedRm)
+
+
+def _base_config(**overrides: Any) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "deploy_mode": "default",
+        "input_bundle": "",
+        "out": "run",
+        "cores": 4,
+        "nprocs": 1,
+        "ppn": 1,
+    }
+    config.update(overrides)
+    return config
+
+
+def _package(tmp_path: Path, config: dict[str, Any]) -> Any:
+    package = object.__new__(rnaseq_package.RnaSeqStarDeseq2)
+    package.config = config
+    package.shared_dir = tmp_path / "shared"
+    package.private_dir = tmp_path / "private"
+    package.env = {}
+    package.mod_env = {"PATH": "/runtime/bin"}
+    package.star_bin = "STAR"
+    package.rscript_bin = "Rscript"
+    package.pipeline = SimpleNamespace(
+        get_hostfile=lambda: Hostfile(find_ips=False),
+        _has_containerized_packages=lambda: False,
+    )
+    package.runtime_line_callback = lambda: None
+    return package
+
+
+def _write_bundle(
+    destination: Path, *, annotation_role: str = "gene_annotation"
+) -> Path:
+    files = {
+        "samples.tsv": (
+            "sample\tcondition\tset_id\taccession\tfastq\n"
+            "a1\ta\t1\tSRR1\treads/a1.fastq.gz\n"
+            "a2\ta\t2\tSRR2\treads/a2.fastq.gz\n"
+            "b1\tb\t1\tSRR3\treads/b1.fastq.gz\n"
+            "b2\tb\t2\tSRR4\treads/b2.fastq.gz\n"
+        ).encode(),
+        "reference/genome.fa.gz": b"genome",
+        "reference/genes.gtf.gz": b"annotation",
+        "reads/a1.fastq.gz": b"read-a1",
+        "reads/a2.fastq.gz": b"read-a2",
+        "reads/b1.fastq.gz": b"read-b1",
+        "reads/b2.fastq.gz": b"read-b2",
+    }
+    roles = {
+        "samples.tsv": "sample_design",
+        "reference/genome.fa.gz": "reference_genome",
+        "reference/genes.gtf.gz": annotation_role,
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "samples.tsv",
+        "files": [
+            {
+                "path": name,
+                "role": roles.get(name, "single_end_fastq"),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, payload in files.items()
+        ],
+    }
+    manifest_bytes = json.dumps(manifest, sort_keys=True).encode()
+    with tarfile.open(destination, mode="w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(manifest_bytes)
+        archive.addfile(info, io.BytesIO(manifest_bytes))
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def test_agent_contract_exposes_native_study_and_hides_legacy_controls() -> None:
+    package = object.__new__(rnaseq_package.RnaSeqStarDeseq2)
+    package.config = _base_config()
+    package.env = {"PATH": ""}
+    package.mod_env = {"PATH": ""}
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    contract = package._deployment_contract().to_dict()
+
+    assert menu["input_bundle"]["input_binding"] == {
+        "schema_version": "jarvis.configuration-input-binding.v1",
+        "kind": "local_file",
+        "structure": "regular_file",
+    }
+    assert menu["out"]["default"] == "run"
+    assert menu["cores"]["default"] == 4
+    assert all(
+        menu[name]["agent_visible"] is False
+        for name in {
+            "nprocs",
+            "ppn",
+            "replicates",
+            "parallel_reps",
+            "parallel_scratch_root",
+            "omp_threads",
+            "base_image",
+        }
+    )
+    assert [profile["name"] for profile in contract["execution_profiles"]] == [
+        "native_supplied_reads"
+    ]
+    assert [item["id"] for item in contract["runtime_requirements"]] == [
+        "star",
+        "deseq2",
+    ]
+    assert contract["execution_profiles"][0]["readiness"] == {
+        "mechanism": "process_exit",
+        "condition": "successful_exit_with_required_products",
+    }
+
+
+def test_bundle_is_verified_and_staged_before_native_launch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle = _write_bundle(tmp_path / "study.tar")
+    source = bundle.read_bytes()
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+    validated: list[Path] = []
+    monkeypatch.setattr(
+        rnaseq_package,
+        "load_rnaseq_result",
+        lambda path: validated.append(path),
+    )
+
+    package.start()
+
+    root = tmp_path / "shared" / "run"
+    assert (root / "input" / "samples.tsv").is_file()
+    assert (root / "input" / "reads" / "a1.fastq.gz").read_bytes() == b"read-a1"
+    assert bundle.read_bytes() == source
+    assert validated == [(root / "results").resolve()]
+    command = _CapturedExec.commands[-1]
+    assert "native_runner.py" in command
+    assert "--samples" in command
+    assert "--genome" in command
+    assert "--annotation" in command
+    assert "--cores 4" in command
+    assert _CapturedExec.infos[-1].cwd == str(root.resolve())
+
+
+def test_bundle_roles_are_closed_before_launch(tmp_path: Path) -> None:
+    bundle = _write_bundle(tmp_path / "study.tar", annotation_role="support_file")
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+
+    with pytest.raises(ValueError, match="unsupported or missing roles"):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
+@pytest.mark.parametrize("cores", [0, 65, True, "4"])
+def test_native_configuration_rejects_invalid_core_counts(
+    tmp_path: Path, cores: object
+) -> None:
+    package = _package(
+        tmp_path,
+        _base_config(input_bundle="study.tar", cores=cores),
+    )
+
+    with pytest.raises(ValueError, match="cores must be an integer"):
+        package.start()
+
+
+def test_native_configuration_requires_a_supplied_bundle(tmp_path: Path) -> None:
+    package = _package(tmp_path, _base_config())
+
+    with pytest.raises(ValueError, match="requires input_bundle"):
+        package.start()
+
+
+def test_stale_execution_tree_cannot_satisfy_completion(tmp_path: Path) -> None:
+    bundle = _write_bundle(tmp_path / "study.tar")
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+    stale = tmp_path / "shared" / "run" / "results"
+    stale.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="target already exists: results"):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
+def test_native_process_failure_fails_package_lifecycle(tmp_path: Path) -> None:
+    bundle = _write_bundle(tmp_path / "study.tar")
+    package = _package(tmp_path, _base_config(input_bundle=str(bundle)))
+    _CapturedExec.return_code = 9
+
+    with pytest.raises(RuntimeError, match="workflow failed"):
+        package.start()
+
+
+def test_clean_uses_one_exact_recursive_output_without_wildcard(tmp_path: Path) -> None:
+    package = _package(tmp_path, _base_config(out="results"))
+
+    package.clean()
+
+    assert _CapturedRm.calls == [
+        (str((tmp_path / "shared" / "results").resolve()), True)
+    ]
+    assert "*" not in _CapturedRm.calls[0][0]

--- a/test/unit/core/test_runtime_phase_callback.py
+++ b/test/unit/core/test_runtime_phase_callback.py
@@ -1,0 +1,52 @@
+"""Tests for multi-phase package runtime callback ownership."""
+
+from __future__ import annotations
+
+from jarvis_cd.runtime_callback import RuntimePhaseLineCallback
+
+
+class _RecordingCallback:
+    """Record callback forwarding and terminal lifecycle operations."""
+
+    def __init__(self) -> None:
+        self.lines: list[tuple[str, str]] = []
+        self.finalized: list[int] = []
+        self.reconciled: list[int] = []
+
+    def __call__(self, stream_name: str, line: str) -> None:
+        """Record one forwarded output line."""
+        self.lines.append((stream_name, line))
+
+    def finalize_process(self, return_code: int) -> None:
+        """Record one delegated process finalization."""
+        self.finalized.append(return_code)
+
+    def reconcile_process_exit(self, return_code: int) -> None:
+        """Record one delegated effective-exit reconciliation."""
+        self.reconciled.append(return_code)
+
+
+def test_runtime_phase_callback_defers_only_successful_intermediate_exit() -> None:
+    """One callback can span processes without hiding an intermediate failure."""
+    delegate = _RecordingCallback()
+    intermediate = RuntimePhaseLineCallback(delegate, terminal=False)
+    terminal = RuntimePhaseLineCallback(delegate, terminal=True)
+
+    intermediate("stdout", "generating\n")
+    intermediate.finalize_process(0)
+    terminal("stdout", "training\n")
+    terminal.finalize_process(0)
+
+    assert delegate.lines == [
+        ("stdout", "generating\n"),
+        ("stdout", "training\n"),
+    ]
+    assert delegate.finalized == [0]
+
+    failed_delegate = _RecordingCallback()
+    failed_intermediate = RuntimePhaseLineCallback(failed_delegate, terminal=False)
+    failed_intermediate.finalize_process(9)
+    failed_intermediate.reconcile_process_exit(9)
+
+    assert failed_delegate.finalized == [9]
+    assert failed_delegate.reconciled == [9]

--- a/test/unit/core/test_scheduler_submission.py
+++ b/test/unit/core/test_scheduler_submission.py
@@ -780,6 +780,187 @@ def test_pipeline_persists_provider_owned_submission_identity(tmp_path: Path) ->
     assert saved_submissions[3]["state"] == "submitted"
 
 
+def test_pipeline_prepares_explicit_scheduler_log_parents_before_submit(
+    tmp_path: Path,
+) -> None:
+    pipeline = _real_pipeline(tmp_path)
+    output = tmp_path / "scheduler-logs" / "stdout-%j.log"
+    error = tmp_path / "scheduler-errors" / "stderr-%j.log"
+    pipeline.scheduler.update({"output": str(output), "error": str(error)})
+    pipeline.save()
+
+    def observe_submit(_command: str) -> SimpleNamespace:
+        assert output.parent.is_dir()
+        assert error.parent.is_dir()
+        return SimpleNamespace(
+            exit_code={"localhost": 0},
+            stdout={"localhost": "24680;ares\n"},
+            stderr={"localhost": ""},
+        )
+
+    executor = Mock()
+    executor.run.side_effect = lambda: observe_submit("unused")
+
+    with patch("jarvis_cd.shell.Exec", return_value=executor):
+        pipeline.submit(
+            submit=True,
+            wait=False,
+            execution_id="prepared-log-parents",
+        )
+
+
+def test_pipeline_reconciles_terminal_scheduler_state_on_query(
+    tmp_path: Path,
+) -> None:
+    pipeline = _real_pipeline(tmp_path)
+    executor = Mock()
+    executor.run.return_value = SimpleNamespace(
+        exit_code={"localhost": 0},
+        stdout={"localhost": "24680;ares\n"},
+        stderr={"localhost": ""},
+    )
+    with patch("jarvis_cd.shell.Exec", return_value=executor):
+        pipeline.submit(
+            submit=True,
+            wait=False,
+            execution_id="scheduler-completed",
+        )
+
+    observation = SimpleNamespace(
+        state="completed",
+        terminal=True,
+        return_code=0,
+        provider_state="COMPLETED",
+        diagnostic=None,
+    )
+    with patch(
+        "jarvis_cd.core.scheduler.query_scheduler_execution",
+        return_value=observation,
+        create=True,
+    ) as query:
+        record = pipeline.get_execution("scheduler-completed")
+
+    query.assert_called_once_with("slurm", "24680")
+    assert record.state == "completed"
+    assert record.terminal is True
+    assert record.return_code == 0
+    assert record.metadata["scheduler_observation"]["provider_state"] == "COMPLETED"
+
+
+def test_pipeline_terminalizes_scheduler_job_missing_after_grace(
+    tmp_path: Path,
+) -> None:
+    pipeline = _real_pipeline(tmp_path)
+    executor = Mock()
+    executor.run.return_value = SimpleNamespace(
+        exit_code={"localhost": 0},
+        stdout={"localhost": "24680;ares\n"},
+        stderr={"localhost": ""},
+    )
+    with patch("jarvis_cd.shell.Exec", return_value=executor):
+        pipeline.submit(
+            submit=True,
+            wait=False,
+            execution_id="scheduler-never-activated",
+        )
+
+    observation = SimpleNamespace(
+        state="missing",
+        terminal=False,
+        return_code=None,
+        provider_state=None,
+        diagnostic="SLURM accounting has no record for the accepted job",
+    )
+    with (
+        patch(
+            "jarvis_cd.core.scheduler.query_scheduler_execution",
+            return_value=observation,
+            create=True,
+        ),
+        patch("jarvis_cd.core.pipeline._SCHEDULER_MISSING_GRACE_SECONDS", 0),
+    ):
+        record = pipeline.get_execution("scheduler-never-activated")
+
+    assert record.state == "failed"
+    assert record.terminal is True
+    assert record.return_code == 1
+    assert "never activated" in (record.error or "")
+    assert record.metadata["scheduler_observation"]["state"] == "missing"
+
+
+def test_slurm_query_uses_accounting_for_completed_job() -> None:
+    scheduler_queue = subprocess.CompletedProcess(
+        args=["squeue"],
+        returncode=0,
+        stdout="",
+        stderr="",
+    )
+    scheduler_accounting = subprocess.CompletedProcess(
+        args=["sacct"],
+        returncode=0,
+        stdout="24680|COMPLETED|0:0\n24680.batch|COMPLETED|0:0\n",
+        stderr="",
+    )
+
+    with patch(
+        "jarvis_cd.core.scheduler.subprocess.run",
+        side_effect=[scheduler_queue, scheduler_accounting],
+    ) as execute:
+        observation = SlurmScheduler.query_execution("24680")
+
+    assert execute.call_count == 2
+    assert observation.state == "completed"
+    assert observation.terminal is True
+    assert observation.return_code == 0
+    assert observation.provider_state == "COMPLETED"
+
+
+def test_slurm_query_reports_missing_only_after_authoritative_empty_accounting() -> (
+    None
+):
+    empty_queue = subprocess.CompletedProcess(
+        args=["squeue"], returncode=0, stdout="", stderr=""
+    )
+    empty_accounting = subprocess.CompletedProcess(
+        args=["sacct"], returncode=0, stdout="", stderr=""
+    )
+
+    with patch(
+        "jarvis_cd.core.scheduler.subprocess.run",
+        side_effect=[empty_queue, empty_accounting],
+    ):
+        observation = SlurmScheduler.query_execution("24680")
+
+    assert observation.state == "missing"
+    assert observation.terminal is False
+    assert observation.return_code is None
+
+
+def test_slurm_query_reports_missing_when_queue_rejects_id_without_accounting() -> None:
+    missing_queue = subprocess.CompletedProcess(
+        args=["squeue"],
+        returncode=1,
+        stdout="",
+        stderr="slurm_load_jobs error: Invalid job id specified\n",
+    )
+    disabled_accounting = subprocess.CompletedProcess(
+        args=["sacct"],
+        returncode=1,
+        stdout="",
+        stderr="Slurm accounting storage is disabled\n",
+    )
+
+    with patch(
+        "jarvis_cd.core.scheduler.subprocess.run",
+        side_effect=[missing_queue, disabled_accounting],
+    ):
+        observation = SlurmScheduler.query_execution("22646")
+
+    assert observation.state == "missing"
+    assert observation.terminal is False
+    assert "no longer reports" in (observation.diagnostic or "")
+
+
 def test_scheduler_log_artifacts_resolve_same_ids_and_finalize(
     tmp_path: Path,
 ) -> None:

--- a/test/unit/core/test_scheduler_submission.py
+++ b/test/unit/core/test_scheduler_submission.py
@@ -961,6 +961,33 @@ def test_slurm_query_reports_missing_when_queue_rejects_id_without_accounting() 
     assert "no longer reports" in (observation.diagnostic or "")
 
 
+def test_slurm_query_reports_missing_when_queue_is_empty_and_accounting_is_disabled() -> (
+    None
+):
+    empty_queue = subprocess.CompletedProcess(
+        args=["squeue"],
+        returncode=0,
+        stdout="",
+        stderr="",
+    )
+    disabled_accounting = subprocess.CompletedProcess(
+        args=["sacct"],
+        returncode=1,
+        stdout="",
+        stderr="Slurm accounting storage is disabled\n",
+    )
+
+    with patch(
+        "jarvis_cd.core.scheduler.subprocess.run",
+        side_effect=[empty_queue, disabled_accounting],
+    ):
+        observation = SlurmScheduler.query_execution("24680")
+
+    assert observation.state == "missing"
+    assert observation.terminal is False
+    assert "no longer reports" in (observation.diagnostic or "")
+
+
 def test_scheduler_log_artifacts_resolve_same_ids_and_finalize(
     tmp_path: Path,
 ) -> None:

--- a/test/unit/core/test_scheduler_submission.py
+++ b/test/unit/core/test_scheduler_submission.py
@@ -1007,7 +1007,10 @@ def test_scheduler_log_artifacts_resolve_same_ids_and_finalize(
     executor = Mock()
     executor.run.return_value = execution
 
-    with patch("jarvis_cd.shell.Exec", return_value=executor) as execute:
+    with (
+        patch("jarvis_cd.shell.Exec", return_value=executor) as execute,
+        patch("jarvis_cd.core.pipeline._prepare_scheduler_log_parents"),
+    ):
         handle = pipeline.submit(
             submit=True,
             wait=False,
@@ -1076,7 +1079,10 @@ def test_unprovable_scheduler_log_path_is_incomplete_without_failing_workload(
         stderr={"localhost": ""},
     )
 
-    with patch("jarvis_cd.shell.Exec", return_value=executor):
+    with (
+        patch("jarvis_cd.shell.Exec", return_value=executor),
+        patch("jarvis_cd.core.pipeline._prepare_scheduler_log_parents"),
+    ):
         handle = pipeline.submit(
             submit=True,
             wait=False,
@@ -1142,7 +1148,10 @@ def test_fast_wait_runtime_resolution_is_idempotent_for_submitter(
         )
 
     executor.run.side_effect = finish_before_sbatch_returns
-    with patch("jarvis_cd.shell.Exec", return_value=executor):
+    with (
+        patch("jarvis_cd.shell.Exec", return_value=executor),
+        patch("jarvis_cd.core.pipeline._prepare_scheduler_log_parents"),
+    ):
         handle = pipeline.submit(
             submit=True,
             wait=True,
@@ -1193,7 +1202,10 @@ def test_runtime_unresolved_log_does_not_fail_fast_wait_workload(
         )
 
     executor.run.side_effect = finish_before_sbatch_returns
-    with patch("jarvis_cd.shell.Exec", return_value=executor):
+    with (
+        patch("jarvis_cd.shell.Exec", return_value=executor),
+        patch("jarvis_cd.core.pipeline._prepare_scheduler_log_parents"),
+    ):
         handle = pipeline.submit(
             submit=True,
             wait=True,
@@ -1224,7 +1236,10 @@ def test_scheduler_artifact_resolution_rejects_mismatched_bound_identity(
     pipeline.save()
     executor = Mock()
     executor.run.side_effect = RuntimeError("submit transport disappeared")
-    with patch("jarvis_cd.shell.Exec", return_value=executor):
+    with (
+        patch("jarvis_cd.shell.Exec", return_value=executor),
+        patch("jarvis_cd.core.pipeline._prepare_scheduler_log_parents"),
+    ):
         with pytest.raises(RuntimeError, match="submit transport disappeared"):
             pipeline.submit(
                 submit=True,
@@ -1289,7 +1304,10 @@ def test_artifact_resolution_failure_preserves_durable_submission_identity(
         )
         raise RuntimeError("artifact store failed")
 
-    with patch("jarvis_cd.shell.Exec", return_value=executor):
+    with (
+        patch("jarvis_cd.shell.Exec", return_value=executor),
+        patch("jarvis_cd.core.pipeline._prepare_scheduler_log_parents"),
+    ):
         with patch.object(
             ExecutionStore,
             "resolve_scheduler_artifact_paths",

--- a/test/unit/core/test_scientific_supplied_profiles.py
+++ b/test/unit/core/test_scientific_supplied_profiles.py
@@ -235,6 +235,7 @@ def test_maintained_profiles_are_agent_visible_and_keep_legacy_controls() -> Non
     openfoam_menu = {item["name"]: item for item in openfoam._configure_menu()}
     assert {"input_bundle", "script_location", "script"}.issubset(openfoam_menu)
     assert openfoam_menu["input_bundle"]["input_binding"]["kind"] == "local_file"
+    assert openfoam_menu["script_location"]["required"] is False
     openfoam_contract = openfoam._deployment_contract()
     assert openfoam_contract.package == "builtin.openfoam"
     assert {profile.name for profile in openfoam_contract.execution_profiles} == {
@@ -252,6 +253,8 @@ def test_maintained_profiles_are_agent_visible_and_keep_legacy_controls() -> Non
     wrf_menu = {item["name"]: item for item in wrf._configure_menu()}
     assert {"input_bundle", "wrf_prefix", "wrf_location", "engine"}.issubset(wrf_menu)
     assert wrf_menu["input_bundle"]["input_binding"]["kind"] == "local_file"
+    assert wrf_menu["wrf_location"]["required"] is False
+    assert wrf_menu["Execution_order"]["required"] is False
     wrf_contract = wrf._deployment_contract()
     assert wrf_contract.package == "builtin.wrf"
     assert {profile.name for profile in wrf_contract.execution_profiles} == {

--- a/test/unit/core/test_scientific_supplied_profiles.py
+++ b/test/unit/core/test_scientific_supplied_profiles.py
@@ -7,6 +7,7 @@ import io
 import json
 import math
 import os
+import shlex
 import sys
 import tarfile
 from collections.abc import Callable
@@ -42,7 +43,10 @@ from builtin.lbm_cfd.contract import (  # pyright: ignore[reportMissingImports] 
 from builtin.lbm_cfd.artifacts import (  # pyright: ignore[reportMissingImports]  # noqa: E402
     adapter_from_package as lbm_artifact_adapter,
 )
-from builtin.lbm_cfd.pkg import LbmCfd  # pyright: ignore[reportMissingImports]  # noqa: E402
+from builtin.lbm_cfd.pkg import (  # pyright: ignore[reportMissingImports]  # noqa: E402
+    LbmCfd,
+    _lbm_command,
+)
 from builtin.openfoam.artifacts import (  # pyright: ignore[reportMissingImports]  # noqa: E402
     adapter_from_package as openfoam_artifact_adapter,
 )
@@ -286,6 +290,19 @@ def test_maintained_profiles_are_discoverable_by_exact_package_name(
         assert jarvis.find_package("lbm_cfd") == "builtin.lbm_cfd"
     finally:
         Jarvis._instance = previous
+
+
+def test_lbm_launcher_uses_bounded_relative_output_directory() -> None:
+    """Long execution roots must not enter LBM-CFD's fixed-size path buffer."""
+
+    executable = Path("/very/long/jarvis/execution/root/bin/lbmcfd3d")
+    command = _lbm_command(executable, "d3q15")
+
+    assert command.startswith(shlex.quote(str(executable)))
+    assert command.endswith("--output-dir d3q15")
+    assert "/very/long/jarvis/execution/root/d3q15" not in command
+    with pytest.raises(ValueError, match="unsupported LBM-CFD lattice"):
+        _lbm_command(executable, "d3q99")
 
 
 def test_release_manifest_includes_complete_maintained_profile_modules() -> None:

--- a/test/unit/core/test_scientific_supplied_profiles.py
+++ b/test/unit/core/test_scientific_supplied_profiles.py
@@ -1,0 +1,411 @@
+"""Contracts for maintained OpenFOAM, WRF, and LBM-CFD supplied studies."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import math
+import os
+import sys
+import tarfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jarvis_cd.artifacts import schema as artifact_schema
+from jarvis_cd.core.config import Jarvis
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+    InputBundleError,
+    extract_input_bundle,
+)
+
+BUILTIN_ROOT = Path(__file__).resolve().parents[3] / "builtin"
+REPOSITORY_ROOT = BUILTIN_ROOT.parent
+sys.path.insert(0, str(BUILTIN_ROOT))
+
+from builtin.lbm_cfd.contract import (  # pyright: ignore[reportMissingImports]  # noqa: E402
+    DIMENSIONS,
+    EXPECTED_FILES as LBM_FILES,
+    FINAL_STEP,
+    LATTICES,
+    RESULT_NAME as LBM_RESULT_NAME,
+    RESULT_SCHEMA as LBM_RESULT_SCHEMA,
+    materialize_run as materialize_lbm,
+    validate_result_document as validate_lbm_result,
+    write_lbm_result,
+)
+from builtin.lbm_cfd.artifacts import (  # pyright: ignore[reportMissingImports]  # noqa: E402
+    adapter_from_package as lbm_artifact_adapter,
+)
+from builtin.lbm_cfd.pkg import LbmCfd  # pyright: ignore[reportMissingImports]  # noqa: E402
+from builtin.openfoam.artifacts import (  # pyright: ignore[reportMissingImports]  # noqa: E402
+    adapter_from_package as openfoam_artifact_adapter,
+)
+from builtin.openfoam.contract import (  # pyright: ignore[reportMissingImports]  # noqa: E402
+    CASE_FILES,
+    CASE_NAMES,
+    RESULT_FILE_SCHEMA,
+    RESULT_NAME as OPENFOAM_RESULT_NAME,
+    materialize_run as materialize_openfoam,
+    validate_result_document as validate_openfoam_result,
+    write_incidence_result,
+)
+from builtin.openfoam.pkg import Openfoam  # pyright: ignore[reportMissingImports]  # noqa: E402
+from builtin.wrf.contract import (  # pyright: ignore[reportMissingImports]  # noqa: E402
+    FORMULATIONS,
+    RESULT_NAME as WRF_RESULT_NAME,
+    RESULT_SCHEMA as WRF_RESULT_SCHEMA,
+    materialize_run as materialize_wrf,
+    prepare_case,
+    validate_result_document as validate_wrf_result,
+    write_result as write_wrf_result,
+)
+from builtin.wrf.artifacts import (  # pyright: ignore[reportMissingImports]  # noqa: E402
+    adapter_from_package as wrf_artifact_adapter,
+)
+from builtin.wrf.pkg import Wrf  # pyright: ignore[reportMissingImports]  # noqa: E402
+
+
+def _write_bundle(
+    destination: Path,
+    files: dict[str, tuple[str, bytes]],
+    *,
+    entrypoint: str,
+) -> Path:
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": entrypoint,
+        "files": [
+            {
+                "path": name,
+                "role": role,
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, (role, payload) in sorted(files.items())
+        ],
+    }
+    encoded = json.dumps(manifest, sort_keys=True).encode("utf-8")
+    with tarfile.open(destination, mode="w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(encoded)
+        archive.addfile(info, io.BytesIO(encoded))
+        for name, (_role, payload) in sorted(files.items()):
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def _openfoam_bundle(path: Path) -> Path:
+    files: dict[str, tuple[str, bytes]] = {}
+    for angle, case_name in CASE_NAMES.items():
+        for relative in CASE_FILES:
+            name = f"{case_name}/{relative}"
+            if relative == "case-metadata.json":
+                payload = json.dumps(
+                    {
+                        "angle_degrees": angle,
+                        "schema_version": "scientific-benchmark.openfoam-airfoil-case.v1",
+                        "speed_metres_per_second": 26.0,
+                    }
+                ).encode("utf-8")
+                role = "case_metadata"
+            else:
+                payload = f"OpenFOAM fixture {name}\n".encode()
+                role = "openfoam_case"
+            files[name] = (role, payload)
+    return _write_bundle(
+        path,
+        files,
+        entrypoint="angle-00/system/controlDict",
+    )
+
+
+def _write_coefficients(case_root: Path, *, cd: float, cl: float) -> None:
+    target = case_root / "postProcessing" / "forceCoeffs" / "0" / "coefficient.dat"
+    target.parent.mkdir(parents=True)
+    rows = ["# Time Cd Cs Cl"]
+    for index in range(1, 51):
+        perturbation = (index % 3 - 1) * 0.0001
+        rows.append(f"{index * 10} {cd + perturbation} 0 {cl + perturbation}")
+    target.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+
+def _wrf_bundle(path: Path) -> Path:
+    assignments = {
+        "run_days": "0",
+        "run_hours": "1",
+        "end_day": "1",
+        "end_hour": "1",
+        "history_interval": "60",
+        "e_we": "81",
+        "e_sn": "81",
+        "isftcflx": "1",
+    }
+    namelist = (
+        "&domains\n"
+        + "".join(f" {name:<35} = {value},\n" for name, value in assignments.items())
+        + "/\n"
+    )
+    return _write_bundle(
+        path,
+        {
+            "input_sounding": ("atmospheric_sounding", b"1000 300 10\n"),
+            "namelist.input": ("wrf_namelist", namelist.encode()),
+        },
+        entrypoint="namelist.input",
+    )
+
+
+def _fake_wrf_prefix(root: Path) -> Path:
+    prefix = root / "wrf"
+    (prefix / "main").mkdir(parents=True)
+    (prefix / "run").mkdir()
+    for name in ("ideal.exe", "wrf.exe"):
+        (prefix / "main" / name).write_text("executable\n", encoding="utf-8")
+    (prefix / "run" / "LANDUSE.TBL").write_text("table\n", encoding="utf-8")
+    return prefix
+
+
+def _write_wrf_cdl(path: Path, *, scale: float) -> None:
+    path.write_text(
+        f"""netcdf wrfout {{
+dimensions:
+ Time = UNLIMITED ; // (2 currently)
+data:
+ U10 = 1, 2, 3, 4, {scale}, {2 * scale}, {3 * scale}, {4 * scale} ;
+ V10 = 0, 0, 0, 0, 0, 0, 0, 0 ;
+ PSFC = 100000, 99900, 99800, 99700, 99000, 98900, 98800, 98700 ;
+}}
+""",
+        encoding="utf-8",
+    )
+
+
+def _lbm_bundle(path: Path) -> Path:
+    roles = {
+        "COPYING": "license",
+        "Makefile": "build_recipe",
+        "README.md": "documentation",
+        "include/lbm_mpi.hpp": "application_source",
+        "include/paraview_sim.hpp": "application_source",
+        "src/main.cpp": "application_source",
+    }
+    assert set(roles) == LBM_FILES
+    return _write_bundle(
+        path,
+        {name: (role, f"fixture {name}\n".encode()) for name, role in roles.items()},
+        entrypoint="Makefile",
+    )
+
+
+def _write_vorticity(path: Path, *, scale: float) -> None:
+    count = math.prod(DIMENSIONS)
+    values = " ".join(str(scale * ((index % 11) - 5)) for index in range(count))
+    extent = f"0 {DIMENSIONS[0] - 1} 0 {DIMENSIONS[1] - 1} 0 {DIMENSIONS[2] - 1}"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        '<?xml version="1.0"?>\n<VTKFile type="StructuredGrid">\n'
+        f'<StructuredGrid WholeExtent="{extent}"><Piece><PointData>'
+        f'<DataArray type="Float32" Name="vorticity" format="ascii">{values}'
+        "</DataArray></PointData></Piece></StructuredGrid></VTKFile>\n",
+        encoding="utf-8",
+    )
+
+
+def _permit_windows_cluster_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep filesystem-backed adapter tests portable; Ares covers POSIX paths."""
+
+    if os.name == "nt":
+        monkeypatch.setattr(
+            artifact_schema, "_validate_cluster_path", lambda _value: None
+        )
+
+
+def test_maintained_profiles_are_agent_visible_and_keep_legacy_controls() -> None:
+    openfoam = object.__new__(Openfoam)
+    openfoam.env = {}
+    openfoam.mod_env = {}
+    openfoam_menu = {item["name"]: item for item in openfoam._configure_menu()}
+    assert {"input_bundle", "script_location", "script"}.issubset(openfoam_menu)
+    assert openfoam_menu["input_bundle"]["input_binding"]["kind"] == "local_file"
+    openfoam_contract = openfoam._deployment_contract()
+    assert openfoam_contract.package == "builtin.openfoam"
+    assert {profile.name for profile in openfoam_contract.execution_profiles} == {
+        "legacy_case_script",
+        "supplied_airfoil_incidence",
+    }
+    assert (
+        openfoam_contract.configuration_rules[0].requires[0].parameter
+        == "script_location"
+    )
+
+    wrf = object.__new__(Wrf)
+    wrf.env = {}
+    wrf.mod_env = {}
+    wrf_menu = {item["name"]: item for item in wrf._configure_menu()}
+    assert {"input_bundle", "wrf_prefix", "wrf_location", "engine"}.issubset(wrf_menu)
+    assert wrf_menu["input_bundle"]["input_binding"]["kind"] == "local_file"
+    wrf_contract = wrf._deployment_contract()
+    assert wrf_contract.package == "builtin.wrf"
+    assert {profile.name for profile in wrf_contract.execution_profiles} == {
+        "legacy_wrf_location",
+        "supplied_surface_exchange_comparison",
+    }
+    assert wrf_contract.configuration_rules[0].requires[0].parameter == "wrf_location"
+    assert wrf_contract.configuration_rules[1].when[0].operator == "is_not_empty"
+
+    lbm = object.__new__(LbmCfd)
+    lbm.env = {}
+    lbm.mod_env = {}
+    lbm_menu = {item["name"]: item for item in lbm._configure_menu()}
+    assert lbm_menu["input_bundle"]["input_binding"]["structure"] == "regular_file"
+    assert lbm._deployment_contract().package == "builtin.lbm_cfd"
+
+
+def test_maintained_profiles_are_discoverable_by_exact_package_name(
+    tmp_path: Path,
+) -> None:
+    """The same package identifiers advertised to agents resolve from the catalog."""
+
+    previous = Jarvis._instance
+    Jarvis._instance = None
+    try:
+        jarvis = Jarvis(jarvis_root=str(tmp_path / "jarvis"))
+        assert jarvis.find_package("openfoam") == "builtin.openfoam"
+        assert jarvis.find_package("wrf") == "builtin.wrf"
+        assert jarvis.find_package("lbm_cfd") == "builtin.lbm_cfd"
+    finally:
+        Jarvis._instance = previous
+
+
+def test_release_manifest_includes_complete_maintained_profile_modules() -> None:
+    """The distribution source list must not collapse profiles to legacy pkg.py."""
+
+    manifest = (REPOSITORY_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    for package in ("lbm_cfd", "openfoam", "wrf"):
+        assert f"recursive-include builtin/builtin/{package} *.md *.py" in manifest
+
+
+def test_openfoam_supplied_profile_materializes_and_validates_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _permit_windows_cluster_paths(monkeypatch)
+    bundle = extract_input_bundle(
+        _openfoam_bundle(tmp_path / "openfoam.tar"), tmp_path / "in"
+    )
+    run = materialize_openfoam(bundle, tmp_path / "runs", "jarvis_openfoam_test")
+    for angle, cd, cl in ((0, 0.02, 0.001), (6, 0.04, 1.0), (12, 0.08, 0.5)):
+        _write_coefficients(run / CASE_NAMES[angle], cd=cd, cl=cl)
+
+    document = write_incidence_result(run, run / OPENFOAM_RESULT_NAME, bundle)
+
+    assert document["schema_version"] == RESULT_FILE_SCHEMA
+    assert validate_openfoam_result(run, run / OPENFOAM_RESULT_NAME, bundle) == document
+    assert document["metrics"]["peak_lift_angle_degrees"] == 6
+    adapter = openfoam_artifact_adapter(
+        {
+            "pkg_type": "builtin.openfoam",
+            "input_bundle": str(tmp_path / "openfoam.tar"),
+            "out": str(run),
+            "shared_dir": str(tmp_path),
+        }
+    )
+    assert adapter is not None
+    assert len(adapter.finalize_artifacts_for_exit(0)) == 5
+    with pytest.raises(InputBundleError, match="already exists"):
+        materialize_openfoam(bundle, tmp_path / "runs", "jarvis_openfoam_test")
+
+
+def test_wrf_supplied_profile_materializes_both_formulations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _permit_windows_cluster_paths(monkeypatch)
+    bundle = extract_input_bundle(_wrf_bundle(tmp_path / "wrf.tar"), tmp_path / "in")
+    run = materialize_wrf(bundle, tmp_path / "runs", "jarvis_wrf_test")
+    prefix = _fake_wrf_prefix(tmp_path)
+    for index, (name, option) in enumerate(FORMULATIONS, start=1):
+        case = prepare_case(run, bundle, prefix, name=name, isftcflx=option)
+        (case / "wrfout_d01_test").write_bytes(bytes([index]) * 1024)
+        _write_wrf_cdl(case / "surface-diagnostics.cdl", scale=float(index))
+
+    document = write_wrf_result(run, run / WRF_RESULT_NAME, bundle)
+
+    assert document["schema_version"] == WRF_RESULT_SCHEMA
+    assert validate_wrf_result(run, run / WRF_RESULT_NAME, bundle) == document
+    assert [case["formulation"] for case in document["cases"]] == [
+        name for name, _option in FORMULATIONS
+    ]
+    adapter = wrf_artifact_adapter(
+        {
+            "pkg_type": "builtin.wrf",
+            "input_bundle": str(tmp_path / "wrf.tar"),
+            "out": str(run),
+            "shared_dir": str(tmp_path),
+        }
+    )
+    assert adapter is not None
+    assert len(adapter.finalize_artifacts_for_exit(0)) == 6
+
+
+def test_lbm_supplied_profile_validates_three_distinct_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _permit_windows_cluster_paths(monkeypatch)
+    bundle = extract_input_bundle(_lbm_bundle(tmp_path / "lbm.tar"), tmp_path / "in")
+    run = materialize_lbm(bundle, tmp_path / "runs", "jarvis_lbm_test")
+    for index, lattice in enumerate(LATTICES, start=1):
+        _write_vorticity(
+            run / lattice / f"simulation_state_t{FINAL_STEP:05d}.vts",
+            scale=float(index),
+        )
+
+    document = write_lbm_result(run, run / LBM_RESULT_NAME, bundle)
+
+    assert document["schema_version"] == LBM_RESULT_SCHEMA
+    assert validate_lbm_result(run, run / LBM_RESULT_NAME, bundle) == document
+    assert [case["lattice"] for case in document["cases"]] == list(LATTICES)
+    adapter = lbm_artifact_adapter(
+        {
+            "pkg_type": "builtin.lbm_cfd",
+            "input_bundle": str(tmp_path / "lbm.tar"),
+            "out": str(run),
+            "shared_dir": str(tmp_path),
+        }
+    )
+    assert adapter is not None
+    assert len(adapter.finalize_artifacts_for_exit(0)) == 5
+
+
+@pytest.mark.parametrize(
+    ("factory", "package"),
+    (
+        (openfoam_artifact_adapter, "builtin.openfoam"),
+        (wrf_artifact_adapter, "builtin.wrf"),
+        (lbm_artifact_adapter, "builtin.lbm_cfd"),
+    ),
+)
+def test_failed_supplied_profiles_do_not_finalize_products(
+    tmp_path: Path,
+    factory: Callable[[dict[str, object]], Any],
+    package: str,
+) -> None:
+    adapter = factory(
+        {
+            "pkg_type": package,
+            "input_bundle": "supplied.tar",
+            "out": str(tmp_path / "missing"),
+            "shared_dir": str(tmp_path),
+        }
+    )
+    assert adapter is not None
+    assert adapter.finalize_artifacts_for_exit(1) == []

--- a/test/unit/core/test_warpx_artifacts.py
+++ b/test/unit/core/test_warpx_artifacts.py
@@ -1,0 +1,138 @@
+"""Tests for builtin WarpX generated-artifact semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import (
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "warpx"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def test_finalization_reports_bounded_plotfiles_and_diagnostics(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Exact staged inputs are excluded while native products remain visible."""
+
+    (tmp_path / "density-low").mkdir()
+    (tmp_path / "density-low" / "inputs").write_text("input\n", encoding="utf-8")
+    diagnostic = tmp_path / "density-low" / "electron_energy.txt"
+    diagnostic.write_text("40 1e-13 0.0 1.0\n", encoding="utf-8")
+    plotfile = tmp_path / "density-low" / "plt00040"
+    plotfile.mkdir()
+    (plotfile / "Header").write_text("WarpX\n", encoding="utf-8")
+    (tmp_path / "density-low" / "unclassified.bin").write_bytes(b"result")
+
+    module = _module()
+    adapter = module.WarpxArtifactAdapter(
+        module.PurePosixPath("/scratch/warpx"),
+        frozenset({module.PurePosixPath("density-low/inputs")}),
+    )
+    monkeypatch.setattr(adapter, "_local_output_path", lambda: tmp_path)
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert adapter.finalize_artifacts_for_exit(0) == []
+    collection = observations[0]
+    assert collection.logical_name == "warpx-results"
+    assert collection.role is ArtifactRole.OUTPUT
+    assert collection.structure is ArtifactStructure.COLLECTION
+    assert collection.state is ArtifactState.FINALIZED
+    names = collection.metadata["member_names"]
+    assert "density-low/inputs" not in names
+    assert "density-low/electron_energy.txt" in names
+    assert "density-low/unclassified.bin" in names
+    concrete = {item.logical_name: item for item in observations[1:]}
+    histogram = concrete["warpx-density-low-electron_energy.txt"]
+    assert histogram.structure is ArtifactStructure.FILE
+    assert histogram.checksum is not None
+    assert concrete["warpx-density-low-plt00040"].format == "amrex-plotfile"
+    assert "warpx-density-low-unclassified.bin" not in concrete
+
+
+def test_nonzero_exit_marks_discovered_outputs_incomplete(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Filesystem presence cannot turn a failed WarpX run into success."""
+
+    (tmp_path / "electron_energy.txt").write_text("partial\n", encoding="utf-8")
+    module = _module()
+    adapter = module.WarpxArtifactAdapter(module.PurePosixPath("/scratch/warpx"))
+    monkeypatch.setattr(adapter, "_local_output_path", lambda: tmp_path)
+
+    observations = adapter.finalize_artifacts_for_exit(17)
+
+    assert observations
+    assert {item.state for item in observations} == {ArtifactState.INCOMPLETE}
+
+
+def test_discovery_bound_cannot_claim_complete_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A truncated output walk is visibly incomplete."""
+
+    for index in range(3):
+        (tmp_path / f"diag-{index}.txt").write_text(str(index), encoding="utf-8")
+    module = _module()
+    adapter = module.WarpxArtifactAdapter(module.PurePosixPath("/scratch/warpx"))
+    monkeypatch.setattr(adapter, "_local_output_path", lambda: tmp_path)
+    monkeypatch.setattr(module, "_MAX_DISCOVERED_ENTRIES", 2)
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert observations[0].state is ArtifactState.INCOMPLETE
+    assert observations[0].metadata["discovery_truncated"] is True
+
+
+def test_factory_scopes_relative_output_to_package_shared_root() -> None:
+    """Artifact discovery receives the same execution-owned output as launch."""
+
+    module = _module()
+
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.warpx",
+            "out": ".",
+            "shared_dir": "/execution/shared/warpx",
+            "runtime_cwd": "/execution/runtime",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.output_dir.as_posix() == "/execution/shared/warpx"
+    assert module.adapter_from_package({"pkg_type": "builtin.lammps"}) is None
+
+
+def test_container_private_output_is_not_claimed() -> None:
+    """A host cannot report artifacts from an unmounted container path."""
+
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.warpx",
+            "out": "/tmp/warpx",
+            "effective_deploy_mode": "container",
+            "shared_dir": "/execution/shared",
+            "private_dir": "/execution/private",
+            "runtime_cwd": "/execution/runtime",
+        }
+    )
+
+    assert adapter is None

--- a/test/unit/core/test_warpx_package_runtime.py
+++ b/test/unit/core/test_warpx_package_runtime.py
@@ -1,0 +1,306 @@
+"""Runtime-contract tests for the builtin JARVIS WarpX package."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import shlex
+import tarfile
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+)
+from jarvis_cd.shell import LocalExecInfo
+from jarvis_cd.util.hostfile import Hostfile
+
+
+def _load_warpx_package() -> ModuleType:
+    """Load the builtin package without changing repository imports."""
+
+    path = (
+        Path(__file__).resolve().parents[3] / "builtin" / "builtin" / "warpx" / "pkg.py"
+    )
+    spec = spec_from_file_location("test_warpx_runtime_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load WarpX package from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+warpx_package = _load_warpx_package()
+
+
+class _CapturedExec:
+    """Capture one launch and expose a configurable process result."""
+
+    commands: list[str] = []
+    infos: list[Any] = []
+    return_code = 0
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": self.return_code}
+        self.commands.append(command)
+        self.infos.append(exec_info)
+
+    def run(self) -> _CapturedExec:
+        """Return the captured result."""
+
+        return self
+
+
+class _CapturedMkdir:
+    """Create a local test output directory and report success."""
+
+    def __init__(self, path: str, exec_info: Any) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedMkdir:
+        """Materialize the test directory."""
+
+        Path(self.path).mkdir(parents=True, exist_ok=True)
+        return self
+
+
+class _CapturedRm:
+    """Capture exact cleanup authority."""
+
+    calls: list[tuple[str, bool]] = []
+
+    def __init__(self, path: str, exec_info: Any, *, recursive: bool = False) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.recursive = recursive
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedRm:
+        """Record the cleanup without deleting test files."""
+
+        self.calls.append((self.path, self.recursive))
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _capture_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep all unit tests free of process and remote-host side effects."""
+
+    _CapturedExec.commands = []
+    _CapturedExec.infos = []
+    _CapturedExec.return_code = 0
+    _CapturedRm.calls = []
+    monkeypatch.setattr(warpx_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(warpx_package, "Mkdir", _CapturedMkdir)
+    monkeypatch.setattr(warpx_package, "Rm", _CapturedRm)
+
+
+def _package(tmp_path: Path, config: dict[str, Any]) -> Any:
+    package = object.__new__(warpx_package.Warpx)
+    package.config = config
+    package.shared_dir = tmp_path / "shared"
+    package.private_dir = tmp_path / "private"
+    package.env = {}
+    package.mod_env = {"PATH": "/runtime/bin"}
+    package.warpx_bin = "warpx.3d.MPI.NOACC.DP.PDP"
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: Hostfile(find_ips=False))
+    package.runtime_line_callback = lambda: None
+    return package
+
+
+def _write_bundle(destination: Path) -> Path:
+    files = {
+        "density-low/inputs": b"max_step = 40\n",
+        "density-high/inputs": b"max_step = 40\nmy_constants.n0 = 4.e24\n",
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "density-low/inputs",
+        "files": [
+            {
+                "path": name,
+                "role": "warpx_input",
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, payload in files.items()
+        ],
+    }
+    manifest_bytes = json.dumps(manifest, sort_keys=True).encode()
+    with tarfile.open(destination, mode="w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(manifest_bytes)
+        archive.addfile(info, io.BytesIO(manifest_bytes))
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def _base_config(**overrides: Any) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "deploy_mode": "default",
+        "example": "custom",
+        "input_bundle": "",
+        "input_path": "",
+        "inputs": "",
+        "max_step": 50,
+        "n_cell": "64 64 128",
+        "nprocs": 4,
+        "out": "run",
+        "override_input_parameters": False,
+        "plot_int": 10,
+        "ppn": 4,
+        "use_gpu": False,
+    }
+    config.update(overrides)
+    return config
+
+
+def test_agent_contract_exposes_owned_single_and_bundle_inputs() -> None:
+    """Agents see staged input profiles without benchmark-specific settings."""
+
+    package = object.__new__(warpx_package.Warpx)
+    package.config = _base_config(example="laser_acceleration")
+    package.env = {}
+    package.mod_env = {}
+    menu = {item["name"]: item for item in package._configure_menu()}
+
+    assert menu["out"]["default"] == "run"
+    assert menu["inputs"]["input_binding"]["kind"] == "local_file"
+    assert menu["input_bundle"]["input_binding"]["kind"] == "local_file"
+    assert menu["override_input_parameters"]["default"] is False
+    contract = package._deployment_contract().to_dict()
+    assert {profile["name"] for profile in contract["execution_profiles"]} == {
+        "input_bundle",
+        "input_file",
+        "installed_example",
+    }
+
+
+def test_bundle_selects_one_manifest_input_and_preserves_scientific_values(
+    tmp_path: Path,
+) -> None:
+    """Two package instances can select different files from one exact bundle."""
+
+    bundle = _write_bundle(tmp_path / "warpx.tar")
+    package = _package(
+        tmp_path,
+        _base_config(input_bundle=str(bundle), input_path="density-high/inputs"),
+    )
+
+    package.start()
+
+    staged = tmp_path / "shared" / "run" / "density-high" / "inputs"
+    assert staged.read_bytes().endswith(b"my_constants.n0 = 4.e24\n")
+    command = _CapturedExec.commands[-1]
+    assert shlex.quote(str(staged.resolve())) in command
+    assert "max_step=" not in command
+    assert "amr.n_cell=" not in command
+    assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
+
+
+def test_single_input_is_copied_to_owned_output_before_launch(tmp_path: Path) -> None:
+    """An input binding never makes WarpX write beside the caller's source."""
+
+    source = tmp_path / "caller" / "inputs"
+    source.parent.mkdir()
+    source.write_text("max_step = 7\n", encoding="utf-8")
+    package = _package(tmp_path, _base_config(inputs=str(source)))
+
+    package.start()
+
+    staged = tmp_path / "shared" / "run" / "inputs"
+    assert staged.read_bytes() == source.read_bytes()
+    assert shlex.quote(str(staged.resolve())) in _CapturedExec.commands[-1]
+    assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
+
+
+def test_explicit_override_is_required_to_change_caller_input(tmp_path: Path) -> None:
+    """Package defaults do not silently replace supplied scientific settings."""
+
+    source = tmp_path / "inputs"
+    source.write_text("max_step = 7\n", encoding="utf-8")
+    package = _package(
+        tmp_path,
+        _base_config(
+            inputs=str(source),
+            max_step=12,
+            n_cell="8 8 16",
+            override_input_parameters=True,
+            plot_int=-1,
+        ),
+    )
+
+    package.start()
+
+    command = _CapturedExec.commands[-1]
+    assert "max_step=12" in command
+    assert "amr.n_cell=8 8 16" in command
+    assert "amr.plot_int=-1" in command
+
+
+def test_ambiguous_or_undeclared_inputs_fail_before_launch(tmp_path: Path) -> None:
+    """Input selection is explicit, closed, and free of path traversal."""
+
+    bundle = _write_bundle(tmp_path / "warpx.tar")
+    source = tmp_path / "inputs"
+    source.write_text("max_step = 1\n", encoding="utf-8")
+    package = _package(
+        tmp_path,
+        _base_config(inputs=str(source), input_bundle=str(bundle)),
+    )
+    with pytest.raises(ValueError, match="cannot be combined"):
+        package.start()
+
+    package.config = _base_config(
+        input_bundle=str(bundle), input_path="../density-high/inputs"
+    )
+    with pytest.raises(ValueError, match="confined manifest path"):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
+def test_process_failure_is_not_silently_accepted(tmp_path: Path) -> None:
+    """Any failing WarpX rank fails the package lifecycle."""
+
+    source = tmp_path / "inputs"
+    source.write_text("max_step = 1\n", encoding="utf-8")
+    package = _package(tmp_path, _base_config(inputs=str(source)))
+    _CapturedExec.return_code = 9
+
+    with pytest.raises(RuntimeError, match="WarpX execution failed"):
+        package.start()
+
+
+def test_clean_uses_one_exact_recursive_output_without_wildcard(tmp_path: Path) -> None:
+    """Cleanup cannot erase prefix-matching sibling directories."""
+
+    package = _package(tmp_path, _base_config(out="results"))
+
+    package.clean()
+
+    assert _CapturedRm.calls == [
+        (str((tmp_path / "shared" / "results").resolve()), True)
+    ]
+    assert "*" not in _CapturedRm.calls[0][0]
+
+
+def test_default_hostfile_uses_local_output_lifecycle(tmp_path: Path) -> None:
+    """Local execution does not require SSH for output directory management."""
+
+    package = _package(tmp_path, _base_config(example="laser_acceleration"))
+
+    assert isinstance(package._node_exec_info(), LocalExecInfo)

--- a/test/unit/core/test_wfcommons_artifacts.py
+++ b/test/unit/core/test_wfcommons_artifacts.py
@@ -1,0 +1,127 @@
+"""Generated-artifact tests for the builtin WfCommons package."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from pathlib import PurePosixPath
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import load_artifacts_module
+
+
+def _load_artifacts() -> ModuleType:
+    """Load WfCommons artifact semantics directly from the builtin package."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "wfcommons"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _closed_run(root: Path, *, return_code: int = 0) -> None:
+    workflow = root / "workflow.json"
+    log = root / "workflow.log"
+    lock = root / "dependency-lock.txt"
+    schema = root / "wfcommons-schema.json"
+    workflow.write_text('{"workflow": {}}\n', encoding="utf-8")
+    log.write_text("complete\n", encoding="utf-8")
+    lock.write_text("wfcommons==1.4\n", encoding="utf-8")
+    schema.write_text("{}\n", encoding="utf-8")
+    result = {
+        "schema_version": "jarvis.wfcommons-result.v1",
+        "recipe": "epigenomics",
+        "requested_task_count": 100,
+        "observed_task_count": 97,
+        "data_footprint_mb": 8,
+        "seed": 424300,
+        "elapsed_seconds": 1.2,
+        "return_code": return_code,
+        "workflow_manifest": workflow.name,
+        "workflow_sha256": _sha(workflow),
+        "workflow_log": log.name,
+        "workflow_log_sha256": _sha(log),
+        "dependency_lock": lock.name,
+        "dependency_lock_sha256": _sha(lock),
+        "schema_file": schema.name,
+        "schema_sha256": _sha(schema),
+    }
+    (root / "wfcommons-result.json").write_text(json.dumps(result), encoding="utf-8")
+
+
+def test_finalized_run_reports_result_workflow_log_and_provenance(
+    tmp_path: Path,
+) -> None:
+    """A successful cell exposes all closed products with exact hashes."""
+
+    module = _load_artifacts()
+    _closed_run(tmp_path)
+    adapter = module.adapter_from_package(
+        {"pkg_type": "builtin.wfcommons", "out": "/execution/shared/wfcommons"}
+    )
+    assert adapter is not None
+    adapter._local_root = tmp_path
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert [item.logical_name for item in observations] == [
+        "wfcommons-result",
+        "wfcommons-workflow",
+        "wfcommons-workflow-log",
+        "wfcommons-dependency-lock",
+        "wfcommons-schema",
+    ]
+    assert all(item.state.value == "finalized" for item in observations)
+    assert all(
+        item.checksum and item.checksum.startswith("sha256:") for item in observations
+    )
+    assert adapter.finalize_artifacts_for_exit(0) == []
+
+
+def test_failed_process_never_finalizes_outputs(tmp_path: Path) -> None:
+    """A nonzero driver result leaves available products explicitly incomplete."""
+
+    module = _load_artifacts()
+    _closed_run(tmp_path, return_code=9)
+    adapter = module.WfcommonsArtifactAdapter(
+        PurePosixPath("/execution/shared/wfcommons"), tmp_path
+    )
+
+    observations = adapter.finalize_artifacts_for_exit(9)
+
+    assert observations
+    assert all(item.state.value == "incomplete" for item in observations)
+
+
+def test_result_cannot_escape_the_owned_output_root(tmp_path: Path) -> None:
+    """Artifact paths from the result document are confined to the output root."""
+
+    module = _load_artifacts()
+    _closed_run(tmp_path)
+    result = json.loads((tmp_path / "wfcommons-result.json").read_text())
+    result["workflow_manifest"] = "../outside.json"
+    (tmp_path / "wfcommons-result.json").write_text(json.dumps(result))
+
+    adapter = module.WfcommonsArtifactAdapter(
+        PurePosixPath("/execution/shared/wfcommons"), tmp_path
+    )
+    with pytest.raises(RuntimeError, match="escaped"):
+        adapter.finalize_artifacts_for_exit(0)
+
+
+def test_unrelated_package_has_no_wfcommons_artifact_adapter() -> None:
+    """Artifact semantics remain package-specific."""
+
+    module = _load_artifacts()
+    assert module.adapter_from_package({"pkg_type": "builtin.ior"}) is None

--- a/test/unit/core/test_wfcommons_driver.py
+++ b/test/unit/core/test_wfcommons_driver.py
@@ -1,0 +1,103 @@
+"""Pure result-contract tests for the WfCommons driver."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_driver() -> ModuleType:
+    """Load the driver as a module without executing its CLI."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "wfcommons"
+        / "run_wfbench.py"
+    )
+    spec = spec_from_file_location("test_builtin_wfcommons_driver", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load the WfCommons driver from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+driver = _load_driver()
+
+
+def _manifest(path: Path) -> None:
+    document = {
+        "workflow": {
+            "specification": {
+                "tasks": [
+                    {"id": "a", "parents": [], "children": ["b"]},
+                    {"id": "b", "parents": ["a"], "children": []},
+                ]
+            }
+        }
+    }
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+
+def test_workflow_identity_is_stable_and_counts_edges(tmp_path: Path) -> None:
+    """Topology identity excludes file sizes and other footprint-only values."""
+
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    _manifest(first)
+    raw = json.loads(first.read_text(encoding="utf-8"))
+    raw["workflow"]["specification"]["files"] = [
+        {"id": "data", "sizeInBytes": 99_000_000}
+    ]
+    second.write_text(json.dumps(raw), encoding="utf-8")
+
+    assert driver.workflow_identity(first) == driver.workflow_identity(second)
+    assert driver.workflow_identity(first)[:2] == (2, 1)
+
+
+def test_result_document_binds_runtime_schema_and_closed_outputs(
+    tmp_path: Path,
+) -> None:
+    """The generic result records exact inputs and successful process completion."""
+
+    manifest = tmp_path / "workflow.json"
+    log = tmp_path / "workflow.log"
+    lock = tmp_path / "dependency-lock.txt"
+    schema = tmp_path / "wfcommons-schema.json"
+    _manifest(manifest)
+    log.write_text("ok\n", encoding="utf-8")
+    lock.write_text("wfcommons==1.4\n", encoding="utf-8")
+    schema.write_text("{}\n", encoding="utf-8")
+
+    result = driver.build_result_document(
+        run_root=tmp_path,
+        recipe="epigenomics",
+        requested_task_count=100,
+        data_footprint_mb=8,
+        seed=424300,
+        elapsed_seconds=1.25,
+        return_code=0,
+        workflow_path=manifest,
+        workflow_log=log,
+        dependency_lock=lock,
+        schema_path=schema,
+        wfcommons_version="1.4",
+        python_version="3.12.8",
+    )
+
+    assert result["schema_version"] == "jarvis.wfcommons-result.v1"
+    assert result["observed_task_count"] == 2
+    assert result["dag_edge_count"] == 1
+    assert result["return_code"] == 0
+    assert (
+        result["workflow_sha256"] == hashlib.sha256(manifest.read_bytes()).hexdigest()
+    )
+    assert result["schema_sha256"] == hashlib.sha256(schema.read_bytes()).hexdigest()
+    assert result["workflow_manifest"] == "workflow.json"
+    assert result["workflow_log"] == "workflow.log"
+    assert result["dependency_lock"] == "dependency-lock.txt"

--- a/test/unit/core/test_wfcommons_package.py
+++ b/test/unit/core/test_wfcommons_package.py
@@ -120,12 +120,18 @@ def test_agent_contract_exposes_one_reproducible_study_cell(
     """Agents configure science dimensions while operators own the runtime path."""
 
     package = _package(Path("."))
+    probes: list[tuple[str, dict[str, str]]] = []
+
+    def probe(program: str, **kwargs: Any) -> SimpleNamespace:
+        probes.append((program, kwargs["environment"]))
+        return SimpleNamespace(
+            status=wfcommons_package.RuntimeStatus("ready", "runtime_probe_succeeded")
+        )
+
     monkeypatch.setattr(
         wfcommons_package,
         "probe_program",
-        lambda *args, **kwargs: SimpleNamespace(
-            status=wfcommons_package.RuntimeStatus("ready", "runtime_probe_succeeded")
-        ),
+        probe,
     )
 
     menu = {item["name"]: item for item in package._configure_menu()}
@@ -134,6 +140,8 @@ def test_agent_contract_exposes_one_reproducible_study_cell(
     assert menu["runtime_python"]["agent_visible"] is False
     assert "venv" not in menu
     contract = package._deployment_contract().to_dict()
+    assert probes[0][0] == "python3"
+    assert probes[0][1]["PATH"].split(wfcommons_package.os.pathsep)[0] == "/runtime/bin"
     assert contract["package"] == "builtin.wfcommons"
     assert contract["execution_profiles"] == [
         {

--- a/test/unit/core/test_wfcommons_package.py
+++ b/test/unit/core/test_wfcommons_package.py
@@ -1,0 +1,213 @@
+"""Runtime-contract tests for the builtin WfCommons package."""
+
+from __future__ import annotations
+
+import shlex
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def _load_package() -> ModuleType:
+    """Load builtin WfCommons without relying on repository registration."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "wfcommons"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_builtin_wfcommons", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load the WfCommons package from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+wfcommons_package = _load_package()
+
+
+class _CapturedExec:
+    """Capture exact package commands and expose configurable process results."""
+
+    commands: list[str] = []
+    infos: list[Any] = []
+    return_code = 0
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": self.return_code}
+        self.commands.append(command)
+        self.infos.append(exec_info)
+
+    def run(self) -> _CapturedExec:
+        """Return the captured result."""
+
+        return self
+
+
+class _CapturedRm:
+    """Capture package-owned cleanup without deleting test files."""
+
+    calls: list[tuple[str, bool]] = []
+
+    def __init__(self, path: str, exec_info: Any, *, recursive: bool = False) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.recursive = recursive
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedRm:
+        """Record the cleanup request."""
+
+        self.calls.append((self.path, self.recursive))
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _capture_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep package tests free of external process side effects."""
+
+    _CapturedExec.commands = []
+    _CapturedExec.infos = []
+    _CapturedExec.return_code = 0
+    _CapturedRm.calls = []
+    monkeypatch.setattr(wfcommons_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(wfcommons_package, "Rm", _CapturedRm)
+
+
+def _package(tmp_path: Path, **updates: object) -> Any:
+    """Build a minimally configured WfCommons package instance."""
+
+    package = object.__new__(wfcommons_package.Wfcommons)
+    package.shared_dir = str(tmp_path / "shared")
+    package.private_dir = str(tmp_path / "private")
+    package.pkg_dir = str(
+        Path(__file__).resolve().parents[3] / "builtin" / "builtin" / "wfcommons"
+    )
+    package.env = {"PATH": "/runtime/bin"}
+    package.mod_env = dict(package.env)
+    package.config = {
+        "clio_prefix": False,
+        "cpu_work": 1,
+        "data_footprint_mb": 8,
+        "deploy_mode": "default",
+        "drop_page_cache": False,
+        "nprocs": 1,
+        "out": "run",
+        "percent_cpu": 1.0,
+        "ppn": 1,
+        "recipe": "epigenomics",
+        "runtime_python": "/runtime/bin/python3",
+        "seed": 424300,
+        "timeout_seconds": 3600,
+        "num_tasks": 100,
+    }
+    package.config.update(updates)
+    package.runtime_line_callback = lambda: None
+    return package
+
+
+def test_agent_contract_exposes_one_reproducible_study_cell(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agents configure science dimensions while operators own the runtime path."""
+
+    package = _package(Path("."))
+    monkeypatch.setattr(
+        wfcommons_package,
+        "probe_program",
+        lambda *args, **kwargs: SimpleNamespace(
+            status=wfcommons_package.RuntimeStatus("ready", "runtime_probe_succeeded")
+        ),
+    )
+
+    menu = {item["name"]: item for item in package._configure_menu()}
+    assert menu["data_footprint_mb"]["type"] is int
+    assert menu["seed"]["type"] is int
+    assert menu["runtime_python"]["agent_visible"] is False
+    assert "venv" not in menu
+    contract = package._deployment_contract().to_dict()
+    assert contract["package"] == "builtin.wfcommons"
+    assert contract["execution_profiles"] == [
+        {
+            "name": "synthetic_workflow_cell",
+            "execution_kind": "batch",
+            "when": [{"parameter": "recipe", "operator": "is_not_empty"}],
+            "runtime_requirements": ["bash", "wfcommons_runtime"],
+            "readiness": {
+                "mechanism": "process_exit",
+                "condition": "successful_exit",
+            },
+            "description": "Generate and execute one deterministic WfBench workflow cell.",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        ({"num_tasks": 0}, "num_tasks"),
+        ({"data_footprint_mb": -1}, "data_footprint_mb"),
+        ({"cpu_work": 0}, "cpu_work"),
+        ({"percent_cpu": 1.1}, "percent_cpu"),
+        ({"seed": -1}, "seed"),
+        ({"nprocs": 2}, "single-process"),
+    ],
+)
+def test_invalid_study_dimensions_fail_closed(
+    tmp_path: Path, updates: dict[str, object], message: str
+) -> None:
+    """Invalid scientific and execution settings are rejected, never coerced."""
+
+    package = _package(tmp_path, **updates)
+
+    with pytest.raises(ValueError, match=message):
+        package._validate_configuration()
+
+
+def test_start_stages_pinned_schema_and_builds_one_cell_command(tmp_path: Path) -> None:
+    """One package instance owns one result directory and one study cell."""
+
+    package = _package(tmp_path)
+
+    package.start()
+
+    output = tmp_path / "shared" / "run"
+    schema = output / "wfcommons-schema.json"
+    assert schema.read_bytes() == package._schema_source().read_bytes()
+    assert package.config["out"] == str(output.resolve())
+    command = _CapturedExec.commands[-1]
+    assert command.startswith(shlex.quote("/runtime/bin/python3"))
+    assert "--recipe epigenomics" in command
+    assert "--num-tasks 100" in command
+    assert "--data-footprint-mb 8" in command
+    assert "--seed 424300" in command
+    assert shlex.quote(str(schema.resolve())) in command
+    assert _CapturedExec.infos[-1].cwd == str(output.resolve())
+    assert _CapturedExec.infos[-1].timeout == 3600
+
+
+def test_start_propagates_driver_failure(tmp_path: Path) -> None:
+    """A failed WfBench cell makes the JARVIS package fail."""
+
+    package = _package(tmp_path)
+    _CapturedExec.return_code = 17
+
+    with pytest.raises(RuntimeError, match="WfCommons execution failed.*17"):
+        package.start()
+
+
+def test_clean_targets_only_the_normalized_package_output(tmp_path: Path) -> None:
+    """Cleanup authority cannot expand beyond the package-owned output."""
+
+    package = _package(tmp_path)
+    package.clean()
+
+    assert _CapturedRm.calls == [(str((tmp_path / "shared" / "run").resolve()), True)]

--- a/test/unit/core/test_xcompact3d_artifacts.py
+++ b/test/unit/core/test_xcompact3d_artifacts.py
@@ -1,0 +1,151 @@
+"""Tests for builtin Xcompact3D generated-artifact semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from jarvis_cd.artifacts import (
+    ArtifactRole,
+    ArtifactState,
+    ArtifactStructure,
+    load_artifacts_module,
+)
+
+
+def _module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "xcompact3d"
+        / "artifacts.py"
+    )
+    return load_artifacts_module(path)
+
+
+def _write_products(root: Path) -> None:
+    (root / "channel").mkdir(parents=True)
+    (root / "channel" / "input.i3d").write_text("input\n", encoding="utf-8")
+    (root / "channel" / "adios2_config.xml").write_text("<xml/>\n", encoding="utf-8")
+    (root / "channel" / "xcompact3d.log").write_text(
+        "UT 6.666662e-1 -4.6e-7\n", encoding="utf-8"
+    )
+    (root / "channel" / "checkpoint").write_bytes(b"checkpoint")
+    (root / "channel" / "restart.info").write_text("100\n", encoding="utf-8")
+    (root / "channel" / "data").mkdir()
+    (root / "channel" / "data" / "snapshot-1.xdmf").write_text(
+        "<Xdmf/>\n", encoding="utf-8"
+    )
+    (root / "channel" / "statistics").mkdir()
+    (root / "channel" / "statistics" / "umean.dat100").write_bytes(b"stats")
+
+
+def test_finalization_reports_owned_results_and_excludes_staged_inputs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Scientific outputs are visible without reclassifying exact inputs."""
+
+    _write_products(tmp_path)
+    module = _module()
+    adapter = module.Xcompact3dArtifactAdapter(
+        module.PurePosixPath("/scratch/xcompact3d"),
+        frozenset(
+            {
+                module.PurePosixPath("channel/input.i3d"),
+                module.PurePosixPath("channel/adios2_config.xml"),
+            }
+        ),
+    )
+    monkeypatch.setattr(adapter, "_local_output_path", lambda: tmp_path)
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert adapter.finalize_artifacts_for_exit(0) == []
+    collection = observations[0]
+    assert collection.logical_name == "xcompact3d-results"
+    assert collection.role is ArtifactRole.OUTPUT
+    assert collection.structure is ArtifactStructure.COLLECTION
+    assert collection.state is ArtifactState.FINALIZED
+    assert "channel/input.i3d" not in collection.metadata["member_names"]
+    names = {item.logical_name: item for item in observations[1:]}
+    assert names["xcompact3d-log"].format == "xcompact3d-runtime-log"
+    assert names["xcompact3d-checkpoint"].checksum is not None
+    assert names["xcompact3d-data"].structure is ArtifactStructure.COLLECTION
+    assert names["xcompact3d-statistics"].structure is ArtifactStructure.COLLECTION
+
+
+def test_nonzero_exit_marks_discovered_outputs_incomplete(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Filesystem presence cannot turn a failed solver run into success."""
+
+    _write_products(tmp_path)
+    module = _module()
+    adapter = module.Xcompact3dArtifactAdapter(
+        module.PurePosixPath("/scratch/xcompact3d")
+    )
+    monkeypatch.setattr(adapter, "_local_output_path", lambda: tmp_path)
+
+    observations = adapter.finalize_artifacts_for_exit(17)
+
+    assert observations
+    assert {item.state for item in observations} == {ArtifactState.INCOMPLETE}
+
+
+def test_discovery_bound_cannot_claim_complete_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A truncated output walk is visibly incomplete."""
+
+    _write_products(tmp_path)
+    module = _module()
+    adapter = module.Xcompact3dArtifactAdapter(
+        module.PurePosixPath("/scratch/xcompact3d")
+    )
+    monkeypatch.setattr(adapter, "_local_output_path", lambda: tmp_path)
+    monkeypatch.setattr(module, "_MAX_DISCOVERED_ENTRIES", 2)
+
+    observations = adapter.finalize_artifacts_for_exit(0)
+
+    assert observations[0].state is ArtifactState.INCOMPLETE
+    assert observations[0].metadata["discovery_truncated"] is True
+
+
+def test_factory_scopes_relative_output_to_package_shared_root() -> None:
+    """Artifact discovery receives the same execution-owned root as launch."""
+
+    module = _module()
+
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.xcompact3d",
+            "out": "run",
+            "shared_dir": "/execution/shared/xcompact3d",
+            "runtime_cwd": "/execution/runtime",
+        }
+    )
+
+    assert adapter is not None
+    assert adapter.output_dir.as_posix() == "/execution/shared/xcompact3d/run"
+    assert module.adapter_from_package({"pkg_type": "builtin.lammps"}) is None
+
+
+def test_container_private_output_is_not_claimed() -> None:
+    """A host cannot report artifacts from an unmounted container path."""
+
+    module = _module()
+    adapter = module.adapter_from_package(
+        {
+            "pkg_type": "builtin.xcompact3d",
+            "out": "/tmp/xcompact3d",
+            "effective_deploy_mode": "container",
+            "shared_dir": "/execution/shared",
+            "private_dir": "/execution/private",
+            "runtime_cwd": "/execution/runtime",
+        }
+    )
+
+    assert adapter is None

--- a/test/unit/core/test_xcompact3d_artifacts.py
+++ b/test/unit/core/test_xcompact3d_artifacts.py
@@ -29,6 +29,7 @@ def _module() -> ModuleType:
 def _write_products(root: Path) -> None:
     (root / "channel").mkdir(parents=True)
     (root / "channel" / "input.i3d").write_text("input\n", encoding="utf-8")
+    (root / "channel" / "jarvis-input.i3d").write_text("input\n", encoding="utf-8")
     (root / "channel" / "adios2_config.xml").write_text("<xml/>\n", encoding="utf-8")
     (root / "channel" / "xcompact3d.log").write_text(
         "UT 6.666662e-1 -4.6e-7\n", encoding="utf-8"
@@ -56,6 +57,7 @@ def test_finalization_reports_owned_results_and_excludes_staged_inputs(
             {
                 module.PurePosixPath("channel/input.i3d"),
                 module.PurePosixPath("channel/adios2_config.xml"),
+                module.PurePosixPath("channel/jarvis-input.i3d"),
             }
         ),
     )
@@ -70,6 +72,7 @@ def test_finalization_reports_owned_results_and_excludes_staged_inputs(
     assert collection.structure is ArtifactStructure.COLLECTION
     assert collection.state is ArtifactState.FINALIZED
     assert "channel/input.i3d" not in collection.metadata["member_names"]
+    assert "channel/jarvis-input.i3d" not in collection.metadata["member_names"]
     names = {item.logical_name: item for item in observations[1:]}
     assert names["xcompact3d-log"].format == "xcompact3d-runtime-log"
     assert names["xcompact3d-checkpoint"].checksum is not None

--- a/test/unit/core/test_xcompact3d_package_runtime.py
+++ b/test/unit/core/test_xcompact3d_package_runtime.py
@@ -199,9 +199,12 @@ def test_bundle_selects_one_manifest_input_without_modifying_it(tmp_path: Path) 
     package.start()
 
     staged = tmp_path / "shared" / "run" / "channel" / "input_test_z.i3d"
+    launch_input = staged.parent / "jarvis-input.i3d"
     assert staged.read_bytes().endswith(b"idir_stream=3\n/End\n")
+    assert launch_input.read_bytes() == staged.read_bytes()
     command = _CapturedExec.commands[-1]
-    assert shlex.quote(str(staged.resolve())) in command
+    assert command.startswith("xcompact3d jarvis-input.i3d ")
+    assert shlex.quote(str(staged.resolve())) not in command
     assert str((staged.parent / "xcompact3d.log").resolve()) in command
     assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
 
@@ -217,9 +220,33 @@ def test_single_input_is_copied_to_owned_output_before_launch(tmp_path: Path) ->
     package.start()
 
     staged = tmp_path / "shared" / "run" / "input.i3d"
+    launch_input = staged.parent / "jarvis-input.i3d"
     assert staged.read_bytes() == source.read_bytes()
-    assert shlex.quote(str(staged.resolve())) in _CapturedExec.commands[-1]
+    assert launch_input.read_bytes() == staged.read_bytes()
+    assert _CapturedExec.commands[-1].startswith("xcompact3d jarvis-input.i3d ")
+    assert shlex.quote(str(staged.resolve())) not in _CapturedExec.commands[-1]
     assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
+
+
+def test_reserved_runtime_input_name_cannot_replace_a_bundle_member(
+    tmp_path: Path,
+) -> None:
+    """A bundle cannot make the short runtime alias overwrite another input."""
+
+    bundle = _write_bundle(tmp_path / "channel.tar")
+    package = _package(
+        tmp_path,
+        _base_config(input_bundle=str(bundle), input_path="channel/input_test_z.i3d"),
+    )
+    collision = tmp_path / "shared" / "run" / "channel" / "jarvis-input.i3d"
+    collision.parent.mkdir(parents=True)
+    collision.write_text("unrelated\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="runtime input alias already exists"):
+        package.start()
+
+    assert collision.read_text(encoding="utf-8") == "unrelated\n"
+    assert _CapturedExec.commands == []
 
 
 def test_ambiguous_or_undeclared_inputs_fail_before_launch(tmp_path: Path) -> None:

--- a/test/unit/core/test_xcompact3d_package_runtime.py
+++ b/test/unit/core/test_xcompact3d_package_runtime.py
@@ -1,0 +1,281 @@
+"""Runtime-contract tests for the builtin JARVIS Xcompact3D package."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import shlex
+import tarfile
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.input_bundle import (
+    INPUT_BUNDLE_MANIFEST_NAME,
+    INPUT_BUNDLE_SCHEMA_VERSION,
+)
+from jarvis_cd.shell import LocalExecInfo
+from jarvis_cd.util.hostfile import Hostfile
+
+
+def _load_package() -> ModuleType:
+    """Load the builtin package without changing repository imports."""
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "builtin"
+        / "builtin"
+        / "xcompact3d"
+        / "pkg.py"
+    )
+    spec = spec_from_file_location("test_xcompact3d_runtime_package", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load Xcompact3D package from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+xcompact3d_package = _load_package()
+
+
+class _CapturedExec:
+    """Capture one launch and expose a configurable process result."""
+
+    commands: list[str] = []
+    infos: list[Any] = []
+    return_code = 0
+
+    def __init__(self, command: str, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": self.return_code}
+        self.commands.append(command)
+        self.infos.append(exec_info)
+
+    def run(self) -> _CapturedExec:
+        """Return the captured result."""
+
+        return self
+
+
+class _CapturedMkdir:
+    """Create a local test output directory and report success."""
+
+    def __init__(self, path: str, exec_info: Any) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedMkdir:
+        """Materialize the test directory."""
+
+        Path(self.path).mkdir(parents=True, exist_ok=True)
+        return self
+
+
+class _CapturedRm:
+    """Capture exact cleanup authority."""
+
+    calls: list[tuple[str, bool]] = []
+
+    def __init__(self, path: str, exec_info: Any, *, recursive: bool = False) -> None:
+        self.path = path
+        self.exec_info = exec_info
+        self.recursive = recursive
+        self.exit_code = {"localhost": 0}
+
+    def run(self) -> _CapturedRm:
+        """Record cleanup without deleting test files."""
+
+        self.calls.append((self.path, self.recursive))
+        return self
+
+
+@pytest.fixture(autouse=True)
+def _capture_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep package tests free of process and remote-host side effects."""
+
+    _CapturedExec.commands = []
+    _CapturedExec.infos = []
+    _CapturedExec.return_code = 0
+    _CapturedRm.calls = []
+    monkeypatch.setattr(xcompact3d_package, "Exec", _CapturedExec)
+    monkeypatch.setattr(xcompact3d_package, "Mkdir", _CapturedMkdir)
+    monkeypatch.setattr(xcompact3d_package, "Rm", _CapturedRm)
+
+
+def _package(tmp_path: Path, config: dict[str, Any]) -> Any:
+    package = object.__new__(xcompact3d_package.Xcompact3d)
+    package.config = config
+    package.shared_dir = tmp_path / "shared"
+    package.private_dir = tmp_path / "private"
+    package.env = {}
+    package.mod_env = {"PATH": "/runtime/bin"}
+    package.xcompact3d_bin = "xcompact3d"
+    package.pipeline = SimpleNamespace(get_hostfile=lambda: Hostfile(find_ips=False))
+    package.runtime_line_callback = lambda: None
+    return package
+
+
+def _write_bundle(destination: Path) -> Path:
+    files = {
+        "channel/input_test_x.i3d": b"&BasicParam\n idir_stream=1\n/End\n",
+        "channel/input_test_z.i3d": b"&BasicParam\n idir_stream=3\n/End\n",
+        "channel/adios2_config.xml": b"<adios-config/>\n",
+    }
+    manifest = {
+        "schema_version": INPUT_BUNDLE_SCHEMA_VERSION,
+        "entrypoint": "channel/input_test_x.i3d",
+        "files": [
+            {
+                "path": name,
+                "role": "xcompact3d_input" if name.endswith(".i3d") else "support",
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            }
+            for name, payload in files.items()
+        ],
+    }
+    manifest_bytes = json.dumps(manifest, sort_keys=True).encode()
+    with tarfile.open(destination, mode="w") as archive:
+        info = tarfile.TarInfo(INPUT_BUNDLE_MANIFEST_NAME)
+        info.size = len(manifest_bytes)
+        archive.addfile(info, io.BytesIO(manifest_bytes))
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return destination
+
+
+def _base_config(**overrides: Any) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "deploy_mode": "default",
+        "input_bundle": "",
+        "input_path": "",
+        "inputs": "",
+        "nprocs": 4,
+        "out": "run",
+        "ppn": 4,
+    }
+    config.update(overrides)
+    return config
+
+
+def test_agent_contract_exposes_generic_single_and_bundle_inputs() -> None:
+    """Agents see ordinary Xcompact3D inputs, not benchmark-specific axes."""
+
+    package = object.__new__(xcompact3d_package.Xcompact3d)
+    package.config = _base_config()
+    package.env = {}
+    package.mod_env = {}
+    menu = {item["name"]: item for item in package._configure_menu()}
+
+    assert menu["out"]["default"] == "run"
+    assert menu["inputs"]["input_binding"]["kind"] == "local_file"
+    assert menu["input_bundle"]["input_binding"]["kind"] == "local_file"
+    assert "axis" not in menu
+    contract = package._deployment_contract().to_dict()
+    assert {profile["name"] for profile in contract["execution_profiles"]} == {
+        "input_bundle",
+        "input_file",
+    }
+
+
+def test_bundle_selects_one_manifest_input_without_modifying_it(tmp_path: Path) -> None:
+    """Independent package instances can select distinct files from one bundle."""
+
+    bundle = _write_bundle(tmp_path / "channel.tar")
+    package = _package(
+        tmp_path,
+        _base_config(input_bundle=str(bundle), input_path="channel/input_test_z.i3d"),
+    )
+
+    package.start()
+
+    staged = tmp_path / "shared" / "run" / "channel" / "input_test_z.i3d"
+    assert staged.read_bytes().endswith(b"idir_stream=3\n/End\n")
+    command = _CapturedExec.commands[-1]
+    assert shlex.quote(str(staged.resolve())) in command
+    assert str((staged.parent / "xcompact3d.log").resolve()) in command
+    assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
+
+
+def test_single_input_is_copied_to_owned_output_before_launch(tmp_path: Path) -> None:
+    """A caller input is never executed in its source directory."""
+
+    source = tmp_path / "caller" / "input.i3d"
+    source.parent.mkdir()
+    source.write_text("&BasicParam\n idir_stream=1\n/End\n", encoding="utf-8")
+    package = _package(tmp_path, _base_config(inputs=str(source)))
+
+    package.start()
+
+    staged = tmp_path / "shared" / "run" / "input.i3d"
+    assert staged.read_bytes() == source.read_bytes()
+    assert shlex.quote(str(staged.resolve())) in _CapturedExec.commands[-1]
+    assert _CapturedExec.infos[-1].cwd == str(staged.parent.resolve())
+
+
+def test_ambiguous_or_undeclared_inputs_fail_before_launch(tmp_path: Path) -> None:
+    """Input selection is explicit and rejects traversal or ambiguity."""
+
+    bundle = _write_bundle(tmp_path / "channel.tar")
+    source = tmp_path / "input.i3d"
+    source.write_text("&BasicParam\n/End\n", encoding="utf-8")
+    package = _package(
+        tmp_path,
+        _base_config(inputs=str(source), input_bundle=str(bundle)),
+    )
+    with pytest.raises(ValueError, match="cannot be combined"):
+        package.start()
+
+    package.config = _base_config(
+        input_bundle=str(bundle), input_path="../channel/input_test_z.i3d"
+    )
+    with pytest.raises(ValueError, match="confined manifest path"):
+        package.start()
+
+    package.config = _base_config()
+    with pytest.raises(ValueError, match="requires inputs or input_bundle"):
+        package.start()
+
+    assert _CapturedExec.commands == []
+
+
+def test_process_failure_is_not_silently_accepted(tmp_path: Path) -> None:
+    """Any failing Xcompact3D rank fails the package lifecycle."""
+
+    source = tmp_path / "input.i3d"
+    source.write_text("&BasicParam\n/End\n", encoding="utf-8")
+    package = _package(tmp_path, _base_config(inputs=str(source)))
+    _CapturedExec.return_code = 9
+
+    with pytest.raises(RuntimeError, match="Xcompact3D execution failed"):
+        package.start()
+
+
+def test_clean_uses_one_exact_recursive_output_without_wildcard(tmp_path: Path) -> None:
+    """Cleanup cannot erase prefix-matching sibling directories."""
+
+    package = _package(tmp_path, _base_config(out="results"))
+
+    package.clean()
+
+    assert _CapturedRm.calls == [
+        (str((tmp_path / "shared" / "results").resolve()), True)
+    ]
+    assert "*" not in _CapturedRm.calls[0][0]
+
+
+def test_default_hostfile_uses_local_output_lifecycle(tmp_path: Path) -> None:
+    """Local output preparation does not require SSH."""
+
+    package = _package(tmp_path, _base_config())
+
+    assert isinstance(package._node_exec_info(), LocalExecInfo)


### PR DESCRIPTION
## Summary

- add maintained scientific application, workflow, service, and interceptor profiles used by the cross-cluster evaluation campaign
- preserve bounded supplied inputs and native scientific artifacts across execution
- create concrete scheduler log parents before submission
- reconcile accepted Slurm executions from live and accounting state when the JARVIS runtime never activates
- keep synthetic tests portable without weakening the dedicated filesystem behavior checks

## Verification

- 97 focused tests passed across the affected scheduler, pipeline, Montage, and Gadget2 paths
- scoped Pyright and Ruff check/format gates passed
- GitHub CI passed: main test job plus Progress provider on Python 3.11 and 3.12
- candidate wheel `jarvis_cd-1.7.0.post1.dev33+g311ebb6-py3-none-any.whl`, SHA-256 `395c858a27183572bba63b5ea2aa36264d46f9548b80bd5597633055058ef36b`
- Ares job `22814`: ordinary `builtin.echo` package completed through JARVIS to Slurm; JARVIS created the configured scheduler log parents, stdout was 1,113 bytes, and stderr was empty
- Ares job `22815`: submitted with a future start, identity-checked, canceled explicitly, then reconciled by JARVIS to terminal `failed` with return code 1 and typed scheduler state `missing`

The Ares checks used an isolated immutable candidate runtime and did not replace the active benchmark JARVIS installation.