### PR TITLE
fix: declare and propagate IOR runtime failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,7 @@ jobs:
             test/unit/core/test_lammps_artifacts.py \
             test/unit/core/test_lammps_progress.py \
             test/unit/core/test_lammps_package_runtime.py \
+            test/unit/core/test_ior_package_runtime.py \
             test/unit/core/test_paraview_artifacts.py \
             test/unit/core/test_paraview_scene_v2.py \
             test/unit/core/test_paraview_service.py \

--- a/builtin/builtin/ior/pkg.py
+++ b/builtin/builtin/ior/pkg.py
@@ -296,7 +296,20 @@ class Ior(Application):
         ).run()
         failures = {host: code for host, code in result.exit_code.items() if code != 0}
         if failures:
-            raise RuntimeError(f"IOR execution failed: {failures}")
+            diagnostics: dict[str, str] = {}
+            for host in failures:
+                output: list[str] = []
+                for stream_name in ("stdout", "stderr"):
+                    streams = getattr(result, stream_name, {})
+                    if not isinstance(streams, dict):
+                        continue
+                    value = streams.get(host)
+                    if value:
+                        output.append(str(value).strip())
+                if output:
+                    diagnostics[host] = "\n".join(output)[-4096:]
+            detail = f"; output={diagnostics!r}" if diagnostics else ""
+            raise RuntimeError(f"IOR execution failed: {failures}{detail}")
 
     def stop(self):
         """Stop IOR (no-op — IOR runs to completion)."""

--- a/builtin/builtin/ior/pkg.py
+++ b/builtin/builtin/ior/pkg.py
@@ -8,7 +8,19 @@ It is mainly targeted for HPC systems and parallel I/O.
 import os
 import pathlib
 import re
+import shlex
+
 from jarvis_cd.core.pkg import Application
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+    probe_program,
+)
 from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo, Rm, Mkdir
 from jarvis_cd.shell.process import GdbServer
 
