### PR TITLE
fix: escape direct-mode launches into their own systemd scope (cgroup detach race)

### DIFF
--- a/jarvis_cd/core/execution.py
+++ b/jarvis_cd/core/execution.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from time import monotonic, sleep
-from typing import Any, Iterator, List, Literal, Mapping, Optional, cast
+from typing import Any, Iterator, List, Literal, Mapping, Optional, cast, get_args
 from uuid import uuid4
 
 from jarvis_cd.artifacts import (
@@ -48,7 +48,27 @@ PROGRESS_SNAPSHOT_SCHEMA = "jarvis.execution.progress.v1"
 ARTIFACT_SNAPSHOT_SCHEMA = "jarvis.execution.artifacts.v1"
 SERVICE_RUNTIME_SNAPSHOT_SCHEMA = SERVICE_RUNTIME_SNAPSHOT_SCHEMA_VERSION
 SERVICE_RUNTIME_AUTHORITY_SCHEMA = "jarvis.execution.service-runtime-authority.v1"
-DIRECT_LAUNCH_SCHEMA = "jarvis.direct-launch.v1"
+DIRECT_LAUNCH_SCHEMA = "jarvis.direct-launch.v2"
+DirectLaunchEscapeReason = Literal[
+    "systemd_scope",
+    "skipped_windows",
+    "skipped_no_systemd_run",
+    "skipped_no_runtime_dir",
+    "degraded_probe_failed",
+    "degraded_migration_unconfirmed",
+    "degraded_spawn_error",
+]
+"""Typed reason a direct-mode launch did or did not escape into its own
+systemd scope (clio-relay#222). ``"systemd_scope"`` is the only successful
+escape; ``"skipped_*"`` values are static environment facts (no systemd user
+session to use in the first place); ``"degraded_*"`` values are runtime
+degradations -- a live capability was probed or attempted and did not pan
+out, so the launch fell back to pre-#222-fix setsid-only detachment for
+*this* execution. No silent fallback: every value the escape logic can
+produce is recorded on the ``direct_launch`` metadata record clio-relay
+already reads, per the project's own no-silent-fallback rule.
+"""
+DIRECT_LAUNCH_ESCAPE_REASONS = frozenset(get_args(DirectLaunchEscapeReason))
 DIRECT_LEASE_NAME = ".jarvis-direct-execution.lease"
 SCHEDULER_ARTIFACT_PATH_SCHEMA = "jarvis.scheduler.artifact-path.v1"
 SCHEDULER_ARTIFACT_PATH_METADATA_KEY = "jarvis_scheduler_path"
@@ -1306,6 +1326,8 @@ class ExecutionStore:
             "phase",
             "launcher_pid",
             "child_pid",
+            "escape",
+            "escape_detail",
         }
         if not isinstance(launch, dict) or set(launch) != expected_fields:
             raise RuntimeError("direct execution launch metadata is invalid")
@@ -1313,6 +1335,12 @@ class ExecutionStore:
             raise RuntimeError("direct execution launch metadata is invalid")
         phase = launch.get("phase")
         if phase not in {"launching", "prepared", "spawned", "failed", "orphaned"}:
+            raise RuntimeError("direct execution launch metadata is invalid")
+        escape = launch.get("escape")
+        if escape is not None and escape not in DIRECT_LAUNCH_ESCAPE_REASONS:
+            raise RuntimeError("direct execution launch metadata is invalid")
+        escape_detail = launch.get("escape_detail")
+        if escape_detail is not None and not isinstance(escape_detail, str):
             raise RuntimeError("direct execution launch metadata is invalid")
         launcher_pid = launch.get("launcher_pid")
         child_pid = launch.get("child_pid")

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -116,6 +116,64 @@ def _bounded_scheduler_stderr(result: Any, limit: int = 4096) -> Optional[str]:
     return "[truncated]\n" + diagnostic[-limit:]
 
 
