### PR TITLE
feat: host_pkgs prerequisite checks + green CI for the perf-eval pipelines

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,10 +40,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Apptainer
 # -----------------------------------------------------------------------
 ARG APPTAINER_VERSION=1.4.1
-RUN wget -qO /tmp/apptainer.deb \
+RUN apt-get update \
+    && wget -qO /tmp/apptainer.deb \
         "https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VERSION}/apptainer_${APPTAINER_VERSION}_amd64.deb" \
     && apt-get install -y /tmp/apptainer.deb \
-    && rm /tmp/apptainer.deb
+    && rm /tmp/apptainer.deb \
+    && rm -rf /var/lib/apt/lists/*
 
 # -----------------------------------------------------------------------
 # SSH server setup (required by jarvis multi-node tests)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,6 +38,7 @@
   "forwardPorts": [2222],
 
   "remoteEnv": {
-    "PYTHONPATH": "${containerWorkspaceFolder}"
+    "PYTHONPATH": "${containerWorkspaceFolder}",
+    "IS_SANDBOX": "1"
   }
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,3 +44,35 @@ jobs:
         with:
           files: coverage.xml
           fail_ci_if_error: false
+
+  # Exercises the `host_pkgs` prerequisite check on a host that is missing
+  # the prerequisite. Runs inside a bare ubuntu container precisely because
+  # that container has no spack and no apptainer: the example pipeline is a
+  # containerized apptainer pipeline whose SIF build needs apptainer on the
+  # *host*, so this is the real "declared but not installed" case rather
+  # than a simulated one.
+  host-pkgs:
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:24.04
+
+    steps:
+      - name: Install container prerequisites
+        # The bare image has no git/python, and actions/checkout needs git.
+        run: |
+          apt-get update -y
+          apt-get install -y --no-install-recommends \
+            git python3 python3-pip python3-venv ca-certificates
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Jarvis
+        # PEP 668 marks the distro interpreter as externally managed; this
+        # throwaway container is the environment, so install into it.
+        run: pip3 install --break-system-packages -e .
+
+      - name: Verify host_pkgs check catches missing spack apptainer
+        run: bash ci/test_host_pkgs.sh

--- a/builtin/builtin/arldm/pkg.py
+++ b/builtin/builtin/arldm/pkg.py
@@ -147,4 +147,4 @@ class Arldm(Application):
         pass
 
     def _get_stat(self, stat_dict):
-        stat_dict[f'{self.pkg_id}.runtime'] = self.start_time
+        stat_dict[f'{self.pkg_id}.runtime'] = self.runtime

--- a/builtin/builtin/cm1/pkg.py
+++ b/builtin/builtin/cm1/pkg.py
@@ -169,4 +169,4 @@ class Cm1(Application):
         pass
 
     def _get_stat(self, stat_dict):
-        stat_dict[f'{self.pkg_id}.runtime'] = self.start_time
+        stat_dict[f'{self.pkg_id}.runtime'] = self.runtime

--- a/builtin/builtin/filebench/pkg.py
+++ b/builtin/builtin/filebench/pkg.py
@@ -151,4 +151,4 @@ class Filebench(Application):
         Rm(self.config['dir'], self._exec_info()).run()
 
     def _get_stat(self, stat_dict):
-        stat_dict[f'{self.pkg_id}.runtime'] = self.start_time
+        stat_dict[f'{self.pkg_id}.runtime'] = self.runtime

--- a/builtin/builtin/fio/pkg.py
+++ b/builtin/builtin/fio/pkg.py
@@ -127,4 +127,4 @@ class Fio(Application):
         Rm(self.config['out'] + '*', self._exec_info()).run()
 
     def _get_stat(self, stat_dict):
-        stat_dict[f'{self.pkg_id}.runtime'] = self.start_time
+        stat_dict[f'{self.pkg_id}.runtime'] = self.runtime

--- a/builtin/builtin/gadget2/pkg.py
+++ b/builtin/builtin/gadget2/pkg.py
@@ -183,4 +183,4 @@ class Gadget2(Application):
         pass
 
     def _get_stat(self, stat_dict):
-        stat_dict[f'{self.pkg_id}.runtime'] = self.start_time
+        stat_dict[f'{self.pkg_id}.runtime'] = self.runtime

--- a/builtin/builtin/ior/README.md
+++ b/builtin/builtin/ior/README.md
@@ -59,3 +59,22 @@ Clean produced data
 ```bash
 jarvis pipeline clean
 ```
+## Performance evaluation options
+
+- `num_nodes` (default `0` = all hosts) — launch on the first N hosts of the
+  pipeline hostfile. Enables node-count sweeps ({1,2,4} nodes) inside one
+  allocation without changing the pipeline hostfile.
+- `single_instance` (default `false`) — pin ior to the FIRST host: the
+  single-client baseline (e.g. NFS) on multi-node pipelines. Applied after
+  `num_nodes` subsetting (it wins in the degenerate combination).
+- `stonewall` (default `0` = off) — ior `-D <seconds>`: cap each write/read
+  phase at a fixed number of seconds.
+- `log` defaults to `<shared_dir>/ior.log`. Pipelines with MORE THAN ONE ior
+  package must set a distinct `log:` per package or their stats overwrite
+  each other.
+
+In containerized pipelines (`base_deploy_mode: container` + a prebuilt SIF)
+ior and mpiexec come from the image and run inside the per-node apptainer
+instance; multi-node ranks spawn over the instance sshd on
+`container_ssh_port`. The package passes an inline `--host` list in container
+mode so the hostfile file itself need not be visible inside the instance.

--- a/builtin/builtin/ior/pkg.py
+++ b/builtin/builtin/ior/pkg.py
@@ -10,6 +10,8 @@ import re
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.shell import Exec, MpiExecInfo, PsshExecInfo, Rm, Mkdir
 from jarvis_cd.shell.process import GdbServer
+from jarvis_cd.util.container_utils import (
+    container_kwargs, eff_hostfile, single_instance_menu_opt)
 
 
 class Ior(Application):
@@ -104,7 +106,28 @@ class Ior(Application):
                 'msg': 'Use direct I/O (O_DIRECT) for POSIX API, bypassing I/O buffers',
                 'type': bool,
                 'default': False,
-            }
+            },
+            {
+                'name': 'num_nodes',
+                'msg': 'Number of nodes to launch on (first N hosts of the '
+                       'pipeline hostfile). 0 means all hosts. Enables '
+                       'node-count sweeps inside one allocation without '
+                       'changing the pipeline hostfile.',
+                'type': int,
+                'default': 0,
+            },
+            {
+                'name': 'stonewall',
+                'msg': 'Stonewalling deadline in seconds (ior -D): cap each '
+                       'write/read phase at this many seconds. 0 disables.',
+                'type': int,
+                'default': 0,
+            },
+            single_instance_menu_opt(
+                msg='Pin ior to the FIRST host even when the pipeline '
+                    'hostfile has >1 host - the single-client baseline '
+                    '(e.g. NFS) on multi-node pipelines. Applied after '
+                    'num_nodes subsetting.'),
         ]
 
     # ------------------------------------------------------------------
@@ -166,9 +189,49 @@ class Ior(Application):
     # Lifecycle
     # ------------------------------------------------------------------
 
+    def _eff_hostfile(self):
+        """The hostfile this ior run actually launches on.
+
+        Order matters: ``num_nodes`` subsets to the first N hosts (the
+        node-count sweep axis), then the ``single_instance`` collapse pins
+        to host[0] (the single-client baseline; it wins in the degenerate
+        combination). In container mode the result is stripped of its
+        backing file path so mpiexec (running inside the instance) gets an
+        inline ``--host`` list instead of a path the instance may not see.
+        """
+        hf = self.hostfile
+        if hf is not None and self.config.get('num_nodes', 0) > 0:
+            hf = hf.subset(self.config['num_nodes'])
+        hf = eff_hostfile(self, hostfile=hf)
+        if (hf is not None and hf.path is not None
+                and self._container_engine != 'none'):
+            hf = hf.copy()
+        return hf
+
     def start(self):
         """Launch IOR via MpiExecInfo; Exec handles container wrapping transparently."""
         cfg = self.config
+
+        # Stale-log guard: a partial/failed run must never report the
+        # previous combo's bandwidths. shared_dir is bound at an identical
+        # path in the container, so a host-side remove is sufficient.
+        log_path = cfg.get('log')
+        if log_path and os.path.isfile(log_path):
+            try:
+                os.remove(log_path)
+            except OSError:
+                pass
+
+        hostfile = self._eff_hostfile()
+
+        # Ensure the output parent dir exists in the deployment context:
+        # inside the container instance when containerized (the path may be
+        # an in-container-only mount), a harmless mkdir -p bare-metal.
+        out = os.path.expandvars(cfg['out'])
+        parent_dir = str(pathlib.Path(out).parent)
+        Mkdir(parent_dir,
+              PsshExecInfo(env=self.mod_env, hostfile=hostfile,
+                           **container_kwargs(self))).run()
 
         cmd = [
             'ior',
@@ -188,6 +251,8 @@ class Ior(Application):
             cmd.append(f'-i {cfg["reps"]}')
         if cfg.get('direct'):
             cmd.append('-O useO_DIRECT=1')
+        if cfg.get('stonewall', 0) > 0:
+            cmd.append(f'-D {cfg["stonewall"]}')
 
         ior_cmd = ' '.join(cmd)
         if cfg.get('log'):
@@ -201,14 +266,56 @@ class Ior(Application):
         Exec(cmd_list, MpiExecInfo(
             nprocs=cfg['nprocs'],
             ppn=cfg['ppn'],
-            hostfile=self.hostfile,
+            hostfile=hostfile,
             port=self.ssh_port,
-            container=self._container_engine,
-            container_image=self.deploy_image_name(),
-            shared_dir=self.shared_dir,
-            private_dir=self.private_dir,
             env=self.mod_env,
+            **container_kwargs(self),
         )).run()
+
+        # Fail loudly on a silent MPI/ior failure. A hard mpiexec abort
+        # (e.g. "PRTE has lost communication with a remote daemon" when the
+        # cross-node spawn fails) or an ior that never reached its results
+        # block leaves no summary in the log, yet Exec does not always raise.
+        # Without this gate the pipeline marks the combination success with
+        # blank bandwidths -- a false green that would let a daily regression
+        # report healthy while multi-node is broken.
+        self._assert_ior_completed()
+
+    def _assert_ior_completed(self):
+        """Raise if the just-finished ior run produced no results summary.
+
+        Reads the log (same file _get_stat parses) and requires a Max
+        Write/Read line for each requested operation. A missing summary
+        means ior aborted or never ran the measured I/O -- surface it as a
+        failed combination instead of a success with empty stats.
+        """
+        wrote = self.config.get('write', True)
+        read = self.config.get('read', False)
+        if not wrote and not read:
+            return  # no workload requested; nothing to validate
+
+        log_path = self.config.get('log')
+        text = ''
+        if log_path and os.path.isfile(log_path):
+            try:
+                with open(log_path, 'r') as f:
+                    text = f.read()
+            except OSError:
+                text = ''
+        stats = self.parse_log(text)
+
+        missing = []
+        if wrote and f'{self.pkg_id}.write_max_mibs' not in stats:
+            missing.append('write')
+        if read and f'{self.pkg_id}.read_max_mibs' not in stats:
+            missing.append('read')
+        if missing:
+            raise RuntimeError(
+                f'ior[{self.pkg_id}]: no IOR {"/".join(missing)} summary in '
+                f'{log_path!r} -- the run failed (mpiexec abort or no '
+                f'cross-node spawn) and produced no bandwidth. Failing this '
+                f'combination rather than reporting a false success; inspect '
+                f'the log for the mpiexec/PRTE error.')
 
     def stop(self):
         """Stop IOR (no-op — IOR runs to completion)."""
@@ -218,7 +325,8 @@ class Ior(Application):
         """Remove IOR output files."""
         Rm(self.config['out'] + '*',
            PsshExecInfo(env=self.env,
-                        hostfile=self.hostfile)).run()
+                        hostfile=self._eff_hostfile(),
+                        **container_kwargs(self))).run()
 
     # ------------------------------------------------------------------
     # Output parsing
@@ -280,7 +388,7 @@ class Ior(Application):
         by ``_configure``) and adds Max/Min/Mean/StdDev MiB/sec entries
         per operation. Missing or unparseable log → only runtime is set.
         """
-        stat_dict[f'{self.pkg_id}.runtime'] = getattr(self, 'start_time', None)
+        stat_dict[f'{self.pkg_id}.runtime'] = self.runtime
 
         log_path = self.config.get('log')
         if not log_path or not os.path.isfile(log_path):

--- a/builtin/builtin/juicefs/Dockerfile.deploy
+++ b/builtin/builtin/juicefs/Dockerfile.deploy
@@ -1,0 +1,17 @@
+FROM ##DEPLOY_BASE##
+
+# JuiceFS ships as a single static binary (no apt package); fuse3 provides
+# the FUSE userspace the mount needs. Version is inlined (not an ARG) so the
+# content also converts cleanly on the apptainer-native build path.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        fuse3 libfuse3-3 \
+        curl ca-certificates \
+        openssh-server openssh-client \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/run/sshd \
+    && curl -fsSL "https://github.com/juicedata/juicefs/releases/download/v1.2.3/juicefs-1.2.3-linux-amd64.tar.gz" \
+       | tar -xz -C /usr/local/bin juicefs \
+    && juicefs version
+
+EXPOSE 22
+CMD ["/bin/bash"]

--- a/builtin/builtin/juicefs/README.md
+++ b/builtin/builtin/juicefs/README.md
@@ -1,0 +1,56 @@
+JuiceFS is a POSIX-compatible distributed filesystem: file data lives in an
+object store, file metadata in a transactional engine (here Redis).
+
+# Installation
+
+JuiceFS ships as a single static binary:
+
+```bash
+curl -fsSL https://github.com/juicedata/juicefs/releases/download/v1.2.3/juicefs-1.2.3-linux-amd64.tar.gz \
+  | tar -xz -C /usr/local/bin juicefs
+```
+
+# Juicefs
+
+Formats a JuiceFS volume (idempotent) and FUSE-mounts it in `start`;
+unmounts in `stop`; removes the local cache/bucket dirs in `clean`.
+
+The expected pipeline order is `redis -> juicefs -> <benchmark driver>` so
+the Redis metadata engine accepts connections before `juicefs format` runs.
+Pair it with `builtin.redis` (use redis `single_instance: true` on
+multi-node pipelines — the default `meta_url` selects DB 1, which cluster
+mode cannot serve).
+
+## Options
+
+- `meta_url` (default `redis://127.0.0.1:6379/1`) — metadata engine URL
+- `meta_use_head` (default `false`) — rewrite `meta_url`'s host to the
+  pipeline hostfile's FIRST host at start. For multi-node pipelines where
+  every node mounts JuiceFS but redis is head-pinned (`single_instance`):
+  keep the loopback `meta_url` and set this true (redis must accept
+  non-loopback connections; the shipped `redis.conf` binds `0.0.0.0`)
+- `storage` (default `file`) — object backend: `file` (local dir) or `gs`
+- `bucket` — bucket URL for non-file storage (e.g. `gs://my-bucket`)
+- `gcs_credentials` — path to a GCS service-account JSON key; exported as
+  `GOOGLE_APPLICATION_CREDENTIALS` at start/stop, never stored in config
+- `data_dir` (default `${HOME}/juicefs_data`) — local object-store dir
+  (`--bucket` when `storage=file`)
+- `mountpoint` (default `${HOME}/juicefs_mnt`) — FUSE mountpoint
+- `name` (default `jfsbench`) — volume name passed to `juicefs format`
+- `cache_dir` / `cache_size_mb` (default 512) — local cache; JuiceFS's own
+  default cap is 100 GiB, which can ENOSPC a small node-local scratch
+- `format_fresh` (default true) — wipe the local bucket dir before format
+  (`storage=file` only; never wipes a cloud bucket)
+- `mount_wait` (default 20) — seconds to wait for mount readiness
+- `extra_mount_opts` — appended verbatim to `juicefs mount`
+- `single_instance` (default false) — pin format/mount to the FIRST host on
+  a multi-node hostfile (JuiceFS here is a head-node-only mount whose redis
+  metadata lives on the head node)
+
+## Container deploys
+
+All lifecycle commands are container-wrapped via
+`jarvis_cd.util.container_utils`, so the FUSE mount lives in the pipeline's
+apptainer/container instance namespace and directory setup happens there
+too (host-side `os.makedirs` of in-container paths would fail). Rootless
+apptainer needs `container_fakeroot: true` at the pipeline level for FUSE.

--- a/builtin/builtin/juicefs/pkg.py
+++ b/builtin/builtin/juicefs/pkg.py
@@ -1,0 +1,402 @@
+"""
+This module provides classes and methods to deploy JuiceFS as a Jarvis
+service package.
+
+JuiceFS is a POSIX-compatible distributed filesystem that stores file
+*data* in an object store (here a local directory via ``--storage file``)
+and file *metadata* in a transactional engine (here Redis). This package
+formats the filesystem once, mounts it via FUSE, and unmounts it on stop --
+mirroring the lifecycle style of the ``redis`` service package.
+
+The expected deployment order is: redis -> juicefs -> <benchmark driver>,
+so the Redis metadata engine is already accepting connections before
+``juicefs format`` runs.
+"""
+import os
+import time
+import urllib.parse
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.util.logger import Color
+from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
+from jarvis_cd.util.container_utils import (
+    container_kwargs, flatten_stdout, eff_hostfile, single_instance_menu_opt)
+
+
+class Juicefs(Application):
+    """
+    Format and FUSE-mount a JuiceFS filesystem (Redis metadata +
+    local-file object backend) for single-node benchmarking.
+    """
+
+    def _init(self):
+        """
+        Initialize paths. Concrete (env-expanded) paths are resolved in
+        ``_configure`` and recomputed on demand via ``_paths``.
+        """
+        pass
+
+    def _configure_menu(self):
+        """
+        Create a CLI menu for the configurator method.
+
+        :return: List(dict)
+        """
+        return [
+            {
+                'name': 'meta_url',
+                'msg': 'Metadata engine URL (Redis) for format/mount',
+                'type': str,
+                'default': 'redis://127.0.0.1:6379/1',
+            },
+            {
+                'name': 'meta_use_head',
+                'msg': 'Rewrite meta_url\'s host to the pipeline hostfile\'s '
+                       'FIRST host at start. Use on multi-node pipelines '
+                       'where every node mounts JuiceFS but the Redis '
+                       'metadata store is pinned to the head node '
+                       '(single_instance redis): keep meta_url on '
+                       '127.0.0.1 and set this true.',
+                'type': bool,
+                'default': False,
+            },
+            {
+                'name': 'storage',
+                'msg': "Object storage backend type ('file' local dir, or 'gs' for Google Cloud Storage)",
+                'type': str,
+                'default': 'file',
+            },
+            {
+                'name': 'bucket',
+                'msg': "Object bucket URL for non-file storage, e.g. gs://my-bucket (required when storage='gs')",
+                'type': str,
+                'default': '',
+            },
+            {
+                'name': 'gcs_credentials',
+                'msg': 'Path to a GCS service-account JSON key (exported as GOOGLE_APPLICATION_CREDENTIALS; never stored in config)',
+                'type': str,
+                'default': '',
+            },
+            {
+                'name': 'data_dir',
+                'msg': "Local object-store dir (used as --bucket only when storage='file')",
+                'type': str,
+                'default': '${HOME}/juicefs_data',
+            },
+            {
+                'name': 'mountpoint',
+                'msg': 'FUSE mountpoint directory',
+                'type': str,
+                'default': '${HOME}/juicefs_mnt',
+            },
+            {
+                'name': 'name',
+                'msg': 'JuiceFS volume name (passed to juicefs format)',
+                'type': str,
+                'default': 'jfsbench',
+            },
+            {
+                'name': 'cache_dir',
+                'msg': 'Local cache directory for the mount',
+                'type': str,
+                'default': '${HOME}/juicefs_cache',
+            },
+            {
+                'name': 'cache_size_mb',
+                'msg': 'Local cache size cap in MiB (juicefs --cache-size). '
+                       'JuiceFS defaults to 100 GiB, which can exhaust a small '
+                       'node-local scratch device; bound it well under free '
+                       'space on the cache_dir filesystem.',
+                'type': int,
+                'default': 512,
+            },
+            {
+                'name': 'juicefs_bin',
+                'msg': 'Path to the juicefs binary',
+                'type': str,
+                'default': 'juicefs',
+            },
+            {
+                'name': 'format_fresh',
+                'msg': "Wipe the local bucket dir before formatting (storage='file' only; no-op for cloud)",
+                'type': bool,
+                'default': True,
+            },
+            {
+                'name': 'mount_wait',
+                'msg': 'Seconds to wait for the mount to become ready',
+                'type': int,
+                'default': 20,
+            },
+            {
+                'name': 'extra_mount_opts',
+                'msg': 'Extra options appended to juicefs mount',
+                'type': str,
+                'default': '',
+            },
+            # Head-node-only pinning: JuiceFS is a single mount here (its redis
+            # metadata store lives only on the first host), so on a multi-node
+            # pipeline it must NOT fan format/mount/rm out to every node.
+            single_instance_menu_opt(),
+        ]
+
+    def _build_deploy_phase(self):
+        if self.config.get('deploy_mode') != 'container':
+            return None
+        base = getattr(self.pipeline, 'container_base', 'ubuntu:24.04')
+        content = self._read_dockerfile('Dockerfile.deploy', {
+            'DEPLOY_BASE': base,
+        })
+        return content, 'default'
+
+    def _paths(self):
+        """
+        Resolve env-expanded, user-expanded absolute paths from config.
+
+        :return: tuple(data_dir, mountpoint, cache_dir)
+        """
+        def fix(p):
+            return os.path.expanduser(os.path.expandvars(str(p)))
+        return (fix(self.config['data_dir']),
+                fix(self.config['mountpoint']),
+                fix(self.config['cache_dir']))
+
+    def _effective_meta_url(self):
+        """
+        ``meta_url``, with its host swapped to the pipeline hostfile's FIRST
+        host when ``meta_use_head`` is set. Lets a multi-node YAML keep the
+        loopback default while the head-pinned (single_instance) redis serves
+        metadata to JuiceFS mounts on every node. Credentials and port in the
+        URL are preserved; only the hostname changes.
+
+        :return: str (the meta URL to pass to juicefs format/mount)
+        """
+        meta_url = self.config['meta_url']
+        if not self.config.get('meta_use_head'):
+            return meta_url
+        hf = self.hostfile
+        if hf is None or not hf.hosts:
+            return meta_url
+        parsed = urllib.parse.urlsplit(meta_url)
+        if not parsed.netloc:
+            return meta_url
+        creds, sep, hostport = parsed.netloc.rpartition('@')
+        _, colon, port = hostport.partition(':')
+        new_netloc = f'{creds}{sep}{hf.hosts[0]}{colon}{port}'
+        return urllib.parse.urlunsplit(parsed._replace(netloc=new_netloc))
+
+    def _bucket_arg(self):
+        """
+        The value passed to ``juicefs format --bucket``. For storage='file'
+        this is the local data_dir; for cloud backends (e.g. 'gs') it is the
+        configured bucket URL (gs://...).
+
+        :return: str
+        """
+        if self.config['storage'] == 'file':
+            data_dir, _, _ = self._paths()
+            return data_dir
+        return str(self.config['bucket'])
+
+    def _inject_cloud_env(self):
+        """
+        Populate ``self.mod_env`` with object-store credentials for the
+        spawned juicefs subprocesses. Secrets are never read from config: the
+        JSON key stays on disk and only its *path* (``gcs_credentials``) is
+        turned into ``GOOGLE_APPLICATION_CREDENTIALS``. Any ``GCS_*`` already
+        in the parent environment is passed through verbatim (env-based
+        credential chain).
+
+        Must run in ``start``/``stop`` -- ``_configure`` runs in a separate
+        process, so mod_env mutations there would not survive to the Exec
+        (the pipeline rebuilds mod_env from the persisted env each invocation).
+
+        :return: None
+        """
+        if self.config['storage'] != 'gs':
+            return
+        cred = os.path.expanduser(os.path.expandvars(
+            str(self.config.get('gcs_credentials', ''))))
+        if cred:
+            self.mod_env['GOOGLE_APPLICATION_CREDENTIALS'] = cred
+        # Pass through pre-set GCS_* (e.g. a short-lived GCS_ACCESS_TOKEN, or
+        # GCS_PROJECT_ID) that the env allowlist would otherwise drop.
+        for key in ('GCS_ACCESS_TOKEN', 'GCS_PROJECT_ID'):
+            if key not in self.mod_env and key in os.environ:
+                self.mod_env[key] = os.environ[key]
+
+    def _configure(self, **kwargs):
+        """
+        Validate config. The mount/cache/bucket directories are NOT created
+        here: ``_configure`` runs host-side in the jarvis process BEFORE the
+        apptainer instance exists, so a host ``os.makedirs`` of an in-container
+        path like ``/mnt/jfs_mnt`` would hit the host's root-owned ``/mnt`` and
+        fail (Errno 13). The dirs are instead created in ``start`` via a
+        (container-wrapped) Exec. Harmless host mkdir in a bare-metal deploy.
+
+        :param kwargs: Configuration parameters for this pkg.
+        :return: None
+        """
+        if not self.config['meta_url']:
+            raise ValueError('juicefs: meta_url must be set')
+
+        storage = self.config['storage']
+        if storage == 'gs':
+            if not str(self.config.get('bucket', '')).startswith('gs://'):
+                raise ValueError(
+                    "juicefs: storage='gs' requires bucket=gs://<bucket>")
+            if not str(self.config.get('gcs_credentials', '')) \
+                    and 'GCS_ACCESS_TOKEN' not in os.environ:
+                self.log("juicefs: storage='gs' with no gcs_credentials and no "
+                         "GCS_ACCESS_TOKEN; relying on Google's ADC chain (e.g. "
+                         "`gcloud auth application-default login`, or a GCE "
+                         "attached service account). Valid if ADC is configured; "
+                         "fails only if the chain resolves no credentials.",
+                         color=Color.YELLOW)
+        elif storage != 'file':
+            self.log(f"juicefs: storage='{storage}' is configured but only "
+                     f"'file' and 'gs' are exercised by this package",
+                     color=Color.YELLOW)
+
+    def _is_mounted(self, mountpoint):
+        """
+        Report whether ``mountpoint`` has a filesystem mounted *in the
+        deployment context* (the apptainer instance's mount namespace for a
+        container deploy, or the host for bare-metal). Uses a container-wrapped
+        Exec probe rather than host-side ``os.path.ismount``: the JuiceFS FUSE
+        mount lives inside the instance, which the host can't see.
+
+        :param mountpoint: Absolute mountpoint path.
+        :return: bool
+        """
+        probe = Exec(
+            f'mountpoint -q {mountpoint} && echo __JFS_MOUNTED__ || true',
+            PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                         collect_output=True, **container_kwargs(self))).run()
+        return '__JFS_MOUNTED__' in flatten_stdout(probe)
+
+    def start(self):
+        """
+        Format (idempotent) and FUSE-mount the JuiceFS filesystem, then
+        block until the mount is ready.
+
+        :return: None
+        """
+        jfs = self.config['juicefs_bin']
+        data_dir, mountpoint, cache_dir = self._paths()
+        meta_url = self._effective_meta_url()
+
+        # Make object-store credentials available to BOTH subprocesses below
+        # (same process as the Exec -- see _inject_cloud_env docstring).
+        self._inject_cloud_env()
+
+        # Create the mount/cache (and, for storage='file', bucket) dirs in the
+        # deployment context. Under a non-setuid apptainer these are container
+        # paths (e.g. /mnt/jfs_mnt), so they must be made via a container-wrapped
+        # Exec, NOT host-side os.makedirs (which would hit the host's root-owned
+        # /mnt). Bare-metal: a harmless local mkdir -p.
+        mkdirs = [mountpoint, cache_dir]
+        if self.config['storage'] == 'file':
+            mkdirs.append(data_dir)
+        Exec(f'mkdir -p {" ".join(mkdirs)}',
+             PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+
+        # Fresh slate: drop any orphaned chunks from a previous run. This is a
+        # LOCAL operation, only meaningful for storage='file' (the Redis
+        # metadata is wiped per-run by the redis package, so stale chunks here
+        # would only be dead bytes). For cloud backends, wiping the bucket is
+        # destructive re-init and is out of scope -- log and skip.
+        if self.config['format_fresh']:
+            if self.config['storage'] == 'file':
+                self.log(f'Clearing bucket dir {data_dir}', color=Color.YELLOW)
+                # Container-wrapped (see mkdir rationale above): host-side
+                # shutil.rmtree on /mnt/jfs_data would fail / hit the wrong fs.
+                Exec(f'rm -rf {data_dir} && mkdir -p {data_dir}',
+                     PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+            else:
+                self.log(f"format_fresh: skipping bucket wipe for "
+                         f"storage='{self.config['storage']}' (no-op; "
+                         f"destructive bucket re-init is out of scope)",
+                         color=Color.YELLOW)
+
+        # Format the volume (safe to re-run against fresh metadata).
+        fmt = [
+            jfs, 'format',
+            '--storage', self.config['storage'],
+            '--bucket', self._bucket_arg(),
+            meta_url,
+            self.config['name'],
+        ]
+        self.log(f"Formatting JuiceFS: {' '.join(fmt)}", color=Color.YELLOW)
+        Exec(' '.join(fmt), PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+
+        # Mount via FUSE. --background daemonizes and returns once the
+        # mount is registered.
+        mnt = [
+            jfs, 'mount',
+            meta_url,
+            mountpoint,
+            '--cache-dir', cache_dir,
+            # Cap the local cache: JuiceFS defaults to 100 GiB, which can fill a
+            # small node-local scratch device (e.g. a compute-node /tmp on a
+            # ~2 GiB-free root fs) and tip a high-thread combo into ENOSPC.
+            '--cache-size', str(self.config['cache_size_mb']),
+            '--background',
+        ]
+        if self.config['extra_mount_opts']:
+            mnt.append(self.config['extra_mount_opts'])
+        self.log(f"Mounting JuiceFS: {' '.join(mnt)}", color=Color.YELLOW)
+        Exec(' '.join(mnt), PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+
+        # Wait for the mount to actually be ready before downstream I/O.
+        deadline = int(self.config['mount_wait'])
+        for _ in range(deadline):
+            if self._is_mounted(mountpoint):
+                self.log(f'JuiceFS mounted at {mountpoint}', color=Color.GREEN)
+                return
+            time.sleep(1)
+        raise RuntimeError(
+            f'juicefs: mountpoint {mountpoint} not ready after '
+            f'{deadline}s (check redis connectivity and /dev/fuse access)')
+
+    def stop(self):
+        """
+        Unmount the JuiceFS filesystem.
+
+        :return: None
+        """
+        _, mountpoint, _ = self._paths()
+        jfs = self.config['juicefs_bin']
+        Exec(f'{jfs} umount {mountpoint}',
+             PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+        # Fallback for a wedged mount; ignore failure if already gone.
+        if self._is_mounted(mountpoint):
+            Exec(f'fusermount -u {mountpoint}',
+                 PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()
+
+    def clean(self):
+        """
+        Unmount (if needed) and delete the local cache (and, for
+        storage='file', the local bucket) directories. A cloud bucket is
+        never deleted here -- teardown is left to the storage provider /
+        its lifecycle rules.
+
+        :return: None
+        """
+        data_dir, mountpoint, cache_dir = self._paths()
+        if self._is_mounted(mountpoint):
+            self.stop()
+        dirs = [cache_dir]
+        if self.config['storage'] == 'file':
+            dirs.append(data_dir)
+        # Container-wrapped removal (see start()'s mkdir rationale): host-side
+        # shutil.rmtree can't reach the in-container paths.
+        Exec(f'rm -rf {" ".join(dirs)}',
+             PsshExecInfo(env=self.mod_env, hostfile=eff_hostfile(self),
+                          **container_kwargs(self))).run()

--- a/builtin/builtin/redis-benchmark/README.md
+++ b/builtin/builtin/redis-benchmark/README.md
@@ -5,3 +5,19 @@ LabStor is a distributed semi-microkernel for building data processing services.
 ```bash
 spack install redis
 ```
+
+## Performance evaluation options
+
+- `clients` (default `50` = tool default) — parallel client connections
+  (`-c`). For a "threads" sweep, zip with `nthreads` so a row means N
+  connections driven by N threads.
+- `nthreads` — I/O-issuing threads (`--threads`); `count` — total requests
+  (`-n`); `req_size` — request size in integer bytes (`-d`).
+- `single_instance` (default `false`) — run the benchmark on the FIRST host
+  (next to a head-pinned `single_instance` redis) and skip cluster
+  addressing.
+
+Output is captured with `--csv` (replacing the human-readable report) and
+teed to `<shared_dir>/<pkg_id>_redis_bench.csv`. results.csv columns:
+`{pkg_id}.set_rps`, `.get_rps`, `.set_p50_ms`, `.get_p50_ms`, `.set_p99_ms`,
+`.get_p99_ms`, `.runtime`.

--- a/builtin/builtin/redis-benchmark/pkg.py
+++ b/builtin/builtin/redis-benchmark/pkg.py
@@ -1,13 +1,22 @@
 """
 This module provides classes and methods to launch the Redis benchmark tool.
 """
+import csv
+import io
+import os
 from jarvis_cd.core.pkg import Application
 from jarvis_cd.shell import Exec, LocalExecInfo
+from jarvis_cd.util.container_utils import (
+    container_kwargs, eff_hostfile, single_instance_menu_opt)
 
 
 class RedisBenchmark(Application):
     """
     Redis benchmark — supports default (host) and container deployment modes.
+
+    Output is captured in ``--csv`` mode (one row per test with rps and
+    latency percentiles) and teed to ``<shared_dir>/<pkg_id>_redis_bench.csv``
+    so ``_get_stat`` can populate results.csv columns from disk.
     """
 
     def _configure_menu(self):
@@ -20,7 +29,7 @@ class RedisBenchmark(Application):
             },
             {
                 'name': 'count',
-                'msg': 'Number of requests to generate',
+                'msg': 'Number of requests to generate (-n)',
                 'type': int,
                 'default': 100000,
             },
@@ -38,19 +47,28 @@ class RedisBenchmark(Application):
             },
             {
                 'name': 'nthreads',
-                'msg': 'Number of threads',
+                'msg': 'Number of I/O-issuing threads (--threads)',
                 'type': int,
                 'default': 1,
             },
             {
+                'name': 'clients',
+                'msg': 'Number of parallel client connections (-c). 50 is '
+                       'the tool default. For a "threads" sweep, zip this '
+                       'with nthreads so a row means N connections driven '
+                       'by N threads.',
+                'type': int,
+                'default': 50,
+            },
+            {
                 'name': 'pipeline',
-                'msg': 'Number of requests to pipeline',
+                'msg': 'Number of requests to pipeline (-P)',
                 'type': int,
                 'default': 1,
             },
             {
                 'name': 'req_size',
-                'msg': 'Size of requests in bytes',
+                'msg': 'Size of requests in bytes (-d, integer bytes)',
                 'type': int,
                 'default': 3,
             },
@@ -60,6 +78,11 @@ class RedisBenchmark(Application):
                 'type': int,
                 'default': 0,
             },
+            single_instance_menu_opt(
+                msg='Run the benchmark on the FIRST host (next to a '
+                    'single_instance redis) instead of the driver node, '
+                    'and skip cluster addressing. For multi-node '
+                    'pipelines with a head-pinned standalone redis.'),
         ]
 
     def _build_deploy_phase(self):
@@ -74,8 +97,22 @@ class RedisBenchmark(Application):
     def _configure(self, **kwargs):
         super()._configure(**kwargs)
 
+    def _csv_path(self):
+        """Where the raw ``--csv`` output lands (shared_dir is bound at an
+        identical path inside the container, so host-side reads work)."""
+        return os.path.join(self.shared_dir,
+                            f'{self.pkg_id}_redis_bench.csv')
+
     def start(self):
-        hostfile = self.hostfile
+        # Stale-output guard: a failed run must not report the previous
+        # combo's numbers.
+        csv_path = self._csv_path()
+        if os.path.isfile(csv_path):
+            try:
+                os.remove(csv_path)
+            except OSError:
+                pass
+
         bench_type = ','.join(filter(None, [
             'set' if self.config.get('write', True) else '',
             'get' if self.config.get('read', True) else '',
@@ -86,22 +123,107 @@ class RedisBenchmark(Application):
             f'-t {bench_type}',
             f'-P {self.config["pipeline"]}',
             f'--threads {self.config["nthreads"]}',
+            f'-c {self.config["clients"]}',
             f'-d {self.config["req_size"]}',
             f'-p {self.config["port"]}',
         ]
-        if len(hostfile) > 1:
-            cmd += [f'-h {hostfile.hosts[self.config["node"]]}', '--cluster']
 
-        Exec(' '.join(cmd), LocalExecInfo(
-            env=self.mod_env,
-            container=self._container_engine,
-            container_image=self.deploy_image_name(),
-            shared_dir=self.shared_dir,
-                private_dir=self.private_dir,
-        )).run()
+        exec_kwargs = dict(env=self.mod_env, **container_kwargs(self))
+        if self.config.get('single_instance'):
+            # Run next to the head-pinned standalone redis (LocalExecInfo
+            # with a remote hostfile promotes to SSH on host[0]); loopback
+            # addressing, no cluster flags.
+            exec_kwargs['hostfile'] = eff_hostfile(self)
+        else:
+            # Legacy behavior: run on the driver node; address a cluster
+            # node explicitly when the pipeline spans hosts.
+            hostfile = self.hostfile
+            if len(hostfile) > 1:
+                cmd += [f'-h {hostfile.hosts[self.config["node"]]}',
+                        '--cluster']
+
+        cmd += ['--csv', f'2>&1 | tee {csv_path}']
+
+        Exec(' '.join(cmd), LocalExecInfo(**exec_kwargs)).run()
 
     def stop(self):
         pass
 
     def clean(self):
-        pass
+        csv_path = self._csv_path()
+        if os.path.isfile(csv_path):
+            try:
+                os.remove(csv_path)
+            except OSError:
+                pass
+
+    # ------------------------------------------------------------------
+    # Output parsing
+    # ------------------------------------------------------------------
+
+    def _parse_output(self, text):
+        """Parse ``redis-benchmark --csv`` output into stat entries.
+
+        Handles the redis 6/7 8-column form
+        (``"test","rps","avg_latency_ms",...,"p50_latency_ms",...``) and
+        falls back to the legacy 2-column ``"test","rps"`` form. Never
+        raises; unparseable text yields an empty dict.
+        """
+        stats = {}
+        prefix = self.pkg_id
+        try:
+            rows = list(csv.reader(io.StringIO(text)))
+        except csv.Error:
+            return stats
+        if not rows:
+            return stats
+
+        header = [h.strip().lower() for h in rows[0]]
+        col = {name: i for i, name in enumerate(header)}
+        # Legacy 2-column output has no header row; detect by first cell.
+        has_header = 'test' in col
+        data_rows = rows[1:] if has_header else rows
+
+        def field(row, name, legacy_idx=None):
+            idx = col.get(name, legacy_idx if not has_header else None)
+            if idx is None or idx >= len(row):
+                return None
+            try:
+                return float(row[idx])
+            except (TypeError, ValueError):
+                return None
+
+        for row in data_rows:
+            if not row:
+                continue
+            test = row[0].strip().strip('"').lower()
+            if test not in ('set', 'get'):
+                continue
+            rps = field(row, 'rps', legacy_idx=1)
+            if rps is not None:
+                stats[f'{prefix}.{test}_rps'] = rps
+            p50 = field(row, 'p50_latency_ms')
+            if p50 is not None:
+                stats[f'{prefix}.{test}_p50_ms'] = p50
+            p99 = field(row, 'p99_latency_ms')
+            if p99 is not None:
+                stats[f'{prefix}.{test}_p99_ms'] = p99
+        return stats
+
+    def _get_stat(self, stat_dict):
+        """Populate ``stat_dict`` from the teed ``--csv`` file on disk.
+
+        Called on a freshly-loaded instance after the run; missing or
+        unparseable file → only runtime is recorded.
+        """
+        stat_dict[f'{self.pkg_id}.runtime'] = self.runtime
+
+        csv_path = self._csv_path()
+        if not os.path.isfile(csv_path):
+            return
+        try:
+            with open(csv_path, 'r') as f:
+                text = f.read()
+        except OSError:
+            return
+        stat_dict.update(self._parse_output(text))

--- a/builtin/builtin/redis/README.md
+++ b/builtin/builtin/redis/README.md
@@ -5,3 +5,40 @@ Redis is a key-value store
 ```bash
 spack install redis
 ```
+
+# Redis
+
+Runs a standalone server on a single-host hostfile, or a redis cluster when
+the hostfile has >1 host.
+
+## Options
+
+- `port` (default 6379)
+- `single_instance` (default false) — force ONE standalone server on the
+  FIRST host even when the hostfile has >1 host, skipping the cluster
+  branch. Use when redis is a metadata singleton: cluster mode is DB0-only,
+  so clients that `SELECT` a non-zero DB (e.g. a JuiceFS `meta_url` of
+  `redis://.../1`) break against a cluster, and N servers sharing one
+  `nodes.conf` on a shared filesystem collide. Default keeps the legacy
+  behaviour (cluster iff >1 host).
+
+## Startup/teardown hardening
+
+- The server runs with `--dir <private_dir>` and any stale `dump.rdb` there
+  is removed pre-launch: redis loads `./dump.rdb` from its CWD at startup,
+  and a stale dump from a prior run (or a newer redis version) either
+  crashes startup ("Can't handle RDB format version N") or leaks old keys.
+  The shipped `redis.conf` also sets `save ""` (no snapshotting — this is
+  an ephemeral service) and `pidfile ""` (`/var/run` is not writable in
+  unprivileged containers; the pidfile is unused since redis is
+  non-daemonized and tracked directly).
+- After launch, `start()` waits for `redis-cli ping` → `PONG` (30 × 1s,
+  warn-only) before returning, so dependent packages don't race a server
+  that is still binding; standalone servers are then `flushall`'d for a
+  fresh slate per run.
+- `stop()` shuts down gracefully (`redis-cli shutdown nosave`), falls back
+  to a force-kill, then waits for the port to be free so a back-to-back
+  restart doesn't race the dying server.
+
+All redis-cli probes run in the deployment context (inside the container
+instance for a container deploy), so `redis-cli` need not exist host-side.

--- a/builtin/builtin/redis/config/redis.conf
+++ b/builtin/builtin/redis/config/redis.conf
@@ -338,7 +338,10 @@ daemonize no
 #
 # Note that on modern Linux systems "/run/redis.pid" is more conforming
 # and should be used instead.
-pidfile /var/run/redis_6379.pid
+# Empty => no pidfile. /var/run is not writable inside the unprivileged
+# apptainer container ("Failed to write PID file: Permission denied"); the pid
+# file is unused here (non-daemonized; jarvis tracks the process directly).
+pidfile ""
 
 # Specify the server verbosity level.
 # This can be one of:
@@ -476,6 +479,12 @@ rdbchecksum yes
 # resharding via MIGRATE, it is temporarily set to 'no' by default.
 #
 # sanitize-dump-payload no
+
+# Disable RDB snapshotting. This is an ephemeral in-memory metadata engine
+# (JuiceFS meta in DB1) + benchmark target (DB0); persistence is undesirable and
+# a stale dump.rdb loaded across runs/sweep-combos leaked 83 keys + old JuiceFS
+# meta. With save "" no dump.rdb is written; the pkg also flushall's on start.
+save ""
 
 # The filename where to dump the DB
 dbfilename dump.rdb

--- a/builtin/builtin/redis/pkg.py
+++ b/builtin/builtin/redis/pkg.py
@@ -2,9 +2,14 @@
 This module provides classes and methods to launch Redis.
 Redis cluster is used if the hostfile has many hosts.
 """
+import time
+
 from jarvis_cd.core.pkg import Service
 from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
 from jarvis_cd.shell.process import Kill
+from jarvis_cd.util.container_utils import (
+    all_hosts_ok, container_kwargs, eff_hostfile, single_instance_menu_opt)
+from jarvis_cd.util.logger import Color
 
 
 class Redis(Service):
@@ -20,6 +25,13 @@ class Redis(Service):
                 'type': int,
                 'default': 6379,
             },
+            single_instance_menu_opt(
+                msg='Force ONE redis server on the first host even when '
+                    'the hostfile has >1 host (skip the cluster branch). '
+                    'Use when redis is a metadata singleton — e.g. '
+                    'JuiceFS meta over redis://.../1, which needs SELECT '
+                    'and so cannot use DB0-only cluster mode. Default '
+                    'keeps the legacy behaviour (cluster iff >1 host).'),
         ]
 
     def _build_deploy_phase(self):
@@ -39,12 +51,50 @@ class Redis(Service):
             {'PORT': self.config['port']},
         )
 
+    def _redis_cli(self, args, expect=None, timeout_s=2):
+        """Run ``redis-cli <args>`` in the deployment context (inside the
+        container instance for a container deploy — redis-cli need not exist
+        host-side). ``timeout N`` bounds each attempt; callers keep their
+        own retry loops.
+
+        :param args: redis-cli argument string (e.g. ``-p 6379 ping``)
+        :param expect: optional substring required in every host's stdout
+        :param timeout_s: per-attempt timeout in seconds
+        :return: True iff every host exited 0 (and printed ``expect``)
+        """
+        res = Exec(f'timeout {timeout_s} redis-cli {args}',
+                   PsshExecInfo(env=self.mod_env,
+                                hostfile=eff_hostfile(self),
+                                collect_output=True,
+                                **container_kwargs(self))).run()
+        return all_hosts_ok(res, expect)
+
     def start(self):
-        hostfile = self.hostfile
-        host_str = ' '.join(f'{h}:{self.config["port"]}' for h in hostfile.hosts)
+        # single_instance pins to the first host (see eff_hostfile), keeping
+        # redis a plain non-cluster server: cluster mode is DB0-only and
+        # breaks clients that SELECT a non-zero DB (e.g. a JuiceFS meta_url
+        # of redis://.../1), and N servers sharing one nodes.conf on a
+        # shared filesystem collide anyway.
+        hostfile = eff_hostfile(self)
+        port = self.config['port']
+        host_str = ' '.join(f'{h}:{port}' for h in hostfile.hosts)
         cluster_config_file = f'{self.private_dir}/nodes.conf'
 
-        cmd = ['redis-server', f'{self.shared_dir}/redis.conf']
+        # Redis loads ./dump.rdb from its working directory at startup. The
+        # conf sets `dir ./`, which resolves to whatever CWD redis starts in —
+        # and a stale dump.rdb left there by a prior run or a newer redis
+        # crashes startup ("Can't handle RDB format version N / Fatal error
+        # loading the DB. Exiting."). Pin --dir to THIS run's private dir and
+        # wipe any leftover dump so startup is clean.
+        Exec(f'rm -f {self.private_dir}/dump.rdb',
+             PsshExecInfo(env=self.mod_env, hostfile=hostfile,
+                          **container_kwargs(self))).run()
+
+        cmd = [
+            'redis-server',
+            f'{self.shared_dir}/redis.conf',
+            f'--dir {self.private_dir}',
+        ]
         if len(hostfile) > 1:
             cmd += [
                 '--cluster-enabled yes',
@@ -56,29 +106,41 @@ class Redis(Service):
             env=self.mod_env,
             hostfile=hostfile,
             exec_async=True,
-            container=self._container_engine,
-            container_image=self.deploy_image_name(),
-            shared_dir=self.shared_dir,
-            private_dir=self.private_dir,
             bind_mounts=self.container_mounts,
+            **container_kwargs(self),
         )).run()
 
         self.sleep()
 
+        # Wait for redis to actually accept connections before dependents
+        # (benchmarks, JuiceFS format) connect. Warn-only: a slow-but-alive
+        # server still comes up; a dead one fails loudly downstream.
+        self.log(f'Waiting for Redis to accept connections on port {port}',
+                 color=Color.YELLOW)
+        for _ in range(30):
+            if self._redis_cli(f'-p {port} ping', expect='PONG'):
+                break
+            time.sleep(1)
+        else:
+            self.log('WARNING: Redis did not respond to PING after 30s',
+                     color=Color.RED)
+
+        # Standalone hygiene — wipe ALL DBs so each run/sweep combo starts
+        # from an empty server, regardless of any dump.rdb a prior run left
+        # behind. The cluster branch below already flushall's per host.
+        if len(hostfile) <= 1:
+            self.log('Flushing all DBs (fresh slate for this run)',
+                     color=Color.YELLOW)
+            self._redis_cli(f'-p {port} flushall', timeout_s=5)
+
         if len(hostfile) > 1:
             for host in hostfile.hosts:
-                Exec(f'redis-cli -p {self.config["port"]} -h {host} flushall',
+                Exec(f'redis-cli -p {port} -h {host} flushall',
                      LocalExecInfo(env=self.mod_env,
-                                   container=self._container_engine,
-                                   container_image=self.deploy_image_name(),
-                                   shared_dir=self.shared_dir,
-                                   private_dir=self.private_dir)).run()
-                Exec(f'redis-cli -p {self.config["port"]} -h {host} cluster reset',
+                                   **container_kwargs(self))).run()
+                Exec(f'redis-cli -p {port} -h {host} cluster reset',
                      LocalExecInfo(env=self.mod_env,
-                                   container=self._container_engine,
-                                   container_image=self.deploy_image_name(),
-                                   shared_dir=self.shared_dir,
-                                   private_dir=self.private_dir)).run()
+                                   **container_kwargs(self))).run()
 
             cmd = ' '.join([
                 'redis-cli',
@@ -88,15 +150,34 @@ class Redis(Service):
             ])
             Exec(cmd, LocalExecInfo(
                 env=self.mod_env,
-                container=self._container_engine,
-                container_image=self.deploy_image_name(),
-                shared_dir=self.shared_dir,
-                private_dir=self.private_dir,
+                **container_kwargs(self),
             )).run()
             self.sleep()
 
     def stop(self):
-        Kill('redis-server', PsshExecInfo(env=self.env, hostfile=self.hostfile)).run()
+        port = self.config['port']
+        hostfile = eff_hostfile(self)
+        # Graceful shutdown via redis-cli on the SAME hosts redis was started
+        # on (single_instance => first host only), else stop tries to reach
+        # servers that were never launched.
+        Exec(f'redis-cli -p {port} shutdown nosave',
+             PsshExecInfo(env=self.mod_env,
+                          hostfile=hostfile,
+                          **container_kwargs(self))).run()
+        # Fallback: force-kill any remaining redis-server processes.
+        Kill('redis-server',
+             PsshExecInfo(env=self.mod_env,
+                          hostfile=hostfile,
+                          **container_kwargs(self))).run()
+        # Wait for the port to be free before returning so the next combo's
+        # server doesn't race a dying one. If the deployment context is
+        # already gone the probe fails -> treated as "port free", the right
+        # best-effort answer at teardown.
+        for _ in range(10):
+            if not self._redis_cli(f'-p {port} ping', expect='PONG'):
+                break
+            time.sleep(1)
+        time.sleep(1)
 
     def clean(self):
         pass

--- a/builtin/builtin/wfcommons/pkg.py
+++ b/builtin/builtin/wfcommons/pkg.py
@@ -264,4 +264,4 @@ class Wfcommons(Application):
     def _get_stat(self, stat_dict):
         stat_dict[f'{self.pkg_id}.recipe'] = self.config['recipe']
         stat_dict[f'{self.pkg_id}.num_tasks'] = self.config['num_tasks']
-        stat_dict[f'{self.pkg_id}.runtime'] = self.start_time
+        stat_dict[f'{self.pkg_id}.runtime'] = self.runtime

--- a/builtin/builtin/ycsbc/pkg.py
+++ b/builtin/builtin/ycsbc/pkg.py
@@ -177,4 +177,4 @@ class Ycsbc(Application):
         if n:
             stat_dict[f'{self.pkg_id}.throughput'] = total
             stat_dict[f'{self.pkg_id}.throughput_per_node'] = total / n
-        stat_dict[f'{self.pkg_id}.runtime'] = self.start_time
+        stat_dict[f'{self.pkg_id}.runtime'] = self.runtime

--- a/builtin/pipelines/examples/ior_apptainer_host_pkgs_test.yaml
+++ b/builtin/pipelines/examples/ior_apptainer_host_pkgs_test.yaml
@@ -1,0 +1,57 @@
+# Pipeline: IOR Apptainer Test with declared host prerequisites
+# Purpose: Demonstrate `host_pkgs` -- software that must exist on the host
+#          baremetal for jarvis itself to work, as opposed to `pkgs`, which
+#          is the workload jarvis deploys.
+#
+# Why this pipeline needs it: `container_engine: apptainer` makes jarvis shell
+# out to the host's `apptainer build` to produce the SIF. Apptainer is a host
+# tool, not something the pipeline can containerize its way out of needing.
+# Declaring it here makes jarvis verify it up front and fail with the exact
+# install command, instead of failing later with `apptainer: command not
+# found` from inside the build -- after directories and packages already
+# exist. When apptainer IS present, the same check activates its environment
+# (`spack load apptainer`) so the build subprocess finds it on PATH.
+#
+# Run:  jarvis ppl run yaml builtin/pipelines/examples/ior_apptainer_host_pkgs_test.yaml
+
+name: ior_apptainer_host_pkgs_test
+base_deploy_mode: container
+
+# Host baremetal prerequisites, checked before anything else happens.
+#   install_method: which backend verifies/installs it (spack, pip, conda)
+#   install_query:  the string that backend installs -- also what jarvis
+#                   probes for, and what the error message tells you to run
+host_pkgs:
+  - install_method: spack
+    install_query: apptainer
+
+container_engine: apptainer
+container_base: ubuntu:24.04
+
+pkgs:
+  # HDF5 + ADIOS2 must precede IOR: they deposit libhdf5*.so* and
+  # libadios2*.so* into the build container's /usr/local/lib so IOR's
+  # Dockerfile.deploy COPY of those globs finds them at deploy time.
+  - pkg_type: builtin.hdf5
+    pkg_name: hdf5
+    parallel: true
+  - pkg_type: builtin.adios2
+    pkg_name: adios2
+    use_hdf5: true
+    use_mpi: true
+    use_fortran: false
+    use_python: false
+  - pkg_type: builtin.ior
+    pkg_name: ior_apptainer
+    nprocs: 4
+    ppn: 4
+    block: 1G
+    xfer: 1M
+    api: posix
+    out: ${HOME}/jarvis_ior_test_file
+    log: ${HOME}/jarvis_ior_output.log
+    write: true
+    read: true
+    fpp: false
+    reps: 1
+    direct: false

--- a/ci/test_host_pkgs.sh
+++ b/ci/test_host_pkgs.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Host-prerequisite (`host_pkgs`) check, exercised on a host that does NOT
+# have the prerequisite installed.
+#
+# The example pipeline is a containerized apptainer pipeline: jarvis has to
+# shell out to the host's apptainer to build the SIF. This CI host has
+# neither spack nor apptainer, which is the whole point -- the run must stop
+# at the declared prerequisite with an actionable message, rather than
+# wandering into the container build and dying on `apptainer: command not
+# found` after it has already created state.
+#
+# Asserted:
+#   1. the run fails (non-zero exit)
+#   2. the failure names the missing package and the command that fixes it
+#   3. it fails BEFORE the container build starts
+#   4. a satisfiable prerequisite does not trip the check (so the test is
+#      proving a real check, not a pipeline that always fails)
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK_DIR="${HOST_PKGS_TEST_DIR:-${HOME}/jarvis-host-pkgs-ci}"
+EXAMPLE="${REPO_ROOT}/builtin/pipelines/examples/ior_apptainer_host_pkgs_test.yaml"
+
+rm -rf "${WORK_DIR}"
+mkdir -p "${WORK_DIR}/home" "${WORK_DIR}/config" "${WORK_DIR}/private" "${WORK_DIR}/shared"
+
+# Jarvis roots its state at $HOME/.ppi-jarvis, and `jarvis init` rewrites
+# that config in place. Point HOME at a throwaway dir so running this
+# script on a developer machine cannot repoint their real jarvis install
+# at these scratch directories.
+export HOME="${WORK_DIR}/home"
+
+echo "=== Initializing jarvis (HOME=${HOME}) ==="
+jarvis init "${WORK_DIR}/config" "${WORK_DIR}/private" "${WORK_DIR}/shared"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# Guard the premise: if this host somehow HAS apptainer/spack, the test below
+# is not testing what it claims to and must not silently "pass".
+if command -v spack >/dev/null 2>&1; then
+    fail "spack is present on this host; the missing-prerequisite case cannot be exercised"
+fi
+if command -v apptainer >/dev/null 2>&1; then
+    fail "apptainer is present on this host; the missing-prerequisite case cannot be exercised"
+fi
+
+echo
+echo "=== Case 1: declared host_pkg (spack apptainer) is NOT installed ==="
+OUTPUT_FILE="${WORK_DIR}/run.log"
+set +e
+jarvis ppl run yaml "${EXAMPLE}" >"${OUTPUT_FILE}" 2>&1
+RC=$?
+set -e
+echo "--- jarvis output (exit ${RC}) ---"
+cat "${OUTPUT_FILE}"
+echo "--- end output ---"
+
+[ "${RC}" -ne 0 ] || fail "expected a non-zero exit for a missing host package, got 0"
+
+grep -q "Missing 1 required host package" "${OUTPUT_FILE}" \
+    || fail "output does not report the missing host package"
+grep -q "apptainer (install_method: spack)" "${OUTPUT_FILE}" \
+    || fail "output does not name the missing package and its install_method"
+grep -q "spack install apptainer" "${OUTPUT_FILE}" \
+    || fail "output does not name the command that fixes it"
+
+# Fail-fast: the check must precede the container build, otherwise the
+# declaration bought nothing over the raw `command not found`.
+if grep -q "ContainerInstaller" "${OUTPUT_FILE}"; then
+    fail "container build started despite the missing host prerequisite"
+fi
+echo "PASS: missing host package stopped the run with an actionable message"
+
+echo
+echo "=== Case 2: a satisfiable host_pkg passes the check ==="
+# pyyaml is a hard dependency of jarvis, so it is installed by definition
+# here. Same code path, opposite outcome -- this is what keeps case 1
+# honest.
+SAT_YAML="${WORK_DIR}/host_pkgs_satisfied.yaml"
+cat >"${SAT_YAML}" <<'YAML'
+name: host_pkgs_satisfied
+host_pkgs:
+  - install_method: pip
+    install_query: pyyaml
+pkgs: []
+YAML
+
+set +e
+jarvis ppl run yaml "${SAT_YAML}" >"${WORK_DIR}/sat.log" 2>&1
+SAT_RC=$?
+set -e
+echo "--- jarvis output (exit ${SAT_RC}) ---"
+cat "${WORK_DIR}/sat.log"
+echo "--- end output ---"
+
+[ "${SAT_RC}" -eq 0 ] || fail "an installed host package should not fail the check (exit ${SAT_RC})"
+grep -q "required host package" "${WORK_DIR}/sat.log" \
+    && fail "an installed host package was reported missing"
+
+echo "PASS: satisfiable host package cleared the check"
+echo
+echo "All host_pkgs CI assertions passed."

--- a/docker/build_perf_eval_image.sh
+++ b/docker/build_perf_eval_image.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Build the performance evaluation SIF — the automated installation step for
+# the containerized single_node/distributed pipelines, which live in clio-core
+# under jarvis_clio_core/pipelines/ares/.
+#
+# Two stages:
+#   1. docker build docker/perf_eval.Dockerfile -> a local OCI image baking
+#      spack iowarp(+fuse) + ior, juicefs, redis, this jarvis-cd checkout, and
+#      clio-core at CLIO_REF. Its final RUN fails if a required binary is
+#      missing.
+#   2. apptainer build <sif> docker-daemon://<image> -> a portable .sif. No
+#      registry round-trip and no apptainer --fakeroot at build time.
+#
+# A CLIO_REF branch name is resolved to a commit SHA first (git ls-remote) so
+# docker's layer cache busts exactly when clio-core pushes; a raw branch name
+# would silently reuse a stale cached clone. The resolved SHA is echoed —
+# record it, it is the exact clio-core commit baked into the image.
+#
+# The SIF lands in the jarvis containers cache so the pipeline YAMLs find it by
+# basename (container_image: "iowarp-perf-eval"):
+#     <jarvis shared_dir>/containers/iowarp-perf-eval.sif
+# On a shared filesystem that makes it visible on every compute node with no
+# per-node copy.
+#
+# Usage:
+#   bash docker/build_perf_eval_image.sh          # re-run daily
+#   Env overrides: IMAGE, SIF_BASENAME (must match the YAMLs' container_image),
+#   SIF_PATH, IOWARP_SPEC, IOR_SPEC, BASE_IMAGE, CLIO_REPO_URL, CLIO_REF,
+#   SKIP_DOCKER_BUILD=1 (reuse an existing local docker image).
+#
+# Output: <SIF_PATH>, printed and listed on success.
+set -euo pipefail
+
+IMAGE="${IMAGE:-iowarp-perf-eval:latest}"
+SIF_BASENAME="${SIF_BASENAME:-iowarp-perf-eval}"
+IOWARP_SPEC="${IOWARP_SPEC:-iowarp@dev +fuse}"
+IOR_SPEC="${IOR_SPEC:-ior@3.3.0}"
+BASE_IMAGE="${BASE_IMAGE:-iowarp/iowarp-build:latest}"
+CLIO_REPO_URL="${CLIO_REPO_URL:-https://github.com/iowarp/clio-core.git}"
+CLIO_REF="${CLIO_REF:-dev}"
+SKIP_DOCKER_BUILD="${SKIP_DOCKER_BUILD:-0}"
+
+# Build context = the jarvis-cd repo root (parent of docker/), so the
+# Dockerfile's `COPY . /opt/jarvis-cd` bakes in this checkout.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_ROOT="$( cd "${SCRIPT_DIR}/.." && pwd )"
+DOCKERFILE="${SCRIPT_DIR}/perf_eval.Dockerfile"
+
+# ---- resolve the SIF destination (jarvis containers cache) ----------------
+# Derive shared_dir from the jarvis config so the SIF lands where the YAMLs
+# look for it by basename. Allow a full SIF_PATH override for non-standard
+# setups.
+if [ -z "${SIF_PATH:-}" ]; then
+  SHARED_DIR="$(grep -hE '^[[:space:]]*shared_dir:' "$HOME"/.ppi-jarvis/*.yaml 2>/dev/null \
+                | head -1 | sed -E 's/^[[:space:]]*shared_dir:[[:space:]]*//; s/["'"'"']//g')"
+  if [ -z "$SHARED_DIR" ]; then
+    echo "ERROR: could not read shared_dir from ~/.ppi-jarvis/*.yaml." >&2
+    echo "       Run 'jarvis init' first, or pass SIF_PATH=/abs/path.sif." >&2
+    exit 1
+  fi
+  SIF_PATH="$SHARED_DIR/containers/$SIF_BASENAME.sif"
+fi
+mkdir -p "$(dirname "$SIF_PATH")"
+
+# ---- resolve CLIO_REF branch/tag -> commit SHA (docker cache-bust) --------
+# docker caches the clio fetch layer on the ARG *value*; a branch name would
+# silently reuse a stale clone after clio-core pushes. Resolving to a SHA
+# makes every clio push produce a fresh value (and records provenance). If
+# CLIO_REF is already a SHA (or the remote is unreachable), pass it through.
+RESOLVED_REF="$(git ls-remote "$CLIO_REPO_URL" "refs/heads/$CLIO_REF" "refs/tags/$CLIO_REF" 2>/dev/null \
+                | head -1 | cut -f1)"
+if [ -n "$RESOLVED_REF" ]; then
+  echo "CLIO_REF '$CLIO_REF' resolved to commit $RESOLVED_REF"
+  CLIO_REF="$RESOLVED_REF"
+else
+  echo "WARNING: could not resolve CLIO_REF '$CLIO_REF' as a branch/tag on" >&2
+  echo "         $CLIO_REPO_URL (already a SHA, or remote unreachable);"    >&2
+  echo "         passing it through as-is. Note docker may reuse a cached"  >&2
+  echo "         clone layer for a previously-seen value."                  >&2
+fi
+
+echo "=== performance evaluation SIF build ==="
+echo "  docker image : $IMAGE"
+echo "  IOWARP_SPEC  : $IOWARP_SPEC"
+echo "  IOR_SPEC     : $IOR_SPEC"
+echo "  BASE_IMAGE   : $BASE_IMAGE"
+echo "  CLIO_REPO_URL: $CLIO_REPO_URL"
+echo "  CLIO_REF     : $CLIO_REF"
+echo "  SIF_PATH     : $SIF_PATH"
+
+# ---- tool presence --------------------------------------------------------
+command -v apptainer >/dev/null || {
+  echo "ERROR: apptainer not on PATH. Install it (e.g. spack install" >&2
+  echo "       apptainer) and 'spack load apptainer' first."          >&2
+  exit 1
+}
+
+# ---- stage 1: docker build ------------------------------------------------
+if [ "$SKIP_DOCKER_BUILD" = "1" ]; then
+  echo "=== SKIP_DOCKER_BUILD=1 — reusing existing local image $IMAGE ==="
+else
+  command -v docker >/dev/null || {
+    echo "ERROR: docker not on PATH — it is required (the docker build is" >&2
+    echo "       the only supported build path for this image)."           >&2
+    exit 1
+  }
+  echo "=== docker build $IMAGE ==="
+  docker build -f "$DOCKERFILE" \
+    --build-arg BASE_IMAGE="$BASE_IMAGE" \
+    --build-arg IOWARP_SPEC="$IOWARP_SPEC" \
+    --build-arg IOR_SPEC="$IOR_SPEC" \
+    --build-arg CLIO_REPO_URL="$CLIO_REPO_URL" \
+    --build-arg CLIO_REF="$CLIO_REF" \
+    -t "$IMAGE" "$PROJECT_ROOT"
+  echo "=== docker build OK: $IMAGE ==="
+fi
+
+# ---- stage 2: convert the local docker image to a SIF ---------------------
+echo "=== apptainer build $SIF_PATH  (docker-daemon://$IMAGE) ==="
+apptainer build --force "$SIF_PATH" "docker-daemon://$IMAGE"
+
+echo "=== SIF ready: $SIF_PATH ==="
+ls -lh "$SIF_PATH"
+echo "The pipeline YAMLs reference this by basename: container_image: \"$SIF_BASENAME\""