@@ -141,6 +153,55 @@ class Ior(Application):
     # Configuration
     # ------------------------------------------------------------------
 
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe IOR's runtime requirement and completion semantics."""
+        if self.config.get("deploy_mode") == "container":
+            status = RuntimeStatus("unknown", "container_runtime_not_probed")
+            capabilities: tuple[str, ...] = ()
+        else:
+            probe = probe_program(
+                "ior",
+                environment=self._deployment_environment(),
+                arguments=("--version",),
+            )
+            status = probe.status
+            capabilities = (
+                ("mpi_execution", "parallel_io_benchmark")
+                if status.usable is True
+                else ()
+            )
+        runtime = RuntimeRequirement(
+            requirement_id="ior",
+            description="IOR runtime able to benchmark parallel I/O under MPI",
+            required_capabilities=("mpi_execution", "parallel_io_benchmark"),
+            available_capabilities=capabilities,
+            status=status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="spack",
+                    query_kind="spec",
+                    query_value="ior",
+                ),
+            ),
+        )
+        return PackageDeploymentContract(
+            package="builtin.ior",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="benchmark",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("nprocs", "greater_than", 0),),
+                    runtime_requirements=("ior",),
+                    readiness=ReadinessContract(
+                        mechanism="process_exit",
+                        condition="successful_exit",
+                    ),
+                    description="Parallel I/O benchmark using the selected API and workload.",
+                ),
+            ),
+            runtime_requirements=(runtime,),
+        )
+
     def _configure(self, **kwargs):
         """
         Configure IOR.
@@ -207,7 +268,8 @@ class Ior(Application):
 
         ior_cmd = " ".join(cmd)
         if cfg.get("log"):
-            ior_cmd += f" 2>&1 | tee {cfg['log']}"
+            logged_command = f"{ior_cmd} 2>&1 | tee {shlex.quote(str(cfg['log']))}"
+            ior_cmd = f"bash -o pipefail -c {shlex.quote(logged_command)}"
 
         gdb_server = GdbServer(ior_cmd, cfg.get("dbg_port", 4000))
         cmd_list = [
@@ -218,7 +280,7 @@ class Ior(Application):
             },
             {"cmd": ior_cmd, "nprocs": None},
         ]
-        Exec(
+        result = Exec(
             cmd_list,
             MpiExecInfo(
                 nprocs=cfg["nprocs"],
@@ -232,6 +294,9 @@ class Ior(Application):
                 env=self.mod_env,
             ),
         ).run()
+        failures = {host: code for host, code in result.exit_code.items() if code != 0}
+        if failures:
+            raise RuntimeError(f"IOR execution failed: {failures}")
 
     def stop(self):
         """Stop IOR (no-op — IOR runs to completion)."""

--- a/test/unit/core/test_ior_package_runtime.py
+++ b/test/unit/core/test_ior_package_runtime.py
@@ -33,6 +33,8 @@ class _ExecResult:
     """Return configured per-host process results without launching IOR."""
 
     exit_code: dict[str, int] = {"localhost": 0}
+    stderr: dict[str, str] = {}
+    stdout: dict[str, str] = {}
     commands: list[object] = []
 
     def __init__(self, command: object, exec_info: Any) -> None:
@@ -104,10 +106,15 @@ def test_start_propagates_failed_ior_processes(
     package = _ior_instance()
     package.config["log"] = "results/ior output.log"
     _ExecResult.exit_code = {"compute-01": 127, "compute-02": 127}
+    _ExecResult.stdout = {
+        "compute-01": "bash: line 1: ior: command not found\n",
+        "compute-02": "bash: line 1: ior: command not found\n",
+    }
+    _ExecResult.stderr = {}
     _ExecResult.commands = []
     monkeypatch.setattr(ior_package, "Exec", _ExecResult)
 
-    with pytest.raises(RuntimeError, match="IOR execution failed"):
+    with pytest.raises(RuntimeError, match="ior: command not found"):
         package.start()
 
     command_list = _ExecResult.commands[0]
@@ -124,6 +131,8 @@ def test_start_accepts_successful_ior_processes(
     """A successful per-host process map remains a successful package launch."""
     package = _ior_instance()
     _ExecResult.exit_code = {"compute-01": 0, "compute-02": 0}
+    _ExecResult.stdout = {}
+    _ExecResult.stderr = {}
     monkeypatch.setattr(ior_package, "Exec", _ExecResult)
 
     package.start()

--- a/test/unit/core/test_ior_package_runtime.py
+++ b/test/unit/core/test_ior_package_runtime.py
@@ -1,0 +1,129 @@
+"""Runtime-contract tests for the builtin JARVIS IOR package."""
+
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import shlex
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from jarvis_cd.deployment import ProgramProbeResult, RuntimeStatus
+
+
+def _load_ior_package() -> ModuleType:
+    """Load the package implementation without changing repository imports."""
+    package_path = (
+        Path(__file__).resolve().parents[3] / "builtin" / "builtin" / "ior" / "pkg.py"
+    )
+    spec = spec_from_file_location("test_ior_runtime_package", package_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load the IOR package from {package_path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ior_package = _load_ior_package()
+
+
+class _ExecResult:
+    """Return configured per-host process results without launching IOR."""
+
+    exit_code: dict[str, int] = {"localhost": 0}
+    commands: list[object] = []
+
+    def __init__(self, command: object, exec_info: Any) -> None:
+        self.command = command
+        self.exec_info = exec_info
+        self.commands.append(command)
+
+    def run(self) -> _ExecResult:
+        """Return this captured result."""
+        return self
+
+
+def _ior_instance() -> Any:
+    """Construct the minimal package state needed by contract and launch tests."""
+    package = object.__new__(ior_package.Ior)
+    package.config = {
+        "api": "POSIX",
+        "block": "1m",
+        "direct": False,
+        "fpp": False,
+        "log": "",
+        "nprocs": 1,
+        "out": "ior.bin",
+        "ppn": 1,
+        "read": False,
+        "reps": 1,
+        "write": True,
+        "xfer": "64k",
+    }
+    package.env = {}
+    package.mod_env = {}
+    package.private_dir = None
+    package.shared_dir = None
+    package.pipeline = SimpleNamespace(
+        _has_containerized_packages=lambda: False,
+        get_hostfile=lambda: None,
+    )
+    return package
+
+
+def test_deployment_contract_declares_spack_runtime_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unavailable IOR binary must advertise its provider-native resolution."""
+    package = _ior_instance()
+    monkeypatch.setattr(
+        ior_package,
+        "probe_program",
+        lambda *args, **kwargs: ProgramProbeResult(
+            RuntimeStatus("unavailable", "software_not_found")
+        ),
+    )
+
+    contract = package._deployment_contract().to_dict()
+
+    assert contract["package"] == "builtin.ior"
+    runtime = contract["runtime_requirements"][0]
+    assert runtime["status"]["usable"] is False
+    assert runtime["provider_resolutions"] == [
+        {"provider": "spack", "query": {"kind": "spec", "value": "ior"}}
+    ]
+    assert contract["execution_profiles"][0]["runtime_requirements"] == ["ior"]
+
+
+def test_start_propagates_failed_ior_processes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JARVIS cannot report success when any IOR process failed to launch."""
+    package = _ior_instance()
+    package.config["log"] = "results/ior output.log"
+    _ExecResult.exit_code = {"compute-01": 127, "compute-02": 127}
+    _ExecResult.commands = []
+    monkeypatch.setattr(ior_package, "Exec", _ExecResult)
+
+    with pytest.raises(RuntimeError, match="IOR execution failed"):
+        package.start()
+
+    command_list = _ExecResult.commands[0]
+    assert isinstance(command_list, list)
+    logged_command = command_list[1]["cmd"]
+    argv = shlex.split(logged_command)
+    assert argv[:4] == ["bash", "-o", "pipefail", "-c"]
+    assert argv[4].endswith("2>&1 | tee 'results/ior output.log'")
+
+
+def test_start_accepts_successful_ior_processes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful per-host process map remains a successful package launch."""
+    package = _ior_instance()
+    _ExecResult.exit_code = {"compute-01": 0, "compute-02": 0}
+    monkeypatch.setattr(ior_package, "Exec", _ExecResult)
+
+    package.start()