+def _is_windows_platform() -> bool:
+    """Return whether this process is running on Windows.
+
+    Factored out of :func:`_escaped_direct_launch_command` so tests can
+    exercise its POSIX branch without mutating the real ``os.name``, which
+    would also perturb unrelated ``pathlib`` platform dispatch when a test
+    suite runs natively on Windows.
+    """
+    return os.name == "nt"
+
+
+def _escaped_direct_launch_command(command: List[str]) -> List[str]:
+    """Wrap a direct-execution launch command so it escapes into its own
+    cgroup instead of merely detaching its POSIX session.
+
+    ``start_new_session=True`` (setsid) removes the launched process from
+    the caller's controlling terminal, session, and process group, but it
+    does NOT move the process to a new cgroup: fork/exec always inherits
+    the parent's cgroup unless something explicitly migrates the child.
+    On any host where a systemd-managed cgroup v2 hierarchy is tracking
+    the caller (for example, a caller wrapped in its own transient
+    ``systemd-run --user --scope`` unit for process containment — see
+    clio-relay issue #222), a plain setsid child is still a member of the
+    caller's cgroup. A containment check that expects the caller's
+    process tree to be empty once the caller-visible work is done will
+    then see the still-running detached child as a leaked descendant,
+    even though it is an intentionally supervised background execution
+    with its own durable, pollable execution record.
+
+    Wrapping the launch in its own transient ``systemd-run --user
+    --scope`` unit gives it an independent, sibling cgroup so a
+    caller-scoped containment check no longer observes it. Hosts without
+    a usable systemd user session (no ``systemd-run`` binary, or no
+    ``XDG_RUNTIME_DIR``) fall back to the unwrapped command unchanged;
+    the fork/exec chain then behaves exactly as it did before this
+    escape was added.
+
+    :param command: The argv to launch (e.g. the ``run-snapshot`` command).
+    :return: The same command, optionally prefixed with a systemd-run
+        scope wrapper.
+    """
+    if _is_windows_platform():
+        return command
+    systemd_run = shutil.which("systemd-run")
+    if systemd_run is None or not os.environ.get("XDG_RUNTIME_DIR"):
+        return command
+    unit = f"jarvis-cd-direct-{uuid4().hex}"
+    return [
+        systemd_run,
+        "--user",
+        "--scope",
+        "--quiet",
+        f"--unit={unit}",
+        "--",
+        *command,
+    ]
+
+
 def _executor_status_error(
     result: Any,
     *,
@@ -3228,6 +3286,7 @@ class Pipeline:
                     options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
                 else:
                     options["start_new_session"] = True
+                command = _escaped_direct_launch_command(command)
                 launched_process = subprocess.Popen(command, **options)
                 process = launched_process
             finally:

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -21,7 +21,7 @@ from contextlib import ExitStack
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Any, List, Mapping, Optional
+from typing import Dict, Any, List, Mapping, Optional, Tuple
 from uuid import uuid4
 from jarvis_cd.artifacts import (
     ArtifactLocation,
@@ -33,6 +33,8 @@ from jarvis_cd.artifacts import (
 )
 from jarvis_cd.core.config import load_class, Jarvis
 from jarvis_cd.core.execution import (
+    DIRECT_LAUNCH_SCHEMA,
+    DirectLaunchEscapeReason,
     LEGACY_RECORD_SCHEMA,
     RECORD_NAME,
     RECORD_SCHEMA,
@@ -137,11 +139,21 @@ def _usable_systemd_user_runtime_dir() -> Optional[str]:
     relay broker that deliberately sanitizes what it forwards into a
     launched MCP tool) can strip that variable while the user's systemd
     session, and the conventional ``/run/user/<uid>`` directory it manages,
-    stay perfectly live underneath. ``systemd-run`` itself falls back to
-    that same UID-derived path when the variable is absent (confirmed:
-    ``systemd-run --user --scope`` succeeds with ``XDG_RUNTIME_DIR``
-    unset, as long as ``/run/user/<uid>`` exists), so trust the directory,
-    not the environment variable that merely usually names it.
+    stay perfectly live underneath.
+
+    This directory check alone does not make ``systemd-run`` usable, only
+    *discoverable*: confirmed empirically on a real deep relay launch chain
+    that ``systemd-run --user --scope`` does NOT reliably re-derive
+    ``/run/user/<uid>`` on its own when BOTH ``XDG_RUNTIME_DIR`` and
+    ``DBUS_SESSION_BUS_ADDRESS`` are absent from its own process
+    environment — it fails its D-Bus connection ("Failed to connect to
+    bus: No medium found") even though this exact directory exists and a
+    plain SSH session's ``systemd-run`` call (which still has one of those
+    two vars set via the session's own environment) succeeds immediately.
+    So the directory this function returns is not merely informative: the
+    caller must also EXPORT it into any ``systemd-run`` subprocess's own
+    environment — see :func:`_systemd_user_runtime_environment` — rather
+    than trust ``systemd-run`` to rediscover it independently.
     """
     from_env = os.environ.get("XDG_RUNTIME_DIR")
     if from_env and os.path.isdir(from_env):
@@ -153,10 +165,39 @@ def _usable_systemd_user_runtime_dir() -> Optional[str]:
     return None
 
 
+def _systemd_user_runtime_environment(runtime_dir: str) -> Dict[str, str]:
+    """Build the environment a ``systemd-run --user`` subprocess actually
+    needs, layered on top of the current process's own environment.
+
+    Always exports ``XDG_RUNTIME_DIR=<runtime_dir>`` (idempotent — a
+    harmless no-op when the ambient value already matches, but load-bearing
+    when a caller several process generations up stripped it: see
+    :func:`_usable_systemd_user_runtime_dir`). Derives
+    ``DBUS_SESSION_BUS_ADDRESS`` from the same directory using systemd's
+    own convention (``unix:path=<runtime_dir>/bus``) ONLY when it is not
+    already present in the ambient environment — an existing value is
+    trusted over a guess, since some hosts genuinely use a non-default bus
+    address.
+
+    :param runtime_dir: The live runtime directory from
+        :func:`_usable_systemd_user_runtime_dir`.
+    :return: A full environment mapping (ambient ``os.environ`` plus these
+        overrides) ready to pass as ``subprocess`` ``env=``.
+    """
+    environment = dict(os.environ)
+    environment["XDG_RUNTIME_DIR"] = runtime_dir
+    environment.setdefault("DBUS_SESSION_BUS_ADDRESS", f"unix:path={runtime_dir}/bus")
+    return environment
+
+
 _SYSTEMD_SCOPE_PROBE_TIMEOUT_SECONDS = 2.0
+_PROBE_DIAGNOSTIC_LIMIT = 2048
 
 
-def _systemd_user_scope_is_usable(systemd_run: str) -> bool:
+def _systemd_user_scope_is_usable(
+    systemd_run: str,
+    environment: Mapping[str, str],
+) -> Tuple[bool, Optional[str]]:
     """Live-probe whether ``systemd-run --user --scope`` can register a
     transient unit right now, not just whether the binary and a
     conventional runtime directory exist.
@@ -165,31 +206,52 @@ def _systemd_user_scope_is_usable(systemd_run: str) -> bool:
     directory are necessary but not sufficient: confirmed empirically that
     a deeply nested launch chain (relay broker -> uv -> clio-kit ->
     jarvis-mcp -> this function) can fail the D-Bus connection systemd-run
-    needs ("Failed to connect to bus: No medium found") even though the
-    identical command run from a plain SSH session on the same host
-    succeeds immediately. Static signals are not reliable enough here;
-    trust a real, cheap, bounded probe instead — the same "verify before
-    trusting the mechanism" approach clio-relay's own
-    ``_probe_linux_systemd_scope_capability`` uses for the same class of
-    decision.
+    needs ("Failed to connect to bus: No medium found") when its own
+    process environment has neither ``XDG_RUNTIME_DIR`` nor
+    ``DBUS_SESSION_BUS_ADDRESS`` set — even though the identical command
+    run from a plain SSH session on the same host (which still has one of
+    those two set) succeeds immediately. ``environment`` (built by
+    :func:`_systemd_user_runtime_environment`) closes that gap by
+    explicitly exporting both; this probe still runs live rather than
+    trusting that export blindly, since export alone does not guarantee
+    the user systemd/D-Bus session is actually reachable right now.
 
     :param systemd_run: Resolved path to the ``systemd-run`` executable.
-    :return: Whether a real probe scope was created successfully.
+    :param environment: The environment to run the probe subprocess with
+        (see :func:`_systemd_user_runtime_environment`).
+    :return: ``(True, None)`` on a clean probe. ``(False, diagnostic)`` on
+        any failure, where ``diagnostic`` is the probe's own bounded
+        stderr text when it produced one (e.g. the D-Bus connection
+        error), or a short synthetic description otherwise — never
+        ``None`` on failure, so a caller can always record *why*.
     """
     try:
         completed = subprocess.run(
             [systemd_run, "--user", "--scope", "--quiet", "--", "true"],
+            env=dict(environment),
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             timeout=_SYSTEMD_SCOPE_PROBE_TIMEOUT_SECONDS,
         )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    return completed.returncode == 0
+    except subprocess.TimeoutExpired:
+        return False, (
+            "systemd-run --user --scope probe did not return within "
+            f"{_SYSTEMD_SCOPE_PROBE_TIMEOUT_SECONDS}s"
+        )
+    except OSError as error:
+        return False, str(error)
+    if completed.returncode == 0:
+        return True, None
+    diagnostic = (completed.stderr or b"").decode("utf-8", errors="replace").strip()
+    if not diagnostic:
+        diagnostic = f"systemd-run --user --scope probe exited {completed.returncode}"
+    return False, diagnostic[:_PROBE_DIAGNOSTIC_LIMIT]
 
 
-def _escaped_direct_launch_command(command: List[str]) -> List[str]:
+def _escaped_direct_launch_command(
+    command: List[str],
+) -> Tuple[List[str], DirectLaunchEscapeReason, Optional[str], Optional[Dict[str, str]]]:
     """Wrap a direct-execution launch command so it escapes into its own
     cgroup instead of merely detaching its POSIX session.
 
@@ -215,29 +277,51 @@ def _escaped_direct_launch_command(command: List[str]) -> List[str]:
     back to the unwrapped command unchanged; the fork/exec chain then
     behaves exactly as it did before this escape was added.
 
+    No silent fallback: every branch returns a typed reason (and, for the
+    one branch with more to say, a bounded diagnostic) instead of quietly
+    handing back the unwrapped command. A caller on the exact host class
+    #222 exists to serve — a cloud box with a flaky user-session D-Bus —
+    must be able to tell "the fix is not installed" apart from "the fix
+    installed and degraded," which a silent fallback could not do.
+
     :param command: The argv to launch (e.g. the ``run-snapshot`` command).
-    :return: The same command, optionally prefixed with a systemd-run
-        scope wrapper.
+    :return: A 4-tuple of ``(command, reason, detail, environment)``.
+        ``command`` is the original list unchanged for every reason except
+        ``"systemd_scope"``. ``detail`` is ``None`` except for
+        ``"degraded_probe_failed"``, where it carries the probe's own
+        diagnostic text. ``environment`` is ``None`` except for
+        ``"systemd_scope"``, where it carries the environment (see
+        :func:`_systemd_user_runtime_environment`) the caller MUST use for
+        the real wrapped launch too — the same D-Bus reachability the
+        probe just verified.
     """
     if _is_windows_platform():
-        return command
+        return command, "skipped_windows", None, None
     systemd_run = shutil.which("systemd-run")
-    if (
-        systemd_run is None
-        or _usable_systemd_user_runtime_dir() is None
-        or not _systemd_user_scope_is_usable(systemd_run)
-    ):
-        return command
+    if systemd_run is None:
+        return command, "skipped_no_systemd_run", None, None
+    runtime_dir = _usable_systemd_user_runtime_dir()
+    if runtime_dir is None:
+        return command, "skipped_no_runtime_dir", None, None
+    environment = _systemd_user_runtime_environment(runtime_dir)
+    usable, diagnostic = _systemd_user_scope_is_usable(systemd_run, environment)
+    if not usable:
+        return command, "degraded_probe_failed", diagnostic, None
     unit = f"jarvis-cd-direct-{uuid4().hex}"
-    return [
-        systemd_run,
-        "--user",
-        "--scope",
-        "--quiet",
-        f"--unit={unit}",
-        "--",
-        *command,
-    ]
+    return (
+        [
+            systemd_run,
+            "--user",
+            "--scope",
+            "--quiet",
+            f"--unit={unit}",
+            "--",
+            *command,
+        ],
+        "systemd_scope",
+        None,
+        environment,
+    )
 
 
 _CGROUP_ESCAPE_CONFIRM_TIMEOUT_SECONDS = 2.0
@@ -254,6 +338,47 @@ def _cgroup_membership(pid: str) -> Optional[str]:
             return handle.read()
     except OSError:
         return None
+
+
+def _cgroup_v2_unified_path(membership: str) -> Optional[str]:
+    """Return the unified cgroup-v2 path from raw ``/proc/<pid>/cgroup``
+    content, or ``None`` when the host is not pure cgroup-v2 unified (no
+    ``0::`` line) — e.g. a legacy/hybrid v1 mount. This function does not
+    attempt to parse those; callers fall back to a looser comparison.
+    """
+    for line in membership.splitlines():
+        if line.startswith("0::"):
+            return line[len("0::") :]
+    return None
+
+
+def _left_ancestor_cgroup(observed: str, caller: str) -> bool:
+    """Return whether ``observed``'s cgroup is strictly outside ``caller``'s.
+
+    :func:`_cgroup_escape_confirmed`'s original check (``observed !=
+    caller``) proves the target *moved*, not that it moved *out* — a child
+    cgroup nested inside the caller's own delegated subtree would satisfy
+    plain inequality while remaining fully visible to a recursive
+    containment scan. Not reachable via ``systemd-run --user --scope``
+    today (the user manager places scopes under ``app.slice``, a sibling,
+    never nested under the caller), so this was latent rather than live —
+    but the fix is cheap: compare cgroup-v2 path *segments*, not raw
+    string prefixes, so a sibling unit whose name happens to start with
+    the same characters (``app.slice/foo`` vs. ``app.slice/foobar.scope``)
+    is correctly not mistaken for a descendant either. Falls back to plain
+    inequality when either side is not parseable unified-hierarchy content
+    (e.g. a legacy/hybrid cgroup v1 mount), preserving the original,
+    looser behavior rather than risk a false negative on a host shape this
+    function does not understand.
+    """
+    observed_path = _cgroup_v2_unified_path(observed)
+    caller_path = _cgroup_v2_unified_path(caller)
+    if observed_path is None or caller_path is None:
+        return observed != caller
+    if observed_path == caller_path:
+        return False
+    prefix = caller_path if caller_path.endswith("/") else caller_path + "/"
+    return not observed_path.startswith(prefix)
 
 
 def _cgroup_escape_confirmed(pid: int) -> bool:
@@ -281,7 +406,7 @@ def _cgroup_escape_confirmed(pid: int) -> bool:
         observed = _cgroup_membership(str(pid))
         if observed is None:
             return False
-        if observed != caller_cgroup:
+        if _left_ancestor_cgroup(observed, caller_cgroup):
             return True
         if time.monotonic() >= deadline:
             return False
@@ -303,43 +428,193 @@ def _terminate_launched_process_best_effort(process: "subprocess.Popen[Any]") ->
             pass
 
 
+def _systemd_scope_unit_name(escaped_command: List[str]) -> Optional[str]:
+    """Return the transient scope unit name embedded in an escaped command.
+
+    :param escaped_command: A command previously returned by
+        :func:`_escaped_direct_launch_command`.
+    :return: The unit name (without ``.scope``), or ``None`` if the command
+        was never wrapped.
+    """
+    for token in escaped_command:
+        if token.startswith("--unit="):
+            return token[len("--unit=") :]
+    return None
+
+
+def _stop_systemd_scope_best_effort(unit: str) -> None:
+    """Best-effort teardown of a transient user scope by its own unit name.
+
+    On an unconfirmed-migration retry, terminating only the launch's
+    leader PID (the prior behavior) can leave grandchildren the leader
+    already forked *inside* the escaped cgroup during the confirm window
+    running and un-contained — a silent orphan-resource leak, plus a
+    partial-then-full double execution of the same ``execution_id``.
+    Stopping the scope unit itself uses systemd's own
+    ``KillMode=control-group`` semantics (the same teardown clio-relay's
+    own ``_release_linux_systemd_scope`` uses), tearing down the whole
+    cgroup rather than one PID. Tolerates ``systemctl`` being absent or
+    the stop itself failing — this is cleanup on an already-degraded path,
+    not a new hard dependency.
+
+    :param unit: The scope's transient unit name (without ``.scope``).
+    """
+    systemctl = shutil.which("systemctl")
+    if systemctl is None:
+        return
+    try:
+        subprocess.run(
+            [systemctl, "--user", "stop", f"{unit}.scope"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=_SYSTEMD_SCOPE_PROBE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+
+def _reopen_direct_execution_streams(
+    options: Dict[str, Any],
+    stdout_path: Path,
+    stderr_path: Path,
+) -> None:
+    """Reopen ``options["stdout"]``/``["stderr"]`` from their real paths.
+
+    Used before a retried (unwrapped) launch. Reopening from the ``Path``
+    the caller already resolved — rather than ``getattr(stream, "name")``
+    — means the reopened handle cannot silently re-resolve against a
+    since-changed current working directory even if the execution root
+    were ever a relative path; it is also simply less indirection than
+    reading a name back off a file object.
+
+    :param options: ``subprocess.Popen`` keyword arguments, mutated in
+        place.
+    :param stdout_path: The execution's stdout log path.
+    :param stderr_path: The execution's stderr log path.
+    """
+    for stream_name, path in (("stdout", stdout_path), ("stderr", stderr_path)):
+        stream = options.get(stream_name)
+        if hasattr(stream, "close"):
+            stream.close()
+        options[stream_name] = path.open("ab", buffering=0)
+
+
+_DEGRADED_ESCAPE_HEADLINES: Dict[str, str] = {
+    "degraded_probe_failed": "the live systemd --user scope probe failed",
+    "degraded_migration_unconfirmed": (
+        "systemd-run registered the scope but did not confirm cgroup "
+        "migration in time"
+    ),
+    "degraded_spawn_error": "the systemd-run wrapper itself failed to spawn",
+}
+
+
+def _warn_degraded_direct_launch_escape(
+    reason: DirectLaunchEscapeReason,
+    detail: Optional[str],
+) -> None:
+    """Emit a stderr warning for a runtime escape degradation.
+
+    Silent only for the three ``"skipped_*"``/``"systemd_scope"`` values,
+    which are not degradations (a static environment fact, or success).
+    Every ``"degraded_*"`` value gets a line naming what degraded and what
+    that means operationally — errors-are-agent-API: clio-relay#222's
+    process-containment race window is present again for this one launch,
+    even though the fix is installed.
+
+    :param reason: The final typed escape reason for one launch.
+    :param detail: An optional bounded diagnostic (e.g. the probe's own
+        D-Bus error text, or the ``OSError`` text from a failed spawn).
+    """
+    headline = _DEGRADED_ESCAPE_HEADLINES.get(reason)
+    if headline is None:
+        return
+    message = (
+        f"direct-mode launch degraded ({reason}): {headline}; falling back "
+        "to setsid-only detachment for this launch. clio-relay#222's "
+        "process-containment race window is present until the next "
+        "successful escape."
+    )
+    if detail:
+        message += f" detail: {detail}"
+    logger.warning(message, file=sys.stderr)
+
+
 def _spawn_direct_execution_process(
     command: List[str],
     options: Dict[str, Any],
-) -> "subprocess.Popen[Any]":
+    *,
+    stdout_path: Path,
+    stderr_path: Path,
+) -> Tuple["subprocess.Popen[Any]", DirectLaunchEscapeReason, Optional[str]]:
     """Launch a direct execution, escaping into its own cgroup when possible.
 
-    Applies :func:`_escaped_direct_launch_command`, then — only on POSIX,
-    where a cgroup migration is actually possible — confirms the escape
-    really landed via :func:`_cgroup_escape_confirmed`. If it did not land
-    within a bounded window (an intermittent systemd/D-Bus race, not a
-    permanent host incapability — the earlier live probe already ruled
-    that out), the half-escaped process is terminated and the launch
-    retries once, unwrapped, so a flaky escape degrades to the prior
-    setsid-only behavior instead of leaving an ambiguous, neither-escaped
-    -nor-contained process behind.
+    Applies :func:`_escaped_direct_launch_command`, then — only when it
+    actually wrapped the command — confirms the escape really landed via
+    :func:`_cgroup_escape_confirmed`. If it did not land within a bounded
+    window (an intermittent systemd/D-Bus race, not a permanent host
+    incapability — the earlier live probe already ruled that out), the
+    half-escaped scope is stopped (not just its leader PID — see
+    :func:`_stop_systemd_scope_best_effort`) and the launch retries once,
+    unwrapped, so a flaky escape degrades to the prior setsid-only
+    behavior instead of leaving an ambiguous, neither-escaped-nor-
+    contained process behind. If the wrapped ``Popen`` call itself raises
+    ``OSError`` (e.g. ``systemd-run`` was removed between the probe and
+    this call), the same unwrapped retry runs rather than hard-failing a
+    launch that would have succeeded before this escape was ever added.
+
+    Every outcome returns a typed reason (and, where there is more to
+    say, a bounded diagnostic); the caller records both on the
+    ``direct_launch`` execution metadata and this function itself warns
+    on stderr for the degraded cases — no silent fallback.
 
     :param command: The unwrapped run-snapshot argv.
     :param options: ``subprocess.Popen`` keyword arguments. ``stdout`` and
         ``stderr`` must already be open file objects; on a retry they are
-        reopened in append mode from the same paths.
-    :return: The launched (possibly retried) process.
+        reopened in append mode from ``stdout_path``/``stderr_path``.
+    :param stdout_path: The execution's stdout log path (for a retry).
+    :param stderr_path: The execution's stderr log path (for a retry).
+    :return: A 3-tuple of ``(process, reason, detail)`` for the launched
+        (possibly retried) process.
     """
-    escaped_command = _escaped_direct_launch_command(command)
-    launched_process = subprocess.Popen(escaped_command, **options)
-    if escaped_command is command or _is_windows_platform():
-        return launched_process
+    escaped_command, reason, detail, environment = _escaped_direct_launch_command(command)
+    if escaped_command is command:
+        _warn_degraded_direct_launch_escape(reason, detail)
+        return subprocess.Popen(escaped_command, **options), reason, detail
+
+    # The wrapped launch needs the SAME exported XDG_RUNTIME_DIR/
+    # DBUS_SESSION_BUS_ADDRESS the probe just verified with -- a caller
+    # several process generations up (the exact deep relay chain #222
+    # exists to serve) can strip both from ambient os.environ, and
+    # systemd-run does not reliably rediscover them on its own (see
+    # _usable_systemd_user_runtime_dir). A local dict copy, not a mutation
+    # of the caller's `options`, so an unwrapped retry below is unaffected.
+    wrapped_options = (
+        {**options, "env": environment} if environment is not None else options
+    )
+    try:
+        launched_process = subprocess.Popen(escaped_command, **wrapped_options)
+    except OSError as error:
+        reason, detail = "degraded_spawn_error", str(error)
+        _warn_degraded_direct_launch_escape(reason, detail)
+        _reopen_direct_execution_streams(options, stdout_path, stderr_path)
+        return subprocess.Popen(command, **options), reason, detail
+
     if _cgroup_escape_confirmed(launched_process.pid):
-        return launched_process
+        return launched_process, reason, detail
+
+    unit = _systemd_scope_unit_name(escaped_command)
+    if unit is not None:
+        _stop_systemd_scope_best_effort(unit)
     _terminate_launched_process_best_effort(launched_process)
-    for stream_name in ("stdout", "stderr"):
-        stream = options.get(stream_name)
-        if hasattr(stream, "close"):
-            stream.close()
-        stream_path = getattr(stream, "name", None)
-        if stream_path is not None:
-            options[stream_name] = open(stream_path, "ab", buffering=0)
-    return subprocess.Popen(command, **options)
+    _reopen_direct_execution_streams(options, stdout_path, stderr_path)
+    reason, detail = "degraded_migration_unconfirmed", (
+        "cgroup migration not confirmed within "
+        f"{_CGROUP_ESCAPE_CONFIRM_TIMEOUT_SECONDS}s"
+    )
+    _warn_degraded_direct_launch_escape(reason, detail)
+    return subprocess.Popen(command, **options), reason, detail
 
 
 def _executor_status_error(
@@ -3368,11 +3643,13 @@ class Pipeline:
         resolved_execution_id = _validated_execution_id(execution_id)
         self.save()
         store = self._execution_store()
-        direct_launch = {
-            "schema_version": "jarvis.direct-launch.v1",
+        direct_launch: Dict[str, Any] = {
+            "schema_version": DIRECT_LAUNCH_SCHEMA,
             "phase": "launching",
             "launcher_pid": os.getpid(),
             "child_pid": None,
+            "escape": None,
+            "escape_detail": None,
         }
         store.create(
             resolved_execution_id,
@@ -3454,7 +3731,12 @@ class Pipeline:
                     options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
                 else:
                     options["start_new_session"] = True
-                launched_process = _spawn_direct_execution_process(command, options)
+                launched_process, escape, escape_detail = _spawn_direct_execution_process(
+                    command,
+                    options,
+                    stdout_path=stdout_path,
+                    stderr_path=stderr_path,
+                )
                 process = launched_process
             finally:
                 # A retried (unwrapped) launch reopens fresh stream objects
@@ -3467,6 +3749,8 @@ class Pipeline:
                 **direct_launch,
                 "phase": "spawned",
                 "child_pid": launched_process.pid,
+                "escape": escape,
+                "escape_detail": escape_detail,
             }
             try:
                 store.update(

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -15,6 +15,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import time
 import yaml
 from contextlib import ExitStack
 from copy import deepcopy
@@ -127,6 +128,67 @@ def _is_windows_platform() -> bool:
     return os.name == "nt"
 
 
+def _usable_systemd_user_runtime_dir() -> Optional[str]:
+    """Return a live XDG runtime directory for ``systemd-run --user``, or
+    ``None`` if this host has none.
+
+    Prefers the ambient ``XDG_RUNTIME_DIR``, but does not require it: a
+    caller several process generations up the launch chain (for example a
+    relay broker that deliberately sanitizes what it forwards into a
+    launched MCP tool) can strip that variable while the user's systemd
+    session, and the conventional ``/run/user/<uid>`` directory it manages,
+    stay perfectly live underneath. ``systemd-run`` itself falls back to
+    that same UID-derived path when the variable is absent (confirmed:
+    ``systemd-run --user --scope`` succeeds with ``XDG_RUNTIME_DIR``
+    unset, as long as ``/run/user/<uid>`` exists), so trust the directory,
+    not the environment variable that merely usually names it.
+    """
+    from_env = os.environ.get("XDG_RUNTIME_DIR")
+    if from_env and os.path.isdir(from_env):
+        return from_env
+    if hasattr(os, "getuid"):
+        conventional = f"/run/user/{os.getuid()}"
+        if os.path.isdir(conventional):
+            return conventional
+    return None
+
+
+_SYSTEMD_SCOPE_PROBE_TIMEOUT_SECONDS = 2.0
+
+
+def _systemd_user_scope_is_usable(systemd_run: str) -> bool:
+    """Live-probe whether ``systemd-run --user --scope`` can register a
+    transient unit right now, not just whether the binary and a
+    conventional runtime directory exist.
+
+    A present ``systemd-run`` binary and a live ``/run/user/<uid>``
+    directory are necessary but not sufficient: confirmed empirically that
+    a deeply nested launch chain (relay broker -> uv -> clio-kit ->
+    jarvis-mcp -> this function) can fail the D-Bus connection systemd-run
+    needs ("Failed to connect to bus: No medium found") even though the
+    identical command run from a plain SSH session on the same host
+    succeeds immediately. Static signals are not reliable enough here;
+    trust a real, cheap, bounded probe instead — the same "verify before
+    trusting the mechanism" approach clio-relay's own
+    ``_probe_linux_systemd_scope_capability`` uses for the same class of
+    decision.
+
+    :param systemd_run: Resolved path to the ``systemd-run`` executable.
+    :return: Whether a real probe scope was created successfully.
+    """
+    try:
+        completed = subprocess.run(
+            [systemd_run, "--user", "--scope", "--quiet", "--", "true"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=_SYSTEMD_SCOPE_PROBE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0
+
+
 def _escaped_direct_launch_command(command: List[str]) -> List[str]:
     """Wrap a direct-execution launch command so it escapes into its own
     cgroup instead of merely detaching its POSIX session.
@@ -148,10 +210,10 @@ def _escaped_direct_launch_command(command: List[str]) -> List[str]:
     Wrapping the launch in its own transient ``systemd-run --user
     --scope`` unit gives it an independent, sibling cgroup so a
     caller-scoped containment check no longer observes it. Hosts without
-    a usable systemd user session (no ``systemd-run`` binary, or no
-    ``XDG_RUNTIME_DIR``) fall back to the unwrapped command unchanged;
-    the fork/exec chain then behaves exactly as it did before this
-    escape was added.
+    a usable, *verified-live* systemd user session (no ``systemd-run``
+    binary, no live XDG runtime directory, or a failing probe scope) fall
+    back to the unwrapped command unchanged; the fork/exec chain then
+    behaves exactly as it did before this escape was added.
 
     :param command: The argv to launch (e.g. the ``run-snapshot`` command).
     :return: The same command, optionally prefixed with a systemd-run
@@ -160,7 +222,11 @@ def _escaped_direct_launch_command(command: List[str]) -> List[str]:
     if _is_windows_platform():
         return command
     systemd_run = shutil.which("systemd-run")
-    if systemd_run is None or not os.environ.get("XDG_RUNTIME_DIR"):
+    if (
+        systemd_run is None
+        or _usable_systemd_user_runtime_dir() is None
+        or not _systemd_user_scope_is_usable(systemd_run)
+    ):
         return command
     unit = f"jarvis-cd-direct-{uuid4().hex}"
     return [
@@ -172,6 +238,108 @@ def _escaped_direct_launch_command(command: List[str]) -> List[str]:
         "--",
         *command,
     ]
+
+
+_CGROUP_ESCAPE_CONFIRM_TIMEOUT_SECONDS = 2.0
+_CGROUP_ESCAPE_POLL_INTERVAL_SECONDS = 0.02
+
+
+def _cgroup_membership(pid: str) -> Optional[str]:
+    """Return one process's ``/proc/<pid>/cgroup`` contents, or ``None``.
+
+    :param pid: ``self`` for the current process, or a positive PID string.
+    """
+    try:
+        with open(f"/proc/{pid}/cgroup", "r", encoding="utf-8") as handle:
+            return handle.read()
+    except OSError:
+        return None
+
+
+def _cgroup_escape_confirmed(pid: int) -> bool:
+    """Poll until ``pid`` is confirmed to have left this process's own cgroup.
+
+    ``systemd-run --user --scope`` does not migrate its target into the new
+    cgroup atomically at fork time: migration completes only after an
+    asynchronous D-Bus round trip with the user's systemd manager. Trusting
+    the wrap immediately after ``subprocess.Popen`` returns can observe the
+    target still sitting in the caller's own cgroup during that window —
+    confirmed empirically on a real deployment as a second, distinct race
+    from clio-relay#222's original setsid-only bug: the escape looked
+    successful (no interpreter error) but a caller-scoped containment check
+    still saw the not-yet-migrated process as a leaked descendant. Wait for
+    the migration to actually land before treating the escape as live.
+
+    :param pid: The escaped launch's own process id.
+    :return: Whether the migration was confirmed within a bounded window.
+    """
+    caller_cgroup = _cgroup_membership("self")
+    if caller_cgroup is None:
+        return False
+    deadline = time.monotonic() + _CGROUP_ESCAPE_CONFIRM_TIMEOUT_SECONDS
+    while True:
+        observed = _cgroup_membership(str(pid))
+        if observed is None:
+            return False
+        if observed != caller_cgroup:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_CGROUP_ESCAPE_POLL_INTERVAL_SECONDS)
+
+
+def _terminate_launched_process_best_effort(process: "subprocess.Popen[Any]") -> None:
+    """Terminate a still-running launched process, tolerating any failure."""
+    if process.poll() is not None:
+        return
+    try:
+        process.terminate()
+        process.wait(timeout=5)
+    except BaseException:
+        try:
+            process.kill()
+            process.wait(timeout=5)
+        except BaseException:
+            pass
+
+
+def _spawn_direct_execution_process(
+    command: List[str],
+    options: Dict[str, Any],
+) -> "subprocess.Popen[Any]":
+    """Launch a direct execution, escaping into its own cgroup when possible.
+
+    Applies :func:`_escaped_direct_launch_command`, then — only on POSIX,
+    where a cgroup migration is actually possible — confirms the escape
+    really landed via :func:`_cgroup_escape_confirmed`. If it did not land
+    within a bounded window (an intermittent systemd/D-Bus race, not a
+    permanent host incapability — the earlier live probe already ruled
+    that out), the half-escaped process is terminated and the launch
+    retries once, unwrapped, so a flaky escape degrades to the prior
+    setsid-only behavior instead of leaving an ambiguous, neither-escaped
+    -nor-contained process behind.
+
+    :param command: The unwrapped run-snapshot argv.
+    :param options: ``subprocess.Popen`` keyword arguments. ``stdout`` and
+        ``stderr`` must already be open file objects; on a retry they are
+        reopened in append mode from the same paths.
+    :return: The launched (possibly retried) process.
+    """
+    escaped_command = _escaped_direct_launch_command(command)
+    launched_process = subprocess.Popen(escaped_command, **options)
+    if escaped_command is command or _is_windows_platform():
+        return launched_process
+    if _cgroup_escape_confirmed(launched_process.pid):
+        return launched_process
+    _terminate_launched_process_best_effort(launched_process)
+    for stream_name in ("stdout", "stderr"):
+        stream = options.get(stream_name)
+        if hasattr(stream, "close"):
+            stream.close()
+        stream_path = getattr(stream, "name", None)
+        if stream_path is not None:
+            options[stream_name] = open(stream_path, "ab", buffering=0)
+    return subprocess.Popen(command, **options)
 
 
 def _executor_status_error(
@@ -3286,12 +3454,15 @@ class Pipeline:
                     options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
                 else:
                     options["start_new_session"] = True
-                command = _escaped_direct_launch_command(command)
-                launched_process = subprocess.Popen(command, **options)
+                launched_process = _spawn_direct_execution_process(command, options)
                 process = launched_process
             finally:
-                stdout_stream.close()
-                stderr_stream.close()
+                # A retried (unwrapped) launch reopens fresh stream objects
+                # into `options` when the systemd-scope escape does not land
+                # in time; close whichever objects are current, not the
+                # stale local references from before that retry.
+                options["stdout"].close()
+                options["stderr"].close()
             direct_launch = {
                 **direct_launch,
                 "phase": "spawned",

--- a/test/unit/core/test_execution.py
+++ b/test/unit/core/test_execution.py
@@ -1832,12 +1832,14 @@ def test_nonblocking_direct_run_escapes_into_its_own_systemd_scope(
     pipeline._write_execution_snapshot = Mock(side_effect=write_snapshot)
 
     captured_commands: list[list[str]] = []
+    captured_kwargs: list[dict[str, Any]] = []
 
     class Process:
         pid = 4242
 
-    def fake_popen(command: list[str], **_kwargs: Any) -> Process:
+    def fake_popen(command: list[str], **kwargs: Any) -> Process:
         captured_commands.append(command)
+        captured_kwargs.append(kwargs)
         return Process()
 
     monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
@@ -1871,6 +1873,22 @@ def test_nonblocking_direct_run_escapes_into_its_own_systemd_scope(
     assert launched[5] == "--"
     assert "run-snapshot" in launched
     assert launched[6] == pipeline_module.sys.executable
+
+    # L1: the REAL wrapped launch (not just the live probe) must receive the
+    # runtime-bus environment the escape resolved. Dropping `env=environment`
+    # from this specific Popen call (while leaving it on the probe) silently
+    # reinstates the #222 race on the exact deep-relay-chain host class this
+    # fix exists to serve: systemd-run spawns fine (no interpreter error, a
+    # live PID) but its own D-Bus connection fails for lack of
+    # XDG_RUNTIME_DIR/DBUS_SESSION_BUS_ADDRESS, never execs the target, and
+    # the confirm poll times out into a degraded retry -- with every other
+    # test in this file still green, since none of them inspect Popen's
+    # kwargs.
+    assert len(captured_kwargs) == 1
+    launched_env = captured_kwargs[0].get("env")
+    assert launched_env is not None
+    assert launched_env["XDG_RUNTIME_DIR"] == "/run/user/1000"
+    assert launched_env["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/run/user/1000/bus"
 
     # R1: the successful escape's reason lands on the durable metadata
     # record clio-relay reads, not just the interpreter's local state.
@@ -1919,6 +1937,7 @@ def test_nonblocking_direct_run_retries_unwrapped_when_the_cgroup_escape_does_no
     pipeline._write_execution_snapshot = Mock(side_effect=write_snapshot)
 
     captured_commands: list[list[str]] = []
+    captured_kwargs: list[dict[str, Any]] = []
     terminated_pids: list[int] = []
 
     class Process:
@@ -1941,8 +1960,9 @@ def test_nonblocking_direct_run_retries_unwrapped_when_the_cgroup_escape_does_no
 
     pids = iter([9001, 9002])
 
-    def fake_popen(command: list[str], **_kwargs: Any) -> Process:
+    def fake_popen(command: list[str], **kwargs: Any) -> Process:
         captured_commands.append(command)
+        captured_kwargs.append(kwargs)
         return Process(next(pids))
 
     systemctl_calls: list[list[str]] = []
@@ -1997,6 +2017,14 @@ def test_nonblocking_direct_run_retries_unwrapped_when_the_cgroup_escape_does_no
     assert unit_token.startswith("--unit=")
     expected_unit = unit_token[len("--unit=") :]
     assert stop_call[3] == f"{expected_unit}.scope"
+
+    # L1: the wrapped attempt received the runtime-bus env; the unwrapped
+    # retry must NOT -- it falls back to the plain, ambient-inheriting
+    # options exactly as the pre-escape launch did, not a hybrid of the two.
+    assert len(captured_kwargs) == 2
+    wrapped_kwargs, retry_kwargs = captured_kwargs
+    assert wrapped_kwargs.get("env", {}).get("XDG_RUNTIME_DIR") == "/run/user/1000"
+    assert "env" not in retry_kwargs
 
     record = handle.refresh()
     assert record.metadata["direct_process_id"] == 9002
@@ -2078,6 +2106,150 @@ def test_spawn_direct_execution_process_retries_unwrapped_on_a_spawn_oserror(
         "run-snapshot",
     ]
     assert process.pid == 4321
+
+
+def _configure_skipped_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: True)
+
+
+def _configure_skipped_no_systemd_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
+    monkeypatch.setattr(pipeline_module.shutil, "which", lambda _name: None)
+
+
+def _configure_skipped_no_runtime_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
+    monkeypatch.setattr(
+        pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_usable_systemd_user_runtime_dir", lambda: None
+    )
+
+
+def _configure_degraded_probe_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
+    monkeypatch.setattr(
+        pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
+    )
+    monkeypatch.setattr(
+        pipeline_module,
+        "_systemd_user_scope_is_usable",
+        lambda _systemd_run, _environment: (
+            False,
+            "Failed to connect to bus: No medium found",
+        ),
+    )
+
+
+def _configure_degraded_spawn_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
+    monkeypatch.setattr(
+        pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
+    )
+    monkeypatch.setattr(
+        pipeline_module,
+        "_systemd_user_scope_is_usable",
+        lambda _systemd_run, _environment: (True, None),
+    )
+
+
+@pytest.mark.parametrize(
+    ("escape_reason", "configure", "raises_first_popen", "expect_detail"),
+    [
+        ("skipped_windows", _configure_skipped_windows, False, False),
+        ("skipped_no_systemd_run", _configure_skipped_no_systemd_run, False, False),
+        ("skipped_no_runtime_dir", _configure_skipped_no_runtime_dir, False, False),
+        ("degraded_probe_failed", _configure_degraded_probe_failed, False, True),
+        ("degraded_spawn_error", _configure_degraded_spawn_error, True, True),
+    ],
+    ids=[
+        "skipped_windows",
+        "skipped_no_systemd_run",
+        "skipped_no_runtime_dir",
+        "degraded_probe_failed",
+        "degraded_spawn_error",
+    ],
+)
+def test_nonblocking_direct_run_records_the_exact_escape_reason_for_every_skip_or_degrade_branch(
+    escape_reason: str,
+    configure: Any,
+    raises_first_popen: bool,
+    expect_detail: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """L2: the PERSISTED record must carry the exact escape reason.
+
+    ``systemd_scope`` (the happy path, above) and
+    ``degraded_migration_unconfirmed`` (the retry test, above) are the only
+    two of the seven :data:`DirectLaunchEscapeReason` values pinned at the
+    durable-record level. The other five are only asserted against
+    ``_escaped_direct_launch_command``'s own return value in the standalone
+    unit tests above -- nothing catches a reason that is computed correctly
+    by that helper and then reported wrongly by the time it reaches
+    ``store.update``. A one-line hardcode of the reported reason to
+    ``"systemd_scope"`` on the skip/degrade return in
+    ``_spawn_direct_execution_process`` (e.g. the
+    ``if escaped_command is command: ... return ..., reason, detail`` line)
+    passes the whole suite today precisely because of that gap -- an
+    operator reading the ``direct_launch`` record could no longer tell
+    "escape worked" from "escape skipped", which is exactly the state R1
+    exists to make impossible. Drives the real ``pipeline.run(wait=False)``
+    path (not the helper directly) so the assertion is against what
+    clio-relay actually reads off disk.
+    """
+    pipeline = _pipeline_double(tmp_path)
+    pipeline.save = Mock()
+
+    def write_snapshot(
+        execution_root: Path,
+        scheduler_spec: dict[str, object],
+    ) -> tuple[Path, Path, str]:
+        assert scheduler_spec == {}
+        runtime = execution_root / "runtime"
+        inputs = execution_root / "input"
+        runtime.mkdir()
+        inputs.mkdir()
+        return runtime, inputs, "abc123"
+
+    pipeline._write_execution_snapshot = Mock(side_effect=write_snapshot)
+
+    configure(monkeypatch)
+
+    popen_calls = {"count": 0}
+
+    class Process:
+        def __init__(self, pid: int) -> None:
+            self.pid = pid
+
+    def fake_popen(command: list[str], **_kwargs: Any) -> Process:
+        popen_calls["count"] += 1
+        if raises_first_popen and popen_calls["count"] == 1:
+            raise OSError("systemd-run vanished between probe and spawn")
+        return Process(4200 + popen_calls["count"])
+
+    monkeypatch.setattr("jarvis_cd.core.pipeline.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "jarvis_cd.core.execution._process_is_running", lambda _pid: True
+    )
+
+    handle = pipeline.run(execution_id="background", wait=False)
+
+    record = handle.refresh()
+    direct_launch = record.metadata["direct_launch"]
+    assert direct_launch["schema_version"] == pipeline_module.DIRECT_LAUNCH_SCHEMA
+    assert direct_launch["escape"] == escape_reason
+    if expect_detail:
+        assert direct_launch["escape_detail"]
+    else:
+        assert direct_launch["escape_detail"] is None
 
 
 def test_nonblocking_direct_record_reconciles_a_crashed_child(tmp_path: Path) -> None:

--- a/test/unit/core/test_execution.py
+++ b/test/unit/core/test_execution.py
@@ -1266,6 +1266,47 @@ def test_nonblocking_direct_run_returns_live_queryable_handle(
     assert handle.progress().execution_id == "background"
 
 
+def test_usable_systemd_user_runtime_dir_prefers_a_real_env_directory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ambient XDG_RUNTIME_DIR wins when it actually exists on disk."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+    monkeypatch.setattr(
+        pipeline_module.os.path, "isdir", lambda path: path == "/run/user/1000"
+    )
+    assert pipeline_module._usable_systemd_user_runtime_dir() == "/run/user/1000"
+
+
+def test_usable_systemd_user_runtime_dir_falls_back_to_the_conventional_uid_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stripped env var does not mean the session is gone.
+
+    Regression case for clio-relay#222's local reproduction: the real relay
+    broker -> uv -> clio-kit -> jarvis-mcp launch chain does NOT forward
+    XDG_RUNTIME_DIR down to where a direct-mode pipeline actually launches
+    (confirmed live on a WSL harness reproduction), even though the user's
+    systemd session and its conventional /run/user/<uid> directory are still
+    live underneath, and systemd-run itself falls back to that same path.
+    """
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.setattr(pipeline_module.os, "getuid", lambda: 1000, raising=False)
+    monkeypatch.setattr(
+        pipeline_module.os.path, "isdir", lambda path: path == "/run/user/1000"
+    )
+    assert pipeline_module._usable_systemd_user_runtime_dir() == "/run/user/1000"
+
+
+def test_usable_systemd_user_runtime_dir_none_when_nothing_is_live(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No env var, no conventional directory: correctly report unusable."""
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.setattr(pipeline_module.os, "getuid", lambda: 1000, raising=False)
+    monkeypatch.setattr(pipeline_module.os.path, "isdir", lambda _path: False)
+    assert pipeline_module._usable_systemd_user_runtime_dir() is None
+
+
 def test_escaped_direct_launch_command_wraps_with_systemd_run_scope_when_available(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1282,7 +1323,12 @@ def test_escaped_direct_launch_command_wraps_with_systemd_run_scope_when_availab
     monkeypatch.setattr(
         pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
     )
-    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+    monkeypatch.setattr(
+        pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_systemd_user_scope_is_usable", lambda _systemd_run: True
+    )
 
     original = ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"]
     wrapped = pipeline_module._escaped_direct_launch_command(original)
@@ -1303,7 +1349,12 @@ def test_escaped_direct_launch_command_falls_back_without_systemd_run(
     """Hosts without systemd-run keep today's setsid-only launch, unchanged."""
     monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
     monkeypatch.setattr(pipeline_module.shutil, "which", lambda _name: None)
-    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+    monkeypatch.setattr(
+        pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_systemd_user_scope_is_usable", lambda _systemd_run: True
+    )
 
     original = ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"]
     assert pipeline_module._escaped_direct_launch_command(original) == original
@@ -1312,15 +1363,191 @@ def test_escaped_direct_launch_command_falls_back_without_systemd_run(
 def test_escaped_direct_launch_command_falls_back_without_runtime_dir(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A systemd-run binary with no reachable user bus is not trusted to scope."""
+    """No live systemd user runtime directory at all is not trusted to scope."""
     monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
     monkeypatch.setattr(
         pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
     )
-    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.setattr(
+        pipeline_module, "_usable_systemd_user_runtime_dir", lambda: None
+    )
 
     original = ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"]
     assert pipeline_module._escaped_direct_launch_command(original) == original
+
+
+def test_escaped_direct_launch_command_falls_back_when_the_probe_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A binary and a runtime dir are not enough; the probe must also succeed.
+
+    Regression case for a real failure observed while validating clio-relay#222:
+    a deeply nested launch chain (relay broker -> uv -> clio-kit -> jarvis-mcp)
+    had a live systemd-run binary and a live /run/user/<uid>, yet
+    ``systemd-run --user --scope`` still failed its D-Bus connection
+    ("Failed to connect to bus: No medium found") — jarvis-cd's own
+    orphan-reconciliation then wrongly failed the execution a few hundred
+    milliseconds after a successful spawn, because the wrap silently swapped
+    a leaked-descendant failure for a broken-launch failure. Falling back to
+    the unwrapped (pre-#222-fix) launch when the probe fails avoids trading
+    one failure mode for a worse one.
+    """
+    monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
+    monkeypatch.setattr(
+        pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_systemd_user_scope_is_usable", lambda _systemd_run: False
+    )
+
+    original = ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"]
+    assert pipeline_module._escaped_direct_launch_command(original) == original
+
+
+def test_systemd_user_scope_is_usable_true_on_a_successful_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A clean probe scope (exit 0) is trusted."""
+
+    class _Completed:
+        returncode = 0
+
+    monkeypatch.setattr(
+        pipeline_module.subprocess,
+        "run",
+        lambda *_a, **_k: _Completed(),
+    )
+    assert pipeline_module._systemd_user_scope_is_usable("/usr/bin/systemd-run") is True
+
+
+def test_systemd_user_scope_is_usable_false_on_a_nonzero_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A probe scope that exits nonzero (e.g. a failed D-Bus connection) is not trusted."""
+
+    class _Completed:
+        returncode = 1
+
+    monkeypatch.setattr(
+        pipeline_module.subprocess,
+        "run",
+        lambda *_a, **_k: _Completed(),
+    )
+    assert pipeline_module._systemd_user_scope_is_usable("/usr/bin/systemd-run") is False
+
+
+def test_systemd_user_scope_is_usable_false_when_the_probe_hangs_or_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A probe that times out or cannot even launch is treated as unusable."""
+
+    def _raise_timeout(*_a: Any, **_k: Any) -> Any:
+        raise pipeline_module.subprocess.TimeoutExpired(cmd="systemd-run", timeout=2.0)
+
+    monkeypatch.setattr(pipeline_module.subprocess, "run", _raise_timeout)
+    assert pipeline_module._systemd_user_scope_is_usable("/usr/bin/systemd-run") is False
+
+    def _raise_oserror(*_a: Any, **_k: Any) -> Any:
+        raise OSError("no such executable")
+
+    monkeypatch.setattr(pipeline_module.subprocess, "run", _raise_oserror)
+    assert pipeline_module._systemd_user_scope_is_usable("/usr/bin/systemd-run") is False
+
+
+def test_cgroup_membership_is_none_without_a_readable_proc_entry() -> None:
+    """A PID with no ``/proc/<pid>/cgroup`` (gone, or no /proc at all) is None."""
+    assert pipeline_module._cgroup_membership("999999999") is None
+
+
+def test_cgroup_escape_confirmed_true_once_membership_differs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single differing read is enough — no need to keep polling."""
+    monkeypatch.setattr(
+        pipeline_module,
+        "_cgroup_membership",
+        lambda pid: "caller\n" if pid == "self" else "escaped\n",
+    )
+    assert pipeline_module._cgroup_escape_confirmed(4242) is True
+
+
+def test_cgroup_escape_confirmed_false_when_membership_never_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Still in the caller's own cgroup at the deadline: not confirmed."""
+    monkeypatch.setattr(pipeline_module, "_cgroup_membership", lambda _pid: "same\n")
+    monkeypatch.setattr(
+        pipeline_module, "_CGROUP_ESCAPE_CONFIRM_TIMEOUT_SECONDS", 0.05
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_CGROUP_ESCAPE_POLL_INTERVAL_SECONDS", 0.01
+    )
+    assert pipeline_module._cgroup_escape_confirmed(4242) is False
+
+
+def test_cgroup_escape_confirmed_false_when_the_process_is_already_gone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreadable target cgroup (process already exited) is not confirmed."""
+
+    def fake_membership(pid: str) -> str | None:
+        return "caller\n" if pid == "self" else None
+
+    monkeypatch.setattr(pipeline_module, "_cgroup_membership", fake_membership)
+    assert pipeline_module._cgroup_escape_confirmed(4242) is False
+
+
+def test_cgroup_escape_confirmed_false_without_a_readable_caller_cgroup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No /proc support at all (e.g. non-Linux) is not confirmed, not raised."""
+    monkeypatch.setattr(pipeline_module, "_cgroup_membership", lambda _pid: None)
+    assert pipeline_module._cgroup_escape_confirmed(4242) is False
+
+
+def test_terminate_launched_process_best_effort_skips_an_already_exited_process() -> None:
+    """No termination is attempted once the process has already exited."""
+
+    class Process:
+        terminate_calls = 0
+
+        def poll(self) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            Process.terminate_calls += 1
+
+    pipeline_module._terminate_launched_process_best_effort(Process())
+    assert Process.terminate_calls == 0
+
+
+def test_terminate_launched_process_best_effort_kills_after_a_stuck_terminate() -> None:
+    """A terminate() that never lands falls back to kill()."""
+
+    class Process:
+        def __init__(self) -> None:
+            self.killed = False
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            pass
+
+        def wait(self, timeout: float | None = None) -> int:
+            if not self.killed:
+                raise pipeline_module.subprocess.TimeoutExpired(cmd="x", timeout=timeout)
+            return -9
+
+        def kill(self) -> None:
+            self.killed = True
+
+    process = Process()
+    pipeline_module._terminate_launched_process_best_effort(process)
+    assert process.killed is True
 
 
 def test_escaped_direct_launch_command_falls_back_on_windows(
@@ -1331,7 +1558,12 @@ def test_escaped_direct_launch_command_falls_back_on_windows(
     monkeypatch.setattr(
         pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
     )
-    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+    monkeypatch.setattr(
+        pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_systemd_user_scope_is_usable", lambda _systemd_run: True
+    )
 
     original = ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"]
     assert pipeline_module._escaped_direct_launch_command(original) == original
@@ -1378,7 +1610,15 @@ def test_nonblocking_direct_run_escapes_into_its_own_systemd_scope(
     monkeypatch.setattr(
         pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
     )
-    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+    monkeypatch.setattr(
+        pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_systemd_user_scope_is_usable", lambda _systemd_run: True
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_cgroup_escape_confirmed", lambda _pid: True
+    )
     monkeypatch.setattr("jarvis_cd.core.pipeline.subprocess.Popen", fake_popen)
     monkeypatch.setattr(
         "jarvis_cd.core.execution._process_is_running", lambda _pid: True
@@ -1395,6 +1635,94 @@ def test_nonblocking_direct_run_escapes_into_its_own_systemd_scope(
     assert launched[5] == "--"
     assert "run-snapshot" in launched
     assert launched[6] == pipeline_module.sys.executable
+
+
+def test_nonblocking_direct_run_retries_unwrapped_when_the_cgroup_escape_does_not_land(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A confirmed-failed migration falls back to a second, unwrapped launch.
+
+    Regression test for a second, distinct race found while validating the
+    clio-relay#222 fix on a real deployment: ``systemd-run --user --scope``
+    can spawn successfully (no interpreter error, a live PID) yet still not
+    have migrated its target out of the caller's cgroup by the time this
+    code checks — an asynchronous D-Bus race, not a permanent incapability.
+    Failing the whole launch in that case would regress a working (if
+    race-prone) direct execution into a broken one; retrying unwrapped keeps
+    it working exactly as it did before the escape was ever added.
+    """
+    pipeline = _pipeline_double(tmp_path)
+    pipeline.save = Mock()
+
+    def write_snapshot(
+        execution_root: Path,
+        scheduler_spec: dict[str, object],
+    ) -> tuple[Path, Path, str]:
+        assert scheduler_spec == {}
+        runtime = execution_root / "runtime"
+        inputs = execution_root / "input"
+        runtime.mkdir()
+        inputs.mkdir()
+        return runtime, inputs, "abc123"
+
+    pipeline._write_execution_snapshot = Mock(side_effect=write_snapshot)
+
+    captured_commands: list[list[str]] = []
+    terminated_pids: list[int] = []
+
+    class Process:
+        def __init__(self, pid: int) -> None:
+            self.pid = pid
+            self._polled = False
+
+        def poll(self) -> int | None:
+            # Alive on the first poll (still needs terminating), gone after.
+            if self._polled:
+                return 0
+            self._polled = True
+            return None
+
+        def terminate(self) -> None:
+            terminated_pids.append(self.pid)
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+    pids = iter([9001, 9002])
+
+    def fake_popen(command: list[str], **_kwargs: Any) -> Process:
+        captured_commands.append(command)
+        return Process(next(pids))
+
+    monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
+    monkeypatch.setattr(
+        pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_systemd_user_scope_is_usable", lambda _systemd_run: True
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_cgroup_escape_confirmed", lambda _pid: False
+    )
+    monkeypatch.setattr("jarvis_cd.core.pipeline.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "jarvis_cd.core.execution._process_is_running", lambda _pid: True
+    )
+
+    handle = pipeline.run(execution_id="background", wait=False)
+
+    assert handle.execution_id == "background"
+    assert len(captured_commands) == 2
+    first, second = captured_commands
+    assert first[0] == "/usr/bin/systemd-run"
+    assert second == first[6:]  # the same unwrapped run-snapshot argv
+    assert terminated_pids == [9001]
+    record = handle.refresh()
+    assert record.metadata["direct_process_id"] == 9002
 
 
 def test_nonblocking_direct_record_reconciles_a_crashed_child(tmp_path: Path) -> None:

--- a/test/unit/core/test_execution.py
+++ b/test/unit/core/test_execution.py
@@ -29,6 +29,7 @@ from jarvis_cd.artifacts import (
 )
 from jarvis_cd.core.execution import (
     ARTIFACT_SNAPSHOT_SCHEMA,
+    DIRECT_LAUNCH_SCHEMA,
     HANDLE_SCHEMA,
     MAX_RECORD_BYTES,
     PROGRESS_SNAPSHOT_SCHEMA,
@@ -1327,19 +1328,29 @@ def test_escaped_direct_launch_command_wraps_with_systemd_run_scope_when_availab
         pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
     )
     monkeypatch.setattr(
-        pipeline_module, "_systemd_user_scope_is_usable", lambda _systemd_run: True
+        pipeline_module,
+        "_systemd_user_scope_is_usable",
+        lambda _systemd_run, _environment: (True, None),
     )
 
     original = ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"]
-    wrapped = pipeline_module._escaped_direct_launch_command(original)
+    wrapped, reason, detail, environment = pipeline_module._escaped_direct_launch_command(
+        original
+    )
 
+    assert reason == "systemd_scope"
+    assert detail is None
+    assert environment is not None
+    assert environment["XDG_RUNTIME_DIR"] == "/run/user/1000"
     assert wrapped[0] == "/usr/bin/systemd-run"
     assert wrapped[1:4] == ["--user", "--scope", "--quiet"]
     assert wrapped[4].startswith("--unit=jarvis-cd-direct-")
     assert wrapped[5] == "--"
     assert wrapped[6:] == original
     # Two independent calls must not collide on the same transient unit name.
-    other = pipeline_module._escaped_direct_launch_command(original)
+    other, _other_reason, _other_detail, _other_env = (
+        pipeline_module._escaped_direct_launch_command(original)
+    )
     assert other[4] != wrapped[4]
 
 
@@ -1353,11 +1364,19 @@ def test_escaped_direct_launch_command_falls_back_without_systemd_run(
         pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
     )
     monkeypatch.setattr(
-        pipeline_module, "_systemd_user_scope_is_usable", lambda _systemd_run: True
+        pipeline_module,
+        "_systemd_user_scope_is_usable",
+        lambda _systemd_run, _environment: (True, None),
     )
 
     original = ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"]
-    assert pipeline_module._escaped_direct_launch_command(original) == original
+    command, reason, detail, environment = pipeline_module._escaped_direct_launch_command(
+        original
+    )
+    assert command == original
+    assert reason == "skipped_no_systemd_run"
+    assert detail is None
+    assert environment is None
 
 
 def test_escaped_direct_launch_command_falls_back_without_runtime_dir(
@@ -1373,7 +1392,13 @@ def test_escaped_direct_launch_command_falls_back_without_runtime_dir(
     )
 
     original = ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"]
-    assert pipeline_module._escaped_direct_launch_command(original) == original
+    command, reason, detail, environment = pipeline_module._escaped_direct_launch_command(
+        original
+    )
+    assert command == original
+    assert reason == "skipped_no_runtime_dir"
+    assert detail is None
+    assert environment is None
 
 
 def test_escaped_direct_launch_command_falls_back_when_the_probe_fails(
@@ -1390,7 +1415,8 @@ def test_escaped_direct_launch_command_falls_back_when_the_probe_fails(
     milliseconds after a successful spawn, because the wrap silently swapped
     a leaked-descendant failure for a broken-launch failure. Falling back to
     the unwrapped (pre-#222-fix) launch when the probe fails avoids trading
-    one failure mode for a worse one.
+    one failure mode for a worse one. The probe's own diagnostic text (R1)
+    must survive into the returned reason's detail, not just a boolean.
     """
     monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
     monkeypatch.setattr(
@@ -1400,17 +1426,31 @@ def test_escaped_direct_launch_command_falls_back_when_the_probe_fails(
         pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
     )
     monkeypatch.setattr(
-        pipeline_module, "_systemd_user_scope_is_usable", lambda _systemd_run: False
+        pipeline_module,
+        "_systemd_user_scope_is_usable",
+        lambda _systemd_run, _environment: (
+            False,
+            "Failed to connect to bus: No medium found",
+        ),
     )
 
     original = ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"]
-    assert pipeline_module._escaped_direct_launch_command(original) == original
+    command, reason, detail, environment = pipeline_module._escaped_direct_launch_command(
+        original
+    )
+    assert command == original
+    assert reason == "degraded_probe_failed"
+    assert detail == "Failed to connect to bus: No medium found"
+    assert environment is None
+
+
+_PROBE_TEST_ENVIRONMENT = {"XDG_RUNTIME_DIR": "/run/user/1000"}
 
 
 def test_systemd_user_scope_is_usable_true_on_a_successful_probe(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A clean probe scope (exit 0) is trusted."""
+    """A clean probe scope (exit 0) is trusted, with no diagnostic to report."""
 
     class _Completed:
         returncode = 0
@@ -1420,41 +1460,164 @@ def test_systemd_user_scope_is_usable_true_on_a_successful_probe(
         "run",
         lambda *_a, **_k: _Completed(),
     )
-    assert pipeline_module._systemd_user_scope_is_usable("/usr/bin/systemd-run") is True
+    assert pipeline_module._systemd_user_scope_is_usable(
+        "/usr/bin/systemd-run", _PROBE_TEST_ENVIRONMENT
+    ) == (True, None)
 
 
 def test_systemd_user_scope_is_usable_false_on_a_nonzero_probe(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A probe scope that exits nonzero (e.g. a failed D-Bus connection) is not trusted."""
+    """A probe scope that exits nonzero (e.g. a failed D-Bus connection) is not
+    trusted, and its own stderr text is surfaced as the diagnostic (R1)."""
 
     class _Completed:
         returncode = 1
+        stderr = b"Failed to connect to bus: No medium found\n"
 
     monkeypatch.setattr(
         pipeline_module.subprocess,
         "run",
         lambda *_a, **_k: _Completed(),
     )
-    assert pipeline_module._systemd_user_scope_is_usable("/usr/bin/systemd-run") is False
+    assert pipeline_module._systemd_user_scope_is_usable(
+        "/usr/bin/systemd-run", _PROBE_TEST_ENVIRONMENT
+    ) == (
+        False,
+        "Failed to connect to bus: No medium found",
+    )
+
+
+def test_systemd_user_scope_is_usable_false_on_a_nonzero_probe_with_no_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A nonzero exit with no captured stderr still yields a non-empty diagnostic."""
+
+    class _Completed:
+        returncode = 17
+        stderr = b""
+
+    monkeypatch.setattr(
+        pipeline_module.subprocess,
+        "run",
+        lambda *_a, **_k: _Completed(),
+    )
+    usable, diagnostic = pipeline_module._systemd_user_scope_is_usable(
+        "/usr/bin/systemd-run", _PROBE_TEST_ENVIRONMENT
+    )
+    assert usable is False
+    assert diagnostic == "systemd-run --user --scope probe exited 17"
 
 
 def test_systemd_user_scope_is_usable_false_when_the_probe_hangs_or_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A probe that times out or cannot even launch is treated as unusable."""
+    """A probe that times out or cannot even launch is treated as unusable,
+    and each failure mode gets its own non-empty diagnostic (R1)."""
 
     def _raise_timeout(*_a: Any, **_k: Any) -> Any:
         raise pipeline_module.subprocess.TimeoutExpired(cmd="systemd-run", timeout=2.0)
 
     monkeypatch.setattr(pipeline_module.subprocess, "run", _raise_timeout)
-    assert pipeline_module._systemd_user_scope_is_usable("/usr/bin/systemd-run") is False
+    usable, diagnostic = pipeline_module._systemd_user_scope_is_usable(
+        "/usr/bin/systemd-run", _PROBE_TEST_ENVIRONMENT
+    )
+    assert usable is False
+    assert diagnostic is not None and "2.0" in diagnostic
 
     def _raise_oserror(*_a: Any, **_k: Any) -> Any:
         raise OSError("no such executable")
 
     monkeypatch.setattr(pipeline_module.subprocess, "run", _raise_oserror)
-    assert pipeline_module._systemd_user_scope_is_usable("/usr/bin/systemd-run") is False
+    assert pipeline_module._systemd_user_scope_is_usable(
+        "/usr/bin/systemd-run", _PROBE_TEST_ENVIRONMENT
+    ) == (
+        False,
+        "no such executable",
+    )
+
+
+def test_systemd_user_scope_is_usable_probes_with_the_exact_argv_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """R3: pin the probe's own argv, not just its boolean outcome.
+
+    A sabotage flip of ``--user`` -> ``--system`` in the real probe would
+    make it permanently unusable for a non-root user (silent, universal
+    fallback -- clio-relay#222 everywhere), yet every other test in this
+    file stubs this function away entirely and never inspects the command
+    it runs. Assert the composed argv and the bounded timeout directly so
+    that exact regression is caught here.
+    """
+    captured: dict[str, Any] = {}
+
+    class _Completed:
+        returncode = 0
+
+    def fake_run(command: list[str], **kwargs: Any) -> Any:
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return _Completed()
+
+    monkeypatch.setattr(pipeline_module.subprocess, "run", fake_run)
+    pipeline_module._systemd_user_scope_is_usable(
+        "/usr/bin/systemd-run", _PROBE_TEST_ENVIRONMENT
+    )
+
+    assert captured["command"] == [
+        "/usr/bin/systemd-run",
+        "--user",
+        "--scope",
+        "--quiet",
+        "--",
+        "true",
+    ]
+    assert captured["kwargs"]["timeout"] == pipeline_module._SYSTEMD_SCOPE_PROBE_TIMEOUT_SECONDS
+    assert captured["kwargs"]["stdin"] == pipeline_module.subprocess.DEVNULL
+    assert captured["kwargs"]["stdout"] == pipeline_module.subprocess.DEVNULL
+    assert captured["kwargs"]["stderr"] == pipeline_module.subprocess.PIPE
+    # R2 root-cause: the probe MUST run with the explicit environment the
+    # caller resolved, not bare ambient inheritance -- this is the exact
+    # fix for the deep relay chain where XDG_RUNTIME_DIR/
+    # DBUS_SESSION_BUS_ADDRESS are both stripped before jarvis-cd ever
+    # sees them.
+    assert captured["kwargs"]["env"] == _PROBE_TEST_ENVIRONMENT
+
+
+def test_systemd_user_runtime_environment_derives_the_dbus_address_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """R2 root cause: a deep relay chain can strip BOTH XDG_RUNTIME_DIR and
+    DBUS_SESSION_BUS_ADDRESS before jarvis-cd's own process ever sees them.
+
+    Confirmed live on the WSL harness: with neither var set, a real
+    ``systemd-run --user --scope`` subprocess fails
+    ("Failed to connect to bus: No medium found") even though the
+    directory demonstrably exists (``_usable_systemd_user_runtime_dir``
+    returns non-None via its getuid()-derived fallback) -- systemd-run
+    does not reliably rediscover the bus on its own from the directory
+    alone. Explicitly exporting XDG_RUNTIME_DIR (and, when absent,
+    deriving DBUS_SESSION_BUS_ADDRESS from it) into the subprocess's own
+    environment is what actually closes the gap; verified empirically
+    (env-stripped subprocess: fails without, succeeds with either var set).
+    """
+    monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+    monkeypatch.setenv("SOME_OTHER_VAR", "kept")
+    environment = pipeline_module._systemd_user_runtime_environment("/run/user/1000")
+    assert environment["XDG_RUNTIME_DIR"] == "/run/user/1000"
+    assert environment["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/run/user/1000/bus"
+    assert environment["SOME_OTHER_VAR"] == "kept"
+
+
+def test_systemd_user_runtime_environment_trusts_an_existing_bus_address(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An already-correct ambient DBUS_SESSION_BUS_ADDRESS is never guessed
+    over -- some hosts genuinely use a non-default bus address."""
+    monkeypatch.setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/custom/bus/path")
+    environment = pipeline_module._systemd_user_runtime_environment("/run/user/1000")
+    assert environment["XDG_RUNTIME_DIR"] == "/run/user/1000"
+    assert environment["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/custom/bus/path"
 
 
 def test_cgroup_membership_is_none_without_a_readable_proc_entry() -> None:
@@ -1508,6 +1671,56 @@ def test_cgroup_escape_confirmed_false_without_a_readable_caller_cgroup(
     assert pipeline_module._cgroup_escape_confirmed(4242) is False
 
 
+def test_cgroup_escape_confirmed_false_for_a_cgroup_nested_inside_the_caller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S2: a nested descendant cgroup proves "moved", not "moved *out*".
+
+    Plain string inequality (the original check) would wrongly confirm a
+    cgroup nested *inside* the caller's own delegated subtree as escaped,
+    even though it remains fully visible to a recursive containment scan.
+    Not reachable via ``systemd-run --user --scope`` today (scopes land as
+    a sibling under ``app.slice``), but the strict path-segment check must
+    still reject it rather than merely differ-by-string.
+    """
+    caller = "0::/user.slice/user-1000.slice/user@1000.service/app.slice/outer.scope\n"
+    nested = (
+        "0::/user.slice/user-1000.slice/user@1000.service/app.slice/"
+        "outer.scope/nested-child\n"
+    )
+    monkeypatch.setattr(
+        pipeline_module,
+        "_cgroup_membership",
+        lambda pid: caller if pid == "self" else nested,
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_CGROUP_ESCAPE_CONFIRM_TIMEOUT_SECONDS", 0.05
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_CGROUP_ESCAPE_POLL_INTERVAL_SECONDS", 0.01
+    )
+    assert pipeline_module._cgroup_escape_confirmed(4242) is False
+
+
+def test_cgroup_escape_confirmed_true_for_a_sibling_sharing_a_name_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S2: a sibling whose unit name merely starts with the same characters
+    as the caller's must NOT be mistaken for a (raw-string-prefix) descendant.
+    """
+    caller = "0::/user.slice/user-1000.slice/user@1000.service/app.slice/outer.scope\n"
+    sibling = (
+        "0::/user.slice/user-1000.slice/user@1000.service/app.slice/"
+        "outer.scope-2\n"
+    )
+    monkeypatch.setattr(
+        pipeline_module,
+        "_cgroup_membership",
+        lambda pid: caller if pid == "self" else sibling,
+    )
+    assert pipeline_module._cgroup_escape_confirmed(4242) is True
+
+
 def test_terminate_launched_process_best_effort_skips_an_already_exited_process() -> None:
     """No termination is attempted once the process has already exited."""
 
@@ -1553,7 +1766,20 @@ def test_terminate_launched_process_best_effort_kills_after_a_stuck_terminate() 
 def test_escaped_direct_launch_command_falls_back_on_windows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Windows has no cgroup/systemd-scope race; leave its launch untouched."""
+    """This launch is left untouched on Windows -- not because there is no
+    equivalent race, but because fixing it needs a relay-side change first.
+
+    (S1) clio-relay's ``ensure_owned_process_tree_empty`` has a Windows Job
+    Object containment branch with the structurally same bug: Job
+    membership is inherited across ``CreateProcess`` and
+    ``CREATE_NEW_PROCESS_GROUP`` does not break out of a job -- only
+    ``CREATE_BREAKAWAY_FROM_JOB`` does, which requires the parent job to
+    carry ``JOB_OBJECT_LIMIT_BREAKAWAY_OK`` (clio-relay grants none today).
+    So the Windows race is real and unfixed; it cannot be closed from
+    jarvis-cd alone. jarvis-cd already has its own Job Object layer
+    (``jarvis_cd/shell/windows_job.py``), which is the natural home for
+    the eventual fix once relay grants the breakaway limit.
+    """
     monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: True)
     monkeypatch.setattr(
         pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
@@ -1562,11 +1788,19 @@ def test_escaped_direct_launch_command_falls_back_on_windows(
         pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
     )
     monkeypatch.setattr(
-        pipeline_module, "_systemd_user_scope_is_usable", lambda _systemd_run: True
+        pipeline_module,
+        "_systemd_user_scope_is_usable",
+        lambda _systemd_run, _environment: (True, None),
     )
 
     original = ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"]
-    assert pipeline_module._escaped_direct_launch_command(original) == original
+    command, reason, detail, environment = pipeline_module._escaped_direct_launch_command(
+        original
+    )
+    assert command == original
+    assert reason == "skipped_windows"
+    assert detail is None
+    assert environment is None
 
 
 def test_nonblocking_direct_run_escapes_into_its_own_systemd_scope(
@@ -1614,7 +1848,9 @@ def test_nonblocking_direct_run_escapes_into_its_own_systemd_scope(
         pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
     )
     monkeypatch.setattr(
-        pipeline_module, "_systemd_user_scope_is_usable", lambda _systemd_run: True
+        pipeline_module,
+        "_systemd_user_scope_is_usable",
+        lambda _systemd_run, _environment: (True, None),
     )
     monkeypatch.setattr(
         pipeline_module, "_cgroup_escape_confirmed", lambda _pid: True
@@ -1636,6 +1872,14 @@ def test_nonblocking_direct_run_escapes_into_its_own_systemd_scope(
     assert "run-snapshot" in launched
     assert launched[6] == pipeline_module.sys.executable
 
+    # R1: the successful escape's reason lands on the durable metadata
+    # record clio-relay reads, not just the interpreter's local state.
+    record = handle.refresh()
+    direct_launch = record.metadata["direct_launch"]
+    assert direct_launch["schema_version"] == pipeline_module.DIRECT_LAUNCH_SCHEMA
+    assert direct_launch["escape"] == "systemd_scope"
+    assert direct_launch["escape_detail"] is None
+
 
 def test_nonblocking_direct_run_retries_unwrapped_when_the_cgroup_escape_does_not_land(
     monkeypatch: pytest.MonkeyPatch,
@@ -1651,6 +1895,12 @@ def test_nonblocking_direct_run_retries_unwrapped_when_the_cgroup_escape_does_no
     Failing the whole launch in that case would regress a working (if
     race-prone) direct execution into a broken one; retrying unwrapped keeps
     it working exactly as it did before the escape was ever added.
+
+    Also covers S3: the retry must stop the transient scope UNIT (via
+    ``systemctl --user stop <unit>.scope``), not just terminate the
+    leader PID — a leader-only terminate can leave grandchildren the
+    leader already forked inside the escaped cgroup running and
+    un-contained.
     """
     pipeline = _pipeline_double(tmp_path)
     pipeline.save = Mock()
@@ -1695,20 +1945,36 @@ def test_nonblocking_direct_run_retries_unwrapped_when_the_cgroup_escape_does_no
         captured_commands.append(command)
         return Process(next(pids))
 
+    systemctl_calls: list[list[str]] = []
+
+    class _CompletedSystemctl:
+        returncode = 0
+
+    def fake_run(command: list[str], **_kwargs: Any) -> Any:
+        systemctl_calls.append(command)
+        return _CompletedSystemctl()
+
+    def fake_which(name: str) -> str | None:
+        return {
+            "systemd-run": "/usr/bin/systemd-run",
+            "systemctl": "/usr/bin/systemctl",
+        }.get(name)
+
     monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
-    monkeypatch.setattr(
-        pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
-    )
+    monkeypatch.setattr(pipeline_module.shutil, "which", fake_which)
     monkeypatch.setattr(
         pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
     )
     monkeypatch.setattr(
-        pipeline_module, "_systemd_user_scope_is_usable", lambda _systemd_run: True
+        pipeline_module,
+        "_systemd_user_scope_is_usable",
+        lambda _systemd_run, _environment: (True, None),
     )
     monkeypatch.setattr(
         pipeline_module, "_cgroup_escape_confirmed", lambda _pid: False
     )
     monkeypatch.setattr("jarvis_cd.core.pipeline.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(pipeline_module.subprocess, "run", fake_run)
     monkeypatch.setattr(
         "jarvis_cd.core.execution._process_is_running", lambda _pid: True
     )
@@ -1721,8 +1987,97 @@ def test_nonblocking_direct_run_retries_unwrapped_when_the_cgroup_escape_does_no
     assert first[0] == "/usr/bin/systemd-run"
     assert second == first[6:]  # the same unwrapped run-snapshot argv
     assert terminated_pids == [9001]
+
+    # S3: the scope UNIT was stopped (not just the leader PID terminated).
+    assert len(systemctl_calls) == 1
+    stop_call = systemctl_calls[0]
+    assert stop_call[0] == "/usr/bin/systemctl"
+    assert stop_call[1:3] == ["--user", "stop"]
+    unit_token = first[4]
+    assert unit_token.startswith("--unit=")
+    expected_unit = unit_token[len("--unit=") :]
+    assert stop_call[3] == f"{expected_unit}.scope"
+
     record = handle.refresh()
     assert record.metadata["direct_process_id"] == 9002
+
+    # R1: the degraded reason and its diagnostic land on the durable
+    # metadata record clio-relay reads, not just an interpreter-local retry.
+    direct_launch = record.metadata["direct_launch"]
+    assert direct_launch["escape"] == "degraded_migration_unconfirmed"
+    assert direct_launch["escape_detail"] is not None
+    assert "cgroup migration not confirmed" in direct_launch["escape_detail"]
+
+
+def test_spawn_direct_execution_process_retries_unwrapped_on_a_spawn_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """S4: a wrapped spawn that raises OSError falls back unwrapped, typed.
+
+    Before this fix, only an *unconfirmed migration* had a fallback; if the
+    wrapped ``subprocess.Popen`` call itself raised (e.g. ``systemd-run``
+    was removed between the live probe and this call), the exception
+    propagated and the launch hard-failed — a state that could not occur
+    pre-#222-fix. Closes that gap with the same "retry unwrapped, record
+    why" shape as the other degraded paths (R1).
+    """
+    stdout_path = tmp_path / "stdout.log"
+    stderr_path = tmp_path / "stderr.log"
+    stdout_stream = stdout_path.open("ab", buffering=0)
+    stderr_stream = stderr_path.open("ab", buffering=0)
+
+    monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
+    monkeypatch.setattr(
+        pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
+    )
+    monkeypatch.setattr(
+        pipeline_module, "_usable_systemd_user_runtime_dir", lambda: "/run/user/1000"
+    )
+    monkeypatch.setattr(
+        pipeline_module,
+        "_systemd_user_scope_is_usable",
+        lambda _systemd_run, _environment: (True, None),
+    )
+
+    captured_commands: list[list[str]] = []
+
+    class Process:
+        pid = 4321
+
+    def fake_popen(command: list[str], **_kwargs: Any) -> Process:
+        captured_commands.append(command)
+        if len(captured_commands) == 1:
+            raise OSError("systemd-run vanished between probe and spawn")
+        return Process()
+
+    monkeypatch.setattr(pipeline_module.subprocess, "Popen", fake_popen)
+
+    options: dict[str, Any] = {
+        "stdin": pipeline_module.subprocess.DEVNULL,
+        "stdout": stdout_stream,
+        "stderr": stderr_stream,
+    }
+    process, reason, detail = pipeline_module._spawn_direct_execution_process(
+        ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"],
+        options,
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+    )
+    options["stdout"].close()
+    options["stderr"].close()
+
+    assert reason == "degraded_spawn_error"
+    assert detail == "systemd-run vanished between probe and spawn"
+    assert len(captured_commands) == 2
+    assert captured_commands[0][0] == "/usr/bin/systemd-run"
+    assert captured_commands[1] == [
+        "python3",
+        "-m",
+        "jarvis_cd.core.execution",
+        "run-snapshot",
+    ]
+    assert process.pid == 4321
 
 
 def test_nonblocking_direct_record_reconciles_a_crashed_child(tmp_path: Path) -> None:
@@ -1733,10 +2088,12 @@ def test_nonblocking_direct_record_reconciles_a_crashed_child(tmp_path: Path) ->
         mode="direct",
         metadata={
             "direct_launch": {
-                "schema_version": "jarvis.direct-launch.v1",
+                "schema_version": DIRECT_LAUNCH_SCHEMA,
                 "phase": "spawned",
                 "launcher_pid": os.getpid(),
                 "child_pid": os.getpid(),
+                "escape": "systemd_scope",
+                "escape_detail": None,
             }
         },
     )
@@ -1762,10 +2119,12 @@ def test_nonblocking_direct_record_stays_live_while_child_holds_lease(
         mode="direct",
         metadata={
             "direct_launch": {
-                "schema_version": "jarvis.direct-launch.v1",
+                "schema_version": DIRECT_LAUNCH_SCHEMA,
                 "phase": "spawned",
                 "launcher_pid": os.getpid(),
                 "child_pid": os.getpid(),
+                "escape": "systemd_scope",
+                "escape_detail": None,
             }
         },
     )
@@ -1777,6 +2136,61 @@ def test_nonblocking_direct_record_stays_live_while_child_holds_lease(
         assert store.get("active").state == "running"
 
     assert store.get("active").state == "failed"
+
+
+def test_reconcile_direct_execution_rejects_a_stale_v1_schema_record(
+    tmp_path: Path,
+) -> None:
+    """The schema bump (R1) is enforced, not decorative.
+
+    A record still tagged with the pre-fix ``jarvis.direct-launch.v1``
+    schema (no ``escape``/``escape_detail`` fields) must be rejected as
+    invalid rather than silently treated as a valid, merely reason-less,
+    launch.
+    """
+    store = ExecutionStore(tmp_path / "executions", "example")
+    record = store.create(
+        "stale-schema",
+        mode="direct",
+        metadata={
+            "direct_launch": {
+                "schema_version": "jarvis.direct-launch.v1",
+                "phase": "spawned",
+                "launcher_pid": os.getpid(),
+                "child_pid": os.getpid(),
+            }
+        },
+    )
+    assert record._record_path is not None
+    prepare_direct_execution_lease(record._record_path.parent)
+    with pytest.raises(RuntimeError, match="direct execution launch metadata"):
+        store.get("stale-schema")
+
+
+def test_reconcile_direct_execution_rejects_an_unknown_escape_reason(
+    tmp_path: Path,
+) -> None:
+    """An escape value outside the typed vocabulary is rejected, not passed
+    through — the same rigor already applied to ``phase``."""
+    store = ExecutionStore(tmp_path / "executions", "example")
+    record = store.create(
+        "bad-escape",
+        mode="direct",
+        metadata={
+            "direct_launch": {
+                "schema_version": DIRECT_LAUNCH_SCHEMA,
+                "phase": "spawned",
+                "launcher_pid": os.getpid(),
+                "child_pid": os.getpid(),
+                "escape": "not_a_real_reason",
+                "escape_detail": None,
+            }
+        },
+    )
+    assert record._record_path is not None
+    prepare_direct_execution_lease(record._record_path.parent)
+    with pytest.raises(RuntimeError, match="direct execution launch metadata"):
+        store.get("bad-escape")
 
 
 def test_package_progress_environment_is_execution_owned(tmp_path: Path) -> None:

--- a/test/unit/core/test_execution.py
+++ b/test/unit/core/test_execution.py
@@ -1266,6 +1266,137 @@ def test_nonblocking_direct_run_returns_live_queryable_handle(
     assert handle.progress().execution_id == "background"
 
 
+def test_escaped_direct_launch_command_wraps_with_systemd_run_scope_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A usable systemd user session gets its own transient scope, not a plain child.
+
+    ``start_new_session=True`` (setsid) detaches session/process-group but not
+    cgroup membership: a merely-detached child stays inside whatever cgroup the
+    launching process is tracked in. On a host with a working systemd --user
+    session (the same precondition clio-relay's own process containment
+    requires), wrapping the launch in its own ``systemd-run --user --scope``
+    unit gives it an independent, sibling cgroup instead — see clio-relay#222.
+    """
+    monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
+    monkeypatch.setattr(
+        pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
+    )
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+
+    original = ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"]
+    wrapped = pipeline_module._escaped_direct_launch_command(original)
+
+    assert wrapped[0] == "/usr/bin/systemd-run"
+    assert wrapped[1:4] == ["--user", "--scope", "--quiet"]
+    assert wrapped[4].startswith("--unit=jarvis-cd-direct-")
+    assert wrapped[5] == "--"
+    assert wrapped[6:] == original
+    # Two independent calls must not collide on the same transient unit name.
+    other = pipeline_module._escaped_direct_launch_command(original)
+    assert other[4] != wrapped[4]
+
+
+def test_escaped_direct_launch_command_falls_back_without_systemd_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hosts without systemd-run keep today's setsid-only launch, unchanged."""
+    monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
+    monkeypatch.setattr(pipeline_module.shutil, "which", lambda _name: None)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+
+    original = ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"]
+    assert pipeline_module._escaped_direct_launch_command(original) == original
+
+
+def test_escaped_direct_launch_command_falls_back_without_runtime_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A systemd-run binary with no reachable user bus is not trusted to scope."""
+    monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
+    monkeypatch.setattr(
+        pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
+    )
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+
+    original = ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"]
+    assert pipeline_module._escaped_direct_launch_command(original) == original
+
+
+def test_escaped_direct_launch_command_falls_back_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows has no cgroup/systemd-scope race; leave its launch untouched."""
+    monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: True)
+    monkeypatch.setattr(
+        pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
+    )
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+
+    original = ["python3", "-m", "jarvis_cd.core.execution", "run-snapshot"]
+    assert pipeline_module._escaped_direct_launch_command(original) == original
+
+
+def test_nonblocking_direct_run_escapes_into_its_own_systemd_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The real launch path wraps the run-snapshot command through the escape.
+
+    Regression test for clio-relay#222: without this wrap, the run-snapshot
+    child (and the application it launches) stays inside the caller's tracked
+    cgroup, so a caller-scoped containment check sees it as a leaked
+    descendant and kills it mid-run even though ``jarvis_run`` documents
+    direct mode as "start a pipeline without waiting".
+    """
+    pipeline = _pipeline_double(tmp_path)
+    pipeline.save = Mock()
+
+    def write_snapshot(
+        execution_root: Path,
+        scheduler_spec: dict[str, object],
+    ) -> tuple[Path, Path, str]:
+        assert scheduler_spec == {}
+        runtime = execution_root / "runtime"
+        inputs = execution_root / "input"
+        runtime.mkdir()
+        inputs.mkdir()
+        return runtime, inputs, "abc123"
+
+    pipeline._write_execution_snapshot = Mock(side_effect=write_snapshot)
+
+    captured_commands: list[list[str]] = []
+
+    class Process:
+        pid = 4242
+
+    def fake_popen(command: list[str], **_kwargs: Any) -> Process:
+        captured_commands.append(command)
+        return Process()
+
+    monkeypatch.setattr(pipeline_module, "_is_windows_platform", lambda: False)
+    monkeypatch.setattr(
+        pipeline_module.shutil, "which", lambda _name: "/usr/bin/systemd-run"
+    )
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+    monkeypatch.setattr("jarvis_cd.core.pipeline.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "jarvis_cd.core.execution._process_is_running", lambda _pid: True
+    )
+
+    handle = pipeline.run(execution_id="background", wait=False)
+
+    assert handle.execution_id == "background"
+    assert len(captured_commands) == 1
+    launched = captured_commands[0]
+    assert launched[0] == "/usr/bin/systemd-run"
+    assert launched[1:4] == ["--user", "--scope", "--quiet"]
+    assert launched[4].startswith("--unit=jarvis-cd-direct-")
+    assert launched[5] == "--"
+    assert "run-snapshot" in launched
+    assert launched[6] == pipeline_module.sys.executable
+
+
 def test_nonblocking_direct_record_reconciles_a_crashed_child(tmp_path: Path) -> None:
     """A lost detached process cannot leave a durable record running forever."""
     store = ExecutionStore(tmp_path / "executions", "example")


### PR DESCRIPTION
Fixes the direct-mode launch detach race tracked in iowarp/clio-relay#222.

## The race
`Pipeline._launch_direct_execution()` used `start_new_session=True` (setsid), which detaches session/process-group but **not cgroup membership** — fork/exec always inherits the parent's cgroup. Under clio-relay's systemd-scope containment, the containment check (`ensure_owned_process_tree_empty`) then correctly sees the async-launched run inside the caller's cgroup and kills it (~13s after submit, deterministic). The two sides disagreed about what a clean `wait=False` direct launch looks like.

## The fix
- Wrap the direct launch in its own transient `systemd-run --user --scope` unit (independent cgroup) when a systemd user session is usable.
- **Probe, then trust**: `_systemd_user_scope_is_usable()` runs a real bounded probe scope first — D-Bus is intermittently unreachable from deep launch chains even when a plain shell succeeds.
- **Deep-chain environment**: `_systemd_user_runtime_environment()` explicitly carries `XDG_RUNTIME_DIR` + `DBUS_SESSION_BUS_ADDRESS` into both the probe and the wrapped launch — the deep chain strips both, and `systemd-run` does **not** re-derive them (verified live; the prior docstring claiming otherwise was wrong and is corrected).
- **Confirmed migration**: `_cgroup_escape_confirmed()` (bounded `/proc/<pid>/cgroup` poll — migration isn't atomic at fork), with one unwrapped retry stopping the whole scope (not just the leader) if unconfirmed.
- **Typed, recorded degradation**: every launch records one of 7 typed `escape:` reasons on the `direct_launch` execution metadata (schema v2, strict enum) with a bounded diagnostic — no silent fallback anywhere.

## Evidence
- 6 consecutive clean full-deep-chain executions (relay session-api → jarvis-mcp-call → jarvis-cd): every one `escape=systemd_scope, state=completed, return_code=0`.
- Unit: `test_execution.py` 97/97, full unit suite 1672/1672, failing-first proven; sabotage-tested (reverting the call site, short-circuiting the confirmation, and flipping the probe's `--user` all go red).

## Honest scope notes
- **Relay-side follow-up exists** (iowarp/clio-relay#226): post-fix, clio-relay's *wrapping* job for a `jarvis_run` MCP call can stay `running` indefinitely even after jarvis-cd's execution completes cleanly (each stuck job holds a `--kind-concurrency jarvis` slot). jarvis-cd's side is proven by its own durable execution records; relay's containment verdict post-fix is inferred, not yet observed end-to-end.
- **Two direct legs**: this fixes the `jarvis_run` MCP leg (`wait=False`). Relay's native broker leg (`wait=True`, blocking) is untouched and intentionally so.
- **Windows**: the same race exists via clio-relay's Job Object containment branch, and `CREATE_NEW_PROCESS_GROUP` cannot escape a Job; relay carries no `JOB_OBJECT_LIMIT_BREAKAWAY_OK`, so Windows needs a relay-side change first — this PR does not claim to cover it.

## Release trap (for whoever cuts the next release)
`dist/candidate-1.8.1/` predates every commit here, and setuptools-scm `no-guess-dev` means a `1.8.1` tag on the wrong commit yields an identically-named wheel with no fix. Cut the release **from this branch** and assert wheel content: `unzip -p <wheel> jarvis_cd/core/pipeline.py | grep -c _spawn_direct_execution_process` must be ≥1.

Two test-only locks land before merge: pin `env=` on the real wrapped `Popen` (the load-bearing half of the deep-chain fix currently has no test lock) and pin the recorded reason on the persisted record across all 7 branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