--- a/docker/perf_eval.Dockerfile
+++ b/docker/perf_eval.Dockerfile
@@ -1,0 +1,164 @@
+# =============================================================================
+# perf_eval.Dockerfile — image for the performance evaluation pipelines
+# (clio-core's single_node.yaml / distributed.yaml, base_deploy_mode:
+#  container).
+# =============================================================================
+#
+# Starting from the IOWarp build base, installs iowarp@dev +fuse and ior@3.3.0
+# through spack in ONE invocation, so ior links against the same MPI whose
+# mpiexec the view puts on PATH — an apt-linked ior would be launched by a
+# different MPI. Also installs juicefs, redis, openmpi, sshd, this jarvis-cd
+# checkout, and clio-core at CLIO_REF. clio-core's spack recipe is registered
+# first so `iowarp` resolves to it rather than the base image's builtin. The
+# final RUN fails the build if any required binary is missing, so a broken
+# install cannot reach the cluster. No +hdf5: the sweeps use posix.
+#
+# Two source trees: jarvis-cd arrives via the docker build CONTEXT, so the
+# image always matches the checkout you build from; clio-core is fetched at
+# CLIO_REPO_URL @ CLIO_REF. The jarvis-cd COPY is kept late so a jarvis-only
+# edit does not rebuild the expensive spack layer.
+#
+# The pipelines deploy under apptainer, but docker is the only build path: an
+# apptainer definition file has no layer cache (every edit would rebuild spack
+# from source) and building one needs root or --fakeroot, whereas converting a
+# finished docker image needs neither. The base image is OCI anyway.
+#
+# Runs as the non-root user `iowarp` for the spack build (it owns
+# /home/iowarp/spack) and as root for system installs and at runtime (the
+# jarvis compose entrypoint uses /root).
+#
+# Usage:
+#   bash docker/build_perf_eval_image.sh
+#   Do not `docker build` this by hand — the script resolves CLIO_REF to a SHA
+#   (docker's cache key) and converts the result into the .sif the pipeline
+#   YAMLs look for.
+#
+# Output: local docker image iowarp-perf-eval:latest, converted by that script
+#   to <jarvis shared_dir>/containers/iowarp-perf-eval.sif.
+
+ARG BASE_IMAGE=iowarp/iowarp-build:latest
+FROM ${BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+# IOWarp spec — built with clio-core's recipe (see header). `@dev` is upstream
+# dev; +fuse builds clio_cte_fuse.
+ARG IOWARP_SPEC=iowarp@dev +fuse
+# IOR pinned: builtin.ior's log parser was written against 3.3.0 output.
+ARG IOR_SPEC=ior@3.3.0
+ARG JUICEFS_VERSION=1.2.3
+# clio-core source: URL + ref (branch or SHA; SHA preferred — see header).
+ARG CLIO_REPO_URL=https://github.com/iowarp/clio-core.git
+ARG CLIO_REF=dev
+ARG SPACK_SETUP=/home/iowarp/spack/share/spack/setup-env.sh
+ARG SPACK_USER=iowarp
+
+# 1) System deps as ROOT (the base defaults to USER iowarp -> apt is denied).
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        fuse3 libfuse3-3 \
+        openmpi-bin libopenmpi-dev \
+        redis-server redis-tools \
+        git curl ca-certificates \
+        python3 python3-pip python3-venv \
+        openssh-server openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# 2) JuiceFS — official single static binary (to a root-owned PATH dir).
+RUN curl -fsSL "https://github.com/juicedata/juicefs/releases/download/v${JUICEFS_VERSION}/juicefs-${JUICEFS_VERSION}-linux-amd64.tar.gz" \
+      | tar -xz -C /usr/local/bin juicefs \
+    && juicefs version
+
+# 3) clio-core at the pinned ref (shallow fetch-by-ref: works for branch
+#    names AND commit SHAs, unlike `git clone --branch`), plus a spack
+#    "view" dir the iowarp user can populate and root can read at runtime.
+#    Only the recipe + jarvis packages are needed from the tree;
+#    `spack install` fetches the `@dev` SOURCE from upstream GitHub.
+RUN git init -q /opt/clio-core \
+    && git -C /opt/clio-core fetch -q --depth 1 ${CLIO_REPO_URL} ${CLIO_REF} \
+    && git -C /opt/clio-core checkout -q FETCH_HEAD \
+    && mkdir -p /opt/iowarp-view && chown ${SPACK_USER}:${SPACK_USER} /opt/iowarp-view
+
+# 4) IOWarp (+FUSE) and IOR via spack, as the user that OWNS spack. Register
+#    clio-core's recipe FIRST so `iowarp@dev +fuse` resolves to clio's
+#    recipe (its namespace `iowarp` overrides the base image's builtin
+#    iowarp pkg). ior is installed in the SAME invocation so it links
+#    against the same MPI whose mpiexec ends up on the view PATH.
+#
+#    The base image's site-scope packages.yaml has external stubs for cmake,
+#    python, openmpi, hdf5, and boost that lack concrete versions — spack
+#    0.22+ rejects them during concretization. Override them in the user
+#    scope (user scope wins over site/system) so spack builds from source
+#    instead.
+USER ${SPACK_USER}
+RUN mkdir -p ~/.spack && cat > ~/.spack/packages.yaml <<'EOF'
+packages:
+  cmake:
+    buildable: true
+    externals: []
+  python:
+    buildable: true
+    externals: []
+  openmpi:
+    buildable: true
+    externals: []
+  hdf5:
+    buildable: true
+    externals: []
+  boost:
+    buildable: true
+    externals: []
+EOF
+RUN . "${SPACK_SETUP}" \
+    && spack repo add /opt/clio-core/installers/spack \
+    && spack install --fail-fast ${IOWARP_SPEC} ${IOR_SPEC} \
+    && spack view --dependencies yes symlink -i /opt/iowarp-view \
+         ${IOWARP_SPEC} ${IOR_SPEC}
+
+# 5) Back to root: put the view on PATH, install jarvis-cd from the build
+#    context (the local checkout — kept LATE so jarvis-only edits do not
+#    rebuild the spack layer), register the clio jarvis repo, prepare sshd.
+#    Runtime user stays root (compose /root).
+USER root
+ENV PATH=/opt/iowarp-view/bin:${PATH}
+ENV LD_LIBRARY_PATH=/opt/iowarp-view/lib:/opt/iowarp-view/lib64:${LD_LIBRARY_PATH}
+
+COPY . /opt/jarvis-cd
+RUN { pip3 install -e /opt/jarvis-cd \
+      || pip3 install --break-system-packages -e /opt/jarvis-cd; } \
+    && jarvis init \
+    && jarvis repo add /opt/clio-core/jarvis_clio_core \
+    && jarvis repo list
+
+RUN mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh
+
+# 5b) Multi-node MPI over the instance sshd needs two image-side fixes:
+#     - Remote prted spawn: sshd child sessions get the compiled-in default
+#       PATH (the image ENV does not survive an sshd login), so the MPI
+#       launch chain must resolve from /usr/local/bin. Spack binaries are
+#       rpath'd, so bare symlinks suffice. The [ -e ] guard tolerates
+#       OMPI4 (orted) vs OMPI5 (prted) daemon naming.
+#     - First-contact host keys: the in-instance `ssh -p <port>` hop to a
+#       peer instance would fail interactive host-key verification
+#       (instance keys != node keys; no port entries in known_hosts). We
+#       PREPEND the Host * block to the system-wide /etc/ssh/ssh_config, not
+#       only a drop-in: the base image's ssh_config may lack an
+#       `Include ssh_config.d/*.conf` line, so the drop-in alone was silently
+#       ignored on Ares (ssh is first-match-wins, so top-of-file always wins).
+RUN for b in mpiexec mpirun prted orted orterun ior; do \
+        [ -e "/opt/iowarp-view/bin/$b" ] \
+            && ln -sf "/opt/iowarp-view/bin/$b" "/usr/local/bin/$b"; \
+    done; \
+    mkdir -p /etc/ssh/ssh_config.d \
+    && printf 'Host *\n    StrictHostKeyChecking no\n    UserKnownHostsFile /dev/null\n    LogLevel ERROR\n' \
+         > /etc/ssh/ssh_config.d/instance.conf \
+    && touch /etc/ssh/ssh_config \
+    && { printf 'Host *\n    StrictHostKeyChecking no\n    UserKnownHostsFile /dev/null\n    LogLevel ERROR\n\n'; \
+         cat /etc/ssh/ssh_config; } > /etc/ssh/ssh_config.new \
+    && mv /etc/ssh/ssh_config.new /etc/ssh/ssh_config
+
+# 6) GATE — fail the build if a required binary is missing.
+RUN for b in clio_run clio_cte_fuse \
+             juicefs ior redis-server redis-cli redis-benchmark mpiexec jarvis; do \
+        command -v "$b" >/dev/null || { echo "MISSING REQUIRED BINARY: $b"; exit 1; }; \
+    done \
+    && echo "iowarp-perf-eval image: required binaries present"

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Jarvis-CD is a unified platform for deploying scientific applications, storage s
 
 ## Reference
 
-- [Pipeline Configuration](pipelines.md) — Full YAML format, install managers (container/spack), environment management, multi-node, devcontainers
+- [Pipeline Configuration](pipelines.md) — Full YAML format, host prerequisites (`host_pkgs`), install managers (container/spack), environment management, multi-node, devcontainers
 - [Package Development Guide](package_dev_guide.md) — Create new packages, Dockerfile templates, container and spack support
 - [Pipeline Tests](pipeline_tests.md) — Automated testing with grid search and parameter sweeps
 - [Hostfile Configuration](hostfile.md) — Multi-node setup, pattern expansion, IP resolution

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -148,6 +148,21 @@ pkgs:
 
 **Requirements:** Apptainer installed, plus either Docker or Podman (used as an intermediate build step — Apptainer cannot build Dockerfiles directly).
 
+Declare those host-side requirements with `host_pkgs` so Jarvis verifies them
+up front instead of failing partway through the build with
+`apptainer: command not found`:
+
+```yaml
+host_pkgs:
+  - install_method: spack
+    install_query: apptainer
+```
+
+A missing prerequisite stops the run with the command that fixes it. When it
+is present, the same check activates its environment (`spack load apptainer`)
+so the build subprocess finds it on `PATH`. See
+[Host Prerequisites](pipelines.md#host-prerequisites-host_pkgs).
+
 **How it works:**
 1. Jarvis builds the image using Docker or Podman (whichever is available)
 2. Converts the image to a `.sif` file in the pipeline's shared directory
@@ -183,6 +198,12 @@ base_deploy_mode: container
 container_engine: docker          # docker, podman, or apptainer
 container_base: ubuntu:24.04     # base image for the build phase
 
+# Host baremetal prerequisites (optional): tools Jarvis shells out to,
+# verified before the pipeline runs
+host_pkgs:
+  - install_method: spack        # spack, pip, or conda
+    install_query: apptainer     # what that backend installs
+
 # Packages to run (required)
 pkgs:
   - pkg_type: builtin.package_name
@@ -203,6 +224,7 @@ interceptors:
 | `base_deploy_mode` | `container` (Docker/Podman/Apptainer), `spack`, or omit for bare-metal |
 | `container_engine` | `docker`, `podman`, or `apptainer` |
 | `container_base` | Base image for the build phase (e.g., `ubuntu:24.04`, `sci-hpc-base`) |
+| `host_pkgs` | Optional host baremetal prerequisites (e.g. apptainer), verified before the run |
 | `pkgs` | List of packages to run |
 | `interceptors` | Optional list of interceptors (profilers, tracers) |
 | `hostfile` | Path to MPI hostfile for multi-node runs |

--- a/docs/package_dev_guide.md
+++ b/docs/package_dev_guide.md
@@ -945,9 +945,16 @@ All packages inherit from the base `Pkg` class and can override these methods:
 def _init(self):
     """Initialize package-specific variables"""
     self.my_variable = None
-    self.start_time = None
     self.output_file = None
 ```
+
+> **Do not assign `self.runtime` here.** It is owned by the framework:
+> `Pipeline.start()` measures it and `Pipeline._load_package_instance` replays
+> it onto each later instance. `_init` runs *inside* that replay path, so
+> re-initializing it to `None` silently blanks the `<pkg_id>.runtime` column in
+> pipeline-test results. `self.start_time` is deprecated and never populated —
+> it exists only so legacy packages reading it get `None` instead of an
+> `AttributeError`.
 
 #### `_configure_menu(self) -> List[Dict[str, Any]]`
 **Purpose**: Define configuration options for the package  
@@ -1110,6 +1117,19 @@ def status(self) -> str:
 **Called**: By `PipelineTest` after each pipeline run to aggregate results
 **Notes**: Only implement this if your package is used in pipeline tests. Prefix all keys with `self.pkg_id` to avoid conflicts between packages.
 
+> **`_get_stat` runs on a fresh instance.** Every phase — `start()`, `stop()`,
+> `_get_stat()` — gets its own package object from
+> `Pipeline._load_package_instance`, so **nothing you assigned during `start()`
+> is still there.** Read your metrics back off disk (a log file under
+> `self.shared_dir`), never out of in-memory state like `self.exec.stdout`.
+> `self.runtime` is the one exception: the framework explicitly replays it onto
+> the new instance. (`self.start_time` is deprecated and always `None`.)
+>
+> `_get_stat` is called inside a `try/except` that logs a warning and moves on,
+> so an `AttributeError` on the first line silently discards **every** stat the
+> package would have reported — not just the one that raised. Failures here look
+> like blank CSV columns, not errors.
+
 ```python
 def _get_stat(self, stat_dict):
     """
@@ -1118,14 +1138,19 @@ def _get_stat(self, stat_dict):
     :param stat_dict: Dictionary to populate with statistics.
     :return: None
     """
-    # Example: parse stdout for a throughput value
-    output = self.exec.stdout.get('localhost', '')
+    # Framework-supplied; safe on a fresh instance.
+    stat_dict[f'{self.pkg_id}.runtime'] = self.runtime
+
+    # Everything else comes off disk -- in-memory run state is gone by now.
+    log_path = self.config.get('log')
+    if not log_path or not os.path.isfile(log_path):
+        return
+    with open(log_path, 'r') as f:
+        output = f.read()
+
     match = re.search(r'Bandwidth:\s+([0-9.]+)\s+MB/s', output)
     if match:
         stat_dict[f'{self.pkg_id}.bandwidth_mb_s'] = float(match.group(1))
-
-    # Always record runtime
-    stat_dict[f'{self.pkg_id}.runtime'] = self.start_time
 ```
 
 **Key naming conventions**:

--- a/docs/pipeline_tests.md
+++ b/docs/pipeline_tests.md
@@ -139,6 +139,28 @@ The directory where results are stored. You can use environment variables:
 - `${CONFIG_DIR}` - Pipeline's config directory
 - `${HOME}` - User's home directory
 
+### run_timeout (optional)
+
+A wall-clock budget, in seconds, for a single combination. Omitted (the
+default), a run is unbounded.
+
+Set it when any package can wedge. The per-run error handling only catches
+exceptions, and a hang is not an exception -- so without a budget one stuck
+package blocks the sweep forever, and under a scheduler it consumes the
+whole allocation and you lose every result, including the combinations that
+would have passed.
+
+On expiry the run is torn down (bounded, best-effort, so a wedged `stop()`
+cannot re-hang the sweep), that row is recorded as `failed` with the reason
+in the `error` column, and the next combination starts.
+
+```yaml
+run_timeout: 1800   # 30 minutes per combination
+```
+
+Pick a value comfortably above the slowest healthy run -- it is a
+deadlock backstop, not a performance bound.
+
 ### scheduler (optional)
 
 A top-level `scheduler:` block plays one of two roles depending on
@@ -379,7 +401,7 @@ test inherits them:
 ```yaml
 config:
   name: ior_sweep
-  ssh_cmd:  "env -u LD_LIBRARY_PATH ssh"   # host openssh, not conda's
+  ssh_cmd:  "env -u LD_LIBRARY_PATH ssh"   # host openssh, not a managed env's
   pssh_cmd: "env -u LD_LIBRARY_PATH ssh"
   mpi_cmd:  "mpiexec"
   pkgs:
@@ -396,7 +418,7 @@ output: "${HOME}/ior_results"
 
 These swap the SSH / parallel-SSH / MPI launchers without modifying
 any package. The canonical use is `env -u LD_LIBRARY_PATH ssh`, which
-keeps a conda environment's `libcrypto` out of the host `ssh` (an ABI
+keeps a managed environment's `libcrypto` out of the host `ssh` (an ABI
 mismatch otherwise makes `ssh` exit 255 before forwarding the remote
 command). See [shell.md → Launcher Overrides](shell.md#launcher-overrides)
 for the full mechanism and the per-MPI-backend bootstrap forwarding.
@@ -544,7 +566,22 @@ This includes:
 
 ## Custom Statistics
 
-Packages can define custom statistics by implementing the `_get_stat()` method:
+Packages can define custom statistics by implementing the `_get_stat()` method.
+
+**`_get_stat` runs on a fresh package instance**, built by
+`Pipeline._load_package_instance` after the run finished — *not* the object that
+executed `start()`. Anything you stashed in memory during the run is gone, so
+read your metrics back off disk (a log under `self.shared_dir`) rather than out
+of `self.exec.stdout`. The one exception is `self.runtime` — seconds `start()`
+took, measured in `Pipeline.start()` and replayed onto the new instance.
+(`self.start_time` is deprecated and always `None`; a package reporting a
+runtime must read `self.runtime`.)
+
+`PipelineTest` calls `_get_stat` inside a `try/except` that logs a warning and
+continues, so raising on the first line silently drops **every** stat that
+package would have contributed. The symptom is a blank CSV column, not an error
+— check the run log for `Could not get stats from <pkg_id>` when a column you
+expected comes back empty.
 
 ```python
 class MyBenchmark(Application):
@@ -555,16 +592,20 @@ class MyBenchmark(Application):
         :param stat_dict: A dictionary to populate with statistics.
         :return: None
         """
-        # Parse output for results
-        output = self.exec.stdout.get('localhost', '')
+        # Framework-supplied; safe on a fresh instance.
+        stat_dict[f'{self.pkg_id}.runtime'] = self.runtime
+
+        # Everything else comes off disk.
+        log_path = self.config.get('log')
+        if not log_path or not os.path.isfile(log_path):
+            return
+        with open(log_path, 'r') as f:
+            output = f.read()
 
         # Extract throughput
         if 'throughput' in output:
             throughput = self._parse_throughput(output)
             stat_dict[f'{self.pkg_id}.throughput'] = throughput
-
-        # Record runtime
-        stat_dict[f'{self.pkg_id}.runtime'] = self.runtime
 ```
 
 ### YCSB Example
@@ -588,7 +629,7 @@ class Ycsb(Application):
                 stat_dict[f'{self.pkg_id}.throughput'] = throughput
 
         # Record runtime
-        stat_dict[f'{self.pkg_id}.runtime'] = self.start_time
+        stat_dict[f'{self.pkg_id}.runtime'] = self.runtime
 ```
 
 ### Best Practices for Statistics

--- a/docs/pipeline_tests.md
+++ b/docs/pipeline_tests.md
@@ -102,9 +102,35 @@ output: "${HOME}/experiment_results"
 This section contains the skeleton of a pipeline. It has the same exact parameters as a regular pipeline script, including:
 - `name`: Pipeline name
 - `env`: Environment reference (optional)
+- `host_pkgs`: Host baremetal prerequisites (optional) — see below
 - `pkgs`: List of packages with their configurations
 - `interceptors`: List of interceptors (optional)
 - Container configuration (optional)
+
+#### host_pkgs in a test
+
+`host_pkgs` declares tooling that must exist on the host for Jarvis itself to
+work — most often apptainer or docker for a containerized sweep. See
+[Host Prerequisites](pipelines.md#host-prerequisites-host_pkgs) for the full
+description of the field.
+
+```yaml
+config:
+  name: ior_apptainer_sweep
+  container_engine: apptainer
+  host_pkgs:
+    - install_method: spack
+      install_query: apptainer
+  pkgs:
+    - pkg_type: builtin.ior
+      pkg_name: ior
+```
+
+The block is checked once when the test loads, before any combination runs. A
+sweep of N combinations should not build N-1 results before discovering the
+host cannot run it. Because `host_pkgs` lives inside `config:`, it also rides
+along into each iteration's pipeline and is re-checked there — but probes are
+memoized per process, so those re-checks cost nothing.
 
 ### vars
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -226,6 +226,81 @@ name: my_pipeline
 # No env field - automatically captures current environment
 ```
 
+### Host Prerequisites (`host_pkgs`)
+
+`host_pkgs` declares software that must exist on the **host baremetal** for
+Jarvis itself to work. This is different from `pkgs`, which is the workload
+Jarvis deploys: `host_pkgs` is the tooling Jarvis shells out to.
+
+The motivating case is a containerized pipeline. `container_engine: apptainer`
+makes Jarvis run `apptainer build` on the host, so apptainer has to be on the
+host's `PATH` before the pipeline starts. Apptainer is not something the
+pipeline can containerize its way out of needing.
+
+```yaml
+name: ior_apptainer_host_pkgs_test
+base_deploy_mode: container
+container_engine: apptainer
+
+host_pkgs:
+  - install_method: spack
+    install_query: apptainer
+
+pkgs:
+  - pkg_type: builtin.ior
+    pkg_name: ior
+```
+
+| Key | Description |
+|-----|-------------|
+| `install_method` | Backend that verifies/installs the package: `spack`, `pip`, or `conda` |
+| `install_query` | The string that backend installs (e.g. a spack spec, a pip requirement). Also what Jarvis probes for, and what the error message tells you to run |
+
+#### What Jarvis does with it
+
+Two things, both before the pipeline does any other work:
+
+1. **Verify.** Every declared package is probed on the host. Anything missing
+   aborts the run with the exact command that fixes it:
+
+   ```
+   Missing 1 required host package(s) for 'ior_apptainer_host_pkgs_test'.
+   These must be installed on the host baremetal before jarvis can run this
+   pipeline:
+     - apptainer (install_method: spack)
+         install it with: spack install apptainer
+   ```
+
+   This is a check, not an install. `spack install apptainer` can run for
+   hours, which is not something a pipeline launch should do unprompted.
+
+2. **Activate.** Packages that *are* present contribute their environment
+   (what `spack load apptainer` sets) to the process environment, so the
+   subprocesses Jarvis spawns to do the containerizing actually find them.
+   The activation is written into the process environment rather than only
+   the pipeline's `env` dict, because the container-build calls run under a
+   plain `LocalExecInfo()` and therefore inherit an unmodified environment.
+
+#### When the check runs
+
+| Path | Checked |
+|------|---------|
+| `jarvis ppl run yaml <file>` | At load, before any package is processed |
+| `jarvis ppl run` (saved current pipeline) | In `run()` |
+| `jarvis ppl submit [file]` | Before the job is queued, on the submitting host |
+| Pipeline tests (`config.host_pkgs`) | Once at load, then per iteration |
+
+Probes are memoized per process, so a sweep that re-loads the same pipeline
+for each combination pays for the probe once.
+
+`host_pkgs` round-trips through the saved pipeline config, so
+`jarvis ppl submit` against the current pipeline re-checks it without
+re-reading the source YAML.
+
+Submitting is checked on the *submitting* host: the job script re-runs Jarvis
+on the compute node and would hit the same missing package, but only after
+sitting in the queue and burning an allocation to fail.
+
 ### Install Manager
 
 The `base_deploy_mode` field determines how packages are installed and deployed. It is a **pipeline-level** setting that applies to all packages uniformly.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -118,6 +118,13 @@ name: my_pipeline
 # Must be a named environment reference or omitted
 env: my_custom_environment  # References a named environment
 
+# Host baremetal prerequisites (optional)
+# Tools Jarvis itself shells out to, verified before the pipeline runs.
+# See "Host Prerequisites (host_pkgs)" below.
+host_pkgs:
+  - install_method: spack
+    install_query: apptainer
+
 # Main packages (required)
 pkgs:
   - pkg_type: repo.package_name
@@ -1725,6 +1732,28 @@ Error: yaml.scanner.ScannerError: while parsing a block mapping
 1. Validate YAML syntax: `python -c "import yaml; yaml.safe_load(open('pipeline.yaml'))"`
 2. Check indentation (use spaces, not tabs)
 3. Quote string values with special characters
+
+**Problem**: A declared host prerequisite is missing
+```
+Error: Missing 1 required host package(s) for 'my_pipeline'. These must be
+installed on the host baremetal before jarvis can run this pipeline:
+  - apptainer (install_method: spack)
+      install it with: spack install apptainer
+```
+
+**Solutions**:
+1. Run the command the error names (`spack install apptainer`). Jarvis
+   reports the missing prerequisite rather than installing it, because an
+   install can run for hours.
+2. If the tool is already installed but Jarvis cannot see it, check that the
+   backend can find it — for spack, that means `spack location -i <spec>`
+   succeeds, and that `SPACK_ROOT` is set if `spack` is not already on `PATH`
+   (the shell-function form from your rc files is invisible to the
+   non-interactive shell Jarvis probes with).
+3. If the pipeline does not actually need it on this host, remove the entry
+   from `host_pkgs`.
+
+See [Host Prerequisites](#host-prerequisites-host_pkgs).
 
 #### Package Configuration Issues
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -307,7 +307,7 @@ file the job script populates inside the allocation.
 
 ### Container Configuration
 
-Pipelines can be configured to run packages inside Docker or Podman containers. Set `base_deploy_mode: container` and provide container configuration. Containers act as SSH compute nodes — the host-side jarvis orchestrates everything by exec-ing commands into the running containers via `docker exec` and MPI over SSH. No jarvis installation is needed inside the containers.
+Pipelines can be configured to run packages inside Docker, Podman, or Apptainer containers. Set `base_deploy_mode: container` and provide container configuration. Containers act as SSH compute nodes — the host-side jarvis orchestrates everything by exec-ing commands into the running containers via `docker exec` (or `apptainer exec`) and MPI over SSH. No jarvis installation is needed inside the containers. Apptainer has its own start model and additional keys — see [Apptainer Pipelines](#apptainer-pipelines).
 
 #### Container Pipeline Parameters
 
@@ -346,13 +346,55 @@ pkgs:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `base_deploy_mode` | string | *(absent)* | Set to `container` to enable containerized deployment |
-| `container_engine` | string | `"podman"` | Container engine: `docker` or `podman` |
+| `container_engine` | string | `"podman"` | Container engine: `docker`, `podman`, or `apptainer` (see [Apptainer Pipelines](#apptainer-pipelines) for the keys it adds) |
 | `container_base` | string | `"iowarp/iowarp-build:latest"` | Base Docker image for package builds |
 | `container_ssh_port` | int | `2222` | SSH port for MPI communication between containers |
 | `container_env` | dict | `{}` | Environment variables injected into containers via compose |
 | `container_host_path` | string | `""` | Docker host path prefix for DinD environments |
 | `container_workspace` | string | `""` | Workspace root path for DinD path remapping |
 | `container_extensions` | dict | `{}` | Custom Docker Compose config merged into service definition |
+
+#### Apptainer Pipelines
+
+Set `container_engine: apptainer` to use Apptainer — the usual choice on HPC clusters. Docker's layered image store is expensive on a quota'd shared filesystem, and its daemon needs root, so it is often unusable even where it is installed; Apptainer runs rootless out of a single SIF file the user owns. The model differs from Docker/Podman: there is no compose file. Jarvis starts a persistent **instance** (with an sshd inside, on `container_ssh_port`) from the pipeline's SIF on **every host in the hostfile**, then runs each package via `apptainer exec instance://<pipeline>`. The SIF defaults to `<pipeline_name>.sif` in the centralized containers directory; `container_image` overrides it with another SIF basename or an absolute path.
+
+Apptainer silently ignores per-exec `--bind` / `--add-caps` / `--fakeroot` flags on a running instance, so everything the workload needs must be declared at the pipeline level — the following keys bake into `apptainer instance start`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `container_overlay` | bool | `true` | Mount a writable `--overlay` upper dir. `false` drops the overlay entirely: the container filesystem is read-only outside bind mounts, and the host `/tmp` mounts normally |
+| `container_overlay_root` | string | `null` | Node-local root for the overlay upper dir: each host uses `<root>/<pipeline>/overlay`, created on every host automatically. `$VAR`s are expanded. **Required for multi-node pipelines** (see below) |
+| `container_caps` | list | `[]` | Capabilities added via `--add-caps` (e.g. `SYS_ADMIN` for FUSE mounts) |
+| `container_fakeroot` | bool | `false` | Start the instance under `--fakeroot`. Rootless (non-setuid) apptainer only grants a FUSE-capable user namespace this way |
+| `container_binds` | list | `[]` | Extra `host:container` bind mounts (e.g. `/dev/fuse:/dev/fuse`). The pipeline shared/private dirs are always bound at identical paths |
+| `container_gpu` | bool | `false` | GPU passthrough (`--nv`) |
+| `tmp_bind_root` | string | `null` | Per-host `/tmp` redirect: binds `<root>/<pipeline>/tmp` (created on every host automatically) into the container at `/tmp`, so parallel hosts don't collide on `/tmp` paths that would otherwise land in a shared overlay. `$VAR`s are expanded |
+
+**Important — multi-node pipelines must relocate the overlay.** By default the overlay upper dir lives under the pipeline's shared directory, which on a real cluster is a shared filesystem (NFS). That layout only works single-node: overlayfs cannot use a shared/NFS directory as its upper layer, and concurrent `apptainer instance start`s on N nodes race each other on the same directory. A pipeline whose hostfile spans more than one host must set `container_overlay_root` to a node-local path (e.g. `/mnt/nvme/$USER`) or set `container_overlay: false` — jarvis refuses to start the known-broken combination rather than hang.
+
+Example 4-node apptainer pipeline:
+
+```yaml
+name: distributed_bench
+base_deploy_mode: container
+container_engine: apptainer
+hostfile: /path/to/hostfile.txt           # 4 compute nodes
+
+container_fakeroot: true                  # rootless FUSE-capable userns
+container_binds: []                       # optional; FUSE needs no /dev/fuse bind under --fakeroot
+container_overlay_root: /mnt/nvme/$USER   # per-host overlay upper dir
+tmp_bind_root: /mnt/nvme/$USER            # per-host /tmp
+
+pkgs:
+  - pkg_type: builtin.ior
+    nprocs: 8
+    ppn: 2
+```
+
+Notes:
+- Jarvis never cleans the per-host overlay/tmp directories; their contents persist per node across runs (the default shared-dir overlay has the same persistence, just centralized).
+- A workload that installs software at runtime (apt/conda/pip inside the container) needs a writable overlay — with `container_overlay: false` the container filesystem is read-only outside bind mounts.
+- If `apptainer instance start` fails on any host, the pipeline aborts immediately naming that host instead of continuing with partial instances.
 
 #### How Container Pipelines Work
 

--- a/jarvis_cd/core/host_pkg.py
+++ b/jarvis_cd/core/host_pkg.py
@@ -1,0 +1,484 @@
+"""
+Host prerequisite packages for Jarvis-CD.
+
+A ``host_pkgs`` entry declares software that must exist on the **host
+baremetal** for jarvis itself to function -- as opposed to ``pkgs``, which
+declares the workload jarvis deploys. The motivating case is a
+containerized pipeline: jarvis shells out to ``apptainer build`` on the
+host, so apptainer has to be on the host's PATH *before* the pipeline
+starts. Without a declaration, a missing apptainer surfaces late as an
+opaque ``apptainer: command not found`` from inside the container build,
+long after jarvis has created directories and started packages.
+
+YAML shape (top level of a pipeline, or inside a pipeline test's
+``config:`` block)::
+
+    host_pkgs:
+      - install_method: spack
+        install_query: apptainer
+
+``install_method`` selects a backend (spack / pip / conda);
+``install_query`` is the string that backend uses to install the
+software, and doubles as the string used to look it up.
+
+Two things happen at check time, in :meth:`HostPkg.check_all`:
+
+1. **Verify.** Every declared package is probed on the host. Anything
+   missing raises :class:`HostPkgError` naming the exact command to run.
+   This is a check, not an install -- ``spack install apptainer`` can run
+   for hours, which is not something a pipeline launch should do behind
+   the user's back.
+2. **Activate.** Packages that *are* present contribute their environment
+   (e.g. the PATH entry ``spack load apptainer`` produces) to the
+   process environment, so the subprocesses jarvis spawns to do the
+   containerizing actually find them.
+
+On (2): the activation is written into ``os.environ``, not just the
+pipeline's ``env`` dict. That is deliberate. ``LocalExec.run`` falls back
+to a bare ``os.environ`` whenever its ``ExecInfo`` carries no explicit
+env, and the container build path (``ContainerInstaller``, the apptainer
+``instance start``/``build`` calls) constructs plain ``LocalExecInfo()``
+at a couple dozen call sites. Threading an env dict through all of them
+would be invasive and would silently miss any new call site; putting the
+activation in the process environment covers every subprocess jarvis
+spawns, present and future, which is exactly the scope a *host*
+prerequisite has.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Tuple, Type
+
+# A POSIX environment variable name. Used to reject the noise that shows
+# up in `env` output but is not a variable an inherited subprocess should
+# see -- most importantly exported bash *functions*, which `env` prints as
+# `BASH_FUNC_name%%=() { ...` with the body spanning further lines. Left
+# unfiltered, each body line parses as its own bogus variable and the
+# function itself lands in os.environ, where it is both useless to a
+# non-bash child and a well-known injection surface.
+_ENV_NAME_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+# Shell bookkeeping that changes on every invocation and means nothing to
+# a child process. Carrying these would make an activation look "dirty"
+# on every probe and would stomp the child's own values.
+_ENV_NOISE = frozenset({'_', 'SHLVL', 'PWD', 'OLDPWD', 'BASH_EXECUTION_STRING'})
+
+
+class HostPkgError(RuntimeError):
+    """A declared host prerequisite is missing, or the declaration is
+    malformed. Carries an actionable message naming the fix."""
+
+
+# How long a single probe / activation subprocess may run. `spack load`
+# on a cold cache is slow but not minutes-slow; a hung probe should not
+# wedge the pipeline launch indefinitely.
+PROBE_TIMEOUT = 120
+
+
+class HostPkg(ABC):
+    """Base class for host-prerequisite backends.
+
+    Subclasses set :attr:`install_method` to register themselves with the
+    factory, mirroring how :class:`jarvis_cd.core.installer.Installer`
+    registers install backends. The two hierarchies are deliberately
+    separate: an Installer *installs the workload*, a HostPkg *verifies
+    the host can run jarvis at all*.
+    """
+
+    install_method: str = ""  # Subclasses set this to register.
+
+    # Probe results are memoized per (method, query) for the life of the
+    # process. A sweep re-loads the same pipeline YAML once per
+    # combination, and each load would otherwise re-run the same
+    # `spack find` subprocess -- 24 combinations meant 24 identical
+    # probes before this cache.
+    _probe_cache: Dict[Tuple[str, str], Tuple[bool, Dict[str, str]]] = {}
+
+    @abstractmethod
+    def is_installed(self, query: str) -> bool:
+        """True when ``query`` is already available on this host."""
+
+    @abstractmethod
+    def activate(self, query: str) -> Dict[str, str]:
+        """Environment variables that make ``query`` usable by
+        subprocesses. Called only after :meth:`is_installed` returns True.
+        Returning an empty dict is valid (nothing to add to the env).
+        """
+
+    @abstractmethod
+    def install_hint(self, query: str) -> str:
+        """The command a user should run to satisfy this prerequisite.
+        Shown verbatim in the error raised for a missing package.
+        """
+
+    # ------------------------------------------------------------------
+    # registry
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _registry() -> Dict[str, Type['HostPkg']]:
+        """Map ``install_method`` -> concrete HostPkg subclass, built by
+        walking subclasses so a new backend is just a new subclass."""
+        reg: Dict[str, Type[HostPkg]] = {}
+
+        def _walk(cls: Type[HostPkg]):
+            for sub in cls.__subclasses__():
+                if sub.install_method:
+                    reg[sub.install_method] = sub
+                _walk(sub)
+
+        _walk(HostPkg)
+        return reg
+
+    @staticmethod
+    def for_method(method: str) -> 'HostPkg':
+        """Instantiate the backend registered for ``method``."""
+        reg = HostPkg._registry()
+        if method not in reg:
+            raise HostPkgError(
+                f"Unknown host_pkgs install_method '{method}'. "
+                f"Known methods: {', '.join(sorted(reg))}."
+            )
+        return reg[method]()
+
+    # ------------------------------------------------------------------
+    # parsing / validation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def parse(raw: Any) -> List[Dict[str, str]]:
+        """Normalize and validate a raw ``host_pkgs`` YAML value.
+
+        Validation is strict and happens at load time rather than at use
+        time: a typo'd key in a prerequisite block should fail the
+        pipeline immediately, not silently skip the check and resurface
+        as a missing binary halfway through a container build.
+
+        :param raw: the YAML value (``None`` / list of dicts)
+        :return: list of ``{'install_method': ..., 'install_query': ...}``
+        :raises HostPkgError: on any malformed entry
+        """
+        if raw is None:
+            return []
+        if not isinstance(raw, list):
+            raise HostPkgError(
+                f"'host_pkgs' must be a list of "
+                f"{{install_method, install_query}} entries, got "
+                f"{type(raw).__name__}."
+            )
+
+        known = sorted(HostPkg._registry())
+        parsed: List[Dict[str, str]] = []
+        for idx, entry in enumerate(raw):
+            where = f"host_pkgs[{idx}]"
+            if not isinstance(entry, dict):
+                raise HostPkgError(
+                    f"{where} must be a mapping with 'install_method' and "
+                    f"'install_query', got {type(entry).__name__}."
+                )
+
+            unknown_keys = set(entry) - {'install_method', 'install_query'}
+            if unknown_keys:
+                raise HostPkgError(
+                    f"{where} has unknown key(s) "
+                    f"{sorted(unknown_keys)}. Supported keys: "
+                    "install_method, install_query."
+                )
+
+            method = str(entry.get('install_method') or '').strip()
+            query = str(entry.get('install_query') or '').strip()
+            if not method:
+                raise HostPkgError(
+                    f"{where} is missing 'install_method'. "
+                    f"Supported methods: {', '.join(known)}.")
+            if not query:
+                raise HostPkgError(
+                    f"{where} (install_method: {method}) is missing "
+                    "'install_query' -- the string used to install the "
+                    "software, e.g. 'apptainer'.")
+            if method not in known:
+                raise HostPkgError(
+                    f"{where} has unknown install_method '{method}'. "
+                    f"Known methods: {', '.join(known)}.")
+
+            parsed.append(
+                {'install_method': method, 'install_query': query})
+        return parsed
+
+    # ------------------------------------------------------------------
+    # check + activate
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def resolve(method: str, query: str) -> Tuple[bool, Dict[str, str]]:
+        """Probe one prerequisite, memoized.
+
+        :return: ``(installed, env)``; ``env`` is empty when not installed.
+        """
+        key = (method, query)
+        if key in HostPkg._probe_cache:
+            return HostPkg._probe_cache[key]
+
+        backend = HostPkg.for_method(method)
+        installed = backend.is_installed(query)
+        env = backend.activate(query) if installed else {}
+        HostPkg._probe_cache[key] = (installed, env)
+        return installed, env
+
+    @staticmethod
+    def clear_cache() -> None:
+        """Drop memoized probe results. Tests use this; so should any
+        caller that installs a prerequisite mid-process and wants the
+        next check to see it."""
+        HostPkg._probe_cache.clear()
+
+    @staticmethod
+    def check_all(host_pkgs: List[Dict[str, str]],
+                  env: Optional[Dict[str, str]] = None,
+                  context: str = "") -> Dict[str, str]:
+        """Verify every declared prerequisite and activate it.
+
+        :param host_pkgs: parsed entries (see :meth:`parse`)
+        :param env: optional pipeline env dict to merge activations into,
+            in addition to ``os.environ``
+        :param context: pipeline / test name, for the error message
+        :return: the merged activation environment
+        :raises HostPkgError: naming every missing package and its fix
+        """
+        if not host_pkgs:
+            return {}
+
+        merged: Dict[str, str] = {}
+        missing: List[Tuple[Dict[str, str], str]] = []
+
+        for spec in host_pkgs:
+            method = spec['install_method']
+            query = spec['install_query']
+            installed, activation = HostPkg.resolve(method, query)
+            if not installed:
+                backend = HostPkg.for_method(method)
+                missing.append((spec, backend.install_hint(query)))
+                continue
+            merged.update(activation)
+
+        if missing:
+            where = f" for '{context}'" if context else ""
+            lines = [
+                f"Missing {len(missing)} required host package(s){where}. "
+                "These must be installed on the host baremetal before "
+                "jarvis can run this pipeline:"
+            ]
+            for spec, hint in missing:
+                lines.append(
+                    f"  - {spec['install_query']} "
+                    f"(install_method: {spec['install_method']})\n"
+                    f"      install it with: {hint}")
+            raise HostPkgError('\n'.join(lines))
+
+        HostPkg.apply_env(merged, env)
+        return merged
+
+    @staticmethod
+    def apply_env(activation: Dict[str, str],
+                  env: Optional[Dict[str, str]] = None) -> None:
+        """Publish an activation into the process environment.
+
+        Writes to ``os.environ`` so that every subprocess jarvis spawns
+        inherits it -- including the container-build calls that construct
+        a bare ``LocalExecInfo()`` and therefore run under an unmodified
+        ``os.environ``. See this module's docstring for why the scope is
+        process-global rather than per-ExecInfo.
+        """
+        if not activation:
+            return
+        for key, value in activation.items():
+            os.environ[key] = str(value)
+        if env is not None:
+            env.update({k: str(v) for k, v in activation.items()})
+
+
+# ---------------------------------------------------------------------------
+# Concrete backends
+# ---------------------------------------------------------------------------
+
+
+def _run_capture(script: str) -> subprocess.CompletedProcess:
+    """Run ``script`` under bash, capturing output.
+
+    Uses subprocess directly rather than the project's ``Exec``: probes
+    run before the pipeline env exists, must stay quiet on the console,
+    and need the raw stdout to parse an environment out of.
+    """
+    return subprocess.run(
+        ['bash', '-c', script],
+        capture_output=True, text=True, timeout=PROBE_TIMEOUT,
+        env=os.environ.copy(),
+    )
+
+
+def _parse_env0(stdout: str) -> Dict[str, str]:
+    """Parse the output of ``env -0`` into a dict.
+
+    NUL-separated rather than newline-separated so that values which
+    themselves contain newlines stay in one piece. Entries whose name is
+    not a plain identifier are dropped -- see :data:`_ENV_NAME_RE`.
+    """
+    parsed: Dict[str, str] = {}
+    for record in stdout.split('\0'):
+        if not record or '=' not in record:
+            continue
+        key, _, value = record.partition('=')
+        if key in _ENV_NOISE or not _ENV_NAME_RE.match(key):
+            continue
+        parsed[key] = value
+    return parsed
+
+
+class SpackHostPkg(HostPkg):
+    """Host prerequisite provided by spack.
+
+    ``install_query`` is a spack spec (``apptainer``, ``apptainer@1.3.6``,
+    ``hdf5+mpi``). Presence is probed with ``spack location -i <spec>``,
+    which succeeds only for a spec that is actually *installed* --
+    ``spack find`` also matches specs that are merely known to spack.
+    """
+
+    install_method = "spack"
+
+    @staticmethod
+    def _setup_prefix() -> str:
+        """Shell prefix that makes ``spack`` callable.
+
+        Sources ``setup-env.sh`` when SPACK_ROOT is set; otherwise relies
+        on spack already being on PATH (the shell-function form installed
+        by a user's rc files is not visible to a non-interactive bash, so
+        SPACK_ROOT is the reliable route).
+        """
+        spack_root = os.environ.get('SPACK_ROOT', '')
+        if spack_root:
+            return f'. {spack_root}/share/spack/setup-env.sh >/dev/null 2>&1 && '
+        return ''
+
+    def _spack_available(self) -> bool:
+        """True when a spack command can be reached at all."""
+        if shutil.which('spack'):
+            return True
+        spack_root = os.environ.get('SPACK_ROOT', '')
+        return bool(spack_root) and os.path.exists(
+            os.path.join(spack_root, 'share', 'spack', 'setup-env.sh'))
+
+    def is_installed(self, query: str) -> bool:
+        if not self._spack_available():
+            return False
+        try:
+            result = _run_capture(
+                f'{self._setup_prefix()}spack location -i {query}')
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return False
+        return result.returncode == 0
+
+    def activate(self, query: str) -> Dict[str, str]:
+        """Capture the environment ``spack load <spec>`` produces.
+
+        Only variables the load actually changed are returned, so an
+        activation cannot smuggle unrelated host state (or a stale
+        working directory) into the pipeline environment.
+        """
+        try:
+            result = _run_capture(
+                f'{self._setup_prefix()}spack load {query} && env -0')
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return {}
+        if result.returncode != 0:
+            return {}
+
+        loaded = _parse_env0(result.stdout)
+        return {
+            key: value for key, value in loaded.items()
+            if os.environ.get(key) != value
+        }
+
+    def install_hint(self, query: str) -> str:
+        return f"spack install {query}"
+
+
+class PipHostPkg(HostPkg):
+    """Host prerequisite provided by pip.
+
+    ``install_query`` is a pip requirement spec. Presence is probed with
+    ``pip show`` against the distribution name, which is the leading
+    token of the spec (``ruamel.yaml>=0.17`` -> ``ruamel.yaml``).
+    """
+
+    install_method = "pip"
+
+    @staticmethod
+    def _dist_name(query: str) -> str:
+        name = query.strip()
+        for sep in ('===', '==', '>=', '<=', '~=', '!=', '>', '<', '[', ';'):
+            name = name.split(sep, 1)[0]
+        return name.strip()
+
+    def is_installed(self, query: str) -> bool:
+        dist = self._dist_name(query)
+        if not dist:
+            return False
+        try:
+            result = _run_capture(
+                f'python3 -m pip show {dist}')
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return False
+        return result.returncode == 0
+
+    def activate(self, query: str) -> Dict[str, str]:
+        # pip installs into the interpreter jarvis is already running
+        # under, so the host environment already resolves it.
+        return {}
+
+    def install_hint(self, query: str) -> str:
+        return f"python3 -m pip install {query}"
+
+
+class CondaHostPkg(HostPkg):
+    """Host prerequisite provided by conda, checked against the currently
+    active environment. ``install_query`` is a conda package spec."""
+
+    install_method = "conda"
+
+    @staticmethod
+    def _pkg_name(query: str) -> str:
+        return query.strip().split('=')[0].strip()
+
+    def is_installed(self, query: str) -> bool:
+        if not shutil.which('conda'):
+            return False
+        name = self._pkg_name(query)
+        if not name:
+            return False
+        try:
+            # `conda list <name>` exits 0 even with no match, so match on
+            # a real output row instead of the exit code.
+            result = _run_capture(f'conda list --no-pip {name}')
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return False
+        if result.returncode != 0:
+            return False
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            if line.split()[0] == name:
+                return True
+        return False
+
+    def activate(self, query: str) -> Dict[str, str]:
+        # Packages land in the already-active conda env; nothing to add.
+        return {}
+
+    def install_hint(self, query: str) -> str:
+        return f"conda install -y {query}"

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -11,6 +11,7 @@ import copy
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 from jarvis_cd.core.config import load_class, Jarvis
+from jarvis_cd.core.host_pkg import HostPkg
 from jarvis_cd.util.logger import logger
 from jarvis_cd.util.hostfile import Hostfile
 
@@ -64,6 +65,12 @@ class Pipeline:
         # their own. None means no default ('default' deploy_mode).
         # Per-package install_method (not this field) selects the Installer.
         self.base_deploy_mode = None
+
+        # Host baremetal prerequisites (top-level YAML key ``host_pkgs``):
+        # [{'install_method': 'spack', 'install_query': 'apptainer'}, ...].
+        # Verified -- and their environments activated -- before the
+        # pipeline does any work. See jarvis_cd/core/host_pkg.py.
+        self.host_pkgs = []
 
         # Launcher overrides (set from YAML top-level keys ``ssh_cmd``,
         # ``pssh_cmd``, ``mpi_cmd``). None = built-in defaults.
@@ -144,6 +151,12 @@ class Pipeline:
                 "pipeline YAML before calling submit().")
         if not self.name:
             raise ValueError("Pipeline name not set; cannot submit job.")
+
+        # Check host prerequisites on the submitting host before the job
+        # is queued. The job script re-runs jarvis on the compute node,
+        # which would hit the same missing package -- but only after
+        # sitting in the queue and burning an allocation to fail.
+        HostPkg.check_all(self.host_pkgs, env=self.env, context=self.name)
 
         from jarvis_cd.core.scheduler import make_scheduler
         shared_dir = self.jarvis.get_pipeline_shared_dir(self.name)
@@ -348,6 +361,12 @@ class Pipeline:
         # Add base_deploy_mode (default deploy_mode propagated to pkgs).
         if self.base_deploy_mode:
             pipeline_config['base_deploy_mode'] = self.base_deploy_mode
+
+        # Persist host prerequisites so a later `jarvis ppl submit` /
+        # `ppl run` against the saved current pipeline re-checks them
+        # without re-reading the original YAML.
+        if self.host_pkgs:
+            pipeline_config['host_pkgs'] = self.host_pkgs
 
         # Persist launcher overrides so reloads round-trip and
         # downstream `ppl run` invocations see the same launcher even
@@ -645,11 +664,21 @@ class Pipeline:
         :param load_type: Type of pipeline file to load (e.g., 'yaml')
         :param pipeline_file: Path to pipeline file to load and run
         """
-        try:
-            # Load pipeline file if specified
-            if load_type and pipeline_file:
-                self.load(load_type, pipeline_file)
+        # Load pipeline file if specified. Both of these run outside the
+        # try below: nothing has started yet, so the except's stop()
+        # recovery has nothing to tear down, and routing a missing host
+        # package through it would bury the actionable message under a
+        # "Attempting to stop packages..." trace.
+        if load_type and pipeline_file:
+            self.load(load_type, pipeline_file)
 
+        # Verify host prerequisites before doing anything. Loading a
+        # YAML above already checked (and the probe is memoized, so this
+        # is free); this call is what covers `jarvis ppl run` against a
+        # saved current pipeline, which never re-reads the source YAML.
+        HostPkg.check_all(self.host_pkgs, env=self.env, context=self.name)
+
+        try:
             # Configure all packages before starting.
             # This runs _configure() on each package, which sets up
             # environment variables (e.g., CHI_SERVER_CONF) needed by start().
@@ -1050,6 +1079,13 @@ class Pipeline:
         self.mpi_cmd = pipeline_config.get('mpi_cmd', None)
         self._apply_launcher_overrides()
 
+        # Host prerequisites round-trip through the saved config. Only
+        # parsed here (no check): loading a saved pipeline is also what
+        # `jarvis ppl status`/`ppl print` do, and those should not fail
+        # on a host that merely cannot run the pipeline. The check runs
+        # on the paths that actually execute: run() and submit().
+        self.host_pkgs = HostPkg.parse(pipeline_config.get('host_pkgs'))
+
         # Load base_deploy_mode. The legacy ``install_manager`` key is
         # still read once with a deprecation warning so saved pipelines
         # from before the rename keep loading.
@@ -1177,6 +1213,17 @@ class Pipeline:
                 "The 'env' field must be either a string (named environment) or omitted (auto-build)."
             )
         
+        # Host prerequisites are verified before anything else touches
+        # the filesystem or spawns a package. A containerized pipeline
+        # shells out to the host's apptainer/docker to build its image,
+        # so a missing host package has to stop the load here -- not
+        # surface as `apptainer: command not found` after jarvis has
+        # already created directories and started services. Activating
+        # here also means the container build below inherits the
+        # prerequisite's PATH.
+        self.host_pkgs = HostPkg.parse(pipeline_def.get('host_pkgs'))
+        HostPkg.check_all(self.host_pkgs, env=self.env, context=self.name)
+
         # Initialize other attributes
         self.created_at = str(Path().cwd())
         self.last_loaded_file = str(pipeline_file.absolute())

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -5,6 +5,7 @@ Provides the consolidated Pipeline class that combines pipeline creation, loadin
 
 import os
 import socket
+import time
 import yaml
 import copy
 from pathlib import Path
@@ -34,6 +35,13 @@ class Pipeline:
         self.created_at = None
         self.last_loaded_file = None
 
+        # Per-package start() timings, keyed by pkg_id ->
+        # {'start_time': epoch, 'runtime': seconds}. Recorded by start() and
+        # replayed onto every later instance by _load_package_instance, since
+        # each phase (start/stop/_get_stat) gets a *fresh* package object and
+        # in-memory state does not survive between them.
+        self.pkg_runtimes = {}
+
         # Container parameters
         self.container_image = ""  # Pre-built image to use
         self.container_uri = ""  # Pre-built deploy image URI (skips build+deploy when set)
@@ -45,9 +53,12 @@ class Pipeline:
         self.container_host_path = ""  # Docker host path prefix for DinD remapping
         self.container_workspace = ""  # Container workspace root for DinD remapping
         self.container_caps = []  # Apptainer --add-caps (e.g. SYS_ADMIN)
+        self.container_fakeroot = False  # Apptainer --fakeroot at instance start
         self.container_binds = []  # Pipeline-level bind mounts (host:container)
         self.container_gpu = False  # --nv / GPU passthrough
         self.tmp_bind_root = None  # Per-host /tmp redirect root (apptainer)
+        self.container_overlay = True  # Apptainer --overlay writable layer
+        self.container_overlay_root = None  # Per-host overlay upper dir root (apptainer)
 
         # Default deploy_mode propagated to packages that don't set
         # their own. None means no default ('default' deploy_mode).
@@ -319,8 +330,20 @@ class Pipeline:
             pipeline_config['container_workspace'] = self.container_workspace
         if self.container_caps:
             pipeline_config['container_caps'] = self.container_caps
+        if self.container_fakeroot:
+            pipeline_config['container_fakeroot'] = self.container_fakeroot
         if self.container_binds:
             pipeline_config['container_binds'] = self.container_binds
+        # container_overlay defaults to True: persist only a non-default
+        # False (the `if truthy` idiom above would drop it silently).
+        if not self.container_overlay:
+            pipeline_config['container_overlay'] = False
+        if self.container_overlay_root:
+            pipeline_config['container_overlay_root'] = self.container_overlay_root
+        if self.container_gpu:
+            pipeline_config['container_gpu'] = self.container_gpu
+        if self.tmp_bind_root:
+            pipeline_config['tmp_bind_root'] = self.tmp_bind_root
 
         # Add base_deploy_mode (default deploy_mode propagated to pkgs).
         if self.base_deploy_mode:
@@ -480,7 +503,7 @@ class Pipeline:
                     self._apply_interceptors_to_package(pkg_instance, pkg_def)
 
                     if hasattr(pkg_instance, 'start'):
-                        pkg_instance.start()
+                        self._timed_start(pkg_def, pkg_instance)
                     else:
                         logger.warning(f"Package {pkg_def['pkg_id']} has no start method")
 
@@ -494,6 +517,34 @@ class Pipeline:
                     logger.error(f"Error starting package {pkg_def['pkg_id']}: {e}")
                     raise RuntimeError(f"Pipeline startup failed at package '{pkg_def['pkg_id']}': {e}") from e
     
+    def _timed_start(self, pkg_def, pkg_instance):
+        """
+        Run a package's ``start()`` and record how long it took.
+
+        Benchmark packages report ``<pkg_id>.runtime`` out of ``self.runtime``,
+        but ``_get_stat`` runs on a *fresh* instance built long after
+        ``start()`` returned (see ``_load_package_instance``), so the
+        measurement cannot live on the instance that made it. Park it on the
+        pipeline; ``_load_package_instance`` replays it onto every later
+        instance of the same ``pkg_id``.
+
+        Timed in ``finally`` on purpose: a package that raised still ran for
+        some time, and that is exactly the number a failed CSV row wants.
+
+        Records ``runtime`` only -- see ``Pkg.__init__`` for why
+        ``start_time`` must stay unpopulated.
+
+        :param pkg_def: Package definition dictionary
+        :param pkg_instance: The instance whose start() to run
+        """
+        counter = time.perf_counter()
+        try:
+            pkg_instance.start()
+        finally:
+            runtime = time.perf_counter() - counter
+            pkg_instance.runtime = runtime
+            self.pkg_runtimes[pkg_def['pkg_id']] = runtime
+
     def stop(self):
         """Stop all packages in the pipeline"""
         from jarvis_cd.util.logger import logger
@@ -972,8 +1023,22 @@ class Pipeline:
         self.container_host_path = pipeline_config.get('container_host_path', '')
         self.container_workspace = pipeline_config.get('container_workspace', '')
         self.container_caps = pipeline_config.get('container_caps', [])
+        self.container_fakeroot = pipeline_config.get(
+            'container_fakeroot', False)
         self.container_binds = Pipeline._expand_env_in_config(
             pipeline_config.get('container_binds', []) or [])
+        self.container_overlay = pipeline_config.get('container_overlay', True)
+        overlay_root_raw = pipeline_config.get('container_overlay_root', None)
+        self.container_overlay_root = (
+            os.path.expandvars(overlay_root_raw)
+            if overlay_root_raw else None
+        )
+        self.container_gpu = pipeline_config.get('container_gpu', False)
+        tmp_bind_root_raw = pipeline_config.get('tmp_bind_root', None)
+        self.tmp_bind_root = (
+            os.path.expandvars(tmp_bind_root_raw)
+            if tmp_bind_root_raw else None
+        )
 
         # Launcher overrides (top-level YAML keys). None = use built-in
         # defaults (ssh / pssh / mpiexec). Typical override pattern:
@@ -1135,6 +1200,13 @@ class Pipeline:
         # the workload needs (e.g., SYS_ADMIN + /dev/fuse for FUSE mounts)
         # has to be declared at the pipeline level here.
         self.container_caps = pipeline_def.get('container_caps', [])
+        # Apptainer-only: run the instance under --fakeroot. Rootless
+        # apptainer grants a FUSE-capable user namespace (CAP_SYS_ADMIN
+        # inside the userns) only via --fakeroot; per-exec flags are
+        # ignored on a running instance, so like caps/binds above it must
+        # bake into `apptainer instance start`.
+        self.container_fakeroot = pipeline_def.get('container_fakeroot',
+                                                   False)
         self.container_binds = Pipeline._expand_env_in_config(
             pipeline_def.get('container_binds', []) or [])
 
@@ -1154,6 +1226,24 @@ class Pipeline:
         self.tmp_bind_root = (
             os.path.expandvars(tmp_bind_root_raw)
             if tmp_bind_root_raw else None
+        )
+
+        # Apptainer-only: writable-overlay controls. The default overlay
+        # upper dir lives under the pipeline's shared_dir, which is
+        # single-node only: overlayfs cannot use a shared/NFS directory
+        # as its upper layer, and concurrent `apptainer instance start`s
+        # across nodes race on the same session/overlay setup. Setting
+        # `container_overlay_root: /mnt/nvme/$USER` (or any per-host
+        # path) puts the upper dir at <root>/<pipeline_name>/overlay on
+        # every host instead — required for multi-node pipelines.
+        # `container_overlay: false` drops --overlay entirely: the
+        # container FS is read-only outside bind mounts and the host
+        # /tmp mounts normally.
+        self.container_overlay = pipeline_def.get('container_overlay', True)
+        overlay_root_raw = pipeline_def.get('container_overlay_root', None)
+        self.container_overlay_root = (
+            os.path.expandvars(overlay_root_raw)
+            if overlay_root_raw else None
         )
 
         # Launcher overrides (top-level YAML keys). None = use built-in
@@ -1312,6 +1402,16 @@ class Pipeline:
 
         # Initialize directories now that pkg_id is set
         pkg_instance._ensure_directories()
+
+        # Replay this package's start() runtime onto the fresh instance. Each
+        # phase (start/stop/_get_stat) gets its own object, so without this the
+        # stats instance has no idea the package ever ran and `<pkg_id>.runtime`
+        # lands in the CSV blank. MUST come after _ensure_directories(), which
+        # is what calls the package's own _init() -- an _init that assigns
+        # self.runtime would otherwise clobber the replay.
+        runtime = self.pkg_runtimes.get(pkg_def['pkg_id'])
+        if runtime is not None:
+            pkg_instance.runtime = runtime
 
         # Set configuration
         base_config = pkg_def.get('config', {})
@@ -1781,21 +1881,59 @@ class Pipeline:
             if self.container_caps:
                 cap_flag = f'--add-caps {",".join(self.container_caps)} '
 
-            # Per-pipeline writable layer backed by NFS, not RAM.
+            fakeroot_flag = '--fakeroot ' if self.container_fakeroot else ''
+
+            # The effective hostfile decides both where instances start
+            # (exec_info below) and whether the default shared overlay
+            # is even legal (guard below). Fetch it once, up front.
+            hostfile = self.get_hostfile()
+
+            # Per-pipeline writable layer backed by disk, not RAM.
             # `--writable-tmpfs` is RAM-only (capped at ~50% of system
             # RAM); workloads that apt-/conda-install at runtime
             # (snakemake conda envs, deferred pip installs, …) blow past
-            # that even though the host has terabytes free. An overlay
-            # directory under shared_dir lives on the same NFS mount as
-            # the SIF, so the container has effectively unlimited
-            # writable space and the data persists across runs.
+            # that even though the host has terabytes free.
+            #
+            # The default overlay dir under shared_dir lives on the same
+            # (typically NFS) mount as the SIF — effectively unlimited
+            # writable space, persists across runs — but is single-node
+            # only: overlayfs cannot use a shared/NFS directory as its
+            # upper layer, and N nodes mounting the same upper dir race
+            # each other's session setup (guarded below).
+            # `container_overlay_root` relocates the upper dir to
+            # <root>/<pipeline_name>/overlay on node-local disk instead;
+            # that dir is created on every host via exec_info further
+            # down, since a head-side mkdir only exists on this node.
             #
             # `--no-mount tmp` keeps the host's small /tmp out of the
-            # picture; in-container /tmp lands in the overlay (NFS).
-            overlay_dir = shared_dir / 'overlay'
-            overlay_dir.mkdir(parents=True, exist_ok=True)
-            overlay_flag = f'--overlay {overlay_dir} '
-            no_mount_flag = '--no-mount tmp '
+            # picture; in-container /tmp lands in the overlay. With
+            # `container_overlay: false` there is no overlay for /tmp to
+            # land in, so the host /tmp stays mounted (apptainer
+            # default).
+            overlay_flag = ''
+            no_mount_flag = ''
+            if self.container_overlay:
+                if self.container_overlay_root:
+                    overlay_dir = (
+                        f"{self.container_overlay_root}/{self.name}/overlay")
+                else:
+                    if (len(hostfile) > 1 and
+                            not self._hostfile_is_local_only(hostfile)):
+                        raise RuntimeError(
+                            f"Pipeline '{self.name}' spans multiple hosts "
+                            f"but uses the default shared apptainer overlay "
+                            f"({shared_dir / 'overlay'}). overlayfs cannot "
+                            "use a shared/NFS directory as its upper layer, "
+                            "and concurrent instance starts race on it. Set "
+                            "`container_overlay_root: <node-local path>` "
+                            "(e.g. /mnt/nvme/$USER) or `container_overlay: "
+                            "false` in the pipeline YAML.")
+                    overlay_dir = shared_dir / 'overlay'
+                    # Head-side mkdir suffices only because this path is
+                    # on the shared FS (single-node guaranteed above).
+                    overlay_dir.mkdir(parents=True, exist_ok=True)
+                overlay_flag = f'--overlay {overlay_dir} '
+                no_mount_flag = '--no-mount tmp '
 
             # When tmp_bind_root is set in the pipeline YAML, replace the
             # overlay-backed /tmp with a per-host bind mount so workloads
@@ -1808,7 +1946,7 @@ class Pipeline:
                 no_mount_flag = ''
 
             start_cmd = (
-                f"apptainer instance start {nv_flag}{cap_flag}{bind_flags}"
+                f"apptainer instance start {fakeroot_flag}{nv_flag}{cap_flag}{bind_flags}"
                 f"{tmp_bind_flag}{no_mount_flag}{overlay_flag}{sif_path} {instance_name}"
                 f" && apptainer exec {nv_flag}instance://{instance_name}"
                 f" /usr/sbin/sshd -p {ssh_port}"
@@ -1828,7 +1966,6 @@ class Pipeline:
             # adopted by pam_slurm_adopt automatically; the pipeline's
             # own ssh_cmd override (e.g. env -u LD_LIBRARY_PATH ssh)
             # neutralizes the conda libcrypto/OpenSSL mismatch.
-            hostfile = self.get_hostfile()
             if self._hostfile_is_local_only(hostfile):
                 logger.info("Hostfile is local-only, deploying to localhost directly")
                 exec_info = LocalExecInfo()
@@ -1836,7 +1973,27 @@ class Pipeline:
                 logger.info(
                     f"Hostfile has {len(hostfile)} hosts; starting "
                     "apptainer instance on every host via PsshExecInfo")
-                exec_info = PsshExecInfo(hostfile=hostfile)
+                exec_info = PsshExecInfo(
+                    hostfile=hostfile,
+                    # ssh propagates no env; inline PATH so the remote resolves
+                    # apptainer via the spack view. PATH only -- never
+                    # LD_LIBRARY_PATH (keep managed libs off apptainer's starter).
+                    env={'PATH': os.environ.get('PATH', '')})
+
+            # A per-host overlay upper dir must exist on every node
+            # before `apptainer instance start` tries to mount it,
+            # otherwise apptainer aborts with "mount source X doesn't
+            # exist". (The default shared overlay was mkdir'd head-side
+            # above — being on the shared FS, every node sees it.)
+            if self.container_overlay and self.container_overlay_root:
+                overlay_mkdir = (
+                    f"mkdir -p "
+                    f"{self.container_overlay_root}/{self.name}/overlay")
+                logger.info(
+                    f"container_overlay_root set; ensuring "
+                    f"{self.container_overlay_root}/{self.name}/overlay "
+                    "exists on every host")
+                Exec(overlay_mkdir, exec_info).run()
 
             # Per-host bind source for tmp_bind_root must exist on every
             # node before the apptainer instance start tries to mount it,
@@ -1849,7 +2006,15 @@ class Pipeline:
                     f"{self.name}/tmp exists on every host")
                 Exec(tmp_mkdir, exec_info).run()
 
-            Exec(start_cmd, exec_info).run()
+            start = Exec(start_cmd, exec_info).run()
+            # A partial instance start must not go unnoticed: the
+            # workload's own clustering layer would wait forever on the
+            # node whose instance never came up.
+            for host, code in start.exit_code.items():
+                if code != 0:
+                    raise RuntimeError(
+                        f"apptainer instance start failed on {host} "
+                        f"(exit {code})")
             logger.success("Apptainer instances started (SSH ready)")
         else:
             # Docker/Podman: start containers via compose
@@ -1871,7 +2036,12 @@ class Pipeline:
             else:
                 logger.info("Deploying containers to all nodes in hostfile")
                 self._distribute_image_to_hosts(hostfile)
-                exec_info = PsshExecInfo(hostfile=hostfile)
+                exec_info = PsshExecInfo(
+                    hostfile=hostfile,
+                    # ssh propagates no env; inline PATH so the remote resolves
+                    # apptainer via the spack view. PATH only -- never
+                    # LD_LIBRARY_PATH (keep managed libs off apptainer's starter).
+                    env={'PATH': os.environ.get('PATH', '')})
 
             Exec(up_cmd, exec_info).run()
             logger.success("Containers started (SSH ready)")
@@ -1886,7 +2056,7 @@ class Pipeline:
                 self._apply_interceptors_to_package(pkg_instance, pkg_def)
 
                 if hasattr(pkg_instance, 'start'):
-                    pkg_instance.start()
+                    self._timed_start(pkg_def, pkg_instance)
                 else:
                     logger.warning(f"Package {pkg_def['pkg_id']} has no start method")
 
@@ -1997,7 +2167,12 @@ class Pipeline:
         if self._hostfile_is_local_only(hostfile):
             exec_info = LocalExecInfo()
         else:
-            exec_info = PsshExecInfo(hostfile=hostfile)
+            exec_info = PsshExecInfo(
+                hostfile=hostfile,
+                # ssh propagates no env; inline PATH so the remote resolves
+                # apptainer via the spack view. PATH only -- never
+                # LD_LIBRARY_PATH (keep managed libs off apptainer's starter).
+                env={'PATH': os.environ.get('PATH', '')})
 
         Exec(stop_cmd, exec_info).run()
         logger.success("Containers stopped")
@@ -2039,7 +2214,12 @@ class Pipeline:
         if self._hostfile_is_local_only(hostfile):
             exec_info = LocalExecInfo()
         else:
-            exec_info = PsshExecInfo(hostfile=hostfile)
+            exec_info = PsshExecInfo(
+                hostfile=hostfile,
+                # ssh propagates no env; inline PATH so the remote resolves
+                # apptainer via the spack view. PATH only -- never
+                # LD_LIBRARY_PATH (keep managed libs off apptainer's starter).
+                env={'PATH': os.environ.get('PATH', '')})
 
         Exec(kill_cmd, exec_info).run()
         logger.success("Containers force-killed")

--- a/jarvis_cd/core/pipeline_test.py
+++ b/jarvis_cd/core/pipeline_test.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Any, List, Optional, Tuple
+from jarvis_cd.core.host_pkg import HostPkg
 from jarvis_cd.core.pipeline import Pipeline
 from jarvis_cd.util.logger import logger, Color
 
@@ -127,6 +128,8 @@ class PipelineTest:
         """Initialize pipeline test instance."""
         self.name = None
         self.config = {}  # The base pipeline configuration
+        # Host baremetal prerequisites declared in ``config.host_pkgs``.
+        self.host_pkgs = []
         self.vars = {}  # Variable definitions
         self.loop = []  # Loop structure
         self.repeat = 1
@@ -312,6 +315,15 @@ class PipelineTest:
         # Load test components
         self.config = test_def['config']
         self.name = self.config.get('name', pipeline_file.stem)
+
+        # Host prerequisites live in the pipeline definition, so they
+        # ride along in `config:` and are re-checked by every iteration's
+        # Pipeline load. Check once here as well: a sweep of N
+        # combinations should not build N-1 outputs before discovering
+        # the host cannot run it. The probe is memoized, so the
+        # per-iteration checks that follow cost nothing.
+        self.host_pkgs = HostPkg.parse(self.config.get('host_pkgs'))
+        HostPkg.check_all(self.host_pkgs, context=self.name)
         self.vars = test_def.get('vars', {})
         self.loop = test_def.get('loop', [])
         self.repeat = test_def.get('repeat', 1)

--- a/jarvis_cd/core/pipeline_test.py
+++ b/jarvis_cd/core/pipeline_test.py
@@ -8,6 +8,7 @@ import csv
 import yaml
 import copy
 import itertools
+from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Any, List, Optional, Tuple
@@ -44,6 +45,73 @@ def is_pipeline_test(yaml_data: Dict[str, Any]) -> bool:
     return has_config
 
 
+# Wall-clock budget for the teardown that follows a timed-out run. The same
+# hang that tripped the deadline can wedge stop() too, so the cleanup is
+# bounded as well -- otherwise the recovery path reintroduces the hang.
+TEARDOWN_TIMEOUT = 300
+
+
+class Deadline:
+    """
+    Records whether an :func:`alarm_timeout` budget actually expired.
+
+    The TimeoutError raised by the alarm does not necessarily reach the
+    caller: ``Pipeline.start`` catches whatever a package raises and
+    re-raises it as ``RuntimeError("Pipeline startup failed at package
+    ...")``. Keying recovery off the exception *type* therefore misses the
+    timeout and skips teardown, which leaks the run's redis, container
+    instances and mounts into the next combination. This flag is set in the
+    signal handler itself, so it survives any downstream re-wrapping.
+    """
+
+    def __init__(self):
+        self.expired = False
+
+
+@contextmanager
+def alarm_timeout(seconds: Optional[int], message: str,
+                  deadline: Optional['Deadline'] = None):
+    """
+    Bound a blocking call with SIGALRM, raising TimeoutError on expiry.
+
+    A wedged package blocks forever inside ``pipeline.start()``. The sweep
+    runner's per-run ``try/except`` only catches exceptions, and a hang is
+    not an exception -- so one bad combination silently consumes the entire
+    grid and, under a scheduler, the entire allocation. Converting the hang
+    into a TimeoutError lets the runner record that combination as failed
+    and move on to the next one.
+
+    Arms only in the main thread, since Python delivers signals there; in a
+    worker thread this is a no-op so threaded/library callers still work.
+
+    :param seconds: Budget in seconds; falsy or <= 0 disables the alarm
+    :param message: Text carried by the raised TimeoutError
+    :param deadline: Optional Deadline marked ``expired`` when the alarm
+        fires, so callers can detect the timeout even if the TimeoutError
+        is re-wrapped as another exception type further up the stack
+    """
+    import signal
+    import threading
+
+    if not seconds or seconds <= 0 or \
+            threading.current_thread() is not threading.main_thread():
+        yield
+        return
+
+    def _on_alarm(signum, frame):
+        if deadline is not None:
+            deadline.expired = True
+        raise TimeoutError(message)
+
+    previous = signal.signal(signal.SIGALRM, _on_alarm)
+    signal.alarm(int(seconds))
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous)
+
+
 class PipelineTest:
     """
     Pipeline test runner for experiment sets using grid search.
@@ -63,6 +131,9 @@ class PipelineTest:
         self.loop = []  # Loop structure
         self.repeat = 1
         self.output = None
+        # Wall-clock budget for a single combination, in seconds. None (the
+        # default) preserves the historical unbounded behaviour.
+        self.run_timeout = None
         self.combinations = []  # Generated test combinations
         self.results = []  # Collected results
         # Top-level scheduler block (one job wraps the whole test run).
@@ -245,6 +316,7 @@ class PipelineTest:
         self.loop = test_def.get('loop', [])
         self.repeat = test_def.get('repeat', 1)
         self.output = test_def.get('output', None)
+        self.run_timeout = test_def.get('run_timeout', None)
         self.scheduler = test_def.get('scheduler', None)
         self.source_path = str(pipeline_file.absolute())
 
@@ -261,6 +333,8 @@ class PipelineTest:
         logger.info(f"  Total combinations: {len(self.combinations)}")
         logger.info(f"  Repeat count: {self.repeat}")
         logger.info(f"  Total runs: {len(self.combinations) * self.repeat}")
+        if self.run_timeout:
+            logger.info(f"  Run timeout: {self.run_timeout}s per combination")
 
     def _build_combinations(self):
         """
@@ -351,6 +425,15 @@ class PipelineTest:
             template, then any nested ``config.scheduler`` overrides it,
             then the ``scheduler.X`` variable values override that.
 
+        When NO ``scheduler.X`` variables are swept, the test's top-level
+        ``scheduler:`` block is NOT copied into iteration configs: in that
+        mode the block describes the single job that ``ppl submit`` wraps
+        around the WHOLE test run, and iterations must run in-process
+        inside that allocation (stamping the block onto every iteration
+        made ``_run_single`` re-submit each one as a nested sbatch job
+        from inside the allocation). A ``scheduler:`` nested inside
+        ``config:`` still requests per-iteration submission explicitly.
+
         :param base_config: Base pipeline configuration
         :param variables: Variable values to apply
         :return: Modified configuration
@@ -363,7 +446,7 @@ class PipelineTest:
         pkg_vars = {k: v for k, v in variables.items()
                     if k.split('.', 1)[0] != 'scheduler'}
 
-        if scheduler_vars or self.scheduler:
+        if scheduler_vars:
             merged = copy.deepcopy(self.scheduler) if self.scheduler else {}
             existing = config.get('scheduler') or {}
             merged.update(existing)
@@ -597,14 +680,43 @@ class PipelineTest:
             # template + scheduler.X vars), submit it as its own job and
             # block until it finishes via ``sbatch --wait``. Otherwise
             # run the pipeline in-process.
-            if pipeline.scheduler:
-                logger.pipeline(
-                    f"Submitting iteration as scheduler job "
-                    f"({pipeline.scheduler.get('name')})")
-                pipeline.submit(submit=True, wait=True)
-            else:
-                pipeline.start()
-                pipeline.stop()
+            deadline = Deadline()
+            try:
+                with alarm_timeout(
+                        self.run_timeout,
+                        f"run exceeded run_timeout of {self.run_timeout}s",
+                        deadline):
+                    if pipeline.scheduler:
+                        logger.pipeline(
+                            f"Submitting iteration as scheduler job "
+                            f"({pipeline.scheduler.get('name')})")
+                        pipeline.submit(submit=True, wait=True)
+                    else:
+                        pipeline.start()
+                        pipeline.stop()
+            except Exception:
+                # Keyed off the Deadline, not the exception type:
+                # Pipeline.start re-raises whatever a package raised as
+                # RuntimeError, so the TimeoutError does not survive to
+                # here. Without teardown the run's redis, container
+                # instances and mounts leak into the next combination --
+                # which then silently benchmarks the previous run's
+                # processes.
+                if not deadline.expired:
+                    raise
+                logger.error(
+                    f"Run exceeded run_timeout of {self.run_timeout}s; "
+                    f"tearing down and continuing to the next combination")
+                try:
+                    with alarm_timeout(
+                            TEARDOWN_TIMEOUT,
+                            f"teardown exceeded {TEARDOWN_TIMEOUT}s"):
+                        pipeline.stop()
+                except Exception as stop_error:
+                    logger.warning(
+                        f"Teardown after timeout did not complete cleanly: "
+                        f"{stop_error}")
+                raise
 
             end_time = time.time()
             result['runtime'] = end_time - start_time

--- a/jarvis_cd/core/pkg.py
+++ b/jarvis_cd/core/pkg.py
@@ -112,6 +112,24 @@ class Pkg:
         self.global_id = None
         self.pkg_id = None
 
+        # Seconds this package's start() took, measured by Pipeline.start()
+        # and restored by Pipeline._load_package_instance. None outside a
+        # pipeline run (standalone packages, or a package that never started).
+        # MUST be defined here: _get_stat runs on a *fresh* instance -- not
+        # the one that ran -- so a package reading it would otherwise raise
+        # AttributeError and lose every stat it collects.
+        self.runtime = None
+
+        # Deprecated, and deliberately never populated. Nine builtin packages
+        # used to report `<pkg_id>.runtime` out of this attribute, which no
+        # code ever assigned; they now read self.runtime. It survives only so
+        # a package still reading it gets an empty cell rather than an
+        # AttributeError that would discard all of its stats. Do NOT start
+        # populating it: any package not yet updated would then file an epoch
+        # timestamp under a column that means "seconds" -- silently wrong data
+        # in place of a visibly blank one.
+        self.start_time = None
+
         # Note: Directories will be initialized by Pipeline._load_package_instance
         # after pkg_id is set, or by user code for standalone packages
 

--- a/jarvis_cd/core/scheduler.py
+++ b/jarvis_cd/core/scheduler.py
@@ -164,9 +164,16 @@ class SlurmScheduler(Scheduler):
             if value is True:
                 lines.append(f"#SBATCH {flag}")
             else:
-                lines.append(f"#SBATCH {flag}={value}")
+                # Expand ${VAR} host-side: slurm does NOT expand env vars in
+                # #SBATCH directives, so an unexpanded ${HOME} in output:/error:
+                # is taken literally (relative to WorkDir), the file can't be
+                # opened, and the job fails at launch with no logs. os.path.
+                # expandvars leaves slurm patterns (%j, %x, ...) and unset vars
+                # untouched. This mirrors how the rest of jarvis expands env
+                # vars in YAML paths (container_binds, tmp_bind_root).
+                lines.append(f"#SBATCH {flag}={os.path.expandvars(str(value))}")
         for raw in self.spec.get('sbatch_args', []) or []:
-            lines.append(f"#SBATCH {raw}")
+            lines.append(f"#SBATCH {os.path.expandvars(str(raw))}")
         return lines
 
     def render(self) -> str:

--- a/jarvis_cd/shell/exec_factory.py
+++ b/jarvis_cd/shell/exec_factory.py
@@ -165,9 +165,16 @@ class Exec(CoreExec):
                 # sshd running inside apptainer instances on remote nodes.
                 # Export PATH so remote orted finds application binaries
                 # (the remote SSH login shell may override the container PATH).
-                if '--mca plm rsh' not in mpi_cmd:
+                #
+                # Exclude the slurm plm rather than naming the ssh launcher:
+                # OpenMPI <=4 (ORTE) calls the ssh launcher 'rsh', OpenMPI 5
+                # (PRRTE) renamed it 'ssh'. '^slurm' defeats slurm's srun-based
+                # launch (which would spawn prted OUTSIDE the container) and
+                # lets PRRTE/ORTE auto-select its ssh launcher under either
+                # name -- no in-container version probe needed.
+                if '--mca plm ' not in mpi_cmd:
                     mpi_cmd = mpi_cmd.replace(
-                        'mpiexec ', 'mpiexec --mca plm rsh ', 1)
+                        'mpiexec ', 'mpiexec --mca plm ^slurm ', 1)
                 mpi_cmd = mpi_cmd.replace(
                     'mpiexec ', 'mpiexec -x PATH -x LD_LIBRARY_PATH ', 1)
                 wrapped_cmd, local_info = self._prepare_container(mpi_cmd)

--- a/jarvis_cd/shell/mpi_exec.py
+++ b/jarvis_cd/shell/mpi_exec.py
@@ -112,10 +112,16 @@ class OpenMpiExec(LocalMpiExec):
         params = self.mpi_cmd.split() if self.mpi_cmd else ['mpiexec']
         params.append('--oversubscribe')
         params.append('--allow-run-as-root')  # For docker
-        # Forward the pipeline-level ssh_cmd to OpenMPI's rsh agent
-        # so prted spawns remote daemons via the wrapped ssh.
+        # Forward the pipeline-level ssh_cmd to OpenMPI's ssh launch agent
+        # so prted spawns remote daemons via the wrapped ssh. OpenMPI <=4
+        # (ORTE) names this plm_rsh_agent; OpenMPI 5 (PRRTE) renamed it to
+        # plm_ssh_agent. The command is assembled on the host but runs inside
+        # the container, so the in-container OMPI version isn't reliably known
+        # here -- emit both names; each runtime honors the one it knows and
+        # ignores the other (an unknown --mca name warns, it is not fatal).
         if self.ssh_cmd:
             params.append(f'--mca plm_rsh_agent "{self.ssh_cmd}"')
+            params.append(f'--mca plm_ssh_agent "{self.ssh_cmd}"')
 
         # Derive --prefix from PATH so remote nodes can find prted
         env_path = self.mpi_env.get('PATH', '')
@@ -127,9 +133,11 @@ class OpenMpiExec(LocalMpiExec):
                     params.append(f'--prefix {prefix}')
                     break
 
-        # Set SSH port if explicitly specified (SSH config will be used otherwise)
+        # Set SSH port if explicitly specified (SSH config used otherwise).
+        # Same rsh(<=4)/ssh(5) launcher rename as the agent above -- emit both.
         if self.ssh_port and self.ssh_port != 22:
             params.append(f'--mca plm_rsh_args "-p {self.ssh_port}"')
+            params.append(f'--mca plm_ssh_args "-p {self.ssh_port}"')
 
 
         if self.ppn is not None:

--- a/jarvis_cd/util/container_utils.py
+++ b/jarvis_cd/util/container_utils.py
@@ -1,0 +1,135 @@
+"""Shared helpers for routing package commands into the pipeline's running
+container instance.
+
+jarvis-cd wraps a command as ``apptainer exec ... instance://<name> bash -c
+'<cmd>'`` only when the ExecInfo passed to Exec carries a container engine
+(``ExecFactory._prepare_container`` gates on ``exec_info.container``). The
+framework never injects this automatically: every package must thread the
+kwargs into each ExecInfo it builds.
+
+These helpers are the shared implementation of that pattern for any package
+(builtin or from an external registered repo) that must behave correctly in
+both bare-metal and containerized pipelines: :func:`container_kwargs` routes
+Execs into the deploy context, :func:`eff_hostfile` +
+:func:`single_instance_menu_opt` implement head-node-only pinning, and
+:func:`flatten_stdout` / :func:`all_hosts_ok` normalize multi-host Exec
+results.
+"""
+from jarvis_cd.util.hostfile import Hostfile
+
+
+def eff_hostfile(pkg, hostfile=None):
+    """The hostfile a *head-node-only* service should actually run on.
+
+    Some packages in a multi-node pipeline are single-client baselines or
+    metadata singletons, NOT distributed workloads: redis (e.g. as JuiceFS's
+    metadata store), the JuiceFS format+FUSE mount, and single-client ior
+    baselines are all meant to run on ONE host even though the pipeline hands
+    every package the full N-node hostfile. Left unpinned they fan out over
+    Pssh to all N nodes and (a) race on shared filesystems (concurrent
+    ``rm -rf``/``mkdir`` of a data dir -> "Directory not empty" and a
+    half-torn state that breaks the next sweep combo), and (b) on the
+    non-head nodes hit services that aren't there ("connection refused") and
+    leave broken FUSE mounts behind.
+
+    When this package sets ``single_instance`` and the (effective) hostfile
+    has >1 host, collapse to just the FIRST host; otherwise return the
+    hostfile unchanged (single-node pipelines and genuinely-distributed
+    packages are unaffected).
+
+    :param pkg: the jarvis package instance (``self``)
+    :param hostfile: optional base hostfile overriding ``pkg.hostfile`` —
+        for packages that pre-slice their hostfile (e.g. ior's ``num_nodes``
+        subset) before the single_instance collapse
+    :return: a Hostfile (possibly sliced to its first host)
+    """
+    hf = hostfile if hostfile is not None else pkg.hostfile
+    if pkg.config.get('single_instance') and hf is not None \
+            and len(hf.hosts) > 1:
+        return Hostfile(hosts=hf.hosts[:1],
+                        hosts_ip=hf.hosts_ip[:1] if hf.hosts_ip else None)
+    return hf
+
+
+def single_instance_menu_opt(msg=None):
+    """The ``single_instance`` config menu entry shared by every
+    head-node-only service. Off by default so single-node pipelines and
+    distributed workloads are unchanged; set true in a multi-node YAML to pin
+    the service to the first host. See :func:`eff_hostfile`.
+
+    :param msg: optional package-specific help text overriding the generic
+        message (semantics must stay those of :func:`eff_hostfile`)
+    :return: dict (a _configure_menu entry)
+    """
+    return {
+        'name': 'single_instance',
+        'msg': msg or (
+            'Pin this service to the FIRST host even when the pipeline '
+            'hostfile has >1 host (skip fanning out over Pssh). Use for '
+            'head-node-only baselines/singletons (e.g. a JuiceFS mount or '
+            'a single-client ior baseline) so they do not race on shared '
+            'filesystems or hit a service that only runs on the head node. '
+            'Default keeps the legacy run-on-every-host behaviour.'),
+        'type': bool,
+        'default': False,
+    }
+
+
+def container_kwargs(pkg):
+    """ExecInfo kwargs that make jarvis's ``Exec._prepare_container`` wrap the
+    command to run inside the pipeline's container instance.
+
+    ``pkg._container_engine`` returns the pipeline's engine (e.g.
+    ``apptainer``) only when this package's ``deploy_mode`` is ``container``
+    (propagated from the pipeline's ``base_deploy_mode``); otherwise it is
+    ``'none'`` and ``_prepare_container`` no-ops, so the result is always
+    safe to splat into any ExecInfo.
+
+    ``pkg.deploy_image_name()`` is the pipeline RUN name (e.g.
+    ``single_node_run1``) — the apptainer instance name — NOT the SIF
+    basename from the YAML's ``container_image``.
+
+    :param pkg: the jarvis package instance (``self``)
+    :return: dict of ExecInfo kwargs
+    """
+    return {
+        'container': pkg._container_engine,
+        'container_image': pkg.deploy_image_name(),
+    }
+
+
+def flatten_stdout(exec_result):
+    """Return an Exec result's stdout as one string.
+
+    Pssh/Local Exec results carry stdout either as ``{host: str}`` or as a
+    plain string depending on the exec type.
+
+    :param exec_result: the object returned by ``Exec(...).run()``
+    :return: stdout joined across hosts
+    """
+    out = getattr(exec_result, 'stdout', '')
+    if isinstance(out, dict):
+        return '\n'.join(str(v) for v in out.values())
+    return str(out)
+
+
+def all_hosts_ok(exec_result, expect=None):
+    """True iff every host exited 0 and, when ``expect`` is given, every
+    host's stdout contains it. Handles dict-or-scalar exit_code/stdout.
+
+    :param exec_result: the object returned by ``Exec(...).run()``
+    :param expect: optional substring required in each host's stdout
+    :return: bool
+    """
+    codes = getattr(exec_result, 'exit_code', 1)
+    if isinstance(codes, dict):
+        if any(c != 0 for c in codes.values()):
+            return False
+    elif codes != 0:
+        return False
+    if expect is None:
+        return True
+    out = getattr(exec_result, 'stdout', '')
+    if isinstance(out, dict):
+        return all(expect in str(v) for v in out.values())
+    return expect in str(out)

--- a/test/unit/core/test_container_apptainer.py
+++ b/test/unit/core/test_container_apptainer.py
@@ -1,0 +1,302 @@
+"""
+Unit tests for the apptainer branch of Pipeline._start_containerized_pipeline.
+Verifies the `apptainer instance start` command construction:
+  - Back-compat golden: defaults produce the exact current command string
+  - container_overlay_root relocates the overlay upper dir per host and
+    fans a mkdir to every node
+  - container_overlay: false omits --overlay (and --no-mount tmp)
+  - Multi-node + default shared overlay raises instead of racing NFS
+  - Per-host instance-start failures raise naming the host
+  - Both keys round-trip save() -> load-from-config and YAML load
+"""
+import unittest
+import sys
+import os
+import tempfile
+import shutil
+import yaml
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+from jarvis_cd.core.config import Jarvis
+from jarvis_cd.core.pipeline import Pipeline
+from jarvis_cd.util.hostfile import Hostfile
+from jarvis_cd.shell import LocalExecInfo, PsshExecInfo
+
+
+def initialize_jarvis_for_test(config_dir, private_dir, shared_dir):
+    jarvis = Jarvis.get_instance()
+    # Save original config so we can restore it after the test
+    saved_config = None
+    if jarvis.config_file.exists():
+        import yaml
+        with open(jarvis.config_file, 'r') as f:
+            saved_config = yaml.safe_load(f)
+    jarvis.initialize(config_dir, private_dir, shared_dir, force=False)
+    return jarvis, saved_config
+
+
+class ApptainerStartTestBase(unittest.TestCase):
+    """Base class with shared setUp/tearDown for apptainer start tests."""
+
+    REMOTE_HOSTS = ['node-01', 'node-02', 'node-03', 'node-04']
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix='jarvis_test_apptainer_')
+        self.config_dir = os.path.join(self.test_dir, 'config')
+        self.private_dir = os.path.join(self.test_dir, 'private')
+        self.shared_dir = os.path.join(self.test_dir, 'shared')
+        os.makedirs(self.config_dir, exist_ok=True)
+        os.makedirs(self.private_dir, exist_ok=True)
+        os.makedirs(self.shared_dir, exist_ok=True)
+
+        os.environ['JARVIS_CONFIG'] = self.config_dir
+        os.environ['JARVIS_PRIVATE'] = self.private_dir
+        os.environ['JARVIS_SHARED'] = self.shared_dir
+
+        self.jarvis, self._saved_config = initialize_jarvis_for_test(
+            self.config_dir, self.private_dir, self.shared_dir
+        )
+
+    def tearDown(self):
+        # Restore the original jarvis config so tests don't clobber the user's setup
+        if self._saved_config:
+            import yaml
+            jarvis = Jarvis.get_instance()
+            jarvis.save_config(self._saved_config)
+            jarvis.config_dir = self._saved_config.get('config_dir', jarvis.config_dir)
+            jarvis.private_dir = self._saved_config.get('private_dir', jarvis.private_dir)
+            jarvis.shared_dir = self._saved_config.get('shared_dir', jarvis.shared_dir)
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+    def _create_pipeline(self, name, hosts=None, **attrs):
+        """Create an apptainer container pipeline; hosts=None keeps the
+        default (local-only) jarvis hostfile."""
+        pipeline = Pipeline()
+        pipeline.create(name)
+        pipeline.base_deploy_mode = 'container'
+        pipeline.container_engine = 'apptainer'
+        if hosts is not None:
+            pipeline.hostfile = Hostfile(hosts=hosts, find_ips=False)
+        for key, value in attrs.items():
+            setattr(pipeline, key, value)
+        pipeline.save()
+        return pipeline
+
+    def _start(self, pipeline, exit_codes=None):
+        """Run _start_containerized_pipeline with Exec mocked; returns the
+        mock. exit_codes is the per-host dict every Exec().run() reports."""
+        with patch('jarvis_cd.shell.Exec') as MockExec:
+            result = MockExec.return_value.run.return_value
+            result.exit_code = exit_codes if exit_codes is not None else {}
+            pipeline._start_containerized_pipeline()
+        return MockExec
+
+    @staticmethod
+    def _cmds(MockExec):
+        """Command strings passed to Exec, in call order."""
+        return [c.args[0] for c in MockExec.call_args_list]
+
+
+class TestApptainerStartCmd(ApptainerStartTestBase):
+
+    def test_default_single_host_golden(self):
+        """Back-compat: with neither overlay key set and a local-only
+        hostfile, the start command is byte-identical to the historical
+        one (shared-dir overlay, --no-mount tmp, LocalExecInfo)."""
+        pipeline = self._create_pipeline('apt_golden')
+        MockExec = self._start(pipeline)
+
+        shared = self.jarvis.get_pipeline_shared_dir('apt_golden')
+        private = self.jarvis.get_pipeline_private_dir('apt_golden')
+        sif = self.jarvis.get_containers_dir() / 'apt_golden.sif'
+        expected = (
+            f"apptainer instance start "
+            f"--bind {shared}:{shared} --bind {private}:{private} "
+            f"--no-mount tmp --overlay {shared / 'overlay'} "
+            f"{sif} apt_golden"
+            f" && apptainer exec instance://apt_golden"
+            f" /usr/sbin/sshd -p 2222 -o StrictModes=no -o UsePAM=no"
+        )
+        self.assertEqual(MockExec.call_count, 1)
+        cmd, exec_info = MockExec.call_args.args
+        self.assertEqual(cmd, expected)
+        self.assertIsInstance(exec_info, LocalExecInfo)
+        self.assertTrue((shared / 'overlay').is_dir())
+
+    def test_overlay_root_relocates_overlay_and_fans_mkdir(self):
+        """container_overlay_root moves the overlay upper dir to a
+        per-host path and fans a mkdir to every node before start."""
+        pipeline = self._create_pipeline('apt_root', hosts=self.REMOTE_HOSTS,
+                                         container_overlay_root='/tmp')
+        MockExec = self._start(
+            pipeline, exit_codes={h: 0 for h in self.REMOTE_HOSTS})
+
+        cmds = self._cmds(MockExec)
+        self.assertIn('mkdir -p /tmp/apt_root/overlay', cmds)
+        mkdir_idx = cmds.index('mkdir -p /tmp/apt_root/overlay')
+        start_idx = next(i for i, c in enumerate(cmds)
+                         if c.startswith('apptainer instance start'))
+        self.assertLess(mkdir_idx, start_idx)
+
+        start_cmd = cmds[start_idx]
+        self.assertIn('--overlay /tmp/apt_root/overlay ', start_cmd)
+        shared = self.jarvis.get_pipeline_shared_dir('apt_root')
+        self.assertNotIn(str(shared / 'overlay'), start_cmd)
+        # Shared overlay dir must NOT be created head-side in this mode
+        self.assertFalse((shared / 'overlay').exists())
+        # Both the mkdir and the start are fanned to all hosts
+        for call in MockExec.call_args_list:
+            self.assertIsInstance(call.args[1], PsshExecInfo)
+
+    def test_overlay_disabled_omits_flag_and_mounts_host_tmp(self):
+        """container_overlay: false drops --overlay entirely and lets the
+        host /tmp mount normally (no --no-mount tmp)."""
+        pipeline = self._create_pipeline('apt_nool', container_overlay=False)
+        MockExec = self._start(pipeline)
+
+        self.assertEqual(MockExec.call_count, 1)
+        cmd = MockExec.call_args.args[0]
+        self.assertNotIn('--overlay', cmd)
+        self.assertNotIn('--no-mount', cmd)
+        shared = self.jarvis.get_pipeline_shared_dir('apt_nool')
+        self.assertFalse((shared / 'overlay').exists())
+
+    def test_overlay_disabled_keeps_tmp_bind(self):
+        """tmp_bind_root still applies when the overlay is disabled."""
+        pipeline = self._create_pipeline('apt_notmp', container_overlay=False,
+                                         tmp_bind_root='/scratch')
+        MockExec = self._start(pipeline)
+
+        cmds = self._cmds(MockExec)
+        self.assertIn('mkdir -p /scratch/apt_notmp/tmp', cmds)
+        start_cmd = cmds[-1]
+        self.assertIn('--bind /scratch/apt_notmp/tmp:/tmp ', start_cmd)
+        self.assertNotIn('--overlay', start_cmd)
+        self.assertNotIn('--no-mount', start_cmd)
+
+    def test_overlay_false_wins_over_overlay_root(self):
+        """container_overlay: false gates the whole overlay feature,
+        including the per-host mkdir fan-out for container_overlay_root."""
+        pipeline = self._create_pipeline('apt_both', container_overlay=False,
+                                         container_overlay_root='/tmp')
+        MockExec = self._start(pipeline)
+
+        for cmd in self._cmds(MockExec):
+            self.assertNotIn('--overlay', cmd)
+            self.assertNotIn('/overlay', cmd)
+
+    def test_multi_node_default_overlay_raises(self):
+        """A multi-host hostfile with the default shared overlay is the
+        known-broken configuration: refuse to start, before any command
+        runs or the overlay dir is created."""
+        pipeline = self._create_pipeline('apt_guard', hosts=self.REMOTE_HOSTS)
+
+        with patch('jarvis_cd.shell.Exec') as MockExec:
+            with self.assertRaises(RuntimeError) as ctx:
+                pipeline._start_containerized_pipeline()
+
+        msg = str(ctx.exception)
+        self.assertIn('container_overlay_root', msg)
+        self.assertIn('container_overlay', msg)
+        MockExec.assert_not_called()
+        shared = self.jarvis.get_pipeline_shared_dir('apt_guard')
+        self.assertFalse((shared / 'overlay').exists())
+
+    def test_multi_node_overlay_disabled_no_raise(self):
+        """Multi-host is fine once the shared overlay is out of the
+        picture; the start command fans out via PsshExecInfo."""
+        pipeline = self._create_pipeline('apt_mnool', hosts=self.REMOTE_HOSTS,
+                                         container_overlay=False)
+        MockExec = self._start(
+            pipeline, exit_codes={h: 0 for h in self.REMOTE_HOSTS})
+
+        self.assertEqual(MockExec.call_count, 1)
+        cmd, exec_info = MockExec.call_args.args
+        self.assertNotIn('--overlay', cmd)
+        self.assertIsInstance(exec_info, PsshExecInfo)
+
+    def test_partial_start_failure_raises_naming_host(self):
+        """An instance start that fails on a subset of hosts raises
+        immediately, naming the failed host, instead of hanging later."""
+        pipeline = self._create_pipeline('apt_fail', hosts=self.REMOTE_HOSTS,
+                                         container_overlay_root='/tmp')
+        codes = {'node-01': 0, 'node-02': 255, 'node-03': 0, 'node-04': 0}
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self._start(pipeline, exit_codes=codes)
+
+        self.assertIn('node-02', str(ctx.exception))
+        self.assertIn('255', str(ctx.exception))
+
+
+class TestApptainerConfigRoundTrip(ApptainerStartTestBase):
+
+    def test_overlay_keys_roundtrip_config(self):
+        """Non-default values survive save() -> load-from-config. The
+        default-True container_overlay needs an inverted save idiom: a
+        truthy-only save would silently drop False."""
+        self._create_pipeline('apt_rt', container_overlay=False,
+                              container_overlay_root='/mnt/nvme/me')
+
+        p2 = Pipeline('apt_rt')
+        self.assertIs(p2.container_overlay, False)
+        self.assertEqual(p2.container_overlay_root, '/mnt/nvme/me')
+
+    def test_overlay_defaults_roundtrip_config(self):
+        """Defaults survive a round trip and stay out of the saved file."""
+        self._create_pipeline('apt_rtdef')
+
+        p2 = Pipeline('apt_rtdef')
+        self.assertIs(p2.container_overlay, True)
+        self.assertIsNone(p2.container_overlay_root)
+
+        config_file = self.jarvis.get_pipeline_dir('apt_rtdef') / 'pipeline.yaml'
+        with open(config_file) as f:
+            saved = yaml.safe_load(f)
+        self.assertNotIn('container_overlay', saved)
+        self.assertNotIn('container_overlay_root', saved)
+
+    def test_tmp_bind_root_roundtrip_config(self):
+        """tmp_bind_root survives save() -> load-from-config, so a
+        pipeline rebuilt from its saved config (ppl start/stop/run)
+        keeps its per-host /tmp bind."""
+        self._create_pipeline('apt_tbr', tmp_bind_root='/mnt/nvme/me')
+
+        p2 = Pipeline('apt_tbr')
+        self.assertEqual(p2.tmp_bind_root, '/mnt/nvme/me')
+
+    def test_container_gpu_roundtrip_config(self):
+        """container_gpu survives save() -> load-from-config."""
+        self._create_pipeline('apt_gpu', container_gpu=True)
+
+        p2 = Pipeline('apt_gpu')
+        self.assertIs(p2.container_gpu, True)
+
+    def test_yaml_load_overlay_keys_expandvars(self):
+        """YAML load honors both keys and expands env vars in the root
+        path, mirroring the tmp_bind_root contract."""
+        os.environ['JARVIS_TEST_OVERLAY'] = '/mnt/testnvme'
+        try:
+            yaml_path = os.path.join(self.test_dir, 'apt_yaml.yaml')
+            with open(yaml_path, 'w') as f:
+                f.write(
+                    'name: apt_yaml\n'
+                    'container_engine: apptainer\n'
+                    'container_overlay: false\n'
+                    'container_overlay_root: $JARVIS_TEST_OVERLAY/root\n'
+                    'pkgs: []\n'
+                )
+            pipeline = Pipeline()
+            pipeline.load('yaml', yaml_path)
+            self.assertIs(pipeline.container_overlay, False)
+            self.assertEqual(pipeline.container_overlay_root,
+                             '/mnt/testnvme/root')
+        finally:
+            del os.environ['JARVIS_TEST_OVERLAY']
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/core/test_container_apptainer.py
+++ b/test/unit/core/test_container_apptainer.py
@@ -188,6 +188,34 @@ class TestApptainerStartCmd(ApptainerStartTestBase):
             self.assertNotIn('--overlay', cmd)
             self.assertNotIn('/overlay', cmd)
 
+    def test_container_gpu_bakes_nv_into_instance(self):
+        """--nv is ignored on a running instance, so container_gpu has to be
+        baked into `instance start` (and the sshd exec that follows it).
+        Exec._prepare_container deliberately does not forward it per-exec."""
+        pipeline = self._create_pipeline('apt_gpu', container_gpu=True)
+        MockExec = self._start(pipeline)
+
+        start_cmd = MockExec.call_args.args[0]
+        self.assertIn('apptainer instance start --nv ', start_cmd)
+        self.assertIn('apptainer exec --nv instance://apt_gpu', start_cmd)
+
+    def test_no_container_gpu_omits_nv(self):
+        """Default (container_gpu unset) emits no --nv anywhere."""
+        pipeline = self._create_pipeline('apt_nogpu')
+        MockExec = self._start(pipeline)
+
+        self.assertNotIn('--nv', MockExec.call_args.args[0])
+
+    def test_container_binds_baked_into_instance(self):
+        """container_binds extras join the shared/private binds at instance
+        start; ExecInfo.bind_mounts is not forwarded per-exec."""
+        pipeline = self._create_pipeline('apt_binds',
+                                         container_binds=['/dev/fuse'])
+        MockExec = self._start(pipeline)
+
+        start_cmd = MockExec.call_args.args[0]
+        self.assertIn('--bind /dev/fuse ', start_cmd)
+
     def test_multi_node_default_overlay_raises(self):
         """A multi-host hostfile with the default shared overlay is the
         known-broken configuration: refuse to start, before any command

--- a/test/unit/core/test_host_pkg.py
+++ b/test/unit/core/test_host_pkg.py
@@ -1,0 +1,524 @@
+"""
+Unit tests for host_pkgs -- the declared host-baremetal prerequisites.
+
+Covers:
+  - parse(): normalization and strict validation of the YAML block
+  - the backend registry (spack / pip / conda)
+  - check_all(): missing packages raise with an actionable install hint
+  - activation lands in os.environ, so plain subprocesses inherit it
+  - probe memoization
+  - Pipeline integration: load-time check, save/load round-trip,
+    and the checks on run() / submit()
+"""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import yaml
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+from jarvis_cd.core.config import Jarvis
+from jarvis_cd.core.host_pkg import (
+    HostPkg, HostPkgError, SpackHostPkg, PipHostPkg, CondaHostPkg,
+    _parse_env0,
+)
+from jarvis_cd.core.pipeline import Pipeline
+
+
+class FakeHostPkg(HostPkg):
+    """Test backend: presence and activation are set by the test."""
+
+    install_method = "faketest"
+
+    present = True
+    activation = {}
+
+    def is_installed(self, query):
+        return type(self).present
+
+    def activate(self, query):
+        return dict(type(self).activation)
+
+    def install_hint(self, query):
+        return f"fake-install {query}"
+
+
+class HostPkgTestBase(unittest.TestCase):
+    """Clears the probe cache around every test: it is process-global and
+    would otherwise leak a previous test's verdict into the next one."""
+
+    def setUp(self):
+        HostPkg.clear_cache()
+        FakeHostPkg.present = True
+        FakeHostPkg.activation = {}
+        self._saved_environ = dict(os.environ)
+
+    def tearDown(self):
+        HostPkg.clear_cache()
+        os.environ.clear()
+        os.environ.update(self._saved_environ)
+
+
+class TestHostPkgParse(HostPkgTestBase):
+
+    def test_none_and_empty_are_empty_list(self):
+        self.assertEqual(HostPkg.parse(None), [])
+        self.assertEqual(HostPkg.parse([]), [])
+
+    def test_valid_entry_normalized(self):
+        parsed = HostPkg.parse(
+            [{'install_method': ' spack ', 'install_query': ' apptainer '}])
+        self.assertEqual(
+            parsed,
+            [{'install_method': 'spack', 'install_query': 'apptainer'}])
+
+    def test_multiple_entries_preserve_order(self):
+        parsed = HostPkg.parse([
+            {'install_method': 'spack', 'install_query': 'apptainer'},
+            {'install_method': 'pip', 'install_query': 'pyyaml'},
+        ])
+        self.assertEqual([e['install_query'] for e in parsed],
+                         ['apptainer', 'pyyaml'])
+
+    def test_non_list_raises(self):
+        with self.assertRaises(HostPkgError) as ctx:
+            HostPkg.parse({'install_method': 'spack'})
+        self.assertIn('must be a list', str(ctx.exception))
+
+    def test_non_mapping_entry_raises(self):
+        with self.assertRaises(HostPkgError) as ctx:
+            HostPkg.parse(['apptainer'])
+        self.assertIn('host_pkgs[0]', str(ctx.exception))
+
+    def test_missing_install_query_raises(self):
+        with self.assertRaises(HostPkgError) as ctx:
+            HostPkg.parse([{'install_method': 'spack'}])
+        self.assertIn('install_query', str(ctx.exception))
+
+    def test_missing_install_method_raises(self):
+        with self.assertRaises(HostPkgError) as ctx:
+            HostPkg.parse([{'install_query': 'apptainer'}])
+        self.assertIn('install_method', str(ctx.exception))
+
+    def test_unknown_install_method_raises_naming_known(self):
+        """A typo'd backend must fail at parse time, not silently skip the
+        check and resurface as a missing binary mid-build."""
+        with self.assertRaises(HostPkgError) as ctx:
+            HostPkg.parse(
+                [{'install_method': 'spak', 'install_query': 'apptainer'}])
+        msg = str(ctx.exception)
+        self.assertIn("'spak'", msg)
+        self.assertIn('spack', msg)
+
+    def test_unknown_key_raises(self):
+        """Catches `install_qeury:`-style typos, which would otherwise
+        parse as a missing install_query with a confusing message."""
+        with self.assertRaises(HostPkgError) as ctx:
+            HostPkg.parse([{'install_method': 'spack',
+                            'install_query': 'apptainer',
+                            'verison': '1.3'}])
+        self.assertIn('verison', str(ctx.exception))
+
+
+class TestHostPkgRegistry(HostPkgTestBase):
+
+    def test_builtin_backends_registered(self):
+        reg = HostPkg._registry()
+        self.assertIs(reg['spack'], SpackHostPkg)
+        self.assertIs(reg['pip'], PipHostPkg)
+        self.assertIs(reg['conda'], CondaHostPkg)
+
+    def test_for_method_unknown_raises(self):
+        with self.assertRaises(HostPkgError):
+            HostPkg.for_method('nope')
+
+    def test_subclass_registers_itself(self):
+        self.assertIsInstance(HostPkg.for_method('faketest'), FakeHostPkg)
+
+
+class TestHostPkgCheckAll(HostPkgTestBase):
+
+    def test_empty_is_noop(self):
+        self.assertEqual(HostPkg.check_all([]), {})
+
+    def test_missing_raises_with_install_hint(self):
+        FakeHostPkg.present = False
+        with self.assertRaises(HostPkgError) as ctx:
+            HostPkg.check_all(
+                [{'install_method': 'faketest', 'install_query': 'apptainer'}],
+                context='my_pipeline')
+        msg = str(ctx.exception)
+        self.assertIn('my_pipeline', msg)
+        self.assertIn('apptainer', msg)
+        self.assertIn('fake-install apptainer', msg)
+
+    def test_all_missing_reported_not_just_first(self):
+        """A user fixing prerequisites one error at a time is a bad loop;
+        report every missing package in one pass."""
+        FakeHostPkg.present = False
+        with self.assertRaises(HostPkgError) as ctx:
+            HostPkg.check_all([
+                {'install_method': 'faketest', 'install_query': 'aaa'},
+                {'install_method': 'faketest', 'install_query': 'bbb'},
+            ])
+        msg = str(ctx.exception)
+        self.assertIn('Missing 2 required host package', msg)
+        self.assertIn('aaa', msg)
+        self.assertIn('bbb', msg)
+
+    def test_present_activates_into_os_environ(self):
+        """The activation has to reach os.environ: the container-build
+        subprocesses run under a bare LocalExecInfo() and therefore see
+        an unmodified process environment."""
+        FakeHostPkg.activation = {'HOSTPKG_TEST_VAR': '/opt/fake/bin'}
+        merged = HostPkg.check_all(
+            [{'install_method': 'faketest', 'install_query': 'x'}])
+        self.assertEqual(merged, {'HOSTPKG_TEST_VAR': '/opt/fake/bin'})
+        self.assertEqual(os.environ['HOSTPKG_TEST_VAR'], '/opt/fake/bin')
+
+    def test_activation_visible_to_subprocess(self):
+        """End-to-end version of the above: a plain subprocess -- what
+        LocalExec.run spawns -- must observe the activated variable."""
+        import subprocess
+        FakeHostPkg.activation = {'HOSTPKG_SUBPROC_VAR': 'activated'}
+        HostPkg.check_all(
+            [{'install_method': 'faketest', 'install_query': 'x'}])
+        out = subprocess.run(
+            ['bash', '-c', 'echo -n "$HOSTPKG_SUBPROC_VAR"'],
+            capture_output=True, text=True)
+        self.assertEqual(out.stdout, 'activated')
+
+    def test_present_also_merges_into_pipeline_env(self):
+        FakeHostPkg.activation = {'HOSTPKG_TEST_VAR': 'v'}
+        env = {}
+        HostPkg.check_all(
+            [{'install_method': 'faketest', 'install_query': 'x'}], env=env)
+        self.assertEqual(env['HOSTPKG_TEST_VAR'], 'v')
+
+    def test_nothing_applied_when_any_package_missing(self):
+        """Partial activation would leave the process half-configured
+        after a failed check."""
+        FakeHostPkg.present = False
+        env = {}
+        with self.assertRaises(HostPkgError):
+            HostPkg.check_all(
+                [{'install_method': 'faketest', 'install_query': 'x'}],
+                env=env)
+        self.assertEqual(env, {})
+
+    def test_probe_is_memoized(self):
+        """A sweep re-loads the same YAML once per combination; the probe
+        subprocess must not re-run each time."""
+        calls = []
+
+        def counting_is_installed(self, query):
+            calls.append(query)
+            return True
+
+        with patch.object(FakeHostPkg, 'is_installed', counting_is_installed):
+            spec = [{'install_method': 'faketest', 'install_query': 'x'}]
+            HostPkg.check_all(spec)
+            HostPkg.check_all(spec)
+            HostPkg.check_all(spec)
+        self.assertEqual(len(calls), 1)
+
+    def test_clear_cache_forces_reprobe(self):
+        calls = []
+
+        def counting_is_installed(self, query):
+            calls.append(query)
+            return True
+
+        with patch.object(FakeHostPkg, 'is_installed', counting_is_installed):
+            spec = [{'install_method': 'faketest', 'install_query': 'x'}]
+            HostPkg.check_all(spec)
+            HostPkg.clear_cache()
+            HostPkg.check_all(spec)
+        self.assertEqual(len(calls), 2)
+
+
+class TestEnvParsing(HostPkgTestBase):
+    """`env -0` parsing. Exported bash functions are the reason this is
+    NUL-separated and identifier-filtered rather than a line split."""
+
+    def test_parses_nul_separated_pairs(self):
+        parsed = _parse_env0('A=1\0B=two\0')
+        self.assertEqual(parsed, {'A': '1', 'B': 'two'})
+
+    def test_value_with_newline_survives(self):
+        parsed = _parse_env0('A=line1\nline2\0B=2\0')
+        self.assertEqual(parsed['A'], 'line1\nline2')
+        self.assertEqual(parsed['B'], '2')
+
+    def test_exported_bash_function_dropped(self):
+        """`BASH_FUNC_spack%%=() { ... }` is not a variable a child process
+        should inherit, and its body would otherwise parse as junk keys."""
+        parsed = _parse_env0(
+            'BASH_FUNC_spack%%=() {  eval spack\n}\0PATH=/usr/bin\0')
+        self.assertEqual(parsed, {'PATH': '/usr/bin'})
+
+    def test_shell_noise_dropped(self):
+        parsed = _parse_env0('_=/usr/bin/env\0SHLVL=3\0PWD=/tmp\0PATH=/bin\0')
+        self.assertEqual(parsed, {'PATH': '/bin'})
+
+
+class TestSpackHostPkg(HostPkgTestBase):
+
+    def test_install_hint(self):
+        self.assertEqual(
+            SpackHostPkg().install_hint('apptainer'),
+            'spack install apptainer')
+
+    def test_not_installed_when_spack_absent(self):
+        """The CI case: no spack binary and no SPACK_ROOT at all."""
+        os.environ.pop('SPACK_ROOT', None)
+        with patch('jarvis_cd.core.host_pkg.shutil.which', return_value=None):
+            self.assertFalse(SpackHostPkg().is_installed('apptainer'))
+
+    def test_activate_returns_only_changed_vars(self):
+        """An activation carries what `spack load` changed -- not a copy of
+        the whole host environment."""
+        os.environ['HOSTPKG_UNCHANGED'] = 'same'
+        fake = type('R', (), {
+            'returncode': 0,
+            'stdout': 'HOSTPKG_UNCHANGED=same\0HOSTPKG_NEW=/opt/x/bin\0',
+        })()
+        with patch('jarvis_cd.core.host_pkg._run_capture', return_value=fake):
+            changed = SpackHostPkg().activate('apptainer')
+        self.assertEqual(changed, {'HOSTPKG_NEW': '/opt/x/bin'})
+
+    def test_activate_empty_on_failure(self):
+        fake = type('R', (), {'returncode': 1, 'stdout': ''})()
+        with patch('jarvis_cd.core.host_pkg._run_capture', return_value=fake):
+            self.assertEqual(SpackHostPkg().activate('apptainer'), {})
+
+
+class TestPipHostPkg(HostPkgTestBase):
+
+    def test_dist_name_strips_version_specifiers(self):
+        self.assertEqual(PipHostPkg._dist_name('pyyaml'), 'pyyaml')
+        self.assertEqual(PipHostPkg._dist_name('pyyaml>=6.0'), 'pyyaml')
+        self.assertEqual(PipHostPkg._dist_name('ruamel.yaml==0.17.1'),
+                         'ruamel.yaml')
+        self.assertEqual(PipHostPkg._dist_name('requests[socks]'), 'requests')
+
+    def test_install_hint(self):
+        self.assertEqual(PipHostPkg().install_hint('pyyaml>=6'),
+                         'python3 -m pip install pyyaml>=6')
+
+    def test_installed_dependency_detected(self):
+        """pyyaml is a hard jarvis dependency, so it is present wherever
+        these tests run."""
+        self.assertTrue(PipHostPkg().is_installed('pyyaml'))
+
+    def test_absent_package_not_detected(self):
+        self.assertFalse(
+            PipHostPkg().is_installed('jarvis-definitely-not-real-pkg'))
+
+
+class TestCondaHostPkg(HostPkgTestBase):
+
+    def test_install_hint(self):
+        self.assertEqual(CondaHostPkg().install_hint('numpy'),
+                         'conda install -y numpy')
+
+    def test_not_installed_when_conda_absent(self):
+        with patch('jarvis_cd.core.host_pkg.shutil.which', return_value=None):
+            self.assertFalse(CondaHostPkg().is_installed('numpy'))
+
+    def test_matches_exact_row_not_substring(self):
+        """`conda list numpy` also lists numpy-base; only an exact name
+        match counts."""
+        fake = type('R', (), {
+            'returncode': 0,
+            'stdout': '# packages\nnumpy-base 1.0 py311\n',
+        })()
+        with patch('jarvis_cd.core.host_pkg.shutil.which',
+                   return_value='/usr/bin/conda'):
+            with patch('jarvis_cd.core.host_pkg._run_capture',
+                       return_value=fake):
+                self.assertFalse(CondaHostPkg().is_installed('numpy'))
+
+
+class TestPipelineHostPkgs(HostPkgTestBase):
+    """Pipeline-level integration: load, persist, run, submit."""
+
+    def setUp(self):
+        super().setUp()
+        self.test_dir = tempfile.mkdtemp(
+            prefix='jarvis_test_host_pkgs_', dir=os.path.expanduser('~'))
+        self.config_dir = os.path.join(self.test_dir, 'config')
+        self.private_dir = os.path.join(self.test_dir, 'private')
+        self.shared_dir = os.path.join(self.test_dir, 'shared')
+        for d in (self.config_dir, self.private_dir, self.shared_dir):
+            os.makedirs(d, exist_ok=True)
+
+        jarvis = Jarvis.get_instance()
+        self._saved_config = None
+        if jarvis.config_file.exists():
+            with open(jarvis.config_file, 'r') as f:
+                self._saved_config = yaml.safe_load(f)
+        jarvis.initialize(self.config_dir, self.private_dir, self.shared_dir,
+                          force=False)
+        self.jarvis = jarvis
+
+    def tearDown(self):
+        # Restore the developer's real jarvis config; initialize() above
+        # rewrites it in place.
+        if self._saved_config:
+            jarvis = Jarvis.get_instance()
+            jarvis.save_config(self._saved_config)
+            jarvis.config_dir = self._saved_config.get(
+                'config_dir', jarvis.config_dir)
+            jarvis.private_dir = self._saved_config.get(
+                'private_dir', jarvis.private_dir)
+            jarvis.shared_dir = self._saved_config.get(
+                'shared_dir', jarvis.shared_dir)
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+        super().tearDown()
+
+    def _write_yaml(self, name, body):
+        path = os.path.join(self.test_dir, f'{name}.yaml')
+        with open(path, 'w') as f:
+            yaml.dump(body, f)
+        return path
+
+    def test_load_fails_fast_on_missing_host_pkg(self):
+        FakeHostPkg.present = False
+        path = self._write_yaml('hp_missing', {
+            'name': 'hp_missing',
+            'host_pkgs': [{'install_method': 'faketest',
+                           'install_query': 'apptainer'}],
+            'pkgs': [],
+        })
+        with self.assertRaises(HostPkgError) as ctx:
+            Pipeline().load('yaml', path)
+        self.assertIn('fake-install apptainer', str(ctx.exception))
+
+    def test_load_fails_before_packages_are_processed(self):
+        """The whole point of declaring a prerequisite is stopping before
+        jarvis does work it cannot finish."""
+        FakeHostPkg.present = False
+        path = self._write_yaml('hp_early', {
+            'name': 'hp_early',
+            'host_pkgs': [{'install_method': 'faketest',
+                           'install_query': 'apptainer'}],
+            'pkgs': [{'pkg_type': 'builtin.ior', 'pkg_name': 'ior'}],
+        })
+        with patch.object(Pipeline, '_process_package_definition') as proc:
+            with self.assertRaises(HostPkgError):
+                Pipeline().load('yaml', path)
+        proc.assert_not_called()
+
+    def test_load_succeeds_and_activates_when_present(self):
+        FakeHostPkg.activation = {'HOSTPKG_PPL_VAR': '/opt/apptainer/bin'}
+        path = self._write_yaml('hp_ok', {
+            'name': 'hp_ok',
+            'host_pkgs': [{'install_method': 'faketest',
+                           'install_query': 'apptainer'}],
+            'pkgs': [],
+        })
+        ppl = Pipeline()
+        ppl.load('yaml', path)
+        self.assertEqual(
+            ppl.host_pkgs,
+            [{'install_method': 'faketest', 'install_query': 'apptainer'}])
+        self.assertEqual(os.environ['HOSTPKG_PPL_VAR'], '/opt/apptainer/bin')
+        self.assertEqual(ppl.env['HOSTPKG_PPL_VAR'], '/opt/apptainer/bin')
+
+    def test_host_pkgs_round_trip_through_saved_config(self):
+        """`jarvis ppl submit` against the current pipeline never re-reads
+        the source YAML, so the declaration has to survive save()."""
+        path = self._write_yaml('hp_rt', {
+            'name': 'hp_rt',
+            'host_pkgs': [{'install_method': 'faketest',
+                           'install_query': 'apptainer'}],
+            'pkgs': [],
+        })
+        Pipeline().load('yaml', path)
+
+        reloaded = Pipeline('hp_rt')
+        self.assertEqual(
+            reloaded.host_pkgs,
+            [{'install_method': 'faketest', 'install_query': 'apptainer'}])
+
+    def test_no_host_pkgs_key_is_empty(self):
+        path = self._write_yaml('hp_none', {'name': 'hp_none', 'pkgs': []})
+        ppl = Pipeline()
+        ppl.load('yaml', path)
+        self.assertEqual(ppl.host_pkgs, [])
+
+    def test_invalid_host_pkgs_block_rejected_at_load(self):
+        path = self._write_yaml('hp_bad', {
+            'name': 'hp_bad',
+            'host_pkgs': [{'install_method': 'faketest'}],
+            'pkgs': [],
+        })
+        with self.assertRaises(HostPkgError):
+            Pipeline().load('yaml', path)
+
+    def test_run_rechecks_saved_pipeline(self):
+        """`jarvis ppl run` on the current pipeline skips _load_from_file,
+        so run() has to check too."""
+        path = self._write_yaml('hp_run', {
+            'name': 'hp_run',
+            'host_pkgs': [{'install_method': 'faketest',
+                           'install_query': 'apptainer'}],
+            'pkgs': [],
+        })
+        Pipeline().load('yaml', path)
+
+        reloaded = Pipeline('hp_run')
+        HostPkg.clear_cache()
+        FakeHostPkg.present = False
+        with self.assertRaises(HostPkgError):
+            reloaded.run()
+
+    def test_run_does_not_attempt_teardown_on_missing_host_pkg(self):
+        """The check precedes the try/except, so a missing prerequisite
+        does not drag the user through a stop() recovery trace."""
+        path = self._write_yaml('hp_noteardown', {
+            'name': 'hp_noteardown',
+            'host_pkgs': [{'install_method': 'faketest',
+                           'install_query': 'apptainer'}],
+            'pkgs': [],
+        })
+        Pipeline().load('yaml', path)
+
+        reloaded = Pipeline('hp_noteardown')
+        HostPkg.clear_cache()
+        FakeHostPkg.present = False
+        with patch.object(Pipeline, 'stop') as stop:
+            with self.assertRaises(HostPkgError):
+                reloaded.run()
+        stop.assert_not_called()
+
+    def test_submit_checks_before_queueing(self):
+        """Queueing a job that is guaranteed to fail wastes an allocation
+        and the queue wait."""
+        path = self._write_yaml('hp_submit', {
+            'name': 'hp_submit',
+            'host_pkgs': [{'install_method': 'faketest',
+                           'install_query': 'apptainer'}],
+            'scheduler': {'type': 'slurm', 'name': 'hp_submit',
+                          'nnodes': 1, 'time': '00:10:00'},
+            'pkgs': [],
+        })
+        Pipeline().load('yaml', path)
+
+        reloaded = Pipeline('hp_submit')
+        HostPkg.clear_cache()
+        FakeHostPkg.present = False
+        with patch('jarvis_cd.core.scheduler.make_scheduler') as mk:
+            with self.assertRaises(HostPkgError):
+                reloaded.submit(submit=True)
+        mk.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/core/test_perf_eval_builtins.py
+++ b/test/unit/core/test_perf_eval_builtins.py
@@ -1,0 +1,207 @@
+"""Unit tests for the performance evaluation builtin-package logic:
+
+- ior's effective-hostfile resolution (num_nodes subset, single_instance
+  collapse, container-mode path stripping)
+- redis-benchmark's --csv output parsing
+- juicefs's meta_use_head URL rewrite
+
+These test the pure logic only; the MPI-in-container launch chain itself is
+exercised on a real cluster by the pipelines themselves.
+"""
+import importlib.util
+import os
+import pathlib
+import tempfile
+import unittest
+
+from jarvis_cd.util.hostfile import Hostfile
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+
+def _load_pkg_module(name, rel_path):
+    spec = importlib.util.spec_from_file_location(
+        name, str(_REPO_ROOT / rel_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_ior_mod = _load_pkg_module('ior_pkg', 'builtin/builtin/ior/pkg.py')
+_rb_mod = _load_pkg_module('rb_pkg', 'builtin/builtin/redis-benchmark/pkg.py')
+_jfs_mod = _load_pkg_module('jfs_pkg', 'builtin/builtin/juicefs/pkg.py')
+
+
+def _stub(cls, config, hostfile=None, engine='none'):
+    """Instance of ``cls`` bypassing Pkg.__init__, with the hostfile /
+    _container_engine properties shadowed by fixed values."""
+    shadow = type('Stub' + cls.__name__, (cls,), {
+        'hostfile': property(lambda self: self._stub_hf),
+        '_container_engine': property(lambda self: self._stub_engine),
+    })
+    obj = object.__new__(shadow)
+    obj.config = config
+    obj._stub_hf = hostfile
+    obj._stub_engine = engine
+    return obj
+
+
+class TestIorEffHostfile(unittest.TestCase):
+    HOSTS = ['n1', 'n2', 'n3', 'n4']
+
+    def _hf(self, path='/tmp/hf.txt'):
+        hf = Hostfile(hosts=list(self.HOSTS), find_ips=False)
+        hf.path = path
+        return hf
+
+    def test_defaults_are_noop(self):
+        pkg = _stub(_ior_mod.Ior, {'num_nodes': 0, 'single_instance': False},
+                    self._hf())
+        hf = pkg._eff_hostfile()
+        self.assertEqual(hf.hosts, self.HOSTS)
+        self.assertEqual(hf.path, '/tmp/hf.txt')  # bare-metal keeps the file
+
+    def test_num_nodes_subsets_first_n(self):
+        pkg = _stub(_ior_mod.Ior, {'num_nodes': 2}, self._hf())
+        self.assertEqual(pkg._eff_hostfile().hosts, ['n1', 'n2'])
+
+    def test_single_instance_collapses_to_head(self):
+        pkg = _stub(_ior_mod.Ior, {'single_instance': True}, self._hf())
+        self.assertEqual(pkg._eff_hostfile().hosts, ['n1'])
+
+    def test_single_instance_wins_over_num_nodes(self):
+        pkg = _stub(_ior_mod.Ior,
+                    {'num_nodes': 3, 'single_instance': True}, self._hf())
+        self.assertEqual(pkg._eff_hostfile().hosts, ['n1'])
+
+    def test_container_mode_strips_hostfile_path(self):
+        pkg = _stub(_ior_mod.Ior, {'num_nodes': 0}, self._hf(),
+                    engine='apptainer')
+        hf = pkg._eff_hostfile()
+        self.assertEqual(hf.hosts, self.HOSTS)
+        self.assertIsNone(hf.path)  # forces an inline --host list
+
+    def test_stonewall_flag_in_menu(self):
+        names = [o['name'] for o in _ior_mod.Ior._configure_menu(
+            object.__new__(_ior_mod.Ior))]
+        for key in ('num_nodes', 'stonewall', 'single_instance'):
+            self.assertIn(key, names)
+
+
+class TestIorCompletionGate(unittest.TestCase):
+    """_assert_ior_completed converts a silent MPI/ior failure (no summary
+    in the log) into a failed combination instead of a false-green success."""
+
+    WRITE_SUMMARY = (
+        'access    bw(MiB/s)\n'
+        'write     112.92     113.96     0.017 65536 1024.0 0.03 1.12 0.0 1.13 0\n'
+        'Max Write: 112.92 MiB/sec (118.40 MB/sec)\n')
+    # A hard multi-node abort: header/options only, no results block.
+    ABORTED = ('PRTE has lost communication with a remote daemon.\n'
+               'Host key verification failed.\n')
+
+    def _pkg(self, config, log_text=None):
+        pkg = object.__new__(_ior_mod.Ior)
+        pkg.pkg_id = 'cte_ior'
+        pkg.config = dict(config)
+        if log_text is not None:
+            fd, path = tempfile.mkstemp(suffix='.log')
+            with os.fdopen(fd, 'w') as f:
+                f.write(log_text)
+            self.addCleanup(os.remove, path)
+            pkg.config['log'] = path
+        return pkg
+
+    def test_passes_when_write_summary_present(self):
+        pkg = self._pkg({'write': True, 'read': False}, self.WRITE_SUMMARY)
+        pkg._assert_ior_completed()  # must not raise
+
+    def test_raises_on_aborted_run(self):
+        pkg = self._pkg({'write': True, 'read': False}, self.ABORTED)
+        with self.assertRaises(RuntimeError):
+            pkg._assert_ior_completed()
+
+    def test_raises_when_log_missing(self):
+        pkg = self._pkg({'write': True, 'read': False})
+        pkg.config['log'] = '/nonexistent/ior.log'
+        with self.assertRaises(RuntimeError):
+            pkg._assert_ior_completed()
+
+    def test_raises_when_read_requested_but_absent(self):
+        # write-only summary but the combo also asked for a read phase.
+        pkg = self._pkg({'write': True, 'read': True}, self.WRITE_SUMMARY)
+        with self.assertRaises(RuntimeError):
+            pkg._assert_ior_completed()
+
+    def test_noop_when_no_workload_requested(self):
+        pkg = self._pkg({'write': False, 'read': False}, self.ABORTED)
+        pkg._assert_ior_completed()  # nothing requested -> nothing to validate
+
+
+class TestRedisBenchmarkParse(unittest.TestCase):
+    V7 = ('"test","rps","avg_latency_ms","min_latency_ms","p50_latency_ms",'
+          '"p95_latency_ms","p99_latency_ms","max_latency_ms"\n'
+          '"SET","95238.10","0.263","0.084","0.255","0.407","0.495","1.351"\n'
+          '"GET","98039.22","0.256","0.084","0.247","0.399","0.479","1.079"\n')
+    LEGACY = '"SET","95238.10"\n"GET","98039.22"\n'
+
+    def _pkg(self):
+        pkg = object.__new__(_rb_mod.RedisBenchmark)
+        pkg.pkg_id = 'redis_bench'
+        return pkg
+
+    def test_v7_eight_column(self):
+        stats = self._pkg()._parse_output(self.V7)
+        self.assertEqual(stats['redis_bench.set_rps'], 95238.10)
+        self.assertEqual(stats['redis_bench.get_rps'], 98039.22)
+        self.assertEqual(stats['redis_bench.set_p50_ms'], 0.255)
+        self.assertEqual(stats['redis_bench.get_p99_ms'], 0.479)
+
+    def test_legacy_two_column(self):
+        stats = self._pkg()._parse_output(self.LEGACY)
+        self.assertEqual(stats['redis_bench.set_rps'], 95238.10)
+        self.assertNotIn('redis_bench.set_p50_ms', stats)
+
+    def test_junk_never_raises(self):
+        self.assertEqual(
+            self._pkg()._parse_output('redis: Connection refused\n'), {})
+        self.assertEqual(self._pkg()._parse_output(''), {})
+
+    def test_clients_flag_in_menu(self):
+        names = [o['name'] for o in _rb_mod.RedisBenchmark._configure_menu(
+            object.__new__(_rb_mod.RedisBenchmark))]
+        self.assertIn('clients', names)
+        self.assertIn('single_instance', names)
+
+
+class TestJuicefsMetaUseHead(unittest.TestCase):
+    def _pkg(self, meta_url, use_head=True, hosts=('head', 'n2')):
+        hf = Hostfile(hosts=list(hosts), find_ips=False) if hosts else None
+        return _stub(_jfs_mod.Juicefs,
+                     {'meta_url': meta_url, 'meta_use_head': use_head}, hf)
+
+    def test_rewrites_host_keeps_port_and_db(self):
+        self.assertEqual(
+            self._pkg('redis://127.0.0.1:6379/1')._effective_meta_url(),
+            'redis://head:6379/1')
+
+    def test_preserves_credentials(self):
+        self.assertEqual(
+            self._pkg('redis://:pw@127.0.0.1:6379/1')._effective_meta_url(),
+            'redis://:pw@head:6379/1')
+
+    def test_disabled_is_identity(self):
+        self.assertEqual(
+            self._pkg('redis://127.0.0.1:6379/1',
+                      use_head=False)._effective_meta_url(),
+            'redis://127.0.0.1:6379/1')
+
+    def test_no_hostfile_is_identity(self):
+        self.assertEqual(
+            self._pkg('redis://127.0.0.1:6379/1',
+                      hosts=None)._effective_meta_url(),
+            'redis://127.0.0.1:6379/1')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/core/test_pipeline_test.py
+++ b/test/unit/core/test_pipeline_test.py
@@ -4,6 +4,7 @@ Tests for pipeline test functionality (grid search experiments).
 import os
 import csv
 import sys
+import time
 import yaml
 import tempfile
 import shutil
@@ -13,8 +14,12 @@ from pathlib import Path
 # Add the project root to the path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 
+from unittest.mock import patch
+
 from jarvis_cd.core.pipeline_test import (
     is_pipeline_test,
+    alarm_timeout,
+    Deadline,
     PipelineTest,
     load_yaml_auto,
 )
@@ -437,8 +442,10 @@ class TestPipelineTestVariableApplication(unittest.TestCase):
 
         self.assertEqual(result['scheduler'], {'nodes': 4})
 
-    def test_apply_top_level_scheduler_propagates_with_no_vars(self):
-        """Top-level scheduler propagates to config even when no vars touch it."""
+    def test_apply_top_level_scheduler_not_stamped_without_vars(self):
+        """A top-level scheduler describes the ONE job wrapping the whole
+        test; without scheduler.X vars it must NOT be stamped onto each
+        iteration config, or every combo would submit a nested sbatch."""
         test = PipelineTest()
         test.scheduler = {'name': 'slurm', 'nodes': 2}
         base_config = {
@@ -448,7 +455,7 @@ class TestPipelineTestVariableApplication(unittest.TestCase):
 
         result = test._apply_variables(base_config, {})
 
-        self.assertEqual(result['scheduler'], {'name': 'slurm', 'nodes': 2})
+        self.assertNotIn('scheduler', result)
 
 
 class TestPipelineTestLoading(unittest.TestCase):
@@ -895,6 +902,197 @@ class TestPipelineTestCsvLog(unittest.TestCase):
 
         # Should not raise any errors
         test._write_csv_log()
+
+
+class TestPipelineTestRunTimeout(unittest.TestCase):
+    """Tests for the per-combination run_timeout guard."""
+
+    def test_alarm_timeout_fires_on_hang(self):
+        """A call that outlives the budget raises TimeoutError."""
+        with self.assertRaises(TimeoutError):
+            with alarm_timeout(1, 'budget exceeded'):
+                time.sleep(30)
+
+    def test_alarm_timeout_allows_fast_call(self):
+        """A call that finishes in time is untouched."""
+        with alarm_timeout(30, 'budget exceeded'):
+            result = 'finished'
+        self.assertEqual(result, 'finished')
+
+    def test_alarm_timeout_disabled_when_unset(self):
+        """None preserves the historical unbounded behaviour."""
+        with alarm_timeout(None, 'never'):
+            result = 'finished'
+        self.assertEqual(result, 'finished')
+
+    def test_alarm_timeout_does_not_leak_alarm(self):
+        """No stray SIGALRM is delivered after the block exits."""
+        with alarm_timeout(1, 'budget exceeded'):
+            pass
+        # Outliving the former budget must not raise.
+        time.sleep(1.5)
+
+    def test_run_timeout_parsed_from_yaml(self):
+        """run_timeout is read off the test definition."""
+        temp_dir = tempfile.mkdtemp()
+        try:
+            yaml_path = os.path.join(temp_dir, 'test.yaml')
+            with open(yaml_path, 'w') as f:
+                yaml.dump({
+                    'config': {
+                        'name': 'demo',
+                        'pkgs': [{'pkg_type': 'builtin.ior',
+                                  'pkg_name': 'ior'}],
+                    },
+                    'repeat': 1,
+                    'run_timeout': 1800,
+                }, f)
+
+            test = PipelineTest()
+            test.load(yaml_path)
+
+            self.assertEqual(test.run_timeout, 1800)
+        finally:
+            shutil.rmtree(temp_dir)
+
+    def test_run_timeout_defaults_to_none(self):
+        """Omitting run_timeout leaves the sweep unbounded as before."""
+        test = PipelineTest()
+        self.assertIsNone(test.run_timeout)
+
+    def test_deadline_records_expiry(self):
+        """The Deadline flag is set from inside the signal handler."""
+        deadline = Deadline()
+        self.assertFalse(deadline.expired)
+        with self.assertRaises(TimeoutError):
+            with alarm_timeout(1, 'budget exceeded', deadline):
+                time.sleep(30)
+        self.assertTrue(deadline.expired)
+
+    def test_deadline_not_marked_when_call_completes(self):
+        """A run that finishes in time leaves the Deadline untouched."""
+        deadline = Deadline()
+        with alarm_timeout(30, 'budget exceeded', deadline):
+            pass
+        self.assertFalse(deadline.expired)
+
+    def test_teardown_runs_when_timeout_is_rewrapped(self):
+        """Teardown must fire even though start() re-wraps TimeoutError.
+
+        Pipeline.start catches whatever a package raises and re-raises it as
+        RuntimeError, so the TimeoutError never reaches the sweep runner.
+        Keying recovery off the exception type silently skipped teardown and
+        leaked redis / container instances into the next combination.
+        """
+        stopped = []
+
+        class HangingPipeline:
+            scheduler = None
+            packages = []
+
+            def load(self, *args, **kwargs):
+                pass
+
+            def configure_all_packages(self, *args, **kwargs):
+                pass
+
+            def start(self):
+                try:
+                    time.sleep(30)
+                except TimeoutError as e:
+                    # Mirrors jarvis_cd/core/pipeline.py:510
+                    raise RuntimeError(
+                        f"Pipeline startup failed at package 'bench': {e}"
+                    ) from e
+
+            def stop(self):
+                stopped.append(True)
+
+        test = PipelineTest()
+        test.name = 'demo'
+        test.combinations = [{'ior.nprocs': 1}]
+        test.run_timeout = 1
+
+        with patch('jarvis_cd.core.pipeline_test.Pipeline', HangingPipeline):
+            with self.assertRaises(RuntimeError):
+                test._run_single({'name': 'demo', 'pkgs': []},
+                                 {'ior.nprocs': 1}, 0)
+
+        self.assertEqual(len(stopped), 1,
+                         'teardown did not run after a re-wrapped timeout')
+
+    def test_no_teardown_for_ordinary_failure(self):
+        """A non-timeout failure is re-raised without the timeout teardown."""
+        stopped = []
+
+        class FailingPipeline:
+            scheduler = None
+            packages = []
+
+            def load(self, *args, **kwargs):
+                pass
+
+            def configure_all_packages(self, *args, **kwargs):
+                pass
+
+            def start(self):
+                raise RuntimeError('package blew up immediately')
+
+            def stop(self):
+                stopped.append(True)
+
+        test = PipelineTest()
+        test.name = 'demo'
+        test.combinations = [{'ior.nprocs': 1}]
+        test.run_timeout = 600
+
+        with patch('jarvis_cd.core.pipeline_test.Pipeline', FailingPipeline):
+            with self.assertRaises(RuntimeError):
+                test._run_single({'name': 'demo', 'pkgs': []},
+                                 {'ior.nprocs': 1}, 0)
+
+        self.assertEqual(stopped, [])
+
+    def test_timed_out_run_is_recorded_failed_and_sweep_continues(self):
+        """A hung combination fails that row only; later rows still run."""
+        temp_dir = tempfile.mkdtemp()
+        try:
+            test = PipelineTest()
+            test.name = 'demo'
+            test.output = temp_dir
+            test.config = {
+                'name': 'demo',
+                'pkgs': [{'pkg_type': 'builtin.ior', 'pkg_name': 'ior'}],
+            }
+            test.combinations = [{'ior.nprocs': 1},
+                                 {'ior.nprocs': 2},
+                                 {'ior.nprocs': 3}]
+            test.run_timeout = 1
+
+            calls = []
+
+            def fake_run_single(config, variables, repeat_idx):
+                nprocs = variables['ior.nprocs']
+                calls.append(nprocs)
+                if nprocs == 1:
+                    raise TimeoutError('run exceeded run_timeout of 1s')
+                return {'combination_idx': nprocs,
+                        'repeat_idx': repeat_idx,
+                        'variables': variables.copy(),
+                        'runtime': 1.0}
+
+            test._run_single = fake_run_single
+            test.run()
+
+            # Every combination was attempted despite the first hanging.
+            self.assertEqual(calls, [1, 2, 3])
+            self.assertEqual(len(test.results), 3)
+            self.assertEqual(test.results[0]['status'], 'failed')
+            self.assertIn('run_timeout', test.results[0]['error'])
+            self.assertEqual(test.results[1]['status'], 'success')
+            self.assertEqual(test.results[2]['status'], 'success')
+        finally:
+            shutil.rmtree(temp_dir)
 
 
 if __name__ == '__main__':

--- a/test/unit/core/test_pkg_runtime_stat.py
+++ b/test/unit/core/test_pkg_runtime_stat.py
@@ -1,0 +1,216 @@
+"""Unit tests for the ``<pkg_id>.runtime`` pipeline-test statistic.
+
+Regression coverage for a defect that shipped blank ``*.runtime`` columns in
+every ``results.csv``: nine builtin packages reported the stat out of
+``self.start_time``, an attribute *nothing in the codebase ever assigned*.
+
+Two independent faults produced it, and both are covered here:
+
+1. ``self.start_time`` was never set. ``ior``/``redis-benchmark`` read it via
+   ``getattr(..., None)`` and quietly emitted an empty cell; the other seven
+   (``fio``, ``filebench``, ``arldm``, ``gadget2``, ``cm1``, ``wfcommons``,
+   ``ycsbc``) read it bare and raised ``AttributeError``. Because ``PipelineTest``
+   wraps ``_get_stat`` in a warn-and-continue ``try/except``, that discarded
+   *every* stat those packages would have reported, not just the runtime.
+2. ``_get_stat`` runs on a **fresh** instance built by
+   ``Pipeline._load_package_instance`` after the run, so even a correctly
+   assigned attribute would not have survived from ``start()``.
+
+The fix: ``Pipeline._timed_start`` measures each package's ``start()`` into
+``Pipeline.pkg_runtimes``, and ``_load_package_instance`` replays it onto every
+later instance of that ``pkg_id``.
+"""
+import importlib.util
+import os
+import pathlib
+import tempfile
+import time
+import unittest
+
+from jarvis_cd.core.pipeline import Pipeline
+from jarvis_cd.core.pkg import Pkg
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+
+def _load_pkg_module(name, rel_path):
+    spec = importlib.util.spec_from_file_location(
+        name, str(_REPO_ROOT / rel_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_ior_mod = _load_pkg_module('rt_ior_pkg', 'builtin/builtin/ior/pkg.py')
+_rb_mod = _load_pkg_module(
+    'rt_rb_pkg', 'builtin/builtin/redis-benchmark/pkg.py')
+_fio_mod = _load_pkg_module('rt_fio_pkg', 'builtin/builtin/fio/pkg.py')
+
+
+class _StubPkg:
+    """Minimal stand-in for a package: records that start() ran."""
+
+    def __init__(self, duration=0.0, boom=None):
+        self.duration = duration
+        self.boom = boom
+        self.started = False
+        self.start_time = None
+        self.runtime = None
+
+    def start(self):
+        self.started = True
+        if self.duration:
+            time.sleep(self.duration)
+        if self.boom:
+            raise self.boom
+
+
+class PkgTimingDefaultsTest(unittest.TestCase):
+    """The base class must define the attributes, not just document them."""
+
+    def test_base_pkg_defines_timing_attributes(self):
+        pkg = Pkg(pipeline=None)
+        # Defined -- so a _get_stat reading them on a package that never ran
+        # emits an empty cell instead of killing the whole stat collection.
+        self.assertIsNone(pkg.start_time)
+        self.assertIsNone(pkg.runtime)
+
+    def test_builtin_packages_read_runtime_not_start_time(self):
+        # The bug was a name mismatch between what _get_stat read and what the
+        # framework populated. Pin the corrected name across every builtin
+        # that reports the stat.
+        offenders = []
+        for pkg_py in sorted(
+                (_REPO_ROOT / 'builtin' / 'builtin').glob('*/pkg.py')):
+            text = pkg_py.read_text()
+            if '.runtime\'] = self.start_time' in text:
+                offenders.append(str(pkg_py.relative_to(_REPO_ROOT)))
+        self.assertEqual([], offenders)
+
+
+class TimedStartTest(unittest.TestCase):
+    """Pipeline.start() must measure each package and park the result."""
+
+    def _pipeline(self):
+        pipeline = object.__new__(Pipeline)
+        pipeline.pkg_runtimes = {}
+        return pipeline
+
+    def test_records_runtime_on_the_pipeline(self):
+        pipeline = self._pipeline()
+        pkg = _StubPkg(duration=0.05)
+
+        pipeline._timed_start({'pkg_id': 'cte_ior'}, pkg)
+
+        self.assertTrue(pkg.started)
+        self.assertIn('cte_ior', pipeline.pkg_runtimes)
+        self.assertGreaterEqual(pipeline.pkg_runtimes['cte_ior'], 0.05)
+
+    def test_sets_runtime_on_the_running_instance(self):
+        pipeline = self._pipeline()
+        pkg = _StubPkg()
+
+        pipeline._timed_start({'pkg_id': 'redis_bench'}, pkg)
+
+        self.assertIsNotNone(pkg.runtime)
+
+    def test_never_populates_deprecated_start_time(self):
+        # A package still reading self.start_time must get an empty cell, not
+        # a wall-clock epoch filed under a column that means "seconds". This
+        # is what keeps a half-deployed install -- updated framework, stale
+        # builtin copy -- visibly blank rather than silently wrong.
+        pipeline = self._pipeline()
+        pkg = _StubPkg(duration=0.02)
+
+        pipeline._timed_start({'pkg_id': 'cte_ior'}, pkg)
+
+        self.assertIsNone(pkg.start_time)
+
+    def test_records_runtime_even_when_start_raises(self):
+        # A failed row still wants to show how long it burned before dying.
+        pipeline = self._pipeline()
+        pkg = _StubPkg(duration=0.02, boom=RuntimeError('ior aborted'))
+
+        with self.assertRaises(RuntimeError):
+            pipeline._timed_start({'pkg_id': 'nfs_ior'}, pkg)
+
+        self.assertIn('nfs_ior', pipeline.pkg_runtimes)
+        self.assertGreaterEqual(pipeline.pkg_runtimes['nfs_ior'], 0.02)
+
+    def test_each_package_timed_separately(self):
+        pipeline = self._pipeline()
+        pipeline._timed_start({'pkg_id': 'fast'}, _StubPkg())
+        pipeline._timed_start({'pkg_id': 'slow'}, _StubPkg(duration=0.05))
+
+        self.assertLess(pipeline.pkg_runtimes['fast'],
+                        pipeline.pkg_runtimes['slow'])
+
+
+class GetStatRuntimeTest(unittest.TestCase):
+    """_get_stat, on a fresh instance, must report the replayed runtime."""
+
+    IOR_LOG = ('Max Write: 112.92 MiB/sec (118.40 MB/sec)\n'
+               'Max Read:  256.10 MiB/sec (268.55 MB/sec)\n')
+
+    def _tempfile(self, text, suffix='.log'):
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        with os.fdopen(fd, 'w') as f:
+            f.write(text)
+        self.addCleanup(os.remove, path)
+        return path
+
+    def test_ior_reports_replayed_runtime_alongside_bandwidth(self):
+        pkg = object.__new__(_ior_mod.Ior)
+        pkg.pkg_id = 'cte_ior'
+        pkg.config = {'log': self._tempfile(self.IOR_LOG)}
+        pkg.runtime = 12.5          # as replayed by _load_package_instance
+
+        stats = {}
+        pkg._get_stat(stats)
+
+        self.assertEqual(12.5, stats['cte_ior.runtime'])
+        # The bandwidth parse must still work -- runtime is additive, and the
+        # two used to come from the same call that AttributeError'd away.
+        self.assertEqual(112.92, stats['cte_ior.write_max_mibs'])
+        self.assertEqual(256.10, stats['cte_ior.read_max_mibs'])
+
+    def test_ior_runtime_blank_but_harmless_when_never_started(self):
+        pkg = object.__new__(_ior_mod.Ior)
+        pkg.pkg_id = 'cte_ior'
+        pkg.config = {'log': self._tempfile(self.IOR_LOG)}
+        pkg.runtime = None
+
+        stats = {}
+        pkg._get_stat(stats)   # must not raise
+
+        self.assertIsNone(stats['cte_ior.runtime'])
+        self.assertEqual(112.92, stats['cte_ior.write_max_mibs'])
+
+    def test_redis_benchmark_reports_replayed_runtime(self):
+        pkg = object.__new__(_rb_mod.RedisBenchmark)
+        pkg.pkg_id = 'redis_bench'
+        pkg.config = {}
+        pkg.runtime = 3.25
+        pkg._csv_path = lambda: '/nonexistent/redis.csv'
+
+        stats = {}
+        pkg._get_stat(stats)
+
+        self.assertEqual(3.25, stats['redis_bench.runtime'])
+
+    def test_fio_get_stat_no_longer_raises(self):
+        # fio's _get_stat is *only* the runtime line, so the old bare
+        # self.start_time read meant fio contributed zero stats to any
+        # pipeline test -- silently, via the warn-and-continue handler.
+        pkg = object.__new__(_fio_mod.Fio)
+        pkg.pkg_id = 'fio_bench'
+        pkg.runtime = 7.0
+
+        stats = {}
+        pkg._get_stat(stats)
+
+        self.assertEqual(7.0, stats['fio_bench.runtime'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/core/test_scheduler_directives.py
+++ b/test/unit/core/test_scheduler_directives.py
@@ -1,0 +1,70 @@
+"""Unit tests for SBATCH directive rendering in jarvis_cd.core.scheduler.
+
+Regression guard: slurm does NOT expand env vars
+in #SBATCH directives, so an unexpanded ``${HOME}`` in output:/error: was
+taken literally (relative to WorkDir), the log file could not be opened, and
+the job failed at launch with no logs. jarvis must expand ${VAR} host-side
+while leaving slurm patterns (%j, %x) and unset vars untouched.
+"""
+import os
+import unittest
+
+from jarvis_cd.core.scheduler import make_scheduler
+
+
+def _render(spec, tmp_path='/tmp/jarvis-sched-test'):
+    sched = make_scheduler(spec, tmp_path, pipeline_yaml='/x/ppl.yaml')
+    return sched.render()
+
+
+class TestSchedulerDirectiveExpansion(unittest.TestCase):
+    def setUp(self):
+        os.environ['JARVIS_SCHED_TEST_HOME'] = '/home/tester'
+
+    def tearDown(self):
+        os.environ.pop('JARVIS_SCHED_TEST_HOME', None)
+
+    def test_expands_env_var_in_output_error(self):
+        text = _render({
+            'name': 'slurm',
+            'job_name': 'smoke',
+            'output': '${JARVIS_SCHED_TEST_HOME}/smoke-%j.out',
+            'error': '${JARVIS_SCHED_TEST_HOME}/smoke-%j.err',
+        })
+        # ${VAR} expanded to an absolute path...
+        self.assertIn('#SBATCH --output=/home/tester/smoke-%j.out', text)
+        self.assertIn('#SBATCH --error=/home/tester/smoke-%j.err', text)
+        # ...and the literal (broken) form is gone.
+        self.assertNotIn('${JARVIS_SCHED_TEST_HOME}', text)
+
+    def test_preserves_slurm_patterns(self):
+        text = _render({
+            'name': 'slurm',
+            'output': '/logs/%x-%j.out',
+        })
+        self.assertIn('#SBATCH --output=/logs/%x-%j.out', text)
+
+    def test_unset_var_left_literal_not_blanked(self):
+        # os.path.expandvars leaves unknown vars untouched rather than
+        # blanking them (so a user's ${SLURM_JOB_ID} typo stays visible
+        # instead of silently collapsing the path).
+        text = _render({
+            'name': 'slurm',
+            'output': '${DEFINITELY_UNSET_XYZ}/o-%j.out',
+        })
+        self.assertIn('#SBATCH --output=${DEFINITELY_UNSET_XYZ}/o-%j.out', text)
+
+    def test_expands_in_sbatch_args_passthrough(self):
+        text = _render({
+            'name': 'slurm',
+            'sbatch_args': ['--comment=${JARVIS_SCHED_TEST_HOME}/note'],
+        })
+        self.assertIn('#SBATCH --comment=/home/tester/note', text)
+
+    def test_partition_value_without_var_unchanged(self):
+        text = _render({'name': 'slurm', 'partition': 'compute'})
+        self.assertIn('#SBATCH --partition=compute', text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/shell/test_exec_factory_container.py
+++ b/test/unit/shell/test_exec_factory_container.py
@@ -51,21 +51,26 @@ class TestPrepareContainerApptainer(unittest.TestCase):
         )
         return make_exec(info)
 
-    def test_apptainer_wraps_with_apptainer_exec(self):
-        """container='apptainer', container_image='myimg', shared_dir set →
-        wrapped cmd contains 'apptainer exec' and 'myimg.sif'."""
+    def test_apptainer_wraps_with_instance_exec(self):
+        """container='apptainer', container_image='myimg' → the command enters
+        the running instance rather than re-launching the SIF."""
         exec_obj = self._make_apptainer_exec(
             container_image='myimg', shared_dir='/shared')
         wrapped_cmd, _ = exec_obj._prepare_container('echo hello')
         self.assertIn('apptainer exec', wrapped_cmd)
-        self.assertIn('myimg.sif', wrapped_cmd)
+        self.assertIn('instance://myimg', wrapped_cmd)
+        # The SIF is launched once by Pipeline._start_containerized_pipeline;
+        # a per-exec SIF launch would start a second, unshared container.
+        self.assertNotIn('.sif', wrapped_cmd)
 
-    def test_apptainer_wraps_with_shared_dir_path(self):
-        """When shared_dir is set, SIF path is resolved from the parent of shared_dir."""
+    def test_apptainer_ignores_shared_dir(self):
+        """shared_dir no longer resolves a SIF path: the instance name is the
+        only thing that selects the container."""
         exec_obj = self._make_apptainer_exec(
             container_image='myimg', shared_dir='/shared/mypkg')
         wrapped_cmd, _ = exec_obj._prepare_container('echo hello')
-        self.assertIn('/shared/myimg.sif', wrapped_cmd)
+        self.assertIn('instance://myimg', wrapped_cmd)
+        self.assertNotIn('/shared', wrapped_cmd)
 
     def test_apptainer_passes_env_vars(self):
         """container='apptainer', env={'MY_VAR': 'val'} → wrapped cmd contains
@@ -89,8 +94,10 @@ class TestPrepareContainerApptainer(unittest.TestCase):
         _, returned_info = exec_obj._prepare_container('echo hello')
         self.assertEqual(returned_info.env, {})
 
-    def test_apptainer_gpu_flag(self):
-        """When gpu=True, '--nv' appears in the wrapped command."""
+    def test_apptainer_gpu_flag_not_forwarded_per_exec(self):
+        """gpu=True does NOT emit '--nv' here: apptainer ignores --nv on a
+        running instance, so it is baked in at `instance start` time
+        (see Pipeline._start_containerized_pipeline)."""
         info = ExecInfo(
             exec_type=ExecType.LOCAL,
             container='apptainer',
@@ -99,7 +106,7 @@ class TestPrepareContainerApptainer(unittest.TestCase):
         )
         exec_obj = make_exec(info)
         wrapped_cmd, _ = exec_obj._prepare_container('echo hello')
-        self.assertIn('--nv', wrapped_cmd)
+        self.assertNotIn('--nv', wrapped_cmd)
 
     def test_apptainer_no_gpu_flag_when_false(self):
         """When gpu=False, '--nv' does NOT appear."""
@@ -107,11 +114,12 @@ class TestPrepareContainerApptainer(unittest.TestCase):
         wrapped_cmd, _ = exec_obj._prepare_container('echo hello')
         self.assertNotIn('--nv', wrapped_cmd)
 
-    def test_apptainer_bind_mounts(self):
-        """bind_mounts entries appear as '--bind ...' in the wrapped command."""
+    def test_apptainer_bind_mounts_not_forwarded_per_exec(self):
+        """bind_mounts are likewise silently ignored on a running instance, so
+        they are baked in at `instance start` time and not emitted here."""
         exec_obj = self._make_apptainer_exec(bind_mounts=['/host/path:/container/path'])
         wrapped_cmd, _ = exec_obj._prepare_container('echo hello')
-        self.assertIn('--bind /host/path:/container/path', wrapped_cmd)
+        self.assertNotIn('--bind', wrapped_cmd)
 
 
 class TestPrepareContainerDocker(unittest.TestCase):

--- a/test/unit/shell/test_openmpi_launcher.py
+++ b/test/unit/shell/test_openmpi_launcher.py
@@ -1,0 +1,58 @@
+"""Unit tests for OpenMPI launcher MCA injection (distributed pipelines).
+
+OpenMPI 5 (PRRTE) renamed the ssh launch plm and its params: OMPI <=4 uses
+plm/rsh + plm_rsh_agent/plm_rsh_args; OMPI 5 uses plm/ssh + plm_ssh_agent/
+plm_ssh_args. jarvis assembles the command on the host but it runs inside the
+container, so it can't detect the in-container version -- it emits both param
+names (each runtime honors the one it knows). The plm component itself is
+selected version-agnostically via '--mca plm ^slurm' in exec_factory.
+"""
+import unittest
+
+from jarvis_cd.shell.mpi_exec import OpenMpiExec
+from jarvis_cd.util.hostfile import Hostfile
+
+
+def _mpicmd(ssh_cmd=None, ssh_port=None, mpi_cmd=None, hosts=('n1', 'n2')):
+    """Call OpenMpiExec.mpicmd() without running LocalExec.__init__."""
+    obj = object.__new__(OpenMpiExec)
+    obj.nprocs = 4
+    obj.ppn = 2
+    obj.hostfile = Hostfile(hosts=list(hosts), find_ips=False)
+    obj.mpi_env = {'PATH': '/nonexistent/bin'}
+    obj.ssh_port = ssh_port
+    obj.mpi_cmd = mpi_cmd
+    obj.ssh_cmd = ssh_cmd
+    obj.original_cmd = 'ior -w'
+    obj.cmd_list = None
+    return obj.mpicmd()
+
+
+class TestOpenMpiLauncherParams(unittest.TestCase):
+    def test_ssh_agent_emits_both_rsh_and_ssh_names(self):
+        cmd = _mpicmd(ssh_cmd='env -u LD_LIBRARY_PATH ssh')
+        self.assertIn('--mca plm_rsh_agent "env -u LD_LIBRARY_PATH ssh"', cmd)
+        self.assertIn('--mca plm_ssh_agent "env -u LD_LIBRARY_PATH ssh"', cmd)
+
+    def test_port_emits_both_rsh_and_ssh_args(self):
+        cmd = _mpicmd(ssh_port=2222)
+        self.assertIn('--mca plm_rsh_args "-p 2222"', cmd)
+        self.assertIn('--mca plm_ssh_args "-p 2222"', cmd)
+
+    def test_port_22_not_injected(self):
+        cmd = _mpicmd(ssh_port=22)
+        self.assertNotIn('plm_ssh_args', cmd)
+        self.assertNotIn('plm_rsh_args', cmd)
+
+    def test_no_ssh_cmd_no_agent(self):
+        cmd = _mpicmd(ssh_cmd=None)
+        self.assertNotIn('plm_ssh_agent', cmd)
+        self.assertNotIn('plm_rsh_agent', cmd)
+
+    def test_inline_host_list_from_pathless_hostfile(self):
+        cmd = _mpicmd(ssh_port=2222)
+        self.assertIn('--host n1,n2', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What this is

Two things, on top of the perf-eval work from #186:

1. **Green CI.** #186 inherited 4 failures that were already red on `dev`.
2. **`host_pkgs`** — a new pipeline key declaring host-baremetal prerequisites, with a containerized CI job that exercises the missing case.

This branch contains #186's commit unchanged (`6e6d819`), so it supersedes that PR rather than stacking on it.

## 1. Fix the pre-existing CI failures

`dev` has been red since at least April with 4 failures in `TestPrepareContainerApptainer`. They are not from #186 — the same 4 fail on `dev`'s own last run (`26959738418`).

Cause: `Exec._prepare_container` was changed to enter a long-running instance (`apptainer exec instance://<name>`) instead of launching the SIF per exec, but the tests still asserted the old SIF-path form and the per-exec `--nv` / `--bind` flags.

Apptainer silently ignores `--nv`, `--bind` and `--add-caps` on a *running* instance, so those have to be baked into `apptainer instance start` — which is what `Pipeline._start_containerized_pipeline` already does. The tests now assert the `instance://` contract (including that no per-exec SIF launch happens, which would start a second unshared container), and the `--nv` / `--bind` coverage moves to `test_container_apptainer.py` where the flags are actually emitted.

## 2. `host_pkgs`

A containerized pipeline shells out to the host's apptainer/docker to build its image. Until now a missing one surfaced late and opaquely — `apptainer: command not found` from inside the container build, after jarvis had already created directories and configured packages.

```yaml
host_pkgs:
  - install_method: spack
    install_query: apptainer
```

`install_method` selects a backend (`spack` / `pip` / `conda`); `install_query` is the string that backend installs, and doubles as what jarvis probes for.

**Two things happen at check time:**

1. **Verify.** Every declared package is probed. Anything missing aborts with the exact command that fixes it, naming *all* missing packages in one pass rather than one error at a time:

   ```
   Missing 1 required host package(s) for 'ior_apptainer_host_pkgs_test'.
   These must be installed on the host baremetal before jarvis can run this pipeline:
     - apptainer (install_method: spack)
         install it with: spack install apptainer
   ```

   This is a check, not an install — `spack install apptainer` can run for hours, which a pipeline launch should not do unprompted.

2. **Activate.** Present packages contribute their environment (what `spack load` sets) so the subprocesses jarvis spawns to do the containerizing actually find them.

**Why the activation goes into `os.environ`** and not just `pipeline.env`: `LocalExec.run` falls back to a bare `os.environ` whenever its `ExecInfo` carries no explicit env, and the container-build path constructs plain `LocalExecInfo()` at a couple dozen call sites. Threading a dict through all of them would be invasive and would silently miss any new one. A *host* prerequisite is process-scoped by nature.

**Where it is checked:**

| Path | When |
|---|---|
| `jarvis ppl run yaml <file>` | At load, before any package is processed |
| `jarvis ppl run` (saved current pipeline) | In `run()` |
| `jarvis ppl submit [file]` | Before the job is queued, on the submitting host |
| Pipeline tests (`config.host_pkgs`) | Once at load, then per iteration |

Probes are memoized per process, so an N-combination sweep pays for the probe once. `host_pkgs` round-trips through the saved config, so `ppl submit` against the current pipeline re-checks without re-reading the source YAML. The check in `run()` sits *outside* the try/except, so a missing prerequisite does not drag the user through a `stop()` recovery trace. Submitting is checked on the submitting host because the job would otherwise sit in the queue and burn an allocation to fail the same way.

One bug found while testing: parsing `spack load && env` line-by-line pulled exported bash *functions* (`BASH_FUNC_spack%%=() {…`) and their body lines into `os.environ` as junk variables. Now parses `env -0` and keeps only plain identifiers.

### CI

A new `host-pkgs` job runs in a bare `ubuntu:24.04` container — chosen precisely because it has neither spack nor apptainer, making this the real "declared but not installed" case rather than a simulated one. `ci/test_host_pkgs.sh` asserts the example apptainer pipeline fails, names the package and the fix, and stops *before* the container build begins. A second case with a satisfiable `pip`/`pyyaml` prerequisite keeps the first honest, plus a guard that aborts if the host unexpectedly does have spack/apptainer.

## Verification

- Full suite: **969 passed, 5 skipped** (was 924 before this branch; no regressions).
- The three `run()` / `submit()` integration tests were mutation-tested — all three fail with the feature removed, so they are not passing vacuously.
- CI dispatched on this branch (`31079174025`): both `test` and `host-pkgs` green. The `host-pkgs` log confirms it hit the real missing-apptainer path, not a trivial pass.
- Every YAML snippet added to the docs was parsed and run through `HostPkg.parse`.

## Reviewer notes

- `host_pkgs` is additive and opt-in: pipelines without the key behave exactly as before.
- Only **check**, not auto-install, is implemented — `install_query` doubles as the remediation string. The backends carry everything needed for an opt-in auto-install flag if that is wanted later.
- `ci/test_host_pkgs.sh` exports a scratch `HOME`, because `jarvis init` rewrites `~/.ppi-jarvis/jarvis_config.yaml` in place and would otherwise repoint a developer's real install at the test's scratch dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