### PR DESCRIPTION
## What changed

- declare the builtin IOR runtime through the package deployment contract
- advertise a provider-neutral Spack resolution when `ior` is unavailable
- preserve visible IOR output while propagating pipeline failures with `pipefail`
- fail the package when any launched process returns nonzero
- include a bounded per-host stdout/stderr excerpt in the lifecycle failure so `ior: command not found` reaches callers

## Why

An agent could select `builtin.ior` without being told that its runtime was unavailable or how to activate an existing provider installation. The package also piped output through `tee` without `pipefail`, so `ior: not found` remained in a log while the execution was incorrectly reported as successful. The corrected boundary reports the missing runtime before execution and returns the real launch diagnostic if the agent ignores that contract.

## Validation

- `uv run pytest -q test/unit/core/test_ior_package_runtime.py test/unit/core/test_ior_delegate.py test/unit/core/test_ior_docker_cluster.py`
- `uv run ruff check builtin/builtin/ior/pkg.py test/unit/core/test_ior_package_runtime.py`
- `uv run ruff format --check builtin/builtin/ior/pkg.py test/unit/core/test_ior_package_runtime.py`
- exact 1.8.1 candidate wheel built from `5e04a1a12f42e4a1aec5cfbc33fa1894bc1cf405`, SHA-256 `c1a8cfdd10b5d0d92c138fe2a5687da77fc1e99944053b84e3bf86e9bb5cf426`
- real CLIO Kit `jarvis_describe(builtin.ior)` integration test passes when pinned only to that candidate wheel

Full released-wheel Relay validation on Ares remains a release gate. GitHub Actions is presently affected by the public Actions outage; platform setup failures do not execute repository code.