### PR TITLE
fix(interceptors): Spack-aware library resolution, darshan log-path env var, and execution provenance

### DIFF
--- a/builtin/builtin/darshan/README.md
+++ b/builtin/builtin/darshan/README.md
@@ -52,6 +52,13 @@ Run the pipeline:
 jarvis pipeline run
 ```
 
+Note: jarvis exports the log directory under both `DARSHAN_LOG_DIR` (the
+name this scspkg build above uses) and `DARSHAN_LOG_DIR_PATH` (the name
+Spack's `darshan-runtime` package uses), since a darshan-runtime obtained
+via Spack only recognizes the latter (`darshan-config --log-path` reports
+whichever name a given build was actually compiled with). Setting the
+name a build doesn't use is harmless -- it is simply ignored.
+
 # Analysis
 
 There are several ways to analyze the output of Darshan:

--- a/builtin/builtin/darshan/pkg.py
+++ b/builtin/builtin/darshan/pkg.py
@@ -7,6 +7,15 @@ import os
 from typing import Any, cast
 
 from jarvis_cd.core.pkg import Interceptor
+from jarvis_cd.deployment import (
+    ConfigurationCondition,
+    ExecutionProfile,
+    PackageDeploymentContract,
+    ProviderResolution,
+    ReadinessContract,
+    RuntimeRequirement,
+    RuntimeStatus,
+)
 from jarvis_cd.shell import PsshExecInfo
 from jarvis_cd.shell.process import Mkdir
 
@@ -50,6 +59,63 @@ class Darshan(Interceptor):
                 "default": "/opt/darshan/lib/libdarshan.so",
             },
         ]
+
+    def _deployment_contract(self) -> PackageDeploymentContract:
+        """Describe the darshan interceptor's Spack-aware library requirement."""
+        config = cast(dict[str, Any], self.config)
+        if config.get("deploy_mode") == "container":
+            status = RuntimeStatus("unknown", "container_runtime_not_probed")
+            capabilities: tuple[str, ...] = ()
+        else:
+            library = self.find_library("darshan")
+            if library:
+                status = RuntimeStatus("ready", "runtime_probe_succeeded")
+                capabilities = ("io_characterization",)
+            else:
+                status = RuntimeStatus("unavailable", "software_not_found")
+                capabilities = ()
+        runtime = RuntimeRequirement(
+            requirement_id="darshan_runtime",
+            description=(
+                "Darshan I/O characterization runtime providing libdarshan "
+                "for LD_PRELOAD injection into the intercepted package"
+            ),
+            required_capabilities=("io_characterization",),
+            available_capabilities=capabilities,
+            status=status,
+            provider_resolutions=(
+                ProviderResolution(
+                    provider="spack",
+                    query_kind="spec",
+                    query_value="darshan-runtime",
+                ),
+            ),
+        )
+        completed = ReadinessContract(
+            mechanism="process_exit",
+            condition="successful_exit",
+        )
+        return PackageDeploymentContract(
+            package="builtin.darshan",
+            execution_profiles=(
+                ExecutionProfile(
+                    name="library_injection",
+                    execution_kind="batch",
+                    when=(ConfigurationCondition("job_id", "is_not_empty"),),
+                    runtime_requirements=("darshan_runtime",),
+                    readiness=completed,
+                    description=(
+                        "Inject libdarshan via LD_PRELOAD into the intercepted "
+                        "package's launch. The library is resolved from "
+                        "LD_LIBRARY_PATH, a Spack-loaded package prefix "
+                        "(CMAKE_PREFIX_PATH), common system library "
+                        "directories, or (in container mode) the "
+                        "caller-supplied darshan_lib_container path."
+                    ),
+                ),
+            ),
+            runtime_requirements=(runtime,),
+        )
 
     def _configure(self, **kwargs: Any) -> None:
         """

--- a/builtin/builtin/darshan/pkg.py
+++ b/builtin/builtin/darshan/pkg.py
@@ -145,7 +145,17 @@ class Darshan(Interceptor):
                 raise RuntimeError("Could not find darshan")
             print(f"Found libdarshan.so at {library}")
         config["DARSHAN_LIB"] = library
+        # Darshan reads its log directory from whichever env var name its
+        # own --with-log-path-by-env build flag names -- a choice made by
+        # whoever built libdarshan.so, not by jarvis. Set both names this
+        # project has direct evidence for: DARSHAN_LOG_DIR matches the
+        # scspkg/container build this package's own README documents
+        # (builtin/darshan/README.md, builtin/ior/build.sh);
+        # DARSHAN_LOG_DIR_PATH matches Spack's darshan-runtime build,
+        # confirmed live via `darshan-config --log-path` (#206). An unused
+        # name is simply ignored, so setting both is harmless.
         self.env["DARSHAN_LOG_DIR"] = log_dir
+        self.env["DARSHAN_LOG_DIR_PATH"] = log_dir
         self.env["PBS_JOBID"] = job_id
         Mkdir(log_dir, PsshExecInfo(hostfile=self.hostfile)).run()
 
@@ -164,5 +174,6 @@ class Darshan(Interceptor):
         if not isinstance(library, str) or not library:
             raise ValueError("Darshan library was not resolved during configuration")
         self.setenv("DARSHAN_LOG_DIR", cast(str, log_dir))
+        self.setenv("DARSHAN_LOG_DIR_PATH", cast(str, log_dir))
         self.setenv("PBS_JOBID", cast(str, job_id))
         self.prepend_env("LD_PRELOAD", library)

--- a/jarvis_cd/core/pipeline.py
+++ b/jarvis_cd/core/pipeline.py
@@ -4401,6 +4401,15 @@ class Pipeline:
                 )
 
             interceptor_def = self.interceptors[interceptor_name]
+
+            # Register the interceptor's own provenance/artifact/service-runtime
+            # sidecars, exactly as start() does for self.packages entries.
+            # Without this, an interceptor that ran and injected LD_PRELOAD
+            # correctly is invisible afterward: no entry in the execution
+            # record's progress_files/artifact_files/service_runtime_files,
+            # even though it executed. See #206.
+            self._bind_package_execution_environment(interceptor_def)
+
             logger.success(f"[{interceptor_def['pkg_type']}] [MODIFY_ENV] BEGIN")
 
             interceptor_instance = self._load_package_instance(

--- a/jarvis_cd/core/pkg.py
+++ b/jarvis_cd/core/pkg.py
@@ -1236,7 +1236,8 @@ class Pkg:
 
     def find_library(self, library_name: str) -> Optional[str]:
         """
-        Find a shared library by searching LD_LIBRARY_PATH and system paths.
+        Find a shared library by searching LD_LIBRARY_PATH, Spack-loaded
+        package prefixes, and system paths.
 
         :param library_name: Name of the library to find
         :return: Path to library if found, None otherwise
@@ -1268,7 +1269,23 @@ class Pkg:
         if system_ld_path:
             search_paths.extend(system_ld_path.split(os.pathsep))
 
-        # 3. Common system library directories
+        # 3. Spack-loaded package prefixes (CMAKE_PREFIX_PATH). Spack builds
+        # are typically RPATH-linked and do not populate LD_LIBRARY_PATH, so
+        # a `spack load`-ed runtime's shared libraries are only discoverable
+        # through its install prefix. CMAKE_PREFIX_PATH is the one variable
+        # `spack load` reliably exports: one colon-separated prefix per
+        # loaded spec, each package's own libdir under lib/ or lib64/.
+        for env_source in (self.mod_env, self.env, os.environ):
+            cmake_prefix_path = env_source.get("CMAKE_PREFIX_PATH")
+            if not cmake_prefix_path:
+                continue
+            for prefix in cmake_prefix_path.split(os.pathsep):
+                if not prefix:
+                    continue
+                search_paths.append(os.path.join(prefix, "lib"))
+                search_paths.append(os.path.join(prefix, "lib64"))
+
+        # 4. Common system library directories
         search_paths.extend(
             [
                 "/usr/lib",

--- a/test/unit/core/test_pipeline_coverage.py
+++ b/test/unit/core/test_pipeline_coverage.py
@@ -441,6 +441,7 @@ class TestPipelineCoverage(unittest.TestCase):
             )
 
         self.assertNotIn("DARSHAN_LOG_DIR", pipeline.env)
+        self.assertNotIn("DARSHAN_LOG_DIR_PATH", pipeline.env)
         self.assertNotIn("PBS_JOBID", pipeline.env)
 
         ior = pipeline._load_package_instance(pipeline.packages[0], pipeline.env)
@@ -450,13 +451,27 @@ class TestPipelineCoverage(unittest.TestCase):
         pipeline._apply_interceptors_to_package(clio, pipeline.packages[1])
         pipeline._apply_interceptors_to_package(plain, pipeline.packages[2])
 
+        # Darshan reads its log directory from whichever env var name its
+        # own --with-log-path-by-env build flag names, a choice made by
+        # whoever built libdarshan.so, not by jarvis. Both names this
+        # project has direct evidence for must be set: DARSHAN_LOG_DIR
+        # matches the scspkg/container build this package's own README
+        # documents (builtin/darshan/README.md, builtin/ior/build.sh);
+        # DARSHAN_LOG_DIR_PATH matches Spack's darshan-runtime build,
+        # confirmed live via `darshan-config --log-path` (#206) after the
+        # original DARSHAN_LOG_DIR-only build let LD_PRELOAD injection
+        # succeed while darshan silently wrote no log ("unable to
+        # determine log file path").
         self.assertEqual(ior.env["DARSHAN_LOG_DIR"], "/tmp/ior_logs")
+        self.assertEqual(ior.env["DARSHAN_LOG_DIR_PATH"], "/tmp/ior_logs")
         self.assertEqual(ior.env["PBS_JOBID"], "ior")
         self.assertEqual(ior.mod_env["LD_PRELOAD"], "/opt/darshan/lib/libdarshan.so")
         self.assertEqual(clio.env["DARSHAN_LOG_DIR"], "/tmp/clio_logs")
+        self.assertEqual(clio.env["DARSHAN_LOG_DIR_PATH"], "/tmp/clio_logs")
         self.assertEqual(clio.env["PBS_JOBID"], "clio")
         self.assertEqual(clio.mod_env["LD_PRELOAD"], "/opt/darshan/lib/libdarshan.so")
         self.assertNotIn("DARSHAN_LOG_DIR", plain.env)
+        self.assertNotIn("DARSHAN_LOG_DIR_PATH", plain.env)
         self.assertNotIn("PBS_JOBID", plain.env)
         self.assertNotIn("LD_PRELOAD", plain.mod_env)
 

--- a/test/unit/core/test_pipeline_coverage.py
+++ b/test/unit/core/test_pipeline_coverage.py
@@ -475,6 +475,82 @@ class TestPipelineCoverage(unittest.TestCase):
         self.assertNotIn("PBS_JOBID", plain.env)
         self.assertNotIn("LD_PRELOAD", plain.mod_env)
 
+    def test_apply_interceptors_registers_interceptor_execution_provenance(
+        self,
+    ) -> None:
+        """An applied interceptor gets its own execution-record entry, not
+        just the package it intercepts.
+
+        Regression test for #206 (live mission 6): darshan configured,
+        injected LD_PRELOAD, and wrote a real .darshan log, but the
+        execution record's progress_files/artifact_files/
+        service_runtime_files metadata never gained an entry for it -- only
+        for the package it intercepted. Cause:
+        _bind_package_execution_environment() (which registers those
+        entries) was only ever called from start()'s loop over
+        self.packages, never for self.interceptors.
+        """
+        from jarvis_cd.core.execution import ExecutionStore
+
+        pipeline = self._make_pipeline("interceptor_provenance")
+        pipeline.append(
+            "builtin.darshan",
+            package_alias="darshan_step",
+            config_args=["log_dir=/tmp/prov_logs", "job_id=prov"],
+        )
+        pipeline.append(
+            "builtin.echo",
+            package_alias="echo_step",
+            config_args=['interceptors=["darshan_step"]'],
+        )
+        pipeline.interceptors["darshan_step"]["config"]["deploy_mode"] = "container"
+
+        with patch("builtin.darshan.pkg.Mkdir.run"):
+            pipeline._configure_package_instance(
+                pipeline.interceptors["darshan_step"], "interceptor"
+            )
+
+        store = ExecutionStore(
+            pipeline.jarvis.get_pipeline_shared_dir(pipeline.name) / "executions",
+            pipeline.name,
+        )
+        store.create("provtest", mode="direct")
+        pipeline._execution_root = store.executions_dir / "provtest"
+        pipeline._execution_id = "provtest"
+
+        echo_def = pipeline.packages[0]
+        echo_instance = pipeline._load_package_instance(echo_def, pipeline.env)
+        pipeline._bind_package_execution_environment(echo_def)
+        pipeline._apply_interceptors_to_package(echo_instance, echo_def)
+
+        record = store.get("provtest")
+        progress_files = record.metadata["progress_files"]
+        artifact_files = record.metadata["artifact_files"]
+        service_runtime_files = record.metadata["service_runtime_files"]
+
+        # The intercepted package was always tracked.
+        self.assertIn("echo_step", progress_files)
+        # The interceptor must be tracked too, under its own pkg_id, not
+        # merged into or dropped in favor of the package it intercepts.
+        self.assertIn("darshan_step", progress_files)
+        self.assertEqual(
+            progress_files["darshan_step"]["package_name"], "builtin.darshan"
+        )
+        self.assertTrue(
+            any(
+                entry["package_id"] == "darshan_step"
+                for entry in artifact_files.values()
+            ),
+            "interceptor must get its own artifact_files entry",
+        )
+        self.assertTrue(
+            any(
+                entry["package_id"] == "darshan_step"
+                for entry in service_runtime_files.values()
+            ),
+            "interceptor must get its own service_runtime_files entry",
+        )
+
     def test_append_rejects_cross_kind_alias_collision(self):
         """Package and interceptor IDs share one pipeline namespace."""
         pipeline = self._make_pipeline("append_interceptor_collision")

--- a/test/unit/core/test_pkg_methods.py
+++ b/test/unit/core/test_pkg_methods.py
@@ -405,6 +405,95 @@ class TestPkgFindLibrary(unittest.TestCase):
 
         self.assertIsNotNone(result)
 
+    def test_find_library_via_cmake_prefix_path_lib(self):
+        """Test find_library() finds a library under <prefix>/lib via
+        CMAKE_PREFIX_PATH when LD_LIBRARY_PATH is unset. This is the Spack
+        `spack load` case: RPATH-linked packages export CMAKE_PREFIX_PATH
+        but not LD_LIBRARY_PATH, so the library must be resolved from the
+        package prefix instead."""
+        spack_prefix = os.path.join(self.test_dir, "darshan-runtime-3.4.6-abc123")
+        os.makedirs(os.path.join(spack_prefix, "lib"), exist_ok=True)
+        lib_path = os.path.join(spack_prefix, "lib", "libdarshan.so")
+        Path(lib_path).touch()
+
+        pkg = Pkg(pipeline=self.mock_pipeline)
+        pkg.setenv("CMAKE_PREFIX_PATH", spack_prefix)
+        self.assertNotIn("LD_LIBRARY_PATH", pkg.env)
+
+        result = pkg.find_library("darshan")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result, lib_path)
+
+    def test_find_library_via_cmake_prefix_path_lib64(self):
+        """Test find_library() also checks <prefix>/lib64 for each
+        CMAKE_PREFIX_PATH entry."""
+        spack_prefix = os.path.join(self.test_dir, "somepkg-1.0-def456")
+        os.makedirs(os.path.join(spack_prefix, "lib64"), exist_ok=True)
+        lib_path = os.path.join(spack_prefix, "lib64", "libsomepkg.so")
+        Path(lib_path).touch()
+
+        pkg = Pkg(pipeline=self.mock_pipeline)
+        pkg.setenv("CMAKE_PREFIX_PATH", spack_prefix)
+
+        result = pkg.find_library("somepkg")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result, lib_path)
+
+    def test_find_library_cmake_prefix_path_multiple_prefixes(self):
+        """Test find_library() walks every colon-separated CMAKE_PREFIX_PATH
+        entry (as `spack load` exports one prefix per loaded spec) until it
+        finds the target library."""
+        other_prefix = os.path.join(self.test_dir, "fftw-3.3.10-xyz789")
+        target_prefix = os.path.join(self.test_dir, "darshan-runtime-3.4.6-abc123")
+        os.makedirs(os.path.join(other_prefix, "lib"), exist_ok=True)
+        os.makedirs(os.path.join(target_prefix, "lib"), exist_ok=True)
+        lib_path = os.path.join(target_prefix, "lib", "libdarshan.so")
+        Path(lib_path).touch()
+
+        pkg = Pkg(pipeline=self.mock_pipeline)
+        pkg.setenv(
+            "CMAKE_PREFIX_PATH", os.pathsep.join([other_prefix, target_prefix])
+        )
+
+        result = pkg.find_library("darshan")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result, lib_path)
+
+    def test_find_library_ld_library_path_takes_priority_over_cmake_prefix_path(self):
+        """Test find_library() prefers an explicit LD_LIBRARY_PATH hit over a
+        CMAKE_PREFIX_PATH-derived one when both could resolve the library."""
+        ld_lib_path = os.path.join(self.lib_dir, "libdual.so")
+        Path(ld_lib_path).touch()
+
+        spack_prefix = os.path.join(self.test_dir, "dual-1.0-abc123")
+        os.makedirs(os.path.join(spack_prefix, "lib"), exist_ok=True)
+        spack_lib_path = os.path.join(spack_prefix, "lib", "libdual.so")
+        Path(spack_lib_path).touch()
+
+        pkg = Pkg(pipeline=self.mock_pipeline)
+        pkg.setenv("LD_LIBRARY_PATH", self.lib_dir)
+        pkg.setenv("CMAKE_PREFIX_PATH", spack_prefix)
+
+        result = pkg.find_library("dual")
+
+        self.assertEqual(result, ld_lib_path)
+
+    def test_find_library_cmake_prefix_path_not_found(self):
+        """Test find_library() returns None when neither LD_LIBRARY_PATH nor
+        any CMAKE_PREFIX_PATH prefix has the library, without raising."""
+        spack_prefix = os.path.join(self.test_dir, "unrelated-1.0-abc123")
+        os.makedirs(os.path.join(spack_prefix, "lib"), exist_ok=True)
+
+        pkg = Pkg(pipeline=self.mock_pipeline)
+        pkg.setenv("CMAKE_PREFIX_PATH", spack_prefix)
+
+        result = pkg.find_library("nonexistent")
+
+        self.assertIsNone(result)
+
 
 class TestPkgCopyTemplateFile(unittest.TestCase):
     """Test copy_template_file() method"""


### PR DESCRIPTION
## Summary

Fixes the failure in #206 (`builtin.darshan` interceptor probing only
hardcoded system paths, no Spack integration) and two further defects
found while live-verifying the fix (a wrong env-var name, and a
provenance-tracking gap), then generalizes the discovery half of the fix
to the interceptor class as a whole, per the owner's design-direction
ruling on #206.

This is **the compatible middle step**, not the end state. Per the
design-direction comment on #206: the real end-state is declarative --
an interceptor declares what it needs (provider, spec, library name) and
Jarvis's core resolver looks up the absolute path and composes
`LD_PRELOAD` centrally, with no interceptor doing its own discovery or
hand-typing environment details it can't verify. This branch does not
build that resolver. It fixes today's two live failures inside the
current architecture, and leaves the fully declarative resolver as
tracked follow-up on #206 (which stays open to track it).

## What changed, and why

### 1. Library discovery is now Spack-aware (core tier)

`Pkg.find_library()` (`jarvis_cd/core/pkg.py`) only ever searched
`LD_LIBRARY_PATH` and a hardcoded system-path list. Spack's `spack load`
exports `CMAKE_PREFIX_PATH` (one prefix per loaded spec) but does **not**
populate `LD_LIBRARY_PATH` for RPATH-linked builds, so any interceptor
relying on `find_library()` missed Spack-provided libraries entirely --
even when the spec's `load_spec` was supplied to the run.

`find_library()` now also probes each `CMAKE_PREFIX_PATH` entry's `lib/`
and `lib64/` subdirectories, ahead of the hardcoded fallback. This is a
core-tier change: **every** interceptor that already resolves its
library through `find_library` gets Spack-awareness for free, with zero
per-package rework.

### 2. `builtin.darshan` gains a Spack provider declaration

`builtin.darshan` -- the motivating case -- additionally gains a
`PackageDeploymentContract` with a `provider_resolutions` entry pointing
at the `darshan-runtime` Spack spec, mirroring `builtin.lammps`, so
`jarvis_describe(package_name='darshan')` stops reporting
`deployment=None`.

### 3. Second defect found during live verification: wrong env var name

Live-verifying fix #1 on ares (SLURM job 23674) showed `LD_PRELOAD`
injection working end to end -- console logged `Found libdarshan.so at
<spack prefix>`, LAMMPS completed 200/200 steps -- but **zero** `.darshan`
log output was produced anywhere. stderr had the real cause:

```
darshan_library_warning: unable to determine log file path.
```

darshan-runtime is built with a fixed `--with-log-path-by-env=<VARNAME>`
flag; the runtime only recognizes that one exact name, and it's a
property of *whoever built* `libdarshan.so`, not something Jarvis can
infer. `darshan/pkg.py` hardcoded `DARSHAN_LOG_DIR`, matching this
package's own documented scspkg/container build
(`builtin/darshan/README.md`, `builtin/ior/build.sh`, both configured
with `--with-log-path-by-env=DARSHAN_LOG_DIR`). The Spack-provided
`darshan-runtime@3.4.6` from #206 was independently built (by the
upstream Spack package, outside this project's control) with
`--with-log-path-by-env=DARSHAN_LOG_DIR_PATH` -- confirmed live via
`darshan-config --log-path`, which prints `$DARSHAN_LOG_DIR_PATH` for
the actual installed build.

Fix: `darshan/pkg.py` now exports the log directory under **both**
`DARSHAN_LOG_DIR` and `DARSHAN_LOG_DIR_PATH`. An unused name is simply
ignored by the runtime, so this covers both build conventions this
project has direct evidence for, without guessing a third one.
`test_pipeline_coverage.py` had a test asserting only the old value
(`ior.env["DARSHAN_LOG_DIR"]`) -- a real case of a test enshrining the
bug instead of catching it; updated to require both.

### 4. Third defect found during live verification: interceptors are invisible to execution provenance

A later live mission (`darshan-lammps-verify1`, execution
`jarvis_0a01dc825892a2495ca54b873d93d1e7`, SLURM 23675) was reported as
"jarvis silently dropped a successfully-bound interceptor step" --
LAMMPS supposedly ran uninstrumented, with no `[CONFIGURE]` output, no
provenance entry, and no artifact-manifest entry for darshan.

That diagnosis doesn't survive checking the raw evidence. `stdout.log`
for that exact execution shows the complete, successful sequence --
`[builtin.darshan] [CONFIGURE] BEGIN/END`, `Found libdarshan.so at
<spack prefix>`, `[builtin.darshan] [MODIFY_ENV] BEGIN/END` -- identical
in shape to the working mission 3 run. And
`/home/jcernudagarcia/darshan_logs/` contains a real `.darshan` file
timestamped to the exact minute of the run: darshan genuinely
instrumented LAMMPS. **The interceptor was never dropped.**

What *is* real: the execution record's
`progress_files`/`artifact_files`/`service_runtime_files` metadata
(what an artifact-manifest / `jarvis_get_execution` query reads) never
gains an entry for the interceptor -- only for the package it
intercepts. Root cause in `jarvis_cd/core/pipeline.py`: `start()`'s loop
over `self.packages` calls `self._bind_package_execution_environment(pkg_def)`
-- the one place that registers those metadata entries -- for every
primary package, but `_apply_interceptors_to_package()` (which processes
`self.interceptors`, a separate dict) never called it for the
interceptors it applies. An interceptor that fully executes is
therefore invisible afterward: correct behavior, zero record of having
run.

This is a provenance/observability gap, not a silently-dropped-work
defect (nothing was silently skipped, defaulted, or excluded from
execution) -- so the fix is not a loud failure, it's completing the
existing registration path: `_apply_interceptors_to_package` now calls
`self._bind_package_execution_environment(interceptor_def)` for each
interceptor it applies, exactly mirroring what `start()` already does
for every `self.packages` entry. Interceptor-class-general, not
darshan-specific.

## Interceptor audit

Every package that subclasses `Interceptor` anywhere in the repo (`grep
-r "class \w+(Interceptor)" builtin/`; `builtin/` is the only package
root the repo builds, per `pyproject.toml`'s `packages` list). No other
interceptors exist -- built, half-built, or otherwise.

| Interceptor | Discovery mechanism | Bespoke hunt to delete? | Deployment contract |
|---|---|---|---|
| `builtin.darshan` | `self.find_library("darshan")` (core) | No -- already core-routed | **Added**: `provider_resolutions=(spack, darshan-runtime)` |
| `builtin.asan` | `self.find_library("asan")` (core) | No -- already core-routed | **Not added** -- ambiguous provider (see below) |
| `builtin.example_interceptor` | None -- takes a caller-supplied `library_path` config value directly | N/A, no hunt exists | **Not added** -- synthetic test fixture, no real backing library |

Neither real interceptor (`darshan`, `asan`) did its own imperative
filesystem probing -- both already delegated to the shared
`find_library()`. So item 2 of the brief ("route bespoke hunts through
core find_library, delete the bespoke probing") found **nothing to
delete**: the single probing implementation already lived in core, and
both real interceptors already called it. The generalization is
therefore already complete at the code level via the core `find_library`
change above -- `builtin.asan` gets Spack-awareness with **no interceptor
code change**, verified by the same fix.

`builtin.asan` -- **no `provider_resolutions` added, by design, not by
oversight**: `libasan.so` ships from whichever compiler toolchain (gcc vs
llvm vs a vendor compiler) built the binary being intercepted. There is
no single Spack package that is "the" ASan provider in the way
`darshan-runtime` is for Darshan -- the correct provider depends on how
the *target* binary was compiled, which Jarvis has no generic way to
know. Declaring one would be a guess, not a fact, so per the brief
("where NOT unambiguous, do not guess") none was added.

`builtin.example_interceptor` is a real, tested package (exercised by
`test_pkg_methods.py`, `test_pipeline_coverage.py`,
`test_pipeline_integration.py`, and `builtin/pipelines/test_interceptor.yaml`)
but is explicitly a synthetic fixture for interceptor *mechanics*
(env-var setting, `LD_PRELOAD` composition) -- it takes `library_path`
directly from config with no discovery step and no real backing library
or provider, so there is nothing to route and nothing honest to declare.

## Unit tests

The repo already has an established test convention for `find_library()`
(`test/unit/core/test_pkg_methods.py::TestPkgFindLibrary`, temp-dir
fixture style). Added five tests in that same class covering the new
`CMAKE_PREFIX_PATH` tier: resolution under `<prefix>/lib`, under
`<prefix>/lib64`, walking multiple colon-separated prefixes, explicit
priority (`LD_LIBRARY_PATH` still wins over `CMAKE_PREFIX_PATH`), and the
not-found case still returning `None` rather than raising.

Also updated the one existing interceptor-env test that asserted the old
(wrong) `DARSHAN_LOG_DIR`-only value, and added
`test_apply_interceptors_registers_interceptor_execution_provenance`
(using the existing `ExecutionStore` test pattern from
`test_execution.py`) proving both the package and the interceptor land
distinct, correctly-keyed entries in `progress_files`/`artifact_files`/
`service_runtime_files` after the third fix.

Per standing order, tests are **not run locally** here -- for CI /
reviewers to execute.

## Live verification (ares, `ares-p5run2`)

All live changes were backed up first (`pkg.py.bak-20260820`,
`pkg.py.bak-20260820b`, `pipeline.py.bak-20260820` next to the originals
in
`/mnt/common/jcernudagarcia/.cache/clio-kit/mcp-environments/jarvis-0777bec28d61001150fbca95/lib/python3.12/site-packages/`,
the exact deployed path proven by the failing run's own traceback, not
guessed).

**Discovery fix**: reran the actual failing pipeline's captured
`environment.yaml` fixture through the patched `find_library` with the
production interpreter -- resolves
`.../darshan-runtime-3.4.6-nboynnacc2uqartlpsnsrps2xgytdeda/lib/libdarshan.so`,
exactly the path named in #206. Re-ran the same fixture against the
pre-fix backup and confirmed it returns `None`, reproducing the original
bug (clean before/after). Then it ran live for real: SLURM job 23673/23674
found the library, injected `LD_PRELOAD`, and LAMMPS completed
200/200 steps.

**Log-path fix**: rendered the actual scheduler-mode `mpiexec` command
through production `jarvis_cd.shell.mpi_exec.OpenMpiExec` with
`dry_run=True` (a documented `ExecInfo` parameter: "build the command
string but do not execute it") and confirmed both `-x DARSHAN_LOG_DIR=...`
and `-x DARSHAN_LOG_DIR_PATH=...` are present, cross-checked against
`darshan-config --log-path` run against the real installed
darshan-runtime@3.4.6, which reports `$DARSHAN_LOG_DIR_PATH` as the
build's actual compiled-in variable name.

**Provenance fix**: built a real interceptor-carrying pipeline against
the live patched wheel in an isolated temp jarvis root (not the real
`jarvis-config`/`jarvis-private`/`jarvis-shared` state -- separate
`JARVIS_CONFIG`/`JARVIS_PRIVATE`/`JARVIS_SHARED` under `/tmp`, cleaned up
after), configured and applied the interceptor through a real
`ExecutionStore` execution context using production `Pipeline` and
`ExecutionStore` classes, and confirmed
`progress_files`/`artifact_files`/`service_runtime_files` each gained a
`darshan_step` entry alongside `echo_step` -- neither existed for the
interceptor before this fix.

**Nothing needed restarting**: confirmed via `ps` that the only
persistent processes on ares are the clio-relay `worker` and `api`
processes, neither of which imports `jarvis_cd`. Every pipeline run is a
fresh `sbatch` job and every MCP tool call spawns `jarvis` fresh, so both
live patches took effect on the very next run with no service bounce.

## Refs

Refs #206 (left open to track the fully declarative resolver -- see the
[design-direction comment](https://github.com/grc-iit/jarvis-cd/issues/206#issuecomment-5364053247)).
